### PR TITLE
fix: removed use of deprecated `pretrained=True` parameter.

### DIFF
--- a/neuracore/ml/algorithm_utils/modules.py
+++ b/neuracore/ml/algorithm_utils/modules.py
@@ -29,7 +29,7 @@ class DepthImageEncoder(nn.Module):
         """
         super().__init__()
         # Modify ResNet for single-channel input
-        resnet = getattr(models, backbone)(pretrained=True)
+        resnet = models.get_model(backbone, weights="DEFAULT")
 
         # Replace first conv layer for single-channel depth input
         resnet.conv1 = nn.Conv2d(1, 64, kernel_size=7, stride=2, padding=3, bias=False)

--- a/neuracore/ml/algorithms/act/modules.py
+++ b/neuracore/ml/algorithms/act/modules.py
@@ -44,7 +44,7 @@ class ACTImageEncoder(nn.Module):
         Returns:
             nn.Module: ResNet18 backbone without classification layers
         """
-        resnet = getattr(models, "resnet18")(pretrained=True)
+        resnet = models.get_model("resnet18", weights="DEFAULT")
         return nn.Sequential(*list(resnet.children())[:-2])
 
     def reset_parameters(self) -> None:

--- a/neuracore/ml/algorithms/cnnmlp/modules.py
+++ b/neuracore/ml/algorithms/cnnmlp/modules.py
@@ -44,7 +44,7 @@ class ImageEncoder(nn.Module):
             nn.Module: ResNet backbone without final classification layers
             int: Input dimension of the final fully connected layer
         """
-        resnet = getattr(models, backbone_name)(pretrained=True)
+        resnet = models.get_model(backbone_name, weights="DEFAULT")
         return nn.Sequential(*list(resnet.children())[:-2]), resnet.fc.in_features
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/neuracore/ml/algorithms/diffusion_policy/modules.py
+++ b/neuracore/ml/algorithms/diffusion_policy/modules.py
@@ -41,7 +41,7 @@ class DiffusionPolicyImageEncoder(nn.Module):
 
     def _build_backbone(self) -> nn.Module:
         """Build backbone CNN, removing avgpool and fc layers."""
-        resnet = getattr(models, "resnet18")(pretrained=True)
+        resnet = models.get_model("resnet18", weights="DEFAULT")
         return nn.Sequential(*list(resnet.children())[:-2])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/neuracore/ml/algorithms/simple_vla/modules.py
+++ b/neuracore/ml/algorithms/simple_vla/modules.py
@@ -41,7 +41,7 @@ class ImageEncoder(nn.Module):
         Returns:
             nn.Module: ResNet backbone without final classification layers
         """
-        resnet = getattr(models, backbone_name)(pretrained=True)
+        resnet = models.get_model(backbone_name, weights="DEFAULT")
         return nn.Sequential(*list(resnet.children())[:-1])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### Updates
- Removed deprecated parameter when instantiating resnet backbones.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-28](https://neuracore.atlassian.net/browse/NC-28)