### PR TITLE
Support different ResNet backbones for CNNMLP image encoder

### DIFF
--- a/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
+++ b/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
@@ -48,6 +48,7 @@ class CNNMLP(NeuracoreModel):
         self,
         model_init_description: ModelInitDescription,
         device: torch.device,
+        image_backbone: str = "resnet18",
         hidden_dim: int = 512,
         cnn_output_dim: int = 512,
         num_layers: int = 3,
@@ -60,6 +61,7 @@ class CNNMLP(NeuracoreModel):
         Args:
             model_init_description: Model initialization parameters
             device: Torch device to run the model on (CPU or GPU, or MPS)
+            image_backbone: Backbone architecture for image encoders
             hidden_dim: Hidden dimension for MLP layers
             cnn_output_dim: Output dimension for CNN encoders
             num_layers: Number of MLP layers
@@ -68,6 +70,7 @@ class CNNMLP(NeuracoreModel):
             weight_decay: Weight decay for optimizer
         """
         super().__init__(model_init_description, device)
+        self.image_backbone = image_backbone
         self.hidden_dim = hidden_dim
         self.cnn_output_dim = cnn_output_dim
         self.num_layers = num_layers
@@ -82,7 +85,7 @@ class CNNMLP(NeuracoreModel):
         # Vision encoders
         if DataType.RGB_IMAGE in self.model_init_description.input_data_types:
             self.encoders["rgb"] = nn.ModuleList([
-                ImageEncoder(output_dim=cnn_output_dim)
+                ImageEncoder(output_dim=cnn_output_dim, backbone=image_backbone)
                 for _ in range(self.dataset_description.rgb_images.max_len)
             ])
             self.feature_dims["rgb"] = (

--- a/neuracore/ml/config/algorithm/cnnmlp.yaml
+++ b/neuracore/ml/config/algorithm/cnnmlp.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 algorithm:
   _target_: neuracore.ml.algorithms.cnnmlp.cnnmlp.CNNMLP
+  image_backbone: "resnet18"
   hidden_dim: 512
   cnn_output_dim: 512
   num_layers: 3


### PR DESCRIPTION
### Features
Support different ResNet backbones, default to resnet18

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-29](hthttps://neuracore.atlassian.net/browse/NCRL-29)

### Related PRs
Pre-req: https://github.com/NeuracoreAI/neuracore/pull/123