### PR TITLE
feat: add guarded cache clear command

### DIFF
--- a/neuracore/core/cli/app.py
+++ b/neuracore/core/cli/app.py
@@ -3,6 +3,7 @@
 import typer
 
 from neuracore import __version__
+from neuracore.core.cli.cache_commands import cache_app
 from neuracore.core.cli.generate_api_key import run as login
 from neuracore.core.cli.launch_server import run as launch_server
 from neuracore.core.cli.select_current_org import run as select_org
@@ -52,6 +53,7 @@ app.command("login")(login)
 app.command("select-org")(select_org)
 app.command("launch-server")(launch_server)
 app.add_typer(data_daemon_app, name="data-daemon")
+app.add_typer(cache_app, name="cache")
 
 if importer_app is not None:
     app.add_typer(importer_app, name="importer")

--- a/neuracore/core/cli/cache_commands.py
+++ b/neuracore/core/cli/cache_commands.py
@@ -34,6 +34,8 @@ def _directory_size(path: Path) -> int:
     total = 0
     for entry in path.rglob("*"):
         try:
+            if entry.is_symlink():
+                continue
             if entry.is_file():
                 total += entry.stat().st_size
         except OSError:

--- a/neuracore/core/cli/cache_commands.py
+++ b/neuracore/core/cli/cache_commands.py
@@ -1,0 +1,131 @@
+"""Cache management CLI commands."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import typer
+
+from neuracore.core.const import DEFAULT_CACHE_DIR, DEFAULT_RECORDING_CACHE_DIR
+
+cache_app = typer.Typer(help="Cache management utilities.")
+
+DEFAULT_DATASET_CACHE_DIR = DEFAULT_CACHE_DIR / "dataset_cache"
+
+
+def _format_bytes(num_bytes: int) -> str:
+    """Format a byte count for CLI output."""
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TiB"
+
+
+def _directory_size(path: Path) -> int:
+    """Return the total size of files under a directory."""
+    if not path.exists():
+        return 0
+
+    total = 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_file():
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _clear_directory_contents(path: Path) -> None:
+    """Remove all children from a cache directory while preserving the directory."""
+    if not path.exists():
+        return
+
+    for entry in path.iterdir():
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink(missing_ok=True)
+
+
+def _selected_cache_dirs(
+    recording_cache: bool,
+    dataset_stats: bool,
+) -> list[tuple[str, Path]]:
+    """Resolve which cache directories should be cleared."""
+    if not any([recording_cache, dataset_stats]):
+        recording_cache = True
+        dataset_stats = True
+
+    selected = []
+    if recording_cache:
+        selected.append(("recording cache", DEFAULT_RECORDING_CACHE_DIR))
+    if dataset_stats:
+        selected.append(("dataset statistics cache", DEFAULT_DATASET_CACHE_DIR))
+    return selected
+
+
+@cache_app.command("clear")
+def clear_cache(
+    recording_cache: bool = typer.Option(
+        False,
+        "--recording-cache",
+        help="Clear downloaded and decoded recording frames.",
+    ),
+    dataset_stats: bool = typer.Option(
+        False,
+        "--dataset-stats",
+        help="Clear cached synchronized dataset statistics.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Confirm cache deletion without prompting.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be cleared without deleting anything.",
+    ),
+) -> None:
+    """Clear disposable Neuracore cache files."""
+    selected = _selected_cache_dirs(recording_cache, dataset_stats)
+    existing = [(label, path) for label, path in selected if path.exists()]
+
+    if not existing:
+        typer.echo("No cache files found.")
+        return
+
+    sizes = [(label, path, _directory_size(path)) for label, path in existing]
+    total_size = sum(size for _, _, size in sizes)
+
+    typer.echo("The following disposable cache directories will be cleared:")
+    for label, path, size in sizes:
+        typer.echo(f"  - {label}: {path} ({_format_bytes(size)})")
+    typer.echo(f"Total: {_format_bytes(total_size)}")
+    typer.echo("Training runs, auth config, and daemon state will not be deleted.")
+
+    if dry_run:
+        typer.echo("Dry run: no files were deleted.")
+        return
+
+    if not yes:
+        confirmed = typer.confirm("Clear these cache files?")
+        if not confirmed:
+            typer.echo("Aborted.")
+            raise typer.Exit(code=0)
+
+    for _, path, _ in sizes:
+        try:
+            _clear_directory_contents(path)
+        except OSError as exc:
+            typer.echo(f"Failed to clear {path}: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Cleared {_format_bytes(total_size)} of cache files.")

--- a/tests/unit/core/cli/test_cli_app.py
+++ b/tests/unit/core/cli/test_cli_app.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from neuracore import __version__
 from neuracore.core.cli.app import app
+from neuracore.core.cli.cache_commands import _directory_size
 from neuracore.core.organizations import Organization
 
 runner = CliRunner()
@@ -151,6 +152,23 @@ def test_neuracore_cache_clear_dry_run_preserves_files(monkeypatch, tmp_path) ->
     assert "Dry run: no files were deleted." in result.output
     assert (recording_cache / "frame.png").exists()
     assert (dataset_cache / "stats.json").exists()
+
+
+def test_directory_size_ignores_symlink_targets(tmp_path) -> None:
+    cache_dir = tmp_path / "cache"
+    external_dir = tmp_path / "external"
+    cache_dir.mkdir()
+    external_dir.mkdir()
+    (cache_dir / "local.bin").write_bytes(b"abc")
+    external_file = external_dir / "large.bin"
+    external_file.write_bytes(b"external")
+
+    try:
+        (cache_dir / "external-link.bin").symlink_to(external_file)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert _directory_size(cache_dir) == 3
 
 
 def test_neuracore_login_help_includes_options() -> None:

--- a/tests/unit/core/cli/test_cli_app.py
+++ b/tests/unit/core/cli/test_cli_app.py
@@ -46,7 +46,111 @@ def test_neuracore_cli_help_includes_subcommands() -> None:
     assert "login" in result.output
     assert "select-org" in result.output
     assert "launch-server" in result.output
+    assert "cache" in result.output
     assert "training" in result.output
+
+
+def test_neuracore_cache_clear_requires_confirmation(monkeypatch, tmp_path) -> None:
+    recording_cache = tmp_path / "recording_cache"
+    dataset_cache = tmp_path / "dataset_cache"
+    recording_cache.mkdir()
+    dataset_cache.mkdir()
+    (recording_cache / "frame.png").write_bytes(b"abc")
+    (dataset_cache / "stats.json").write_text("{}")
+
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_RECORDING_CACHE_DIR",
+        recording_cache,
+    )
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_DATASET_CACHE_DIR",
+        dataset_cache,
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "clear"],
+        input="n\n",
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "Clear these cache files?" in result.output
+    assert "Aborted." in result.output
+    assert (recording_cache / "frame.png").exists()
+    assert (dataset_cache / "stats.json").exists()
+
+
+def test_neuracore_cache_clear_yes_deletes_only_cache_contents(
+    monkeypatch, tmp_path
+) -> None:
+    recording_cache = tmp_path / "recording_cache"
+    dataset_cache = tmp_path / "dataset_cache"
+    training_runs = tmp_path / "runs"
+    recording_cache.mkdir()
+    dataset_cache.mkdir()
+    training_runs.mkdir()
+    (recording_cache / "frame.png").write_bytes(b"abc")
+    (dataset_cache / "stats.json").write_text("{}")
+    (training_runs / "training_run.json").write_text("{}")
+
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_RECORDING_CACHE_DIR",
+        recording_cache,
+    )
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_DATASET_CACHE_DIR",
+        dataset_cache,
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "clear", "--yes"],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "Training runs, auth config, and daemon state will not be deleted." in (
+        result.output
+    )
+    assert "Cleared" in result.output
+    assert recording_cache.exists()
+    assert dataset_cache.exists()
+    assert not (recording_cache / "frame.png").exists()
+    assert not (dataset_cache / "stats.json").exists()
+    assert (training_runs / "training_run.json").exists()
+
+
+def test_neuracore_cache_clear_dry_run_preserves_files(monkeypatch, tmp_path) -> None:
+    recording_cache = tmp_path / "recording_cache"
+    dataset_cache = tmp_path / "dataset_cache"
+    recording_cache.mkdir()
+    dataset_cache.mkdir()
+    (recording_cache / "frame.png").write_bytes(b"abc")
+    (dataset_cache / "stats.json").write_text("{}")
+
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_RECORDING_CACHE_DIR",
+        recording_cache,
+    )
+    monkeypatch.setattr(
+        "neuracore.core.cli.cache_commands.DEFAULT_DATASET_CACHE_DIR",
+        dataset_cache,
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "clear", "--dry-run"],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "Dry run: no files were deleted." in result.output
+    assert (recording_cache / "frame.png").exists()
+    assert (dataset_cache / "stats.json").exists()
 
 
 def test_neuracore_login_help_includes_options() -> None:


### PR DESCRIPTION
## Summary
- Add `neuracore cache clear` for safe local cache cleanup
- Show users exactly which disposable cache directories will be cleared before deletion
- Require confirmation unless `--yes` is passed
- Support `--dry-run` so users can preview disk cleanup without deleting files
- Keep training runs, auth config, and daemon state out of cache clearing

## User Experience
The command is built around a preview-first flow. Users see what will be deleted, how much disk space is involved, and what is explicitly protected before they confirm.

Default flow:
```bash
neuracore cache clear
```

Example prompt:
```text
The following disposable cache directories will be cleared:
  - recording cache: ~/.neuracore/training/recording_cache (3.8 GiB)
  - dataset statistics cache: ~/.neuracore/training/dataset_cache (24.0 KiB)
Total: 3.8 GiB
Training runs, auth config, and daemon state will not be deleted.
Clear these cache files? [y/N]
```

Preview-only flow:
```bash
neuracore cache clear --dry-run
```

Automation flow:
```bash
neuracore cache clear --yes
```

Scoped cleanup:
```bash
neuracore cache clear --recording-cache
neuracore cache clear --dataset-stats
```