### PR TITLE
Delete old checkpoints from cloud storage

### DIFF
--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -366,8 +366,7 @@ class DistributedTrainer:
             checkpoint_to_remove = (
                 self.checkpoint_dir / f"checkpoint_{checkpoint_epoch_to_remove}.pt"
             )
-            if checkpoint_to_remove.exists():
-                checkpoint_to_remove.unlink()
+            self.storage_handler.delete_checkpoint(checkpoint_to_remove)
 
         logger.info("... checkpoint saved!")
 


### PR DESCRIPTION
### Features
Clear out google bucket checkpoints during training. Only keep last N. Will need to be triggered from the training script in training_stroage_handler.py

### Items
 - [NCRL-34](https://neuracore.atlassian.net/browse/NCRL-34)

### Related PRs
https://github.com/NeuracoreAI/neuracore_backend/pull/174