### PR TITLE
feat: add preprocessing configs

### DIFF
--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -34,6 +34,10 @@ from neuracore.core.get_latest_sync_point import get_latest_sync_point
 from neuracore.core.utils.download import download_with_progress
 from neuracore.ml.logging.endpoint_log_streamer import EndpointLogStreamer
 from neuracore.ml.utils.endpoint_storage_handler import EndpointStorageHandler
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    serialize_preprocessing_config,
+)
 
 from .auth import get_auth
 from .const import API_URL, PING_ENDPOINT, PREDICT_ENDPOINT, SET_CHECKPOINT_ENDPOINT
@@ -147,6 +151,7 @@ class DirectPolicy(Policy):
         org_id: str,
         input_embodiment_description: EmbodimentDescription | None = None,
         output_embodiment_description: EmbodimentDescription | None = None,
+        input_preprocessing_config: PreprocessingConfiguration | None = None,
         job_id: str | None = None,
         device: str | None = None,
         robot_id: str | None = None,
@@ -159,6 +164,7 @@ class DirectPolicy(Policy):
         self._policy = PolicyInference(
             input_embodiment_description=input_embodiment_description,
             output_embodiment_description=output_embodiment_description,
+            input_preprocessing_config=input_preprocessing_config,
             org_id=org_id,
             job_id=job_id,
             model_file=model_path,
@@ -363,6 +369,7 @@ class LocalServerPolicy(ServerPolicy):
         model_path: Path,
         input_embodiment_description: EmbodimentDescription | None = None,
         output_embodiment_description: EmbodimentDescription | None = None,
+        input_preprocessing_config: PreprocessingConfiguration | None = None,
         device: str | None = None,
         job_id: str | None = None,
         port: int = 8080,
@@ -386,6 +393,8 @@ class LocalServerPolicy(ServerPolicy):
             endpoint_id: Optional deployed endpoint ID used for cloud log uploads.
             robot_id: Optional robot ID used to resolve embodiments from model
                 metadata when explicit embodiments are omitted.
+            input_preprocessing_config: Preprocessing configuration for the input
+                data.
         """
         super().__init__(
             f"http://{host}:{port}",
@@ -393,6 +402,7 @@ class LocalServerPolicy(ServerPolicy):
         )
         self.input_embodiment_description = input_embodiment_description
         self.output_embodiment_description = output_embodiment_description
+        self.input_preprocessing_config = input_preprocessing_config
         self.robot_id = robot_id
         self.org_id = org_id
         self.job_id = job_id
@@ -460,6 +470,14 @@ class LocalServerPolicy(ServerPolicy):
             cmd.extend([
                 "--output-embodiment-description",
                 f"{output_embodiment_description_str}",
+            ])
+        if self.input_preprocessing_config is not None:
+            input_preprocessing_config_serialized = serialize_preprocessing_config(
+                self.input_preprocessing_config
+            )
+            cmd.extend([
+                "--input-preprocessing-config",
+                json.dumps(input_preprocessing_config_serialized),
             ])
         if self.robot_id is not None:
             cmd.extend(["--robot-id", self.robot_id])
@@ -613,6 +631,7 @@ class RemoteServerPolicy(ServerPolicy):
 def policy(
     input_embodiment_description: EmbodimentDescription | None = None,
     output_embodiment_description: EmbodimentDescription | None = None,
+    input_preprocessing_config: PreprocessingConfiguration | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
@@ -625,6 +644,7 @@ def policy(
             be fed into the model
         output_embodiment_description: Specification of the order that will
             be output from the model
+        input_preprocessing_config: Preprocessing configuration for the input data.
         train_run_name: Name of the training run to load the model from.
         model_file: Path to the model file to load.
         device: Torch device to run the model on (CPU or GPU, or MPS).
@@ -647,6 +667,7 @@ def policy(
     return DirectPolicy(
         input_embodiment_description=input_embodiment_description,
         output_embodiment_description=output_embodiment_description,
+        input_preprocessing_config=input_preprocessing_config,
         org_id=org_id,
         job_id=job_id,
         model_path=model_path,
@@ -658,6 +679,7 @@ def policy(
 def policy_local_server(
     input_embodiment_description: EmbodimentDescription | None = None,
     output_embodiment_description: EmbodimentDescription | None = None,
+    input_preprocessing_config: PreprocessingConfiguration | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
@@ -674,6 +696,7 @@ def policy_local_server(
             will be fed into the model
         output_embodiment_description: Specification of the order that
             will be output from the model
+        input_preprocessing_config: Preprocessing configuration for the input data.
         train_run_name: Name of the training run to load the model from.
         model_file: Path to the model file to load.
         device: Device model to be loaded on.
@@ -709,6 +732,7 @@ def policy_local_server(
         model_path=model_path,
         input_embodiment_description=input_embodiment_description,
         output_embodiment_description=output_embodiment_description,
+        input_preprocessing_config=input_preprocessing_config,
         device=device,
         job_id=job_id,
         port=port,

--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -34,10 +34,7 @@ from neuracore.core.get_latest_sync_point import get_latest_sync_point
 from neuracore.core.utils.download import download_with_progress
 from neuracore.ml.logging.endpoint_log_streamer import EndpointLogStreamer
 from neuracore.ml.utils.endpoint_storage_handler import EndpointStorageHandler
-from neuracore.ml.utils.preprocessing_utils import (
-    PreprocessingConfiguration,
-    serialize_preprocessing_config,
-)
+from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
 
 from .auth import get_auth
 from .const import API_URL, PING_ENDPOINT, PREDICT_ENDPOINT, SET_CHECKPOINT_ENDPOINT
@@ -472,9 +469,10 @@ class LocalServerPolicy(ServerPolicy):
                 f"{output_embodiment_description_str}",
             ])
         if self.input_preprocessing_config is not None:
-            input_preprocessing_config_serialized = serialize_preprocessing_config(
-                self.input_preprocessing_config
-            )
+            input_preprocessing_config_serialized = {
+                data_type.value: [m.to_dict() for m in methods]
+                for data_type, methods in self.input_preprocessing_config.items()
+            }
             cmd.extend([
                 "--input-preprocessing-config",
                 json.dumps(input_preprocessing_config_serialized),

--- a/neuracore/core/utils/server.py
+++ b/neuracore/core/utils/server.py
@@ -19,6 +19,7 @@ from neuracore_types import (
     EmbodimentDescription,
     SynchronizedPoint,
 )
+from omegaconf import OmegaConf
 from pydantic import BaseModel
 
 from neuracore.core.const import (
@@ -28,6 +29,10 @@ from neuracore.core.const import (
 )
 from neuracore.core.exceptions import InsufficientSynchronizedPointError
 from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    resolve_preprocessing_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +91,7 @@ class ModelServer:
         org_id: str,
         input_embodiment_description: EmbodimentDescription | None = None,
         output_embodiment_description: EmbodimentDescription | None = None,
+        input_preprocessing_config: PreprocessingConfiguration | None = None,
         job_id: str | None = None,
         device: str | None = None,
         robot_id: str | None = None,
@@ -101,6 +107,8 @@ class ModelServer:
             device: Device the model loaded on
             robot_id: Robot ID used to select embodiments from the model
                 archive or training metadata.
+            input_preprocessing_config: Preprocessing configuration for the input
+                data.
         """
         # Import here to avoid the need for pytorch unless the user uses this policy
         from neuracore.ml.utils.policy_inference import PolicyInference
@@ -108,6 +116,7 @@ class ModelServer:
         self.policy_inference = PolicyInference(
             input_embodiment_description=input_embodiment_description,
             output_embodiment_description=output_embodiment_description,
+            input_preprocessing_config=input_preprocessing_config,
             org_id=org_id,
             job_id=job_id,
             model_file=model_file,
@@ -204,6 +213,7 @@ def start_server(
     org_id: str,
     input_embodiment_description: EmbodimentDescription | None = None,
     output_embodiment_description: EmbodimentDescription | None = None,
+    input_preprocessing_config: PreprocessingConfiguration | None = None,
     job_id: str | None = None,
     host: str = "0.0.0.0",
     port: int = 8080,
@@ -229,6 +239,7 @@ def start_server(
         device: Device model loaded on
         robot_id: Robot ID used to select embodiments from the model archive
             or training metadata.
+        input_preprocessing_config: Preprocessing configuration for the input data.
 
     Returns:
         ModelServer instance
@@ -238,6 +249,7 @@ def start_server(
     server = ModelServer(
         input_embodiment_description=input_embodiment_description,
         output_embodiment_description=output_embodiment_description,
+        input_preprocessing_config=input_preprocessing_config,
         model_file=model_file,
         org_id=org_id,
         job_id=job_id,
@@ -271,6 +283,14 @@ if __name__ == "__main__":
             "dict mapping DataType to list of strings. If not provided, "
             "the robot ID will be used to select embodiments from the model "
             "archive or training metadata."
+        ),
+    )
+    parser.add_argument(
+        "--input-preprocessing-config",
+        required=False,
+        help=(
+            "Input preprocessing config as JSON mapping DataType to "
+            "PreprocessingMethod."
         ),
     )
     parser.add_argument(
@@ -314,9 +334,18 @@ if __name__ == "__main__":
             output_embodiment_description = _parse_embodiment_description(
                 args.output_embodiment_description
             )
+        input_preprocessing_config = None
+        if args.input_preprocessing_config is not None:
+            input_preprocessing_config_serialized = json.loads(
+                args.input_preprocessing_config
+            )
+            input_preprocessing_config = resolve_preprocessing_config(
+                OmegaConf.create(input_preprocessing_config_serialized)
+            )
         start_server(
             input_embodiment_description=input_embodiment_description,
             output_embodiment_description=output_embodiment_description,
+            input_preprocessing_config=input_preprocessing_config,
             model_file=Path(args.model_file),
             org_id=args.org_id,
             job_id=args.job_id,

--- a/neuracore/ml/algorithms/act/act.py
+++ b/neuracore/ml/algorithms/act/act.py
@@ -212,6 +212,7 @@ class ACT(NeuracoreModel):
                 self.input_dataset_statistics[DataType.RGB_IMAGES],
             )
             max_cameras = len(stats)
+            self.image_normalizers = nn.ModuleList()
             self.image_encoders = nn.ModuleList()
             for i in range(max_cameras):
                 if use_resnet_stats:
@@ -220,15 +221,8 @@ class ACT(NeuracoreModel):
                     mean_c_h_w, std_c_h_w = stats[i].frame.mean, stats[i].frame.std
                     mean = mean_c_h_w.mean(axis=(1, 2)).tolist()
                     std = std_c_h_w.mean(axis=(1, 2)).tolist()
-
-                encoder = nn.ModuleDict({
-                    "transform": torch.nn.Sequential(
-                        T.Resize((224, 224)),
-                        T.Normalize(mean=mean, std=std),
-                    ),
-                    "encoder": ACTImageEncoder(output_dim=hidden_dim),
-                })
-                self.image_encoders.append(encoder)
+                self.image_normalizers.append(T.Normalize(mean=mean, std=std))
+                self.image_encoders.append(ACTImageEncoder(output_dim=hidden_dim))
 
         # CLS token embedding for latent encoder
         self.cls_embed = nn.Parameter(torch.randn(1, 1, hidden_dim))
@@ -473,12 +467,12 @@ class ACT(NeuracoreModel):
         # Process images
         image_features = []
         image_pos = []
-        for cam_id, (encoder_dict, input_rgb) in enumerate(
-            zip(self.image_encoders, batched_rgb_data)
+        for cam_id, (normalizer, encoder, input_rgb) in enumerate(
+            zip(self.image_normalizers, self.image_encoders, batched_rgb_data)
         ):
             last_frame = input_rgb.frame[:, -1, :, :, :]  # (B, 3, H, W)
-            transformed = encoder_dict["transform"](last_frame)
-            features, pos = encoder_dict["encoder"](
+            transformed = normalizer(last_frame)
+            features, pos = encoder(
                 transformed
             )  # Vision backbone provides features and pos
             features *= camera_images_mask[:, cam_id].view(batch_size, 1, 1, 1)

--- a/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
+++ b/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
@@ -203,6 +203,7 @@ class CNNMLP(NeuracoreModel):
                 self.input_dataset_statistics[DataType.RGB_IMAGES],
             )
             max_cameras = len(stats)
+            self.rgb_normalizers = nn.ModuleList()
             self.encoder_output_dims[DataType.RGB_IMAGES] = max_cameras * cnn_output_dim
             self.encoders[DataType.RGB_IMAGES] = nn.ModuleList()
             for i in range(max_cameras):
@@ -213,12 +214,10 @@ class CNNMLP(NeuracoreModel):
                     mean_c_h_w, std_c_h_w = stats[i].frame.mean, stats[i].frame.std
                     mean = mean_c_h_w.mean(axis=(1, 2)).tolist()
                     std = std_c_h_w.mean(axis=(1, 2)).tolist()
-                encoder = torch.nn.Sequential(
-                    T.Resize((224, 224)),
-                    T.Normalize(mean=mean, std=std),
-                    ImageEncoder(output_dim=cnn_output_dim, backbone=image_backbone),
+                self.rgb_normalizers.append(T.Normalize(mean=mean, std=std))
+                self.encoders[DataType.RGB_IMAGES].append(
+                    ImageEncoder(output_dim=cnn_output_dim, backbone=image_backbone)
                 )
-                self.encoders[DataType.RGB_IMAGES].append(encoder)
 
         if DataType.DEPTH_IMAGES in self.input_data_types:
             stats = cast(
@@ -231,11 +230,9 @@ class CNNMLP(NeuracoreModel):
             )
             self.encoders[DataType.DEPTH_IMAGES] = nn.ModuleList()
             for i in range(max_cameras):
-                encoder = torch.nn.Sequential(
-                    T.Resize((224, 224)),
-                    DepthImageEncoder(output_dim=cnn_output_dim),
+                self.encoders[DataType.DEPTH_IMAGES].append(
+                    DepthImageEncoder(output_dim=cnn_output_dim)
                 )
-                self.encoders[DataType.DEPTH_IMAGES].append(encoder)
 
         if DataType.POINT_CLOUDS in self.input_data_types:
             stats = cast(
@@ -392,9 +389,11 @@ class CNNMLP(NeuracoreModel):
             encoders
         ), "Number of camera inputs does not match number of encoders."
         feats = []
-        for encoder, input in zip(encoders, batched_rgb_data):
+        for normalizer, encoder, input in zip(
+            self.rgb_normalizers, encoders, batched_rgb_data
+        ):
             last_frame = input.frame[:, -1, :, :, :]  # (B, 3, H, W)
-            feats.append(encoder(last_frame))
+            feats.append(encoder(normalizer(last_frame)))
         combined_feats = torch.stack(feats, dim=1)  # (B, num_cams, feat_dim)
         combined_feats *= mask.unsqueeze(-1)
         # (B, num_cams, feat_dim) -> (B, num_cams * feat_dim)

--- a/neuracore/ml/algorithms/diffusion_policy/diffusion_policy.py
+++ b/neuracore/ml/algorithms/diffusion_policy/diffusion_policy.py
@@ -227,6 +227,7 @@ class DiffusionPolicy(NeuracoreModel):
                 self.input_dataset_statistics[DataType.RGB_IMAGES],
             )
             max_cameras = len(stats)
+            self.image_normalizers = nn.ModuleList()
             self.image_encoders = nn.ModuleList()
             for i in range(max_cameras):
                 if use_resnet_stats:
@@ -235,23 +236,16 @@ class DiffusionPolicy(NeuracoreModel):
                     mean_c_h_w, std_c_h_w = stats[i].frame.mean, stats[i].frame.std
                     mean = mean_c_h_w.mean(axis=(1, 2)).tolist()
                     std = std_c_h_w.mean(axis=(1, 2)).tolist()
-
-                encoder = nn.ModuleDict({
-                    "transform": torch.nn.Sequential(
-                        T.Resize((224, 224)),
-                        T.Normalize(mean=mean, std=std),
-                    ),
-                    "encoder": DiffusionPolicyImageEncoder(
+                self.image_normalizers.append(T.Normalize(mean=mean, std=std))
+                self.image_encoders.append(
+                    DiffusionPolicyImageEncoder(
                         feature_dim=hidden_dim,
                         spatial_softmax_num_keypoints=spatial_softmax_num_keypoints,
                         use_pretrained_weights=use_pretrained_weights,
-                    ),
-                })
-                self.image_encoders.append(encoder)
+                    )
+                )
 
-            global_cond_dim += (
-                self.image_encoders[0]["encoder"].feature_dim * max_cameras
-            )
+            global_cond_dim += self.image_encoders[0].feature_dim * max_cameras
 
         self.unet = DiffusionConditionalUnet1d(
             action_dim=self.max_output_size,
@@ -429,12 +423,12 @@ class DiffusionPolicy(NeuracoreModel):
             batch_size = batched_rgb_data[0].frame.shape[0]
 
         # Extract image features.
-        for cam_id, (encoder_dict, input_rgb) in enumerate(
-            zip(self.image_encoders, batched_rgb_data)
+        for cam_id, (normalizer, encoder, input_rgb) in enumerate(
+            zip(self.image_normalizers, self.image_encoders, batched_rgb_data)
         ):
             last_frame = input_rgb.frame[:, -1, :, :, :]  # (B, 3, H, W)
-            transformed = encoder_dict["transform"](last_frame)
-            features = encoder_dict["encoder"](transformed)
+            transformed = normalizer(last_frame)
+            features = encoder(transformed)
             features = features * camera_images_mask[:, cam_id].view(batch_size, 1)
             global_cond_feats.append(features)
 

--- a/neuracore/ml/algorithms/pi0/pi0.py
+++ b/neuracore/ml/algorithms/pi0/pi0.py
@@ -39,7 +39,7 @@ from neuracore.ml import (
 from neuracore.ml.algorithm_utils.normalizer import MeanStdNormalizer
 
 from .modules import PI0Policy
-from .utils import PI0Config, build_lr_lambda, pad_vector, resize_with_pad_torch
+from .utils import PI0Config, build_lr_lambda, pad_vector
 
 logger = logging.getLogger(__name__)
 
@@ -409,8 +409,8 @@ class Pi0(NeuracoreModel):
     ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
         """Prepare RGB images for the vision encoder.
 
-        Resizes images to 224x224 and normalizes pixel values to [-1, 1]
-        as expected by the SigLIP vision encoder.
+        Normalizes pixel values to [-1, 1] as expected by the SigLIP vision
+        encoder. Spatial resizing is handled upstream by preprocessing config.
 
         Args:
             batch: Batch of inference samples
@@ -429,9 +429,8 @@ class Pi0(NeuracoreModel):
         image_masks = []
         for cam_id, input_rgb in enumerate(batched_rgb_data):
             last_frame = input_rgb.frame[:, -1, :, :, :]  # (B, 3, H, W)
-            image = resize_with_pad_torch(last_frame, *IMAGE_RESIZE_SHAPE)
             # Normalize from range [0,1] to [-1,1] as expected by siglip
-            image = image * 2.0 - 1.0
+            image = last_frame * 2.0 - 1.0
             images.append(image)
             image_masks.append(camera_mask[:, cam_id])
 

--- a/neuracore/ml/algorithms/pi05/pi05.py
+++ b/neuracore/ml/algorithms/pi05/pi05.py
@@ -42,13 +42,7 @@ from neuracore.ml import (
 from neuracore.ml.algorithm_utils.normalizer import QuantileNormalizer
 
 from .modules import PI05Policy
-from .utils import (
-    PI05Config,
-    _load_tokenizer,
-    build_lr_lambda,
-    pad_vector,
-    resize_with_pad_torch,
-)
+from .utils import PI05Config, _load_tokenizer, build_lr_lambda, pad_vector
 
 logger = logging.getLogger(__name__)
 
@@ -443,8 +437,8 @@ class Pi05(NeuracoreModel):
     ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
         """Prepare RGB images for the vision encoder.
 
-        Resizes images to 224x224 and normalizes pixel values to [-1, 1]
-        as expected by the SigLIP vision encoder.
+        Normalizes pixel values to [-1, 1] as expected by the SigLIP vision
+        encoder. Spatial resizing is handled upstream by preprocessing config.
 
         Args:
             batch: Batch of inference samples
@@ -463,9 +457,8 @@ class Pi05(NeuracoreModel):
         image_masks = []
         for cam_id, input_rgb in enumerate(batched_rgb_data):
             last_frame = input_rgb.frame[:, -1, :, :, :]  # (B, 3, H, W)
-            image = resize_with_pad_torch(last_frame, *IMAGE_RESIZE_SHAPE)
             # Normalize from range [0,1] to [-1,1] as expected by siglip
-            image = image * 2.0 - 1.0
+            image = last_frame * 2.0 - 1.0
             images.append(image)
             image_masks.append(camera_mask[:, cam_id])
 

--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -48,6 +48,24 @@ output_cross_embodiment_description: {
 
 }
 
+# Dict[str, Dict[DataType, List[MethodConfig]]], e.g.:
+# for images, we must have a resize step to reshape all images from different sources to the same size.
+preprocessing:
+  input:
+    RGB_IMAGES:
+      - _target_: neuracore.ml.preprocessing.methods.resize_pad.ResizePad
+        size: [224, 224]
+    DEPTH_IMAGES:
+      - _target_: neuracore.ml.preprocessing.methods.resize_pad.ResizePad
+        size: [224, 224]
+  output:
+    RGB_IMAGES:
+      - _target_: neuracore.ml.preprocessing.methods.resize_pad.ResizePad
+        size: [224, 224]
+    DEPTH_IMAGES:
+      - _target_: neuracore.ml.preprocessing.methods.resize_pad.ResizePad
+        size: [224, 224]
+
 # Paths and IDs (for cloud vs local training)
 algorithm_id: null    # For cloud training
 training_id: null     # For cloud training

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -13,6 +13,7 @@ from neuracore_types import (
     CrossEmbodimentDescription,
     DataType,
     EmbodimentDescription,
+    EmbodimentUnion,
     NCDataStats,
     SynchronizedDatasetStatistics,
     SynchronizedPoint,
@@ -29,6 +30,10 @@ from neuracore.core.utils.training_input_args_validation import (
 from neuracore.ml import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_neuracore_dataset import PytorchNeuracoreDataset
 from neuracore.ml.utils.memory_monitor import MemoryMonitor
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    apply_preprocessing_methods,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +62,8 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         synchronized_dataset: SynchronizedDataset,
         input_cross_embodiment_description: CrossEmbodimentDescription,
         output_cross_embodiment_description: CrossEmbodimentDescription,
+        input_preprocessing_config: PreprocessingConfiguration,
+        output_preprocessing_config: PreprocessingConfiguration,
         output_prediction_horizon: int,
     ):
         """Initialize the dataset.
@@ -67,8 +74,11 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                 include in the dataset.
             output_cross_embodiment_description: List of output data types to
                 include in the dataset.
+            input_preprocessing_config: Preprocessing configuration applied
+                to input slots.
+            output_preprocessing_config: Preprocessing configuration applied
+                to output slots.
             output_prediction_horizon: Number of future timesteps to predict.
-            order_configuration: Configuration for ordering data types.
         """
         self._validate_cross_embodiment_specs(
             synchronized_dataset,
@@ -162,6 +172,9 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         self.episode_indices = self._get_episode_indices()
         self._logged_in = False
 
+        self._input_preprocessing_config = input_preprocessing_config
+        self._output_preprocessing_config = output_preprocessing_config
+
     def _get_num_training_observations(self) -> int:
         # The count attribute of the stats should give total number of training
         # observations and should be same across all data types
@@ -230,8 +243,8 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
 
         return episode_indices
 
-    def convert_to_embodiment_description(
-        self, value: dict[DataType, list[str]]
+    def _convert_to_embodiment_description(
+        self, value: EmbodimentUnion
     ) -> EmbodimentDescription:
         """Normalize list-based sensor specs into indexed embodiment mappings.
 
@@ -275,7 +288,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         return embodiment_description
 
     @staticmethod
-    def _project_sync_point_to_spec(
+    def _project_sync_point_to_embodiment_description(
         sync_point: SynchronizedPoint,
         embodiment_description: EmbodimentDescription,
     ) -> SynchronizedPoint:
@@ -341,22 +354,22 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             ],
         )
 
-        # Order the SynchronizedPoints
+        # Order the SynchronizedPoints to the merged embodiment description.
         robot_id = synced_recording.robot_id
 
-        spec_for_ordering: dict[DataType, list[str]] = (
+        robot_embodiment_union: EmbodimentUnion = (
             self.merged_cross_embodiment_description[robot_id]
         )
-        converted_embodiment_description: EmbodimentDescription = (
-            self.convert_to_embodiment_description(spec_for_ordering)
+        robot_merged_embodiment_description: EmbodimentDescription = (
+            self._convert_to_embodiment_description(robot_embodiment_union)
         )
-        sync_point = self._project_sync_point_to_spec(
-            sync_point, converted_embodiment_description
+        sync_point = self._project_sync_point_to_embodiment_description(
+            sync_point, robot_merged_embodiment_description
         )
 
         for i in range(len(future_sync_points)):
-            future_sync_points[i] = self._project_sync_point_to_spec(
-                future_sync_points[i], converted_embodiment_description
+            future_sync_points[i] = self._project_sync_point_to_embodiment_description(
+                future_sync_points[i], robot_merged_embodiment_description
             )
 
         # Padding for future sync points
@@ -392,15 +405,23 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     # get the data. Otherwise, pad with zeros.
                     nc_data = sync_point.data[data_type][name]
                     batched_nc_data = batched_nc_data_class.from_nc_data(nc_data)
-                    batched_nc_data.transform_nc_data()
+                    batched_nc_data = apply_preprocessing_methods(
+                        batched_data=batched_nc_data,
+                        methods=self._input_preprocessing_config.get(data_type, []),
+                    )
                     inputs[data_type].append(batched_nc_data)
                     mask.append(1.0)
 
                 else:
                     # Pad missing data with zeros
-                    inputs[data_type].append(
-                        batched_nc_data_class.sample(batch_size=1, time_steps=1)
+                    batched_nc_data = batched_nc_data_class.sample(
+                        batch_size=1, time_steps=1
                     )
+                    batched_nc_data = apply_preprocessing_methods(
+                        batched_data=batched_nc_data,
+                        methods=self._input_preprocessing_config.get(data_type, []),
+                    )
+                    inputs[data_type].append(batched_nc_data)
                     mask.append(0.0)
 
             # Create mask for inputs
@@ -439,17 +460,23 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     batched_nc_data = batched_nc_data_class.from_nc_data_list(
                         nc_data_list
                     )
-                    batched_nc_data.transform_nc_data()
+                    batched_nc_data = apply_preprocessing_methods(
+                        batched_data=batched_nc_data,
+                        methods=self._output_preprocessing_config.get(data_type, []),
+                    )
                     outputs[data_type].append(batched_nc_data)
                     mask.append(1.0)
                 else:
                     # Pad missing data with zeros.
-                    outputs[data_type].append(
-                        batched_nc_data_class.sample(
-                            batch_size=1,
-                            time_steps=self.output_prediction_horizon,
-                        )
+                    batched_nc_data = batched_nc_data_class.sample(
+                        batch_size=1,
+                        time_steps=self.output_prediction_horizon,
                     )
+                    batched_nc_data = apply_preprocessing_methods(
+                        batched_data=batched_nc_data,
+                        methods=self._output_preprocessing_config.get(data_type, []),
+                    )
+                    outputs[data_type].append(batched_nc_data)
                     mask.append(0.0)
 
             # Create mask for outputs.

--- a/neuracore/ml/preprocessing/__init__.py
+++ b/neuracore/ml/preprocessing/__init__.py
@@ -1,0 +1,7 @@
+"""Preprocessing runtime utilities."""
+
+from .base import PreprocessingMethod
+
+__all__ = [
+    "PreprocessingMethod",
+]

--- a/neuracore/ml/preprocessing/base.py
+++ b/neuracore/ml/preprocessing/base.py
@@ -1,0 +1,36 @@
+"""Base class for preprocessing runtime methods."""
+
+from __future__ import annotations
+
+import inspect
+from abc import ABC, abstractmethod
+from typing import Any
+
+from neuracore_types import BatchedNCData, DataType
+
+
+class PreprocessingMethod(ABC):
+    """Base interface for preprocessing implementations."""
+
+    @staticmethod
+    @abstractmethod
+    def allowed_data_types() -> frozenset[DataType]:
+        """Return all data types the method supports."""
+
+    @abstractmethod
+    def __call__(self, data: BatchedNCData) -> BatchedNCData:
+        """Apply preprocessing and return transformed data."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the preprocessing method to a OmegaConf-style dictionary."""
+        target_name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        init_signature = inspect.signature(type(self).__init__)
+        params = {}
+        for param_name in init_signature.parameters:
+            if param_name == "self":
+                continue
+            if param_name == "kwargs" or param_name == "args":
+                continue
+            params[param_name] = getattr(self, param_name, None)
+
+        return {"_target_": target_name, **params}

--- a/neuracore/ml/preprocessing/methods/__init__.py
+++ b/neuracore/ml/preprocessing/methods/__init__.py
@@ -1,0 +1,5 @@
+"""Preprocessing method implementations."""
+
+from .resize_pad import ResizePad
+
+__all__ = ["ResizePad"]

--- a/neuracore/ml/preprocessing/methods/resize_pad.py
+++ b/neuracore/ml/preprocessing/methods/resize_pad.py
@@ -1,0 +1,76 @@
+"""Resize and pad preprocessing method."""
+
+from __future__ import annotations
+
+import torch
+from neuracore_types import BatchedDepthData, BatchedNCData, BatchedRGBData, DataType
+
+from ..base import PreprocessingMethod
+
+
+class ResizePad(PreprocessingMethod):
+    """Resize images into a target size (height, width) while preserving aspect ratio.
+
+    The frame is first resized with its aspect ratio preserved, then symmetrically
+    padded with zeros to get the output to the target size (height, width).
+    """
+
+    def __init__(self, size: list[int] | tuple[int, int] = (224, 224)) -> None:
+        """Initialize resize target as (height, width)."""
+        self.size = size
+
+    @staticmethod
+    def allowed_data_types() -> frozenset[DataType]:
+        """Return data types supported by this method."""
+        return frozenset({DataType.RGB_IMAGES, DataType.DEPTH_IMAGES})
+
+    def __call__(self, data: BatchedNCData) -> BatchedNCData:
+        """Resize while preserving aspect ratio, then center-pad to target size."""
+        batched_data = data
+        if len(self.size) != 2:
+            raise ValueError("resize_pad expects size as [height, width].")
+        target_h, target_w = int(self.size[0]), int(self.size[1])
+        if target_h <= 0 or target_w <= 0:
+            raise ValueError("resize_pad expects positive size values.")
+
+        frame = batched_data.frame
+        if frame.shape[-2:] == (target_h, target_w):
+            return batched_data
+
+        batch_size, time_steps, channels, src_h, src_w = frame.shape
+        scale = min(target_h / src_h, target_w / src_w)
+        resized_h = max(1, int(round(src_h * scale)))
+        resized_w = max(1, int(round(src_w * scale)))
+
+        reshaped = frame.reshape(batch_size * time_steps, channels, src_h, src_w)
+        if isinstance(batched_data, BatchedRGBData):
+            mode = "bilinear"
+        elif isinstance(batched_data, BatchedDepthData):
+            mode = "nearest"
+        else:
+            raise TypeError(
+                f"Unsupported batched data type for resize_pad: {type(batched_data)!r}"
+            )
+        resized = torch.nn.functional.interpolate(
+            reshaped,
+            size=(resized_h, resized_w),
+            mode=mode,
+        )
+
+        pad_h = target_h - resized_h
+        pad_w = target_w - resized_w
+        pad_top = pad_h // 2
+        pad_bottom = pad_h - pad_top
+        pad_left = pad_w // 2
+        pad_right = pad_w - pad_left
+
+        padded = torch.nn.functional.pad(
+            resized,
+            (pad_left, pad_right, pad_top, pad_bottom),
+            mode="constant",
+            value=0.0,
+        )
+        batched_data.frame = padded.reshape(
+            batch_size, time_steps, channels, target_h, target_w
+        )
+        return batched_data

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -61,6 +61,10 @@ from neuracore.ml.trainers.distributed_trainer import (
 from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
 from neuracore.ml.utils.algorithm_storage_handler import AlgorithmStorageHandler
 from neuracore.ml.utils.device_utils import cpu_count, get_default_device
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    resolve_preprocessing_config,
+)
 from neuracore.ml.utils.training_storage_handler import TrainingStorageHandler
 
 # Environment setup
@@ -539,6 +543,8 @@ def run_training(
     batch_size: int,
     input_cross_embodiment_description: CrossEmbodimentDescription,
     output_cross_embodiment_description: CrossEmbodimentDescription,
+    input_preprocessing_config: PreprocessingConfiguration,
+    output_preprocessing_config: PreprocessingConfiguration,
     dataset: PytorchSynchronizedDataset,
     device: torch.device | None = None,
 ) -> None:
@@ -663,6 +669,8 @@ def run_training(
             algorithm_config=algorithm_config,
             input_cross_embodiment_description=input_cross_embodiment_description,
             output_cross_embodiment_description=output_cross_embodiment_description,
+            input_preprocessing_config=input_preprocessing_config,
+            output_preprocessing_config=output_preprocessing_config,
         )
 
         logger.info(
@@ -983,6 +991,37 @@ def _main(cfg: DictConfig) -> None:
         else:
             device = get_default_device()
 
+        preprocessing_dictconfig = cfg.get("preprocessing", {})
+        if not preprocessing_dictconfig:
+            raise ValueError(
+                "Preprocessing configuration is missing ! Please provide a "
+                "preprocessing configuration."
+            )
+        input_preprocessing_config_cfg = preprocessing_dictconfig.get(
+            "input", OmegaConf.create({})
+        )
+        if not input_preprocessing_config_cfg:
+            raise ValueError(
+                "Input preprocessing configuration is missing ! Please provide an "
+                "input preprocessing configuration."
+            )
+        output_preprocessing_config_cfg = preprocessing_dictconfig.get(
+            "output", OmegaConf.create({})
+        )
+        if not output_preprocessing_config_cfg:
+            raise ValueError(
+                "Output preprocessing configuration is missing ! Please provide an "
+                "output preprocessing configuration."
+            )
+
+        input_preprocessing_config = resolve_preprocessing_config(
+            input_preprocessing_config_cfg
+        )
+
+        output_preprocessing_config = resolve_preprocessing_config(
+            output_preprocessing_config_cfg
+        )
+
         # Create a pytorch synchronized dataset
         # NOTE: we are creating it here, and not in training to access the first sample
         # for batch size autotuning, if used.
@@ -991,6 +1030,8 @@ def _main(cfg: DictConfig) -> None:
             input_cross_embodiment_description=input_cross_embodiment_description,
             output_cross_embodiment_description=output_cross_embodiment_description,
             output_prediction_horizon=cfg.output_prediction_horizon,
+            input_preprocessing_config=input_preprocessing_config,
+            output_preprocessing_config=output_preprocessing_config,
         )
 
         # Handle batch size configuration
@@ -1028,6 +1069,8 @@ def _main(cfg: DictConfig) -> None:
                     batch_size,
                     input_cross_embodiment_description,
                     output_cross_embodiment_description,
+                    input_preprocessing_config,
+                    output_preprocessing_config,
                     pytorch_dataset,
                     device,
                 ),
@@ -1043,6 +1086,8 @@ def _main(cfg: DictConfig) -> None:
                 batch_size,
                 input_cross_embodiment_description,
                 output_cross_embodiment_description,
+                input_preprocessing_config,
+                output_preprocessing_config,
                 pytorch_dataset,
                 device,
             )

--- a/neuracore/ml/utils/nc_archive.py
+++ b/neuracore/ml/utils/nc_archive.py
@@ -24,7 +24,6 @@ from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.preprocessing_utils import (
     PreprocessingConfiguration,
     resolve_preprocessing_config,
-    serialize_preprocessing_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -112,15 +111,23 @@ def create_nc_archive(
         with open(temp_path / "output_cross_embodiment_description.json", "w") as f:
             json.dump(output_cross_embodiment_description, f, indent=2)
         with open(temp_path / "input_preprocessing_config.json", "w") as f:
-            input_preprocessing_config_serialized = serialize_preprocessing_config(
-                input_preprocessing_config
+            json.dump(
+                {
+                    data_type.value: [m.to_dict() for m in methods]
+                    for data_type, methods in input_preprocessing_config.items()
+                },
+                f,
+                indent=2,
             )
-            json.dump(input_preprocessing_config_serialized, f, indent=2)
         with open(temp_path / "output_preprocessing_config.json", "w") as f:
-            output_preprocessing_config_serialized = serialize_preprocessing_config(
-                output_preprocessing_config
+            json.dump(
+                {
+                    data_type.value: [m.to_dict() for m in methods]
+                    for data_type, methods in output_preprocessing_config.items()
+                },
+                f,
+                indent=2,
             )
-            json.dump(output_preprocessing_config_serialized, f, indent=2)
 
         # Save archive metadata
         with open(temp_path / "metadata", "w") as f:

--- a/neuracore/ml/utils/nc_archive.py
+++ b/neuracore/ml/utils/nc_archive.py
@@ -16,10 +16,16 @@ from typing import Any
 
 import torch
 from neuracore_types import CrossEmbodimentDescription, ModelInitDescription
+from omegaconf import OmegaConf
 
 from neuracore.ml.core.neuracore_model import NeuracoreModel
 from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
 from neuracore.ml.utils.device_utils import get_default_device
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    resolve_preprocessing_config,
+    serialize_preprocessing_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +58,8 @@ def create_nc_archive(
     algorithm_config: dict = {},
     input_cross_embodiment_description: dict[str, Any] = {},
     output_cross_embodiment_description: dict[str, Any] = {},
+    input_preprocessing_config: PreprocessingConfiguration = {},
+    output_preprocessing_config: PreprocessingConfiguration = {},
 ) -> Path:
     """Create a Neuracore model archive (NC.ZIP) file from a Neuracore model.
 
@@ -65,6 +73,8 @@ def create_nc_archive(
         algorithm_config: Custom configuration for the algorithm.
         input_cross_embodiment_description: Input embodiment mapping.
         output_cross_embodiment_description: Output embodiment mapping.
+        input_preprocessing_config: preprocessing configuration for the input data.
+        output_preprocessing_config: preprocessing configuration for the output data.
 
     Returns:
         Path to the created NC.ZIP file.
@@ -101,6 +111,16 @@ def create_nc_archive(
             json.dump(input_cross_embodiment_description, f, indent=2)
         with open(temp_path / "output_cross_embodiment_description.json", "w") as f:
             json.dump(output_cross_embodiment_description, f, indent=2)
+        with open(temp_path / "input_preprocessing_config.json", "w") as f:
+            input_preprocessing_config_serialized = serialize_preprocessing_config(
+                input_preprocessing_config
+            )
+            json.dump(input_preprocessing_config_serialized, f, indent=2)
+        with open(temp_path / "output_preprocessing_config.json", "w") as f:
+            output_preprocessing_config_serialized = serialize_preprocessing_config(
+                output_preprocessing_config
+            )
+            json.dump(output_preprocessing_config_serialized, f, indent=2)
 
         # Save archive metadata
         with open(temp_path / "metadata", "w") as f:
@@ -128,6 +148,14 @@ def create_nc_archive(
             zip_file.write(
                 temp_path / "output_cross_embodiment_description.json",
                 "output_cross_embodiment_description.json",
+            )
+            zip_file.write(
+                temp_path / "input_preprocessing_config.json",
+                "input_preprocessing_config.json",
+            )
+            zip_file.write(
+                temp_path / "output_preprocessing_config.json",
+                "output_preprocessing_config.json",
             )
 
             # Add archive metadata
@@ -192,6 +220,10 @@ def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
                 extracted_files["input_cross_embodiment_description"] = file_path
             elif file_info.filename == "output_cross_embodiment_description.json":
                 extracted_files["output_cross_embodiment_description"] = file_path
+            elif file_info.filename == "input_preprocessing_config.json":
+                extracted_files["input_preprocessing_config"] = file_path
+            elif file_info.filename == "output_preprocessing_config.json":
+                extracted_files["output_preprocessing_config"] = file_path
             elif file_info.filename == "metadata":
                 extracted_files["metadata"] = file_path
             elif file_info.filename == "algorithm/requirements.txt":
@@ -251,7 +283,13 @@ def load_cross_embodiment_descriptions_from_nc_archive(
 
 def load_model_from_nc_archive(
     archive_file: Path, extract_to: Path | None = None, device: str | None = None
-) -> tuple[NeuracoreModel, CrossEmbodimentDescription, CrossEmbodimentDescription]:
+) -> tuple[
+    NeuracoreModel,
+    CrossEmbodimentDescription,
+    CrossEmbodimentDescription,
+    PreprocessingConfiguration,
+    PreprocessingConfiguration,
+]:
     """Load a Neuracore model from a NC.ZIP archive file.
 
     Extracts the archive file and reconstructs the original Neuracore model instance
@@ -268,6 +306,8 @@ def load_model_from_nc_archive(
           - The reconstructed model instance ready for inference.
           - Input cross-embodiment description loaded from the archive (if present).
           - Output cross-embodiment description loaded from the archive (if present).
+          - Input preprocessing config loaded from the archive (if present).
+          - Output preprocessing config loaded from the archive (if present).
     """
     use_temp_dir = extract_to is None
 
@@ -308,6 +348,30 @@ def load_model_from_nc_archive(
         if "output_cross_embodiment_description" in extracted_files:
             with open(extracted_files["output_cross_embodiment_description"]) as f:
                 output_cross_embodiment_description = json.load(f)
+        input_preprocessing_config: PreprocessingConfiguration = {}
+        if "input_preprocessing_config" in extracted_files:
+            with open(extracted_files["input_preprocessing_config"]) as f:
+                input_preprocessing_config_serialized = json.load(f)
+                if input_preprocessing_config_serialized:
+                    input_preprocessing_config = resolve_preprocessing_config(
+                        OmegaConf.create(input_preprocessing_config_serialized)
+                    )
+                else:
+                    logger.warning(
+                        "Input preprocessing config in model archive is empty"
+                    )
+        output_preprocessing_config: PreprocessingConfiguration = {}
+        if "output_preprocessing_config" in extracted_files:
+            with open(extracted_files["output_preprocessing_config"]) as f:
+                output_preprocessing_config_serialized = json.load(f)
+                if output_preprocessing_config_serialized:
+                    output_preprocessing_config = resolve_preprocessing_config(
+                        OmegaConf.create(output_preprocessing_config_serialized)
+                    )
+                else:
+                    logger.warning(
+                        "Output preprocessing config in model archive is empty"
+                    )
 
         # Find the algorithm directory
         algorithm_dir = extract_to / "algorithm"
@@ -339,6 +403,8 @@ def load_model_from_nc_archive(
             model,
             input_cross_embodiment_description,
             output_cross_embodiment_description,
+            input_preprocessing_config,
+            output_preprocessing_config,
         )
 
     finally:

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -25,6 +25,11 @@ from neuracore.core.utils.robot_data_spec_utils import (
 from neuracore.ml import BatchedInferenceInputs
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.nc_archive import load_model_from_nc_archive
+from neuracore.ml.utils.preprocessing_utils import (
+    PreprocessingConfiguration,
+    apply_preprocessing_methods,
+    validate_preprocessing_configuration,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +58,7 @@ class PolicyInference:
         org_id: str,
         input_embodiment_description: EmbodimentDescription | None = None,
         output_embodiment_description: EmbodimentDescription | None = None,
+        input_preprocessing_config: PreprocessingConfiguration | None = None,
         job_id: str | None = None,
         device: str | None = None,
         robot_id: str | None = None,
@@ -69,6 +75,8 @@ class PolicyInference:
             robot_id: Robot ID used to select embodiments from cross-embodiment
                 metadata in the model archive when explicit embodiments are not
                 provided.
+            input_preprocessing_config: preprocessing configuration for the input data.
+                When None, values are loaded from the model archive.
         """
         self.org_id = org_id
         self.job_id = job_id
@@ -76,6 +84,8 @@ class PolicyInference:
             self.model,
             input_cross_embodiment_description,
             output_cross_embodiment_description,
+            archive_input_preprocessing_config,
+            _,
         ) = load_model_from_nc_archive(model_file, device=device)
         self.model.eval()
         self.input_dataset_statistics = (
@@ -94,6 +104,20 @@ class PolicyInference:
             input_cross_embodiment_description=input_cross_embodiment_description,
             output_cross_embodiment_description=output_cross_embodiment_description,
         )
+
+        self.input_preprocessing_config = (
+            input_preprocessing_config or archive_input_preprocessing_config
+        )
+        if not self.input_preprocessing_config:
+            raise ValueError(
+                "Input preprocessing configuration is missing "
+                "from policy initialization and not found in the model archive! "
+                "Please provide a input preprocessing configuration."
+            )
+        if input_preprocessing_config:
+            validate_preprocessing_configuration(
+                preprocessing_config=self.input_preprocessing_config
+            )
 
         self.prediction_horizon = (
             self.model.model_init_description.output_prediction_horizon
@@ -137,9 +161,13 @@ class PolicyInference:
                 dtype=torch.float32,
             )
             inputs_mask[data_type].unsqueeze_(0)  # Add batch dimension
-            for name, nc_data in sync_point.data[data_type].items():
+            for _, nc_data in sync_point.data[data_type].items():
                 tensor = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type].from_nc_data(
                     nc_data
+                )
+                tensor = apply_preprocessing_methods(
+                    batched_data=tensor,
+                    methods=self.input_preprocessing_config.get(data_type, []),
                 )
                 inputs[data_type].append(tensor)
         return BatchedInferenceInputs(

--- a/neuracore/ml/utils/preprocessing_utils.py
+++ b/neuracore/ml/utils/preprocessing_utils.py
@@ -1,0 +1,83 @@
+"""Preprocessing helpers for config resolution and runtime application."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from neuracore_types import BatchedNCData, DataType
+from omegaconf import DictConfig
+
+from neuracore.ml.preprocessing.base import PreprocessingMethod
+
+PreprocessingConfiguration = dict[DataType, list[PreprocessingMethod]]
+
+
+def validate_preprocessing_configuration(
+    preprocessing_config: PreprocessingConfiguration,
+) -> None:
+    """Validate preprocessing methods are allowed for configured data types."""
+    for data_type, methods in preprocessing_config.items():
+        for method in methods:
+            allowed_types = method.allowed_data_types()
+            if data_type not in allowed_types:
+                allowed_list = ", ".join(sorted(dt.value for dt in allowed_types))
+                raise ValueError(
+                    f"Preprocessing method '{type(method).__name__}' "
+                    "is not allowed for data type "
+                    f"{data_type.value}. Allowed data types: [{allowed_list}]"
+                )
+
+
+def resolve_preprocessing_config(
+    config_dict: DictConfig,
+) -> PreprocessingConfiguration:
+    """Resolve one preprocessing role to serialized and runtime forms.
+
+    Args:
+        config_dict: Dictionary containing the preprocessing
+            configuration.
+                  Example:
+                      {
+                         "RGB_IMAGES": [
+                          {
+                              "_target_":
+                                  "neuracore.ml.preprocessing.methods.ResizePad",
+                              "size": [224, 224]
+                          }
+                         ]
+                      }
+
+    Returns:
+        A preprocessing configuration in the runtime form.
+    """
+    from hydra.utils import instantiate
+
+    resolved = {}
+    for data_type_key, methods_list in config_dict.items():
+        data_type = DataType(data_type_key)
+        methods = [instantiate(m) for m in methods_list]
+        resolved[data_type] = methods
+    validate_preprocessing_configuration(preprocessing_config=resolved)
+    return resolved
+
+
+def serialize_preprocessing_config(
+    preprocessing_config: PreprocessingConfiguration,
+) -> dict[str, list[dict[str, Any]]]:
+    """Serialize a preprocessing configuration to a dictionary."""
+    serialized = {}
+    for data_type, methods in preprocessing_config.items():
+        serialized[str(data_type)] = [
+            m if isinstance(m, dict) else m.to_dict() for m in methods
+        ]
+    return serialized
+
+
+def apply_preprocessing_methods(
+    batched_data: BatchedNCData,
+    methods: list[PreprocessingMethod],
+) -> BatchedNCData:
+    """Apply preprocessing methods to a batch of data."""
+    for method in methods:
+        batched_data = method(batched_data)
+    return batched_data

--- a/neuracore/ml/utils/preprocessing_utils.py
+++ b/neuracore/ml/utils/preprocessing_utils.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from neuracore_types import BatchedNCData, DataType
 from omegaconf import DictConfig
 
@@ -59,18 +57,6 @@ def resolve_preprocessing_config(
         resolved[data_type] = methods
     validate_preprocessing_configuration(preprocessing_config=resolved)
     return resolved
-
-
-def serialize_preprocessing_config(
-    preprocessing_config: PreprocessingConfiguration,
-) -> dict[str, list[dict[str, Any]]]:
-    """Serialize a preprocessing configuration to a dictionary."""
-    serialized = {}
-    for data_type, methods in preprocessing_config.items():
-        serialized[str(data_type)] = [
-            m if isinstance(m, dict) else m.to_dict() for m in methods
-        ]
-    return serialized
 
 
 def apply_preprocessing_methods(

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -14,6 +14,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.utils.http_session import get_session
 from neuracore.ml.utils.nc_archive import create_nc_archive
+from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,8 @@ class TrainingStorageHandler(UploadStorageMixin):
         algorithm_config: dict = {},
         input_cross_embodiment_description: dict[str, Any] = {},
         output_cross_embodiment_description: dict[str, Any] = {},
+        input_preprocessing_config: PreprocessingConfiguration = {},
+        output_preprocessing_config: PreprocessingConfiguration = {},
     ) -> None:
         """Initialize the storage handler.
 
@@ -40,12 +43,18 @@ class TrainingStorageHandler(UploadStorageMixin):
                 to persist with model artifacts.
             output_cross_embodiment_description: Output embodiment mapping
                 to persist with model artifacts.
+            input_preprocessing_config: preprocessing configuration for the input
+                data.
+            output_preprocessing_config: preprocessing configuration for the output
+                data.
         """
         self.local_dir = Path(local_dir or "./output")
         self.training_job_id = training_job_id
         self.algorithm_config = algorithm_config
         self.input_cross_embodiment_description = input_cross_embodiment_description
         self.output_cross_embodiment_description = output_cross_embodiment_description
+        self.input_preprocessing_config = input_preprocessing_config
+        self.output_preprocessing_config = output_preprocessing_config
         self.log_to_cloud = self.training_job_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
@@ -235,6 +244,8 @@ class TrainingStorageHandler(UploadStorageMixin):
             algorithm_config=self.algorithm_config,
             input_cross_embodiment_description=self.input_cross_embodiment_description,
             output_cross_embodiment_description=self.output_cross_embodiment_description,
+            input_preprocessing_config=self.input_preprocessing_config,
+            output_preprocessing_config=self.output_preprocessing_config,
         )
         if self.log_to_cloud:
             for file_path in artifacts_dir.glob("*"):

--- a/neuracore/ml/utils/validate.py
+++ b/neuracore/ml/utils/validate.py
@@ -27,7 +27,9 @@ from torch.utils.data import DataLoader
 
 import neuracore as nc
 from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
+from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
 from neuracore.ml.utils.device_utils import get_default_device
+from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
 
 from ..core.ml_types import BatchedTrainingOutputs, BatchedTrainingSamples
 from ..datasets.pytorch_dummy_dataset import MAX_LEN_PER_DATA_TYPE, PytorchDummyDataset
@@ -147,6 +149,16 @@ def run_validation(
         logger.info(f"Supported input data types: {supported_input_data_types}")
         logger.info(f"Supported output data types: {supported_output_data_types}")
 
+        # Build validation preprocessing configuration
+        input_preprocessing_config: PreprocessingConfiguration = {
+            DataType.RGB_IMAGES: [ResizePad(size=(224, 224))],
+            DataType.DEPTH_IMAGES: [ResizePad(size=(224, 224))],
+        }
+        output_preprocessing_config: PreprocessingConfiguration = {
+            DataType.RGB_IMAGES: [ResizePad(size=(224, 224))],
+            DataType.DEPTH_IMAGES: [ResizePad(size=(224, 224))],
+        }
+
         # Create dummy robot data specs
         input_cross_embodiment_description = {
             "robot_1": {
@@ -256,6 +268,8 @@ def run_validation(
                     algorithm_config,
                     input_cross_embodiment_description,
                     output_cross_embodiment_description,
+                    input_preprocessing_config,
+                    output_preprocessing_config,
                 )
 
                 algo_check.successfully_exported_model = True

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -25,6 +25,8 @@ from neuracore.ml import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
 )
+from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
+from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
 
 DATA_ITEMS = 3
 
@@ -45,6 +47,13 @@ def _full_data_spec() -> dict[DataType, dict[int, str]]:
             DataType.JOINT_TARGET_POSITIONS, 3
         ),
         DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+    }
+
+
+def _default_preprocessing_config() -> PreprocessingConfiguration:
+    return {
+        DataType.RGB_IMAGES: [ResizePad(size=(224, 224))],
+        DataType.DEPTH_IMAGES: [ResizePad(size=(224, 224))],
     }
 
 
@@ -236,6 +245,180 @@ def _stats_cache_path(cache_root, sync_id, input_spec, output_spec):
     return cache_root / "dataset_cache" / f"{sync_id}_statistics_{spec_hash}.json"
 
 
+@pytest.fixture
+def synchronization_point_with_depth() -> SynchronizedPoint:
+    """Create a sample SynchronizedPoint including depth data."""
+    all_data_types = [
+        DataType.JOINT_POSITIONS,
+        DataType.JOINT_TARGET_POSITIONS,
+        DataType.RGB_IMAGES,
+        DataType.DEPTH_IMAGES,
+    ]
+
+    return SynchronizedPoint(
+        robot_id=ROBOT_ID,
+        timestamp=1234567890.0,
+        data={
+            data_type: {
+                f"{data_type.value}_{i}": DATA_TYPE_TO_NC_DATA_CLASS[data_type].sample()
+                for i in range(DATA_ITEMS)
+            }
+            for data_type in all_data_types
+        },
+    )
+
+
+@pytest.fixture
+def dataset_statistics_with_depth(
+    synchronization_point_with_depth: SynchronizedPoint,
+) -> dict[str, dict[DataType, list[NCDataStats]]]:
+    """Create sample dataset statistics for tests including depth."""
+    stats = {
+        DataType.JOINT_POSITIONS: [
+            list(
+                synchronization_point_with_depth.data[DataType.JOINT_POSITIONS].values()
+            )[i].calculate_statistics()
+            for i in range(DATA_ITEMS)
+        ],
+        DataType.JOINT_TARGET_POSITIONS: [
+            list(
+                synchronization_point_with_depth.data[
+                    DataType.JOINT_TARGET_POSITIONS
+                ].values()
+            )[i].calculate_statistics()
+            for i in range(DATA_ITEMS)
+        ],
+        DataType.RGB_IMAGES: [
+            list(synchronization_point_with_depth.data[DataType.RGB_IMAGES].values())[
+                i
+            ].calculate_statistics()
+            for i in range(DATA_ITEMS)
+        ],
+        DataType.DEPTH_IMAGES: [
+            list(synchronization_point_with_depth.data[DataType.DEPTH_IMAGES].values())[
+                i
+            ].calculate_statistics()
+            for i in range(DATA_ITEMS)
+        ],
+    }
+    for data_type_stats in stats.values():
+        for stat in data_type_stats:
+            for attr_name, attr_value in vars(stat).items():
+                if isinstance(attr_value, DataItemStats):
+                    attr_value.count[0] = NUM_EPISODES * NUM_OBSERVATIONS_PER_EPISODE
+    return {
+        "input": {
+            DataType.JOINT_POSITIONS: stats[DataType.JOINT_POSITIONS],
+            DataType.RGB_IMAGES: stats[DataType.RGB_IMAGES],
+            DataType.DEPTH_IMAGES: stats[DataType.DEPTH_IMAGES],
+        },
+        "output": {
+            DataType.JOINT_TARGET_POSITIONS: stats[DataType.JOINT_TARGET_POSITIONS],
+        },
+    }
+
+
+@pytest.fixture
+def mock_synced_recording_with_depth(
+    synchronization_point_with_depth: SynchronizedPoint,
+) -> SynchronizedRecording:
+    """Create a mock recording including depth data."""
+    sync_points = [synchronization_point_with_depth] * 10
+
+    class MockSynchronizedRecording(SynchronizedRecording):
+        def __init__(self):
+            self.sync_points = sync_points
+            self.robot_id = ROBOT_ID
+
+        def __len__(self):
+            return len(self.sync_points)
+
+        def __getitem__(self, idx):
+            if isinstance(idx, int):
+                return self.sync_points[idx]
+            elif isinstance(idx, slice):
+                start = idx.start or 0
+                stop = idx.stop or len(self.sync_points)
+                step = idx.step or 1
+                return self.sync_points[start:stop:step]
+            else:
+                raise TypeError(f"Invalid index type: {type(idx)}")
+
+        def __iter__(self):
+            return iter(self.sync_points)
+
+    return MockSynchronizedRecording()
+
+
+@pytest.fixture
+def mock_synchronized_dataset_with_depth(
+    mock_synced_recording_with_depth: SynchronizedRecording,
+    dataset_statistics_with_depth: dict[str, dict[DataType, list[NCDataStats]]],
+) -> SynchronizedDataset:
+    """Create a mock synchronized dataset including depth data."""
+
+    class MockSynchronizedDataset(SynchronizedDataset):
+        def __init__(self):
+            self.id = "mock_dataset"
+            self.dataset = MagicMock()
+            self.dataset.data_types = [
+                DataType.JOINT_POSITIONS,
+                DataType.JOINT_TARGET_POSITIONS,
+                DataType.RGB_IMAGES,
+                DataType.DEPTH_IMAGES,
+            ]
+            self.dataset.get_full_embodiment_description.side_effect = (
+                lambda robot_id: (
+                    {
+                        **_full_data_spec(),
+                        DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
+                    }
+                    if robot_id == ROBOT_ID
+                    else (_ for _ in ()).throw(
+                        ValueError(f"Input robot IDs [{robot_id}] not found")
+                    )
+                )
+            )
+            self.cross_embodiment_description = {
+                ROBOT_ID: {
+                    DataType.JOINT_POSITIONS: _indexed_names(
+                        DataType.JOINT_POSITIONS, 3
+                    ),
+                    DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                        DataType.JOINT_TARGET_POSITIONS, 3
+                    ),
+                    DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+                    DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
+                }
+            }
+
+        def calculate_statistics(
+            self,
+            input_cross_embodiment_description: CrossEmbodimentDescription,
+            output_cross_embodiment_description: CrossEmbodimentDescription,
+        ) -> SynchronizedDatasetStatistics:
+            return SynchronizedDatasetStatistics(
+                synchronized_dataset_id="mock_dataset",
+                input_cross_embodiment_description=input_cross_embodiment_description,
+                output_cross_embodiment_description=output_cross_embodiment_description,
+                dataset_statistics=dataset_statistics_with_depth,
+            )
+
+        def __len__(self):
+            return NUM_EPISODES
+
+        def __getitem__(self, idx):
+            return mock_synced_recording_with_depth
+
+        def __next__(self) -> SynchronizedRecording:
+            if self._recording_idx >= NUM_EPISODES:
+                raise StopIteration
+            self._recording_idx += 1
+            return mock_synced_recording_with_depth
+
+    return MockSynchronizedDataset()
+
+
 def test_should_initialize_with_correct_args(
     mock_synchronized_dataset: SynchronizedDataset,
 ):
@@ -259,6 +442,8 @@ def test_should_initialize_with_correct_args(
         input_cross_embodiment_description=input_embodiment_description,
         output_cross_embodiment_description=output_embodiment_description,
         output_prediction_horizon=5,
+        input_preprocessing_config=_default_preprocessing_config(),
+        output_preprocessing_config=_default_preprocessing_config(),
     )
 
     assert dataset.synchronized_dataset == mock_synchronized_dataset
@@ -293,6 +478,8 @@ def test_should_throw_error_with_missing_robot_id(
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=5,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
 
@@ -320,6 +507,8 @@ def test_should_throw_error_with_missing_data_type(
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=5,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
 
@@ -343,6 +532,8 @@ def test_initialization_invalid_synchronized_dataset():
                 }
             },
             output_prediction_horizon=5,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
 
@@ -485,6 +676,8 @@ class TestDataLoading:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -523,6 +716,8 @@ class TestDataLoading:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -535,6 +730,93 @@ class TestDataLoading:
 
             # Memory should be checked at least once
             assert mock_monitor.check_memory.call_count >= 1
+
+    @patch("neuracore.login")
+    def test_load_sample_applies_input_preprocessing(
+        self, mock_login, mock_synchronized_dataset_with_depth
+    ):
+        input_spec: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
+                DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+                DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
+            }
+        }
+        output_spec: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                    DataType.JOINT_TARGET_POSITIONS, 3
+                )
+            }
+        }
+        RGB_TEST_SHAPE = (123, 456)
+        DEPTH_TEST_SHAPE = (789, 101)
+        input_preprocessing_config = {
+            DataType.RGB_IMAGES: [ResizePad(size=RGB_TEST_SHAPE)],
+            DataType.DEPTH_IMAGES: [ResizePad(size=DEPTH_TEST_SHAPE)],
+        }
+        dataset = PytorchSynchronizedDataset(
+            synchronized_dataset=mock_synchronized_dataset_with_depth,
+            input_cross_embodiment_description=input_spec,
+            output_cross_embodiment_description=output_spec,
+            output_prediction_horizon=3,
+            input_preprocessing_config=input_preprocessing_config,
+            output_preprocessing_config=_default_preprocessing_config(),
+        )
+
+        with patch.object(dataset, "_memory_monitor") as mock_monitor:
+            mock_monitor.check_memory.return_value = None
+            sample = dataset.load_sample(episode_idx=0, timestep=0)
+
+        assert sample.inputs[DataType.RGB_IMAGES][0].frame.shape[-2:] == RGB_TEST_SHAPE
+        assert (
+            sample.inputs[DataType.DEPTH_IMAGES][0].frame.shape[-2:] == DEPTH_TEST_SHAPE
+        )
+
+    @patch("neuracore.login")
+    def test_load_sample_applies_output_preprocessing(
+        self, mock_login, mock_synchronized_dataset_with_depth
+    ):
+        input_spec: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
+                DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+                DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
+            }
+        }
+        output_spec: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+                DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                    DataType.JOINT_TARGET_POSITIONS, 3
+                ),
+            }
+        }
+        RGB_TEST_SHAPE = (160, 200)
+        DEPTH_TEST_SHAPE = (180, 220)
+        output_preprocessing_config = {
+            DataType.RGB_IMAGES: [ResizePad(size=RGB_TEST_SHAPE)],
+            DataType.DEPTH_IMAGES: [ResizePad(size=DEPTH_TEST_SHAPE)],
+        }
+        dataset = PytorchSynchronizedDataset(
+            synchronized_dataset=mock_synchronized_dataset_with_depth,
+            input_cross_embodiment_description=input_spec,
+            output_cross_embodiment_description=output_spec,
+            output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=output_preprocessing_config,
+        )
+
+        with patch.object(dataset, "_memory_monitor") as mock_monitor:
+            mock_monitor.check_memory.return_value = None
+            sample = dataset.load_sample(episode_idx=0, timestep=0)
+
+        assert sample.outputs[DataType.RGB_IMAGES][0].frame.shape[-2:] == RGB_TEST_SHAPE
+        assert (
+            sample.outputs[DataType.DEPTH_IMAGES][0].frame.shape[-2:]
+            == DEPTH_TEST_SHAPE
+        )
 
 
 class TestDataTypeProcessing:
@@ -562,6 +844,8 @@ class TestDataTypeProcessing:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=2,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -610,6 +894,8 @@ class TestDatasetIntegration:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -642,6 +928,8 @@ class TestDatasetIntegration:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -671,6 +959,8 @@ class TestDatasetIntegration:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         # Test positive out of bounds
@@ -701,6 +991,8 @@ class TestDatasetIntegration:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         assert len(dataset) == 45
@@ -726,6 +1018,8 @@ class TestDatasetIntegration:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         with patch.object(dataset, "load_sample") as mock_load_sample:
@@ -759,6 +1053,8 @@ class TestPerformanceAndOptimization:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         assert dataset._memory_monitor is not None
@@ -784,6 +1080,8 @@ class TestPerformanceAndOptimization:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         # Should have episode indices for each sample (excluding last frames)
@@ -818,6 +1116,8 @@ class TestErrorRecovery:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         # Initial error count should be 0
@@ -852,6 +1152,8 @@ class TestIntegrationWithPyTorchDataLoader:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         dataloader = DataLoader(
@@ -895,6 +1197,8 @@ class TestDatasetStatistics:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         stats = dataset.dataset_statistics
@@ -942,6 +1246,8 @@ class TestDatasetStatistics:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         assert mock_synchronized_dataset.calculate_statistics.call_count == 0
@@ -982,10 +1288,14 @@ class TestDatasetStatistics:
             input_cross_embodiment_description=input_spec,
             output_cross_embodiment_description=output_spec,
             output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
         )
 
         assert mock_synchronized_dataset.calculate_statistics.call_count == 1
         cache_path = _stats_cache_path(
             tmp_path, mock_synchronized_dataset.id, input_spec, output_spec
         )
+        assert cache_path.exists()
+
         assert cache_path.exists()

--- a/tests/unit/ml/preprocessing/test_apply_preprocessing_configs.py
+++ b/tests/unit/ml/preprocessing/test_apply_preprocessing_configs.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+from neuracore_types import BatchedNCData, BatchedRGBData, DataType
+
+from neuracore.ml.preprocessing.base import PreprocessingMethod
+from neuracore.ml.utils.preprocessing_utils import (
+    apply_preprocessing_methods,
+    validate_preprocessing_configuration,
+)
+
+
+def _sample_rgb(height: int = 100, width: int = 200) -> BatchedRGBData:
+    return BatchedRGBData(
+        frame=torch.zeros((1, 1, 3, height, width), dtype=torch.float32),
+        extrinsics=torch.zeros((1, 1, 4, 4), dtype=torch.float32),
+        intrinsics=torch.zeros((1, 1, 3, 3), dtype=torch.float32),
+    )
+
+
+class _RecordStep(PreprocessingMethod):
+    def __init__(self, call_order: list[str], label: str) -> None:
+        self._call_order = call_order
+        self._label = label
+
+    @staticmethod
+    def allowed_data_types() -> frozenset[DataType]:
+        return frozenset({DataType.RGB_IMAGES})
+
+    def __call__(self, data: BatchedNCData) -> BatchedNCData:
+        self._call_order.append(self._label)
+        return data
+
+
+def test_apply_methods_for_data_type_rejects_unsupported_data_type():
+    methods = [_RecordStep(call_order=[], label="depth-step")]
+
+    with pytest.raises(ValueError, match="not allowed for data type"):
+        validate_preprocessing_configuration(
+            preprocessing_config={DataType.DEPTH_IMAGES: methods},
+        )
+
+
+def test_apply_methods_for_data_type_executes_handlers_in_order():
+    call_order: list[str] = []
+    methods = [_RecordStep(call_order, "first"), _RecordStep(call_order, "second")]
+
+    result = apply_preprocessing_methods(
+        batched_data=_sample_rgb(),
+        methods=methods,
+    )
+
+    assert isinstance(result, BatchedRGBData)
+    assert call_order == ["first", "second"]

--- a/tests/unit/ml/preprocessing/test_resize_pad.py
+++ b/tests/unit/ml/preprocessing/test_resize_pad.py
@@ -1,0 +1,66 @@
+import pytest
+import torch
+from neuracore_types import BatchedDepthData, BatchedRGBData
+
+from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
+
+
+def _rgb(height: int, width: int) -> BatchedRGBData:
+    return BatchedRGBData(
+        frame=torch.ones((2, 3, 3, height, width), dtype=torch.float32),
+        extrinsics=torch.zeros((2, 3, 4, 4), dtype=torch.float32),
+        intrinsics=torch.zeros((2, 3, 3, 3), dtype=torch.float32),
+    )
+
+
+def _depth(height: int, width: int) -> BatchedDepthData:
+    return BatchedDepthData(
+        frame=torch.ones((2, 3, 1, height, width), dtype=torch.float32),
+        extrinsics=torch.zeros((2, 3, 4, 4), dtype=torch.float32),
+        intrinsics=torch.zeros((2, 3, 3, 3), dtype=torch.float32),
+    )
+
+
+def test_resize_pad_rgb_changes_shape_and_preserves_batch_time_channels():
+    data = _rgb(80, 120)
+    out = ResizePad(size=[200, 160])(data)
+
+    assert out.frame.shape == (2, 3, 3, 200, 160)
+
+
+def test_resize_pad_depth_changes_shape_and_preserves_batch_time_channels():
+    data = _depth(90, 60)
+    out = ResizePad(size=[128, 256])(data)
+
+    assert out.frame.shape == (2, 3, 1, 128, 256)
+
+
+def test_resize_pad_is_noop_when_shape_already_matches():
+    data = _rgb(224, 224)
+    out = ResizePad(size=[224, 224])(data)
+
+    assert out is data
+    assert out.frame.shape == (2, 3, 3, 224, 224)
+
+
+def test_resize_pad_invalid_size_length_raises():
+    data = _rgb(80, 120)
+    with pytest.raises(ValueError, match="expects size as"):
+        ResizePad(size=[224])(data)
+
+
+def test_resize_pad_non_positive_sizes_raise():
+    data = _depth(80, 120)
+    with pytest.raises(ValueError, match="expects positive"):
+        ResizePad(size=[0, 224])(data)
+    with pytest.raises(ValueError, match="expects positive"):
+        ResizePad(size=[224, -1])(data)
+
+
+def test_resize_pad_rejects_unsupported_batched_type():
+    class DummyBatched:
+        def __init__(self):
+            self.frame = torch.zeros((1, 1, 2, 20, 20), dtype=torch.float32)
+
+    with pytest.raises(TypeError, match="Unsupported batched data type"):
+        ResizePad(size=[32, 32])(DummyBatched())  # type: ignore[arg-type]

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -47,6 +47,7 @@ from neuracore.ml.train import (
     setup_logging,
 )
 from neuracore.ml.trainers.batch_autotuner import find_optimal_batch_size
+from neuracore.ml.utils.preprocessing_utils import resolve_preprocessing_config
 
 SKIP_TEST = (
     os.environ.get("CI", "false").lower() == "true" or not torch.cuda.is_available()
@@ -90,6 +91,73 @@ OUTPUT_CROSS_EMBODIMENT_SPEC = {
     },
 }
 
+MINIMAL_PREPROCESSING_CFG = {
+    "input": {
+        "RGB_IMAGES": [{
+            "_target_": "neuracore.ml.preprocessing.methods.resize_pad.ResizePad",
+            "size": [224, 224],
+        }]
+    },
+    "output": {
+        "RGB_IMAGES": [{
+            "_target_": "neuracore.ml.preprocessing.methods.resize_pad.ResizePad",
+            "size": [224, 224],
+        }]
+    },
+}
+
+
+class TestResolvePreprocessingConfig:
+    def test_resolves_input_preprocessing_config(self):
+        cfg = OmegaConf.create({
+            "preprocessing": {
+                "input": {
+                    "RGB_IMAGES": [{
+                        "_target_": (
+                            "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                        ),
+                        "size": [224, 224],
+                    }],
+                    "DEPTH_IMAGES": [{
+                        "_target_": (
+                            "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                        ),
+                        "size": [200, 300],
+                    }],
+                }
+            }
+        })
+
+        resolved = resolve_preprocessing_config(cfg.preprocessing.input)
+
+        assert set(resolved.keys()) == {DataType.RGB_IMAGES, DataType.DEPTH_IMAGES}
+        assert len(resolved[DataType.RGB_IMAGES]) == 1
+        assert len(resolved[DataType.DEPTH_IMAGES]) == 1
+        assert resolved[DataType.RGB_IMAGES][0].__class__.__name__ == "ResizePad"
+        assert resolved[DataType.DEPTH_IMAGES][0].__class__.__name__ == "ResizePad"
+        assert tuple(resolved[DataType.RGB_IMAGES][0].size) == (224, 224)
+        assert tuple(resolved[DataType.DEPTH_IMAGES][0].size) == (200, 300)
+
+    def test_resolves_output_preprocessing_config(self):
+        cfg = OmegaConf.create({
+            "preprocessing": {
+                "output": {
+                    "RGB_IMAGES": [{
+                        "_target_": (
+                            "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                        ),
+                        "size": [160, 200],
+                    }]
+                }
+            }
+        })
+
+        resolved = resolve_preprocessing_config(cfg.preprocessing.output)
+
+        assert set(resolved.keys()) == {DataType.RGB_IMAGES}
+        assert resolved[DataType.RGB_IMAGES][0].__class__.__name__ == "ResizePad"
+        assert tuple(resolved[DataType.RGB_IMAGES][0].size) == (160, 200)
+
 
 class MainTestSetup:
     def __init__(self, monkeypatch, cuda_device_count=1):
@@ -116,6 +184,7 @@ class MainTestSetup:
             return_value=self.mock_synchronized_dataset
         )
         self.mock_pytorch_dataset_class = Mock(return_value=self.mock_pytorch_dataset)
+        self.mock_resolve_preprocessing_config = Mock(return_value={})
         self.mock_run_training = Mock()
         self.mock_cuda_device_count = Mock(return_value=self.cuda_device_count)
         self.mock_storage_handler = Mock()
@@ -155,6 +224,10 @@ class MainTestSetup:
         self.monkeypatch.setattr(
             "neuracore.ml.train.validate_training_params",
             self.mock_validate_training_params,
+        )
+        self.monkeypatch.setattr(
+            "neuracore.ml.train.resolve_preprocessing_config",
+            self.mock_resolve_preprocessing_config,
         )
         self.monkeypatch.setattr(
             "neuracore.ml.train.PytorchSynchronizedDataset",
@@ -293,6 +366,12 @@ class RunTrainingTestSetup:
 
     def call_run_training(self, cfg, dataset):
         """Call run_training with the configured parameters."""
+        input_preprocessing_config = resolve_preprocessing_config(
+            cfg.preprocessing.input
+        )
+        output_preprocessing_config = resolve_preprocessing_config(
+            cfg.preprocessing.output
+        )
         return run_training(
             self.rank,
             self.world_size,
@@ -300,6 +379,8 @@ class RunTrainingTestSetup:
             self.batch_size,
             cfg.input_cross_embodiment_description,
             cfg.output_cross_embodiment_description,
+            input_preprocessing_config,
+            output_preprocessing_config,
             dataset,
         )
 
@@ -395,6 +476,36 @@ def mock_cfg_batch_size(temp_output_dir):
         "max_delay_s": 0.5,
         "allow_duplicates": True,
         "trim_start_end": True,
+        "preprocessing": {
+            "input": {
+                "RGB_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+                "DEPTH_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+            },
+            "output": {
+                "RGB_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+                "DEPTH_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+            },
+        },
     })
 
 
@@ -419,7 +530,48 @@ def mock_cfg_training(temp_output_dir) -> DictConfig:
         "max_delay_s": 0.5,
         "allow_duplicates": True,
         "trim_start_end": True,
+        "preprocessing": {
+            "input": {
+                "RGB_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+                "DEPTH_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+            },
+            "output": {
+                "RGB_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+                "DEPTH_IMAGES": [{
+                    "_target_": (
+                        "neuracore.ml.preprocessing.methods.resize_pad.ResizePad"
+                    ),
+                    "size": [224, 224],
+                }],
+            },
+        },
     })
+
+
+@pytest.fixture
+def mock_preprocessing_configs_batch_size(
+    mock_cfg_batch_size: DictConfig,
+) -> tuple[dict[DataType, list], dict[DataType, list]]:
+    """Resolve preprocessing once for batch-size tests."""
+    return (
+        resolve_preprocessing_config(mock_cfg_batch_size.preprocessing.input),
+        resolve_preprocessing_config(mock_cfg_batch_size.preprocessing.output),
+    )
 
 
 @pytest.fixture
@@ -784,7 +936,10 @@ class TestDetermineOptimalBatchSize:
         # assert set(kwargs.keys()) == {"cfg", "model", "dataset", "device"}
 
     def test_determine_optimal_batch_size_raises_error_when_no_gpu(
-        self, mock_cfg_batch_size, mock_dataset, monkeypatch
+        self,
+        mock_cfg_batch_size,
+        mock_dataset,
+        monkeypatch,
     ):
         mock_get_device = Mock(return_value=torch.device("cpu"))
         monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
@@ -919,7 +1074,10 @@ class TestDetermineOptimalBatchSize:
         mock_find_optimal.assert_called_once()
 
     def test_determine_optimal_batch_size_raises_error_when_cpu_device_provided(
-        self, mock_cfg_batch_size, mock_dataset, monkeypatch
+        self,
+        mock_cfg_batch_size,
+        mock_dataset,
+        monkeypatch,
     ):
         monkeypatch.setattr("torch.cuda.is_available", lambda: True)
 
@@ -1684,6 +1842,7 @@ class TestMain:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         }
         base_cfg.update(cfg_updates)
         cfg = OmegaConf.create(base_cfg)
@@ -1715,6 +1874,7 @@ class TestMain:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1747,6 +1907,7 @@ class TestMain:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1781,6 +1942,7 @@ class TestMain:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1881,6 +2043,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1918,6 +2081,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1926,7 +2090,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
         main(cfg)
 
         setup.mock_get_default_device.assert_called_once()
-        assert setup.mock_run_training.call_args[0][7] == torch.device("cuda:0")
+        assert setup.mock_run_training.call_args[0][-1] == torch.device("cuda:0")
 
     def test_main_uses_explicit_device_when_device_is_provided(
         self, monkeypatch, temp_output_dir
@@ -1950,6 +2114,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -1960,7 +2125,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
         # get_default_device should NOT be called when device is explicitly provided
         setup.mock_get_default_device.assert_not_called()
         # Verify the explicit device is passed to run_training
-        assert setup.mock_run_training.call_args[0][7] == torch.device("cuda:1")
+        assert setup.mock_run_training.call_args[0][-1] == torch.device("cuda:1")
 
     def test_main_uses_provided_batch_size_when_not_auto(
         self, monkeypatch, temp_output_dir
@@ -1984,6 +2149,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2019,6 +2185,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2054,6 +2221,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2092,6 +2260,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2123,6 +2292,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2162,6 +2332,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch, cuda_device_count=world_size)
@@ -2207,6 +2378,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2239,6 +2411,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2281,6 +2454,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2321,6 +2495,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2368,6 +2543,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "allow_duplicates": True,
             "trim_start_end": True,
             "recording_cache_dir": None,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2399,6 +2575,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "allow_duplicates": True,
             "trim_start_end": True,
             "recording_cache_dir": str(custom_cache_dir),
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2432,6 +2609,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
         setup = MainTestSetup(monkeypatch)
@@ -2482,6 +2660,7 @@ class TestMainErrorReporting:
             "max_delay_s": 0.5,
             "allow_duplicates": True,
             "trim_start_end": True,
+            "preprocessing": MINIMAL_PREPROCESSING_CFG,
         })
 
     def test_calls_try_report_error_to_cloud_when_training_id_set_and_run_training_raises(  # noqa: E501

--- a/tests/unit/ml/utils/test_policy_inference.py
+++ b/tests/unit/ml/utils/test_policy_inference.py
@@ -7,12 +7,14 @@ import pytest
 import torch
 from neuracore_types import (
     BatchedJointData,
+    BatchedNCData,
     CrossEmbodimentDescription,
     DataType,
     JointData,
     SynchronizedPoint,
 )
 
+from neuracore.ml.preprocessing.base import PreprocessingMethod
 from neuracore.ml.utils.policy_inference import PolicyInference
 
 
@@ -22,6 +24,7 @@ def _make_policy_inference(
     policy_inference = PolicyInference.__new__(PolicyInference)
     policy_inference.output_embodiment_description = output_embodiment_description or {}
     policy_inference.input_embodiment_description = {}
+    policy_inference.input_preprocessing_config = {}
     policy_inference.org_id = "test_org"
     policy_inference.job_id = None
     policy_inference.device = torch.device("cpu")
@@ -29,7 +32,9 @@ def _make_policy_inference(
     policy_inference.input_dataset_statistics = {}
     policy_inference.prediction_horizon = 1
     policy_inference.model = SimpleNamespace(
-        model_init_description=SimpleNamespace(input_data_types=[])
+        model_init_description=SimpleNamespace(
+            input_data_types=[],
+        )
     )
     return policy_inference
 
@@ -259,12 +264,15 @@ def test_init_loads_embodiments_from_archive_when_robot_id_provided(
             fake_model,
             {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
             {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
+            {"JOINT_POSITIONS": []},
+            {"JOINT_TARGET_POSITIONS": []},
         ),
     )
 
     inference = PolicyInference(
         input_embodiment_description=None,
         output_embodiment_description=None,
+        input_preprocessing_config=None,
         model_file=Path("dummy.nc.zip"),
         org_id="org",
         robot_id="robot-1",
@@ -286,7 +294,7 @@ def test_init_raises_when_no_descriptions_and_no_robot_id(
     )
     monkeypatch.setattr(
         "neuracore.ml.utils.policy_inference.load_model_from_nc_archive",
-        lambda model_file, device=None: (fake_model, {}, {}),
+        lambda model_file, device=None: (fake_model, {}, {}, {}, {}),
     )
 
     with pytest.raises(
@@ -299,6 +307,53 @@ def test_init_raises_when_no_descriptions_and_no_robot_id(
         PolicyInference(
             input_embodiment_description=None,
             output_embodiment_description=None,
+            input_preprocessing_config=None,
             model_file=Path("dummy.nc.zip"),
             org_id="org",
+        )
+
+
+class _RgbOnlyMethod(PreprocessingMethod):
+    @staticmethod
+    def allowed_data_types() -> frozenset[DataType]:
+        return frozenset({DataType.RGB_IMAGES})
+
+    def __call__(
+        self, data: BatchedNCData
+    ) -> BatchedNCData:  # pragma: no cover - behavior irrelevant for validation
+        return data
+
+
+def test_init_raises_when_input_preprocessing_method_is_not_allowed_for_data_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_model = SimpleNamespace(
+        eval=lambda: None,
+        model_init_description=SimpleNamespace(
+            input_dataset_statistics={},
+            output_prediction_horizon=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "neuracore.ml.utils.policy_inference.load_model_from_nc_archive",
+        lambda model_file, device=None: (
+            fake_model,
+            {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
+            {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
+            {DataType.JOINT_POSITIONS: []},
+            {"JOINT_TARGET_POSITIONS": []},
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="is not allowed for data type JOINT_POSITIONS",
+    ):
+        PolicyInference(
+            input_embodiment_description=None,
+            output_embodiment_description=None,
+            input_preprocessing_config={DataType.JOINT_POSITIONS: [_RgbOnlyMethod()]},
+            model_file=Path("dummy.nc.zip"),
+            org_id="org",
+            robot_id="robot-1",
         )

--- a/tests/unit/ml/utils/test_training_storage_handler.py
+++ b/tests/unit/ml/utils/test_training_storage_handler.py
@@ -340,6 +340,8 @@ class TestSaveModelArtifacts:
             algorithm_config={},
             input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
             output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            input_preprocessing_config={},
+            output_preprocessing_config={},
         )
 
     def test_save_model_artifacts_uploads_each_artifact_file_to_cloud(
@@ -359,6 +361,8 @@ class TestSaveModelArtifacts:
             algorithm_config,
             input_cross_embodiment_description,
             output_cross_embodiment_description,
+            input_preprocessing_config,
+            output_preprocessing_config,
         ):
             (output_dir / "model.pt").write_bytes(b"model_data")
             (output_dir / "config.json").write_bytes(b"{}")


### PR DESCRIPTION
This is a first version of having preprocessing pipelines. The structure of the pydantic models used is defined in neuracore_types with its own pr.

For this stage as you see, we are:
- not exposing any pipeline setup to the user, but rather having our fixed pipeline. (mainly to make sure all plumping is working as intended). Note that defining a preprocessing pipeline (in python and with yaml) is doable with this version.
- only introducing one built-in preprocessing function for rgb and depth images called resize_pad.
-  removed hard-coded reshaping inside each algorithm so they fully depend on the preprocessing.
- introduced unit tests for added functionality

Next stages should:
- add user documentation
- remove fixed preprocessing config
- add algorithm-specific restrictions (restriction on the allowed resizing size, normalisation methods etc)
- add more methods (gaussian noise, blur, jittering etc for images, normalisation, language embedding etc for other modalities)
- add automatic generation of output inference postprocessing generation. Note that this will need to be added in the same pr when normalisation gets added.
- add gui and cli interfaces to create and inspect preprocessing configs.
