### PR TITLE
fix: ensure daemon has bound its socket before signalling ready

### DIFF
--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -37,6 +37,8 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
         f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/active",
         headers=get_auth().get_headers(),
     )
+    if response.status_code == 404:
+        return []
     response.raise_for_status()
     data = response.json() or []
     return [RecordingDataTrace.model_validate(item) for item in data]

--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -149,7 +149,7 @@ def launch_daemon_subprocess(
     timeout_s: float = 5.0,
     env_overrides: dict[str, str] | None = None,
 ) -> subprocess.Popen:
-    """Launch the daemon runner subprocess and wait briefly for startup success."""
+    """Launch the daemon runner subprocess and poll until it is ready."""
     pid_path.parent.mkdir(parents=True, exist_ok=True)
 
     process = _start_daemon_subprocess(
@@ -159,9 +159,24 @@ def launch_daemon_subprocess(
         env_overrides=env_overrides,
     )
 
-    time.sleep(min(timeout_s, 0.1))
-    if process.poll() is not None:
-        raise RuntimeError("Daemon failed to start.")
+    socket_poll_interval_s = 0.05
+    daemon_startup_timeout_s = time.monotonic() + timeout_s
+
+    while time.monotonic() < daemon_startup_timeout_s:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"Daemon process exited unexpectedly during startup "
+                f"(exit code {process.returncode})."
+            )
+        if SOCKET_PATH.exists():
+            break
+        time.sleep(socket_poll_interval_s)
+    else:
+        process.terminate()
+        raise RuntimeError(
+            f"Daemon did not become ready within {timeout_s}s: "
+            f"socket {SOCKET_PATH} never appeared."
+        )
 
     pid_path.write_text(str(process.pid), encoding="utf-8")
     return process

--- a/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
+++ b/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
@@ -55,6 +55,8 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
 ) -> None:
     pid_path = tmp_path / "daemon.pid"
     db_path = tmp_path / "state.db"
+    fake_socket_path = tmp_path / "management.sock"
+    fake_socket_path.touch()
     captured: dict[str, object] = {}
 
     def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
@@ -64,6 +66,7 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
 
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", fake_socket_path)
 
     proc = launch_daemon_subprocess(
         pid_path=pid_path,
@@ -92,6 +95,8 @@ def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
 ) -> None:
     pid_path = tmp_path / "daemon.pid"
     db_path = tmp_path / "state.db"
+    fake_socket_path = tmp_path / "management.sock"
+    fake_socket_path.touch()
     captured: dict[str, object] = {}
 
     def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
@@ -101,6 +106,7 @@ def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
 
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", fake_socket_path)
 
     proc = launch_daemon_subprocess(
         pid_path=pid_path,


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - To avoid race conditions, 404 in get active data traces should be treated as empty list rather than a runtime error because we remove the traces subcollection and pending recording doc as soon as a recording is complete.
 - When start recording was called, the daemon subprocess was started but given 100ms before the producer immediately tried to send OPEN_RING_BUFFER over ZMQ, and since the daemon's auth HTTP call could take some time during init, sometimes its ZMQ socket wasn't bound yet, so zmq silently dropped the message and the daemon never knew a recording had started.
 
- Daemon Readiness is now determined by the appearance of the ZMQ socket file, Polling instead of sleeping a fixed interval avoids this race condition.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-886](https://neuracore.atlassian.net/browse/NCP-886)
 - [NCP-888](https://neuracore.atlassian.net/browse/NCP-888)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
