### PR TITLE
add fix for prefetching videos

### DIFF
--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -47,16 +47,14 @@ class SynchronizedDataset:
         self._synced_recording_cache: dict[int, SynchronizedRecording] = {}
 
         if prefetch_videos:
-            prefetch_needed = False
             for rec in self.dataset.recordings:
                 cache_dir = (
                     self.dataset.cache_dir / f"{rec['id']}" / f"{self.frequency}Hz"
                 )
-                if not cache_dir.exists():
-                    prefetch_needed = True
+                # Check if cache directory exists and contains any files
+                if not cache_dir.exists() or not any(cache_dir.iterdir()):
+                    self._perform_videos_prefetch(max_workers=max_workers)
                     break
-            if prefetch_needed:
-                self._perform_videos_prefetch(max_workers=max_workers)
 
     def _perform_videos_prefetch(self, max_workers: int) -> None:
         """Prefetch video data for all recordings using multiple threads.

--- a/tests/unit/core/data/test_synced_dataset.py
+++ b/tests/unit/core/data/test_synced_dataset.py
@@ -240,10 +240,13 @@ class TestSynchronizedDataset:
         self, dataset_mock, dataset_description, mock_auth_requests, tmp_path
     ):
         """Test that prefetch is skipped when cache exists."""
-        # Create cache directories for all recordings
+        # Create cache directories for all recordings with at least one file
+        # to indicate cache is complete (frames are cached as PNG files)
         for rec in dataset_mock.recordings:
             cache_path = dataset_mock.cache_dir / f"{rec['id']}" / "30Hz"
             cache_path.mkdir(parents=True, exist_ok=True)
+            # Create a dummy file to indicate cache exists and has content
+            (cache_path / "0.png").touch()
 
         with patch.object(
             SynchronizedDataset, "_perform_videos_prefetch"
@@ -262,11 +265,13 @@ class TestSynchronizedDataset:
         self, dataset_mock, dataset_description, mock_auth_requests, tmp_path
     ):
         """Test that prefetch runs if only some recordings are cached."""
-        # Create cache for only first recording
+        # Create cache for only first recording with at least one file
         cache_path = (
             dataset_mock.cache_dir / f"{dataset_mock.recordings[0]['id']}" / "30Hz"
         )
         cache_path.mkdir(parents=True, exist_ok=True)
+        # Create a dummy file to indicate cache exists and has content
+        (cache_path / "0.png").touch()
 
         with patch.object(
             SynchronizedDataset, "_perform_videos_prefetch"


### PR DESCRIPTION
### Features
Fix prefetching videos when prefetching fails but empty folder is created, the old version will still see it as downloaded and skips it. The fix checks if there is really any thing downloaded 