### PR TITLE
fix: background tasks completed after threadpool shutdown

### DIFF
--- a/neuracore/core/utils/background_coroutine_tracker.py
+++ b/neuracore/core/utils/background_coroutine_tracker.py
@@ -39,6 +39,12 @@ class BackgroundCoroutineTracker:
             task.result()
         except asyncio.CancelledError:
             logger.info("Background task cancelled")
+        except RuntimeError as e:
+            if "cannot schedule new futures after shutdown" in str(e).lower():
+                logger.debug("Event loop is shutting down; ignoring exception.")
+                pass
+            else:
+                logger.exception("Background task runtime error: %s", e)
         except Exception as e:
             logger.exception("Background task raised exception: %s", e)
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
This bug occurs when the threadpool executor has shutdown and we still have background tasks running which try to create subtasks, such as making request to update num active streams and removing background task. When a ThreadPoolExecutor is shutdown it cannot accept new tasks.

To avoid the problem entirely we can either ensure tasks are only submitted to the ThreadPoolExecutor from one context, e.g. the point in the program where the ThreadPoolExecutor is created and shutdown. We can use a queue to connect done callback functions to the main thread to signal what and when subtasks should be issued.

This exception however,  will be resolved when we switch to daemon.
<!-- Please explain any existing functionality improved/changed -->
 - Suppressed the runtime error (Cannot schedule new futures after shutdown)
 - Tested with random camera frames.
 - Occurs sometimes with the usual data collection as well with a slow internet connection

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-265](https://neuracore.atlassian.net/browse/NC-265)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
