### PR TITLE
fix device mismatch in batch size autotuning

### DIFF
--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -46,11 +46,9 @@ class BatchSizeAutotuner:
         self.num_iterations = num_iterations
         self.device = model.device
 
-        if not torch.cuda.is_available():
-            raise ValueError(
-                "No GPU available. Autotuning batch size is only supported on GPU."
-            )
-        self.model = model.to(self.device)
+        if not torch.cuda.is_available() or "cuda" not in self.device.type:
+            raise ValueError("Autotuning batch size is only supported on GPUs.")
+        self.model = model
 
         # create optimizers
         self.optimizers = self.model.configure_optimizers()


### PR DESCRIPTION
Due to changing the way we move pytorch model to a device, batch size autotuning was failing because its dummy model stayed on CPU.

Fixes:
- ensure batch size autotuning dummy model is moved properly to a device
-  removed device param from get_model_and_algorithm_config() as it wasn't used
- added more safeguards to not allow autotuning on cpu.