### PR TITLE
small fix on validation log

### DIFF
--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -253,8 +253,8 @@ class DistributedTrainer:
         avg_losses, avg_metrics = self._average_epoch_metrics(
             val_losses, val_metrics, epoch
         )
-        self._log_scalars(avg_losses, self.global_val_step, prefix="val/epoch/loss")
-        self._log_scalars(avg_metrics, self.global_val_step, prefix="val/epoch/metrics")
+        self._log_scalars(avg_losses, epoch, prefix="val/epoch/loss")
+        self._log_scalars(avg_metrics, epoch, prefix="val/epoch/metrics")
         return avg_losses
 
     def train(self, start_epoch: int = 0) -> None:


### PR DESCRIPTION
<img width="1522" height="942" alt="image" src="https://github.com/user-attachments/assets/e2cd5850-4dbf-4e21-8fe9-38ecf828937c" />

`val/epoch/loss/mse_loss` and  `val/epoch/loss/mse_loss` the x axis was wrong and now it is fixed 