### PR TITLE
Parameterise logging frequency

### DIFF
--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -8,6 +8,7 @@ seed: 42
 epochs: 100
 output_prediction_horizon: 10
 validation_split: 0.2
+logging_frequency: 50
 
 # Batch size (can be "auto" for automatic tuning or an integer)
 batch_size: "auto"

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -327,6 +327,7 @@ def run_training(
             storage_handler=training_storage_handler,
             output_dir=Path(cfg.local_output_dir),
             num_epochs=cfg.epochs,
+            log_freq=cfg.logging_frequency,
             rank=rank,
             world_size=world_size,
         )


### PR DESCRIPTION
### Features
After tensors are cached, logging was taking up most of the time during training. This PR parameterises logging frequency with a default of "every 50 steps".

Before:
<img width="1907" height="444" alt="Screenshot from 2025-11-06 11-32-07" src="https://github.com/user-attachments/assets/79c8cd07-a1a5-491e-9b4c-c8e703006d3e" />

After:
<img width="1905" height="624" alt="image" src="https://github.com/user-attachments/assets/a4710aa1-4195-417c-abb9-006aaf73afa0" />

### Items
 - [NC-20](https://neuracore.atlassian.net/browse/NCRL-20)
