### PR TITLE
fix: update training script to resolve configuration values in logs

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -364,7 +364,7 @@ def main(cfg: DictConfig) -> None:
     """Main function to run the training script."""
     # Print configuration
     logger.info("Training configuration:")
-    logger.info(OmegaConf.to_yaml(cfg))
+    logger.info(OmegaConf.to_yaml(cfg, resolve=True))
 
     if "algorithm" in cfg and cfg.algorithm_id is not None:
         raise ValueError(


### PR DESCRIPTION
### Bugfixes
- The training log would log the output directory as `${oc.env:HOME}/neuracore_logs` as a raw string instead of resolving to `/home/username/neuracore_logs`

The logs now show 

```
local_output_dir: /home/username/neuracore_logs
```

instead of
```
local_output_dir: ${oc.env:HOME}/neuracore_logs
```
### Items
 - [NCRL-30](https://neuracore.atlassian.net/browse/NCRL-30)
