### PR TITLE
fix: launch-server CLI docs

### DIFF
--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -34,8 +34,8 @@ neuracore training inspect --training-name <RUN_NAME_OR_ID>
 4) **Launch a local policy server to sanity-check inference**
 ```bash
 neuracore launch-server \
-  --input_embodiment_description '{"RGB_IMAGES": {0:"front_cam"}}' \
-  --output_embodiment_description '{"JOINT_TARGET_POSITIONS": {0:"arm"}' \
+  --input_embodiment_description '{"RGB_IMAGES": {"0": "front_cam"}}' \
+  --output_embodiment_description '{"JOINT_TARGET_POSITIONS": {"0": "arm"}}' \
   --job_id <RUN_ID> \
   --org_id <ORG_ID> \
   --port 8080
@@ -60,7 +60,7 @@ neuracore training delete --training-name <RUN_NAME_OR_ID> --yes
   - Cloud is the default; add `--local` to remove a run directory under `--root`. Prompts unless `--yes` is used.
 - `neuracore training start` — currently a placeholder; use the SDK to launch training and return here to monitor.
 - `neuracore launch-server --input_embodiment_description '<JSON>' --output_embodiment_description '<JSON>' [--job_id <RUN_ID>] [--org_id <ORG_ID>] [--host <HOST>] [--port <PORT>]`  
-  - JSON must map DataType strings (e.g., `"RGB_IMAGES"`) to ordered name lists.
+  - JSON must map DataType strings (e.g., `"RGB_IMAGES"`) to indexed name mappings, with JSON string keys for the indexes (for example, `{"RGB_IMAGES": {"0": "front_cam"}}`).
 
 
 ## Troubleshooting

--- a/neuracore/core/cli/launch_server.py
+++ b/neuracore/core/cli/launch_server.py
@@ -24,7 +24,7 @@ def run(
         "--input_embodiment_description",
         help=(
             "Input embodiment description consisting of json dump of "
-            "dict mapping DataType to list of strings"
+            "dict mapping DataType to indexed name mapping"
         ),
     ),
     output_embodiment_description: str = typer.Option(
@@ -32,7 +32,7 @@ def run(
         "--output_embodiment_description",
         help=(
             "Output embodiment description consisting of json dump of "
-            "dict mapping DataType to list of strings"
+            "dict mapping DataType to indexed name mapping"
         ),
     ),
     job_id: str | None = typer.Option(None, "--job_id", help="Job ID to run"),

--- a/tests/unit/core/cli/test_cli_app.py
+++ b/tests/unit/core/cli/test_cli_app.py
@@ -85,6 +85,53 @@ def test_neuracore_launch_server_help_includes_options() -> None:
     assert result.exit_code == 0
     assert "Input embodiment description" in result.output
     assert "Output embodiment description" in result.output
+    assert "indexed name mapping" in result.output
+
+
+def test_neuracore_launch_server_accepts_documented_json(monkeypatch) -> None:
+    launched = {}
+
+    class DummyPolicy:
+        class ServerProcess:
+            def wait(self) -> None:
+                launched["waited"] = True
+
+        server_process = ServerProcess()
+
+    def fake_policy_local_server(**kwargs):
+        launched.update(kwargs)
+        return DummyPolicy()
+
+    monkeypatch.setattr("neuracore.core.cli.launch_server.nc.login", lambda: None)
+    monkeypatch.setattr(
+        "neuracore.core.cli.launch_server.nc.set_organization", lambda org_id: None
+    )
+    monkeypatch.setattr(
+        "neuracore.core.cli.launch_server.policy_local_server",
+        fake_policy_local_server,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "launch-server",
+            "--input_embodiment_description",
+            '{"RGB_IMAGES": {"0": "front_cam"}}',
+            "--output_embodiment_description",
+            '{"JOINT_TARGET_POSITIONS": {"0": "arm"}}',
+            "--job_id",
+            "run-1",
+            "--org_id",
+            "org-1",
+        ],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert launched["input_embodiment_description"]
+    assert launched["output_embodiment_description"]
+    assert launched["waited"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes the broken launch-server JSON example in the CLI docs.

Also updates the CLI help text and adds a small test so the documented JSON shape keeps working.