### PR TITLE
fix: use PyPI neuracore for production performance tests

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
@@ -83,24 +83,6 @@ jobs:
           pip install --no-cache-dir ".[dev,ml,examples]"
         fi
 
-    - name: Verify production uses PyPI neuracore
-      if: ${{ matrix.environment == 'production' }}
-      run: |
-        python - <<'EOF'
-        import os
-        from pathlib import Path
-
-        import neuracore
-
-        package_path = Path(neuracore.__file__).resolve()
-        workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
-        if workspace in package_path.parents:
-            raise SystemExit(
-                f"Production must use the released PyPI package, got {package_path}"
-            )
-        print(f"Using neuracore from {package_path}")
-        EOF
-
     - name: Run Evaluation
       env:
         NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
@@ -35,9 +35,18 @@ jobs:
 
     steps:
     - name: Checkout code
+      if: ${{ matrix.environment != 'production' }}
       uses: actions/checkout@v4
       with:
         ref: main
+    - name: Checkout production test harness
+      if: ${{ matrix.environment == 'production' }}
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        sparse-checkout: |
+          tests/integration/ml
+          examples/common
     - name: Pull LFS objects
       run: git lfs pull
 
@@ -74,27 +83,10 @@ jobs:
           pip install --no-cache-dir ".[dev,ml,examples]"
         fi
 
-    - name: Run Evaluation
-      env:
-        NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}
-        NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
-        NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
-        NEURACORE_ENDPOINT_TIMEOUT: 30
-        ALGORITHM_NAME: ${{ matrix.algorithm }}
-        DISPLAY: :0
+    - name: Verify production uses PyPI neuracore
+      if: ${{ matrix.environment == 'production' }}
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
-        Xvfb $DISPLAY -screen 0 1280x1024x24 &
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          TEST_DIR="$RUNNER_TEMP/neuracore-performance-tests-${{ matrix.algorithm }}-${{ matrix.environment }}"
-          mkdir -p "$TEST_DIR/tests/integration/ml" "$TEST_DIR/examples"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/test_algorithm_performance.py" "$TEST_DIR/tests/integration/ml/"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/conftest.py" "$TEST_DIR/tests/integration/ml/"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/algorithm_configs.yaml" "$TEST_DIR/tests/integration/ml/"
-          cp -R "$GITHUB_WORKSPACE/examples/common" "$TEST_DIR/examples/"
-          cd "$TEST_DIR"
-          python - <<'EOF'
+        python - <<'EOF'
         import os
         from pathlib import Path
 
@@ -108,7 +100,17 @@ jobs:
             )
         print(f"Using neuracore from {package_path}")
         EOF
-          pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
-        else
-          pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
-        fi
+
+    - name: Run Evaluation
+      env:
+        NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}
+        NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
+        NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
+        NEURACORE_ENDPOINT_TIMEOUT: 30
+        ALGORITHM_NAME: ${{ matrix.algorithm }}
+        DISPLAY: :0
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
+        Xvfb $DISPLAY -screen 0 1280x1024x24 &
+        pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
@@ -86,4 +86,29 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
-        pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
+        if [ "${{ matrix.environment }}" = "production" ]; then
+          TEST_DIR="$RUNNER_TEMP/neuracore-performance-tests-${{ matrix.algorithm }}-${{ matrix.environment }}"
+          mkdir -p "$TEST_DIR/tests/integration/ml" "$TEST_DIR/examples"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/test_algorithm_performance.py" "$TEST_DIR/tests/integration/ml/"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/conftest.py" "$TEST_DIR/tests/integration/ml/"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/algorithm_configs.yaml" "$TEST_DIR/tests/integration/ml/"
+          cp -R "$GITHUB_WORKSPACE/examples/common" "$TEST_DIR/examples/"
+          cd "$TEST_DIR"
+          python - <<'EOF'
+        import os
+        from pathlib import Path
+
+        import neuracore
+
+        package_path = Path(neuracore.__file__).resolve()
+        workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+        if workspace in package_path.parents:
+            raise SystemExit(
+                f"Production must use the released PyPI package, got {package_path}"
+            )
+        print(f"Using neuracore from {package_path}")
+        EOF
+          pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
+        else
+          pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
+        fi

--- a/.github/workflows/integration-ml-algorithm-performance-start.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start.yaml
@@ -35,9 +35,18 @@ jobs:
 
     steps:
     - name: Checkout code
+      if: ${{ matrix.environment != 'production' }}
       uses: actions/checkout@v4
       with:
         ref: main
+    - name: Checkout production test harness
+      if: ${{ matrix.environment == 'production' }}
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        sparse-checkout: |
+          tests/integration/ml
+          examples/common
     - name: Pull LFS objects
       run: git lfs pull
 
@@ -56,23 +65,10 @@ jobs:
           pip install --no-cache-dir ".[dev,ml,examples]"
         fi
 
