### PR TITLE
fix: training spec resolution from data types

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -242,7 +242,9 @@ def _resolve_cross_embodiment_description(
         ValueError: If ``cross_embodiment_description_cfg`` is invalid.
     """
     # if cross_embodiment_description is provided
-    if cross_embodiment_description_cfg is not None:
+    if cross_embodiment_description_cfg is not None and len(
+        cross_embodiment_description_cfg
+    ):
         if not isinstance(cross_embodiment_description_cfg, DictConfig):
             raise ValueError(
                 f"'{field_name}' must either be None or a dictionary mapping robot "
@@ -259,7 +261,7 @@ def _resolve_cross_embodiment_description(
         for robot_id in dataset.robot_ids:
             robot_full_spec = dataset.get_full_embodiment_description(robot_id)
             cross_embodiment_description[robot_id] = {
-                data_type: list(robot_full_spec.get(data_type.value, []))
+                data_type: dict(robot_full_spec.get(data_type, {}))
                 for data_type in data_types
             }
         return cross_embodiment_description

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -36,6 +36,7 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 )
 from neuracore.ml.train import (
     _resolve_algorithm_name_and_supported_data_types,
+    _resolve_cross_embodiment_description,
     _resolve_output_dir,
     _resolve_recording_cache_dir,
     determine_optimal_batch_size,
@@ -517,6 +518,84 @@ class TestResolveRecordingCacheDir:
         custom_dir = tmp_path / "recordings"
         cfg = OmegaConf.create({"recording_cache_dir": str(custom_dir)})
         assert _resolve_recording_cache_dir(cfg) == custom_dir
+
+
+class TestResolveCrossEmbodimentDescription:
+    def test_uses_explicit_cross_embodiment_description_when_provided(self):
+        cfg = OmegaConf.create({
+            "robot-1": {
+                "JOINT_POSITIONS": {
+                    0: "joint_1",
+                },
+            },
+        })
+        dataset = Mock()
+
+        result = _resolve_cross_embodiment_description(
+            cross_embodiment_description_cfg=cfg,
+            data_types_cfg=["RGB_IMAGES"],
+            dataset=dataset,
+            field_name="input_cross_embodiment_description",
+        )
+
+        assert result == {
+            "robot-1": {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_1",
+                },
+            },
+        }
+        dataset.get_full_embodiment_description.assert_not_called()
+
+    def test_empty_cross_embodiment_description_falls_back_to_data_types(self):
+        dataset = Mock()
+        dataset.robot_ids = ["robot-1", "robot-2"]
+        dataset.get_full_embodiment_description.side_effect = [
+            {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_1",
+                    1: "joint_2",
+                },
+                DataType.RGB_IMAGES: {
+                    0: "front",
+                },
+            },
+            {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_a",
+                },
+                DataType.RGB_IMAGES: {
+                    0: "wrist",
+                },
+            },
+        ]
+
+        result = _resolve_cross_embodiment_description(
+            cross_embodiment_description_cfg=OmegaConf.create({}),
+            data_types_cfg=["JOINT_POSITIONS", "RGB_IMAGES"],
+            dataset=dataset,
+            field_name="input_cross_embodiment_description",
+        )
+
+        assert result == {
+            "robot-1": {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_1",
+                    1: "joint_2",
+                },
+                DataType.RGB_IMAGES: {
+                    0: "front",
+                },
+            },
+            "robot-2": {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_a",
+                },
+                DataType.RGB_IMAGES: {
+                    0: "wrist",
+                },
+            },
+        }
 
 
 class TestGetModelAndAlgorithmConfig:


### PR DESCRIPTION
## Summary
- Treat empty input/output cross-embodiment configs as unset so data type configs can generate specs.
- Preserve dataset indexed sensor-name mappings when generating cross-embodiment descriptions from data types.
- Add unit coverage for explicit specs and data-type fallback behavior.

## Tests
- `pytest tests/unit/ml/test_train.py`
- Commit pre-commit hooks: pyupgrade, isort, black, ruff, pydocstyle, mypy, cspell