### PR TITLE
Rollback mujoco version to 2.3.7 for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- None
+- Temporarily moved back to Mujoco 2.3.7 from Mujoco 3+ for the examples while we look at tuning the physics parameters
 
 
 ## [3.2.0]

--- a/examples/common/assets/robots/vx300s/bimanual_viperx_ee_transfer_cube.xml
+++ b/examples/common/assets/robots/vx300s/bimanual_viperx_ee_transfer_cube.xml
@@ -2,11 +2,9 @@
     <include file="scene.xml"/>
     <include file="vx300s_dependencies.xml"/>
 
-    <option timestep="0.002" />
-
     <equality>
-        <weld body1="mocap_right" body2="vx300s_right/gripper_link" solref="0.004 1" solimp="0.9 0.95 0.001 0.5 2"  />
-        <weld body1="mocap_left" body2="vx300s_left/gripper_link" solref="0.004 1" solimp="0.9 0.95 0.001 0.5 2"  />
+        <weld body1="mocap_left" body2="vx300s_left/gripper_link" solref="0.01 1" solimp=".25 .25 0.001" />
+        <weld body1="mocap_right" body2="vx300s_right/gripper_link" solref="0.01 1" solimp=".25 .25 0.001" />
     </equality>
 
     <worldbody>
@@ -14,13 +12,11 @@
         <include file="vx300s_right.xml" />
 
         <body mocap="true" name="mocap_left" pos="0.095 0.50 0.425">
-            <site name="mocap_left_weld" pos="0 0 0"/>
             <site pos="0 0 0" size="0.003 0.003 0.03" type="box" name="mocap_left_site1" rgba="1 0 0 1"/>
             <site pos="0 0 0" size="0.003 0.03 0.003" type="box" name="mocap_left_site2" rgba="1 0 0 1"/>
             <site pos="0 0 0" size="0.03 0.003 0.003" type="box" name="mocap_left_site3" rgba="1 0 0 1"/>
         </body>
         <body mocap="true" name="mocap_right" pos="-0.095 0.50 0.425">
-            <site name="mocap_right_weld" pos="0 0 0"/>
             <site pos="0 0 0" size="0.003 0.003 0.03" type="box" name="mocap_right_site1" rgba="1 0 0 1"/>
             <site pos="0 0 0" size="0.003 0.03 0.003" type="box" name="mocap_right_site2" rgba="1 0 0 1"/>
             <site pos="0 0 0" size="0.03 0.003 0.003" type="box" name="mocap_right_site3" rgba="1 0 0 1"/>
@@ -29,7 +25,7 @@
         <body name="box" pos="0.2 0.5 0.05">
             <joint name="red_box_joint" type="free" frictionloss="0.01" />
             <inertial pos="0 0 0" mass="0.05" diaginertia="0.002 0.002 0.002" />
-            <geom condim="4" solimp="2 1 0.01" solref="0.01 1" friction="4 0.02 0.0004" pos="0 0 0" size="0.02 0.02 0.02" type="box" name="red_box" rgba="1 0 0 1" />
+            <geom condim="4" solimp="2 1 0.01" solref="0.01 1" friction="1 0.005 0.0001" pos="0 0 0" size="0.02 0.02 0.02" type="box" name="red_box" rgba="1 0 0 1" />
         </body>
     </worldbody>
 

--- a/examples/common/assets/robots/vx300s/bimanual_viperx_transfer_cube.xml
+++ b/examples/common/assets/robots/vx300s/bimanual_viperx_transfer_cube.xml
@@ -14,18 +14,18 @@
     </worldbody>
 
     <actuator>
-        <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_left/waist" kp="3200"  user="1" forcelimited="true" forcerange="-150 150"/>
-        <position ctrllimited="true" ctrlrange="-1.85005 1.25664" joint="vx300s_left/shoulder" kp="3200"  user="1" forcelimited="true" forcerange="-300 300"/>
-        <position ctrllimited="true" ctrlrange="-1.76278 1.6057" joint="vx300s_left/elbow" kp="3200"  user="1" forcelimited="true" forcerange="-100 100"/>
+        <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_left/waist" kp="800"  user="1" forcelimited="true" forcerange="-150 150"/>
+        <position ctrllimited="true" ctrlrange="-1.85005 1.25664" joint="vx300s_left/shoulder" kp="1600"  user="1" forcelimited="true" forcerange="-300 300"/>
+        <position ctrllimited="true" ctrlrange="-1.76278 1.6057" joint="vx300s_left/elbow" kp="800"  user="1" forcelimited="true" forcerange="-100 100"/>
         <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_left/forearm_roll" kp="10"  user="1" forcelimited="true" forcerange="-100 100"/>
         <position ctrllimited="true" ctrlrange="-1.8675 2.23402" joint="vx300s_left/wrist_angle" kp="50"  user="1"/>
         <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_left/wrist_rotate" kp="20"  user="1"/>
         <position ctrllimited="true" ctrlrange="0.021 0.057" joint="vx300s_left/left_finger" kp="200"  user="1"/>
         <position ctrllimited="true" ctrlrange="-0.057 -0.021" joint="vx300s_left/right_finger" kp="200"  user="1"/>
 
-        <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_right/waist" kp="3200"  user="1" forcelimited="true" forcerange="-150 150"/>
-        <position ctrllimited="true" ctrlrange="-1.85005 1.25664" joint="vx300s_right/shoulder" kp="3200"  user="1" forcelimited="true" forcerange="-300 300"/>
-        <position ctrllimited="true" ctrlrange="-1.76278 1.6057" joint="vx300s_right/elbow" kp="3200"  user="1" forcelimited="true" forcerange="-100 100"/>
+        <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_right/waist" kp="800"  user="1" forcelimited="true" forcerange="-150 150"/>
+        <position ctrllimited="true" ctrlrange="-1.85005 1.25664" joint="vx300s_right/shoulder" kp="1600"  user="1" forcelimited="true" forcerange="-300 300"/>
+        <position ctrllimited="true" ctrlrange="-1.76278 1.6057" joint="vx300s_right/elbow" kp="800"  user="1" forcelimited="true" forcerange="-100 100"/>
         <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_right/forearm_roll" kp="10"  user="1" forcelimited="true" forcerange="-100 100"/>
         <position ctrllimited="true" ctrlrange="-1.8675 2.23402" joint="vx300s_right/wrist_angle" kp="50"  user="1"/>
         <position ctrllimited="true" ctrlrange="-3.14158 3.14158" joint="vx300s_right/wrist_rotate" kp="20"  user="1"/>

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     extras_require={
         "examples": [
             "matplotlib>=3.3.0",
-            "mujoco>3",
+            "mujoco==2.3.7",
             "pyquaternion>=0.9.5",
         ],
         "mjcf": [


### PR DESCRIPTION
When upgrading to Mujoco 3 in https://github.com/NeuracoreAI/neuracore/pull/74, a regression was introduced. Simulation parameters were not tuned well, and this resulted in unstable demos and policies. 

For now, we temporarily roll back to Mujoco 2.3.7.