### PR TITLE
doc: added documentation for tmpdir location

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,12 +334,13 @@ class MyCustomAlgorithm(NeuracoreModel):
 
 Configure Neuracore behavior with environment variables (case insensitive, prefixed with `NEURACORE_`):
 
-| Variable                                     | Function                                   | Valid Values   | Default                         |
-| -------------------------------------------- | ------------------------------------------ | -------------- | ------------------------------- |
-| `NEURACORE_REMOTE_RECORDING_TRIGGER_ENABLED` | Allow remote recording triggers            | `true`/`false` | `true`                          |
-| `NEURACORE_PROVIDE_LIVE_DATA`                | Enable live data streaming from this node  | `true`/`false` | `true`                          |
-| `NEURACORE_CONSUME_LIVE_DATA`                | Enable live data consumption for inference | `true`/`false` | `true`                          |
-| `NEURACORE_API_URL`                          | Base URL for Neuracore platform            | URL string     | `https://api.neuracore.app/api` |
+| Variable                                     | Function                                               | Valid Values   | Default                               |
+| -------------------------------------------- | ------------------------------------------------------ | -------------- | ------------------------------------- |
+| `NEURACORE_REMOTE_RECORDING_TRIGGER_ENABLED` | Allow remote recording triggers                        | `true`/`false` | `true`                                |
+| `NEURACORE_PROVIDE_LIVE_DATA`                | Enable live data streaming from this node              | `true`/`false` | `true`                                |
+| `NEURACORE_CONSUME_LIVE_DATA`                | Enable live data consumption for inference             | `true`/`false` | `true`                                |
+| `NEURACORE_API_URL`                          | Base URL for Neuracore platform                        | URL string     | `https://api.neuracore.app/api`       |
+| `TMPDIR`                                     | Specifies a directory used for storing temporary files | Filepath       | An appropriate folder for your system |
 
 
 ## Performance Considerations


### PR DESCRIPTION
What do you think about making this explicit? this env controls the tmpdir used for datasets 