### PR TITLE
chore: fix pre-commit warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_install_hook_types: [pre-commit]
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/pycqa/isort
@@ -30,7 +30,7 @@ repos:
         args: ["--convention=google"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: ""
+    rev: v1.18.2
     hooks:
       - id: mypy
         files: neuracore/


### PR DESCRIPTION
### Updates

- Change default stages to `pre-commit` as `commit` is deprecated.
- Fix `mypy` version to `v1.18.2` to remove dangling reference.

### Items
 - [NC-49](https://neuracore.atlassian.net/browse/NC-49)