### PR TITLE
Use loaded syncpoint instead of creating new ones when using joint_target_positions as output

### DIFF
--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -299,7 +299,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     # We dont need to shift the sync_point by 1, since we are
                     # using the target joint positions as the action
                     jtp_points = [sync_point] + future_sync_points
-                    jtp_points = jtp_points[:self.output_prediction_horizon]
+                    jtp_points = jtp_points[: self.output_prediction_horizon]
 
                     sample.outputs.joint_target_positions = (
                         self._create_joint_maskable_output_data(


### PR DESCRIPTION
When using joint_target_position as output, a new list of syncpoints is created as we want to use the joint_target_position from the current timestep. This causes the video frames to be loaded again slowing down training.

This fix creates the syncpoint list by combining the syncpoint at the current timestep with the future_sync_points list that are already loaded earlier instead of creating a new variable.