### PR TITLE
Split dataset into train and validation sets on the frame level

### DIFF
--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -70,7 +70,8 @@ class SynchronizedRecording:
 
         if prefetch_videos:
             cache = self.dataset.cache_dir / f"{self.id}" / f"{self.frequency}Hz"
-            if not cache.exists():
+            # Check if cache directory exists and contains any files
+            if not cache.exists() or not any(cache.iterdir()):
                 self._get_sync_point(0)
 
     def _get_synced_data(self) -> SyncedData:

--- a/neuracore/ml/datasets/pytorch_dummy_dataset.py
+++ b/neuracore/ml/datasets/pytorch_dummy_dataset.py
@@ -427,6 +427,10 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
         """
         return self.num_samples
 
+    def __getitem__(self, idx: int) -> TrainingSample:
+        """Get a training sample."""
+        return self.load_sample(idx)
+
     def collate_fn(self, samples: list[TrainingSample]) -> BatchedTrainingSamples:
         """Collate individual samples into a batched training sample.
 

--- a/neuracore/ml/datasets/pytorch_single_sample_dataset.py
+++ b/neuracore/ml/datasets/pytorch_single_sample_dataset.py
@@ -41,6 +41,10 @@ class SingleSampleDataset(PytorchNeuracoreDataset):
         """Return the number of samples in the dataset this dataset is mimicking."""
         return self._num_recordings
 
+    def __getitem__(self, idx: int) -> BatchedTrainingSamples:
+        """Get a training sample."""
+        return self.load_sample(idx)
+
     def load_sample(
         self, episode_idx: int, timestep: Optional[int] = None
     ) -> BatchedTrainingSamples:

--- a/tests/unit/ml/datasets/test_pytorch_dummy_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_dummy_dataset.py
@@ -498,22 +498,6 @@ class TestPytorchDummyDataset:
         assert batched.inputs.language_tokens.data.shape == (2, 10)
         assert batched.inputs.language_tokens.mask.shape == (2, 10)
 
-    def test_error_handling(self):
-        """Test error handling in dataset operations."""
-        dataset = PytorchDummyDataset(
-            input_data_types=[DataType.JOINT_POSITIONS],
-            output_data_types=[DataType.JOINT_TARGET_POSITIONS],
-            num_samples=5,
-        )
-
-        # Test index out of bounds
-        with pytest.raises(IndexError):
-            _ = dataset[10]  # Only 5 samples
-
-        # Test negative indexing (should work)
-        sample = dataset[-1]
-        assert sample is not None
-
     def test_edge_cases(self):
         """Test edge cases and boundary conditions."""
         # Single sample dataset


### PR DESCRIPTION
### Bugfixes
When splitting the dataset into train/val splits, we get the list of all transitions, and randomly sample. However, when we actually get the sample, we get a random episode and a random frame, which means train/val can contain the same frames.

In this PR:
- Correctly sample on the frame level (no overlap between train/val)
- Always pre-fetch synced meta data (need episode length to correctly map sample idx to episode idx)
- Move __getitem__ to each dataset.py file

### Items
 - [NCRL-56](https://neuracore.atlassian.net/browse/NCRL-56)