### PR TITLE
fix: 404 errors for paligemma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "torch",
             "torchvision",
             "transformers==4.57.1",
-            "huggingface-hub==0.34.0",
+            "huggingface-hub==0.36.0",
             "diffusers>=0.27.2",
             "einops",
             "hydra-core>=1.3.0",


### PR DESCRIPTION
### Bugfixes
 - `huggingface-hub` `v0.34.0` had broken links to PaliGemma. Bumped to `v0.36.0` to fix the issue.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-82](https://neuracore.atlassian.net/browse/NC-82)