-    - name: Start training job
-      id: start-training
-      env:
-        NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}
-        NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
-        NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
-        ALGORITHM_NAME: ${{ matrix.algorithm }}
+    - name: Verify production uses PyPI neuracore
+      if: ${{ matrix.environment == 'production' }}
       run: |
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          TEST_DIR="$RUNNER_TEMP/neuracore-performance-tests-${{ matrix.algorithm }}-${{ matrix.environment }}"
-          mkdir -p "$TEST_DIR/tests/integration/ml" "$TEST_DIR/examples"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/test_algorithm_performance.py" "$TEST_DIR/tests/integration/ml/"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/conftest.py" "$TEST_DIR/tests/integration/ml/"
-          cp "$GITHUB_WORKSPACE/tests/integration/ml/algorithm_configs.yaml" "$TEST_DIR/tests/integration/ml/"
-          cp -R "$GITHUB_WORKSPACE/examples/common" "$TEST_DIR/examples/"
-          cd "$TEST_DIR"
-          python - <<'EOF'
+        python - <<'EOF'
         import os
         from pathlib import Path
 
@@ -86,10 +82,15 @@ jobs:
             )
         print(f"Using neuracore from {package_path}")
         EOF
-          pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
-        else
-          pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
-        fi
+
+    - name: Start training job
+      id: start-training
+      env:
+        NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}
+        NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
+        NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
+        ALGORITHM_NAME: ${{ matrix.algorithm }}
+      run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
 
     - name: Write job ID to file
       run: echo "${{ steps.start-training.outputs.training_job_id }}" > training_job_id.txt

--- a/.github/workflows/integration-ml-algorithm-performance-start.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start.yaml
@@ -65,24 +65,6 @@ jobs:
           pip install --no-cache-dir ".[dev,ml,examples]"
         fi
 
-    - name: Verify production uses PyPI neuracore
-      if: ${{ matrix.environment == 'production' }}
-      run: |
-        python - <<'EOF'
-        import os
-        from pathlib import Path
-
-        import neuracore
-
-        package_path = Path(neuracore.__file__).resolve()
-        workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
-        if workspace in package_path.parents:
-            raise SystemExit(
-                f"Production must use the released PyPI package, got {package_path}"
-            )
-        print(f"Using neuracore from {package_path}")
-        EOF
-
     - name: Start training job
       id: start-training
       env:

--- a/.github/workflows/integration-ml-algorithm-performance-start.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start.yaml
@@ -63,7 +63,33 @@ jobs:
         NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
         NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
         ALGORITHM_NAME: ${{ matrix.algorithm }}
-      run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
+      run: |
+        if [ "${{ matrix.environment }}" = "production" ]; then
+          TEST_DIR="$RUNNER_TEMP/neuracore-performance-tests-${{ matrix.algorithm }}-${{ matrix.environment }}"
+          mkdir -p "$TEST_DIR/tests/integration/ml" "$TEST_DIR/examples"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/test_algorithm_performance.py" "$TEST_DIR/tests/integration/ml/"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/conftest.py" "$TEST_DIR/tests/integration/ml/"
+          cp "$GITHUB_WORKSPACE/tests/integration/ml/algorithm_configs.yaml" "$TEST_DIR/tests/integration/ml/"
+          cp -R "$GITHUB_WORKSPACE/examples/common" "$TEST_DIR/examples/"
+          cd "$TEST_DIR"
+          python - <<'EOF'
+        import os
+        from pathlib import Path
+
+        import neuracore
+
+        package_path = Path(neuracore.__file__).resolve()
+        workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+        if workspace in package_path.parents:
+            raise SystemExit(
+                f"Production must use the released PyPI package, got {package_path}"
+            )
+        print(f"Using neuracore from {package_path}")
+        EOF
+          pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
+        else
+          pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
+        fi
 
     - name: Write job ID to file
       run: echo "${{ steps.start-training.outputs.training_job_id }}" > training_job_id.txt


### PR DESCRIPTION
## Summary

Updates the production ML algorithm performance workflows so production test runs import the released `neuracore` package from PyPI instead of the checked-out `main` branch package.

Changed workflows:
- `.github/workflows/integration-ml-algorithm-performance-start.yaml`
- `.github/workflows/integration-ml-algorithm-performance-evaluate.yaml`

## Why

Staging and production currently run the same workflow code path from the repository checkout. That means production can accidentally validate against the `neuracore` code on `main`, while production users and services are actually running the released PyPI package. This PR separates those paths:

- staging continues using the checked-out branch via `.[dev,ml,examples]`
- production installs `neuracore[dev,ml,examples]` from PyPI
- production copies only the test harness/assets into `$RUNNER_TEMP`
- production runs pytest from that temp directory so `./neuracore` from the checkout is not on `sys.path`
- production asserts that `import neuracore` resolves outside `$GITHUB_WORKSPACE`

This keeps production performance tests aligned with the version of `neuracore` that production actually consumes, while staging can still exercise unreleased branch code.

## Validation

- Parsed both updated workflow YAML files with PyYAML
- Ran `bash -n` against the modified workflow run scripts after substituting matrix values
- Ran `git diff --cached --check`
- Commit hook ran `cspell` successfully

The actual ML performance workflows were not run locally because they depend on GitHub Actions secrets and production/staging ML infrastructure.
