### PR TITLE
Decouple robot from checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ policy = nc.policy(train_run_name="MyTrainingJob")
 policy.set_checkpoint(epoch=-1)
 
 # Predict actions
-predicted_sync_points = policy.predict(timeout=5)
+predicted_sync_points = policy.predict(timeout=5, robot_name="MyRobot")
 joint_target_positions = [sp.joint_target_positions for sp in predicted_sync_points]
 actions = [jtp.numpy() for jtp in joint_target_positions if jtp is not None]
 ```
@@ -156,7 +156,7 @@ actions = [jtp.numpy() for jtp in joint_target_positions if jtp is not None]
 # Connect to a remote endpoint
 try:
     policy = nc.policy_remote_server("MyEndpointName")
-    predicted_sync_points = policy.predict(timeout=5)
+    predicted_sync_points = policy.predict(timeout=5, robot_name="MyRobot")
     # Process predictions...
 except nc.EndpointError:
     print("Endpoint not available. Please start it at neuracore.app/dashboard/endpoints")

--- a/examples/example_local_endpoint_no_robot.py
+++ b/examples/example_local_endpoint_no_robot.py
@@ -1,0 +1,85 @@
+import matplotlib.pyplot as plt
+from common.transfer_cube import BOX_POSE, make_sim_env
+from neuracore_types import CameraData, JointData, SyncPoint
+
+import neuracore as nc
+
+TRAINING_JOB_NAME = "MyTrainingJob"
+ROBOT_NAME = "Mujoco VX300s"
+
+
+def main():
+    # If you know the path to the local model.nc.zip file
+    # you can use it directly without connecting to a robot
+    policy = nc.policy(model_file="PATH/TO/MODEL.nc.zip")
+
+    # Optional. Set the checkpoint to the last epoch.
+    # Note by default, model is loaded from the last epoch.
+    # policy.set_checkpoint(epoch=-1)
+
+    onscreen_render = True
+    render_cam_name = "angle"
+    num_rollouts = 10
+
+    for episode_idx in range(num_rollouts):
+        print(f"{episode_idx=}")
+
+        # Setup the environment
+        env = make_sim_env()
+        # resample the initial cube pose
+        BOX_POSE[0] = env.sample_box_pose()
+        obs = env.reset()
+
+        # Setup plotting
+        if onscreen_render:
+            ax = plt.subplot()
+            plt_img = ax.imshow(obs.cameras[render_cam_name].rgb)
+            plt.ion()
+
+        horizon = 1
+        # Run episode
+        for i in range(400):
+            # Create a sync point manually without logging data to the robot
+            sp = SyncPoint(
+                joint_positions=JointData(values=obs.qpos),
+                rgb_images={
+                    render_cam_name: CameraData(frame=obs.cameras[render_cam_name].rgb),
+                },
+            )
+            idx_in_horizon = i % horizon
+            if idx_in_horizon == 0:
+                # No active robot, so we need to pass in the robot name
+                predicted_sync_points = policy.predict(
+                    sync_point=sp, robot_name=ROBOT_NAME, timeout=5
+                )
+                joint_target_positions = [
+                    sp.joint_target_positions for sp in predicted_sync_points
+                ]
+                actions = [
+                    jtp.numpy(order=env.ACTION_KEYS)
+                    for jtp in joint_target_positions
+                    if jtp is not None
+                ]
+                horizon = len(actions)
+            a = actions[idx_in_horizon]
+            obs, reward, done = env.step(a)
+
+            if onscreen_render:
+                plt_img.set_data(obs.cameras[render_cam_name].rgb)
+                plt.pause(0.002)
+
+            if done:
+                print(f"Episode {episode_idx} done")
+                break
+        if reward == 4:
+            print(f"Episode {episode_idx} successful.")
+        else:
+            print(f"Episode {episode_idx} failed.")
+
+        plt.close()
+
+    policy.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -30,7 +30,7 @@ from neuracore.core.get_latest_sync_point import (
 def policy(
     train_run_name: Optional[str] = None,
     model_file: Optional[str] = None,
-    output_mapping: Optional[dict[DataType, list[str]]] = None,
+    robot_to_output_mapping: Optional[dict[str, dict[DataType, list[str]]]] = None,
     device: Optional[str] = None,
 ) -> DirectPolicy:
     """Launch a direct policy that runs the model in-process without any server.
@@ -41,7 +41,8 @@ def policy(
     Args:
         train_run_name: Name of the training run to load the model from.
         model_file: Path to the model file to load. If provided, overrides
-        output_mapping: Optional mapping of output data types to response fields.
+        robot_to_output_mapping: Output mapping per robot type supported by the model.
+        Each output mapping is a dictionary of data types to list of output names.
         device: Torch device to run the model on (CPU or GPU, or MPS)
 
     Returns:
@@ -52,7 +53,10 @@ def policy(
         ConfigError: If there is an error trying to get the current org.
     """
     return _policy(
-        train_run_name, model_file, output_mapping=output_mapping, device=device
+        train_run_name,
+        model_file,
+        robot_to_output_mapping=robot_to_output_mapping,
+        device=device,
     )
 
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -574,3 +574,37 @@ def get_robot(robot_name: str, instance: int) -> Robot:
             f"Robot {robot_name}:{instance} not initialized. Call init() first."
         )
     return _robots[key]
+
+
+def list_organization_robots(
+    org_id: str, is_shared: bool = False, mode: str = "current"
+) -> list[dict]:
+    """List all robots in an organization.
+
+    Args:
+        org_id: Organization ID
+        is_shared: Whether to list shared robots
+        mode: Robot list mode ("current", "archived", or "mixed")
+    """
+    if not get_auth().is_authenticated:
+        raise RobotError("Not authenticated. Please call nc.login() first.")
+    if not org_id:
+        raise RobotError("No organization selected. Please call nc.select_org() first.")
+    if mode not in ["current", "archived", "mixed"]:
+        raise RobotError(
+            "Invalid robot list mode. Please use 'current', 'archived', or 'mixed'."
+        )
+    try:
+        response = requests.get(
+            f"{API_URL}/org/{org_id}/robots?is_shared={is_shared}&mode={mode}",
+            headers=get_auth().get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.ConnectionError:
+        raise RobotError((
+            "Failed to connect to neuracore server, "
+            "please check your internet connection and try again."
+        ))
+    except requests.exceptions.RequestException as e:
+        raise RobotError(f"Failed to list robots: {str(e)}")

--- a/neuracore/ml/datasets/pytorch_dummy_dataset.py
+++ b/neuracore/ml/datasets/pytorch_dummy_dataset.py
@@ -90,7 +90,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 min=-np.ones(6),
                 max=np.ones(6),
                 max_len=6,
-                robot_to_ncdata_keys={self.robot.id: [f"jps_{i}" for i in range(6)]},
+                robot_to_ncdata_keys={self.robot.name: [f"jps_{i}" for i in range(6)]},
             )
         if DataType.JOINT_VELOCITIES in self.data_types:
             self.dataset_description.joint_velocities = DataItemStats(
@@ -99,7 +99,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 min=-np.ones(6),
                 max=np.ones(6),
                 max_len=6,
-                robot_to_ncdata_keys={self.robot.id: [f"jvs_{i}" for i in range(6)]},
+                robot_to_ncdata_keys={self.robot.name: [f"jvs_{i}" for i in range(6)]},
             )
         if DataType.JOINT_TORQUES in self.data_types:
             self.dataset_description.joint_torques = DataItemStats(
@@ -108,7 +108,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 min=-np.ones(6),
                 max=np.ones(6),
                 max_len=6,
-                robot_to_ncdata_keys={self.robot.id: [f"jts_{i}" for i in range(6)]},
+                robot_to_ncdata_keys={self.robot.name: [f"jts_{i}" for i in range(6)]},
             )
         if DataType.JOINT_TARGET_POSITIONS in self.data_types:
             self.dataset_description.joint_target_positions = DataItemStats(
@@ -117,7 +117,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 min=-np.ones(7),
                 max=np.ones(7),
                 max_len=7,
-                robot_to_ncdata_keys={self.robot.id: [f"jtps_{i}" for i in range(7)]},
+                robot_to_ncdata_keys={self.robot.name: [f"jtps_{i}" for i in range(7)]},
             )
 
         # End-effector data
@@ -128,7 +128,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 std=np.ones(2),
                 max_len=2,  # e.g., gripper open amounts
                 robot_to_ncdata_keys={
-                    self.robot.id: [f"end_effector_{i}" for i in range(2)]
+                    self.robot.name: [f"end_effector_{i}" for i in range(2)]
                 },
             )
 
@@ -139,7 +139,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 std=np.ones(7),
                 max_len=7,  # 1 gripper x 7DOF pose
                 robot_to_ncdata_keys={
-                    self.robot.id: [f"end_effector_pose_{i}" for i in range(7)]
+                    self.robot.name: [f"end_effector_pose_{i}" for i in range(7)]
                 },
             )
         # Parallel gripper open amounts
@@ -148,7 +148,9 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 mean=np.zeros(1),
                 std=np.ones(1),
                 max_len=1,  # 1 parallel gripper x 1 open amount float value
-                robot_to_ncdata_keys={self.robot.id: ["parallel_gripper_open_amount"]},
+                robot_to_ncdata_keys={
+                    self.robot.name: ["parallel_gripper_open_amount"]
+                },
             )
 
         # Pose data
@@ -158,25 +160,29 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                 mean=np.zeros(12),
                 std=np.ones(12),
                 max_len=12,  # 2 poses x 6DOF each
-                robot_to_ncdata_keys={self.robot.id: [f"pose_{i}" for i in range(12)]},
+                robot_to_ncdata_keys={
+                    self.robot.name: [f"pose_{i}" for i in range(12)]
+                },
             )
 
         # Visual data
         if DataType.RGB_IMAGE in self.data_types:
             self.dataset_description.rgb_images = DataItemStats(
                 max_len=2,  # e.g., two RGB images per sample
-                robot_to_ncdata_keys={self.robot.id: [f"rgb_{i}" for i in range(2)]},
+                robot_to_ncdata_keys={self.robot.name: [f"rgb_{i}" for i in range(2)]},
             )
         if DataType.DEPTH_IMAGE in self.data_types:
             self.dataset_description.depth_images = DataItemStats(
                 max_len=2,  # e.g., two depth images per sample
-                robot_to_ncdata_keys={self.robot.id: [f"depth_{i}" for i in range(2)]},
+                robot_to_ncdata_keys={
+                    self.robot.name: [f"depth_{i}" for i in range(2)]
+                },
             )
         if DataType.POINT_CLOUD in self.data_types:
             self.dataset_description.point_clouds = DataItemStats(
                 max_len=1,  # e.g., one point cloud per sample
                 robot_to_ncdata_keys={
-                    self.robot.id: [f"point_cloud_{i}" for i in range(1)]
+                    self.robot.name: [f"point_cloud_{i}" for i in range(1)]
                 },
             )
 
@@ -197,7 +203,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                     min=-np.ones(10),
                     max=np.ones(10),
                     max_len=10,
-                    robot_to_ncdata_keys={self.robot.id: ["sensor_1"]},
+                    robot_to_ncdata_keys={self.robot.name: ["sensor_1"]},
                 ),
                 "sensor_2": DataItemStats(
                     mean=np.zeros(5),
@@ -205,7 +211,7 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                     min=-np.ones(5),
                     max=np.ones(5),
                     max_len=5,
-                    robot_to_ncdata_keys={self.robot.id: ["sensor_2"]},
+                    robot_to_ncdata_keys={self.robot.name: ["sensor_2"]},
                 ),
             }
 

--- a/neuracore/ml/utils/validate.py
+++ b/neuracore/ml/utils/validate.py
@@ -542,7 +542,7 @@ def run_validation(
                         )
 
                     # Test the policy prediction
-                    action = policy.predict(sync_point)
+                    action = policy.predict(sync_point, robot_name=dataset.robot.name)
                     logger.info(f"Exported model loaded successfully, action: {action}")
 
                     for pred_sync_point in action:

--- a/tests/integration/test_algorithm.py
+++ b/tests/integration/test_algorithm.py
@@ -70,7 +70,7 @@ def eval_model(
                     },
                 )
                 predicted_sync_points = policy.predict(
-                    sync_point=sync_point, timeout=10
+                    sync_point=sync_point, robot_name="Mujoco VX300s", timeout=10
                 )
                 joint_target_positions = [
                     sp.joint_target_positions for sp in predicted_sync_points


### PR DESCRIPTION
### Features
- Link output mapping to robot name instead of robot id when synchronising dataset
- Model inference now take robot name as input (falls back to active robot)
- No need to log in during inference if syncpoints is provided as input and using model.nc.zip locally (new example added)

### Items
 - [NCRL-40](https://neuracore.atlassian.net/browse/NCRL-40)

### Related PRs
https://github.com/NeuracoreAI/neuracore_backend/pull/189
https://github.com/NeuracoreAI/neuracore_types/pull/12