### PR TITLE
fix: capture cloud training setup logs

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -777,16 +777,14 @@ def _main(cfg: DictConfig) -> None:
                 "Please specify only one."
             )
 
-        # TODO: make sure only the data_types or cross_embodiment_description
-        # is provided for both input and output,
-        # and that they are consistent with each other
-
         # Login before constructing cloud storage so org/auth state is available.
         nc.login()
         if cfg.org_id is not None:
             nc.set_organization(cfg.org_id)
 
         training_id = getattr(cfg, "training_id", None)
+        # If a training ID is provided,
+        # We assume it is a Cloud Training Run
         if training_id is not None:
             setup_storage_handler = TrainingStorageHandler(
                 local_dir=cfg.local_output_dir,

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -463,8 +463,6 @@ def run_training(
     device: torch.device | None = None,
 ) -> None:
     """Run the training process for a single GPU."""
-    log_streamer: CloudLogStreamer | None = None
-
     # Setup for distributed training
     if world_size > 1:
         nc.login()  # Ensure Neuracore is logged in on this process
@@ -585,16 +583,6 @@ def run_training(
             algorithm_config=algorithm_config,
         )
 
-        # Only start log streamer on rank 0 to avoid multiple processes
-        # uploading the same logs
-        # and only if this is a cloud run (training_id is not None)
-        if rank == 0 and cfg.training_id is not None:
-            log_streamer = CloudLogStreamer(
-                storage_handler=training_storage_handler,
-                output_dir=Path(cfg.local_output_dir),
-            )
-            log_streamer.start()
-
         logger.info(
             f"Created model with "
             f"{sum(p.numel() for p in model.parameters()):,} parameters"
@@ -646,8 +634,6 @@ def run_training(
             raise
 
     finally:
-        if log_streamer is not None:
-            log_streamer.close()
         # Clean up distributed process group
         if world_size > 1:
             cleanup_distributed()
@@ -759,200 +745,219 @@ def _main(cfg: DictConfig) -> None:
     """
     # Resolve the configuration
     OmegaConf.resolve(cfg)
-
-    logger.info(f"Training run directory: {cfg.local_output_dir}")
-
-    # Print configuration
-    logger.info("Training configuration:")
-    logger.info(OmegaConf.to_yaml(cfg, resolve=True))
-
-    # Validate algorithm
-    if "algorithm" in cfg and cfg.algorithm_id is not None:
-        raise ValueError(
-            "Both 'algorithm' and 'algorithm_id' are provided. "
-            "Please specify only one."
-        )
-    if "algorithm" not in cfg and cfg.algorithm_id is None:
-        raise ValueError(
-            "Neither 'algorithm' nor 'algorithm_id' is provided. " "Please specify one."
-        )
-
-    # Validate dataset specification
-    if cfg.dataset_id is None and cfg.dataset_name is None:
-        raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
-    if cfg.dataset_id is not None and cfg.dataset_name is not None:
-        raise ValueError(
-            "Both 'dataset_id' and 'dataset_name' are provided. "
-            "Please specify only one."
-        )
-
-    # TODO: make sure only the data_types or cross_embodiment_description
-    # is provided for both input and output,
-    # and that they are consistent with each other
-
-    # Login and get dataset
-    nc.login()
-    if cfg.org_id is not None:
-        nc.set_organization(cfg.org_id)
-
-    # Dataset retrieval and preparation
-    if cfg.dataset_id is not None:
-        dataset = nc.get_dataset(id=cfg.dataset_id)
-    elif cfg.dataset_name is not None:
-        dataset = nc.get_dataset(name=cfg.dataset_name)
-    else:
-        raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
-    dataset.cache_dir = _resolve_recording_cache_dir(cfg)
-    dataset.cache_dir.mkdir(parents=True, exist_ok=True)
-
-    # Convert data_types to the final cross_embodiment_description
-    input_cross_embodiment_description = _resolve_cross_embodiment_description(
-        cross_embodiment_description_cfg=cfg.input_cross_embodiment_description,
-        data_types_cfg=cfg.input_data_types,
-        dataset=dataset,
-        field_name="input_cross_embodiment_description",
-    )
-    output_cross_embodiment_description = _resolve_cross_embodiment_description(
-        cross_embodiment_description_cfg=cfg.output_cross_embodiment_description,
-        data_types_cfg=cfg.output_data_types,
-        dataset=dataset,
-        field_name="output_cross_embodiment_description",
-    )
-
-    input_cross_embodiment_description = (
-        convert_cross_embodiment_description_names_to_ids(
-            input_cross_embodiment_description
-        )
-    )
-    output_cross_embodiment_description = (
-        convert_cross_embodiment_description_names_to_ids(
-            output_cross_embodiment_description
-        )
-    )
-
-    # =========================================================
-    # From here onwards we only deal with robot IDs, not names
-    # =========================================================
-
-    batch_size = cfg.batch_size
-
-    # Get algorithm JSONs parameters
-    algorithms_jsons = _get_algorithms()
-    algorithm_name, supported_input_data_types, supported_output_data_types = (
-        _resolve_algorithm_name_and_supported_data_types(cfg, algorithms_jsons)
-    )
-
-    # Validate that the provided parameters are consistent and sufficient
-    validate_training_params(
-        dataset,
-        dataset_name=cfg.dataset_name if cfg.dataset_name is not None else "",
-        algorithm_name=algorithm_name,
-        input_cross_embodiment_description=input_cross_embodiment_description,
-        output_cross_embodiment_description=output_cross_embodiment_description,
-        supported_input_data_types=supported_input_data_types,
-        supported_output_data_types=supported_output_data_types,
-    )
-
-    # Prepare data types for synchronization
-    cross_embodiment_union: CrossEmbodimentUnion = merge_cross_embodiment_description(
-        input_cross_embodiment_description, output_cross_embodiment_description
-    )
-
-    # Save local metadata so CLI can inspect local runs without cloud access
-    _save_local_training_metadata(
-        cfg=cfg,
-        algorithm_name=algorithm_name,
-        input_cross_embodiment_description=input_cross_embodiment_description,
-        output_cross_embodiment_description=output_cross_embodiment_description,
-        cross_embodiment_union=cross_embodiment_union,
-    )
-
-    synchronized_dataset = dataset.synchronize(
-        frequency=cfg.frequency,
-        cross_embodiment_union=cross_embodiment_union,
-        prefetch_videos=True,
-        max_prefetch_workers=cfg.max_prefetch_workers,
-        max_delay_s=(
-            sys.float_info.max
-            if getattr(cfg, "max_delay_s", None) is None
-            else cfg.max_delay_s
-        ),
-        allow_duplicates=cfg.allow_duplicates,
-        trim_start_end=cfg.trim_start_end,
-    )
-
-    # Setup logging for main process
     setup_logging(cfg.local_output_dir)
 
-    # Check if distributed training is enabled and multiple GPUs are available
-    world_size = torch.cuda.device_count()
+    log_streamer: CloudLogStreamer | None = None
 
-    if cfg.algorithm_id is not None:
-        # Download the algorithm so that it can be processed later
-        logger.info(f"Downloading algorithm from cloud with ID: {cfg.algorithm_id}")
-        storage_handler = AlgorithmStorageHandler(algorithm_id=cfg.algorithm_id)
-        extract_dir = Path(cfg.local_output_dir) / "algorithm"
-        storage_handler.download_algorithm(extract_dir=extract_dir)
-        logger.info(f"Algorithm extracted to {extract_dir}")
+    try:
+        logger.info(f"Training run directory: {cfg.local_output_dir}")
 
-    device = None
-    if cfg.device is not None:
-        device = torch.device(cfg.device)
-    else:
-        device = get_default_device()
+        # Print configuration
+        logger.info("Training configuration:")
+        logger.info(OmegaConf.to_yaml(cfg, resolve=True))
 
-    # Create a pytorch synchronized dataset
-    # NOTE: we are creating it here, and not in training to access the first sample
-    # for batch size autotuning, if used.
-    pytorch_dataset = PytorchSynchronizedDataset(
-        synchronized_dataset=synchronized_dataset,
-        input_cross_embodiment_description=input_cross_embodiment_description,
-        output_cross_embodiment_description=output_cross_embodiment_description,
-        output_prediction_horizon=cfg.output_prediction_horizon,
-    )
+        # Validate algorithm
+        if "algorithm" in cfg and cfg.algorithm_id is not None:
+            raise ValueError(
+                "Both 'algorithm' and 'algorithm_id' are provided. "
+                "Please specify only one."
+            )
+        if "algorithm" not in cfg and cfg.algorithm_id is None:
+            raise ValueError(
+                "Neither 'algorithm' nor 'algorithm_id' is provided. "
+                "Please specify one."
+            )
 
-    # Handle batch size configuration
-    if isinstance(batch_size, str) and batch_size.lower() == "auto":
-        optimal_batch_size = determine_optimal_batch_size(
-            cfg=cfg,
-            dataset=pytorch_dataset,
-            input_cross_embodiment_description=input_cross_embodiment_description,
-            output_cross_embodiment_description=output_cross_embodiment_description,
-            device=device,
+        # Validate dataset specification
+        if cfg.dataset_id is None and cfg.dataset_name is None:
+            raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
+        if cfg.dataset_id is not None and cfg.dataset_name is not None:
+            raise ValueError(
+                "Both 'dataset_id' and 'dataset_name' are provided. "
+                "Please specify only one."
+            )
+
+        # TODO: make sure only the data_types or cross_embodiment_description
+        # is provided for both input and output,
+        # and that they are consistent with each other
+
+        # Login before constructing cloud storage so org/auth state is available.
+        nc.login()
+        if cfg.org_id is not None:
+            nc.set_organization(cfg.org_id)
+
+        training_id = getattr(cfg, "training_id", None)
+        if training_id is not None:
+            setup_storage_handler = TrainingStorageHandler(
+                local_dir=cfg.local_output_dir,
+                training_job_id=training_id,
+            )
+            log_streamer = CloudLogStreamer(
+                storage_handler=setup_storage_handler,
+                output_dir=Path(cfg.local_output_dir),
+            )
+            log_streamer.start()
+
+        # Dataset retrieval and preparation
+        if cfg.dataset_id is not None:
+            dataset = nc.get_dataset(id=cfg.dataset_id)
+        elif cfg.dataset_name is not None:
+            dataset = nc.get_dataset(name=cfg.dataset_name)
+        else:
+            raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
+        dataset.cache_dir = _resolve_recording_cache_dir(cfg)
+        dataset.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Convert data_types to the final cross_embodiment_description
+        input_cross_embodiment_description = _resolve_cross_embodiment_description(
+            cross_embodiment_description_cfg=cfg.input_cross_embodiment_description,
+            data_types_cfg=cfg.input_data_types,
+            dataset=dataset,
+            field_name="input_cross_embodiment_description",
+        )
+        output_cross_embodiment_description = _resolve_cross_embodiment_description(
+            cross_embodiment_description_cfg=cfg.output_cross_embodiment_description,
+            data_types_cfg=cfg.output_data_types,
+            dataset=dataset,
+            field_name="output_cross_embodiment_description",
         )
 
-        batch_size = optimal_batch_size
-    else:
-        batch_size = int(batch_size)
+        input_cross_embodiment_description = (
+            convert_cross_embodiment_description_names_to_ids(
+                input_cross_embodiment_description
+            )
+        )
+        output_cross_embodiment_description = (
+            convert_cross_embodiment_description_names_to_ids(
+                output_cross_embodiment_description
+            )
+        )
 
-    if world_size > 1:
-        # Use multiprocessing to launch multiple processes
-        mp.spawn(
-            run_training,
-            args=(
-                world_size,
+        # =========================================================
+        # From here onwards we only deal with robot IDs, not names
+        # =========================================================
+
+        batch_size = cfg.batch_size
+
+        # Get algorithm JSONs parameters
+        algorithms_jsons = _get_algorithms()
+        algorithm_name, supported_input_data_types, supported_output_data_types = (
+            _resolve_algorithm_name_and_supported_data_types(cfg, algorithms_jsons)
+        )
+
+        # Validate that the provided parameters are consistent and sufficient
+        validate_training_params(
+            dataset,
+            dataset_name=cfg.dataset_name if cfg.dataset_name is not None else "",
+            algorithm_name=algorithm_name,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            supported_input_data_types=supported_input_data_types,
+            supported_output_data_types=supported_output_data_types,
+        )
+
+        # Prepare data types for synchronization
+        cross_embodiment_union: CrossEmbodimentUnion = (
+            merge_cross_embodiment_description(
+                input_cross_embodiment_description, output_cross_embodiment_description
+            )
+        )
+
+        # Save local metadata so CLI can inspect local runs without cloud access
+        _save_local_training_metadata(
+            cfg,
+            algorithm_name=algorithm_name,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            cross_embodiment_union=cross_embodiment_union,
+        )
+
+        synchronized_dataset = dataset.synchronize(
+            frequency=cfg.frequency,
+            cross_embodiment_union=cross_embodiment_union,
+            prefetch_videos=True,
+            max_prefetch_workers=cfg.max_prefetch_workers,
+            max_delay_s=(
+                sys.float_info.max
+                if getattr(cfg, "max_delay_s", None) is None
+                else cfg.max_delay_s
+            ),
+            allow_duplicates=cfg.allow_duplicates,
+            trim_start_end=cfg.trim_start_end,
+        )
+
+        # Check if distributed training is enabled and multiple GPUs are available
+        world_size = torch.cuda.device_count()
+
+        if cfg.algorithm_id is not None:
+            # Download the algorithm so that it can be processed later
+            logger.info(f"Downloading algorithm from cloud with ID: {cfg.algorithm_id}")
+            storage_handler = AlgorithmStorageHandler(algorithm_id=cfg.algorithm_id)
+            extract_dir = Path(cfg.local_output_dir) / "algorithm"
+            storage_handler.download_algorithm(extract_dir=extract_dir)
+            logger.info(f"Algorithm extracted to {extract_dir}")
+
+        device = None
+        if cfg.device is not None:
+            device = torch.device(cfg.device)
+        else:
+            device = get_default_device()
+
+        # Create a pytorch synchronized dataset
+        # NOTE: we are creating it here, and not in training to access the first sample
+        # for batch size autotuning, if used.
+        pytorch_dataset = PytorchSynchronizedDataset(
+            synchronized_dataset=synchronized_dataset,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            output_prediction_horizon=cfg.output_prediction_horizon,
+        )
+
+        # Handle batch size configuration
+        if isinstance(batch_size, str) and batch_size.lower() == "auto":
+            optimal_batch_size = determine_optimal_batch_size(
+                cfg=cfg,
+                dataset=pytorch_dataset,
+                input_cross_embodiment_description=input_cross_embodiment_description,
+                output_cross_embodiment_description=output_cross_embodiment_description,
+                device=device,
+            )
+
+            batch_size = optimal_batch_size
+        else:
+            batch_size = int(batch_size)
+
+        if world_size > 1:
+            # Use multiprocessing to launch multiple processes
+            mp.spawn(
+                run_training,
+                args=(
+                    world_size,
+                    cfg,
+                    batch_size,
+                    input_cross_embodiment_description,
+                    output_cross_embodiment_description,
+                    pytorch_dataset,
+                    device,
+                ),
+                nprocs=world_size,
+                join=True,
+            )
+        else:
+            # Single GPU or CPU training
+            run_training(
+                0,
+                1,
                 cfg,
                 batch_size,
                 input_cross_embodiment_description,
                 output_cross_embodiment_description,
                 pytorch_dataset,
                 device,
-            ),
-            nprocs=world_size,
-            join=True,
-        )
-    else:
-        # Single GPU or CPU training
-        run_training(
-            0,
-            1,
-            cfg,
-            batch_size,
-            input_cross_embodiment_description,
-            output_cross_embodiment_description,
-            pytorch_dataset,
-            device,
-        )
+            )
+    finally:
+        if log_streamer is not None:
+            log_streamer.close()
 
 
 @hydra.main(version_base=None, config_path="config", config_name="config")

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -120,6 +120,14 @@ class MainTestSetup:
         self.mock_storage_handler = Mock()
         self.mock_storage_handler.download_algorithm = Mock()
         self.mock_storage_handler_class = Mock(return_value=self.mock_storage_handler)
+        self.mock_training_storage_handler = Mock()
+        self.mock_training_storage_handler_class = Mock(
+            return_value=self.mock_training_storage_handler
+        )
+        self.mock_cloud_log_streamer = Mock()
+        self.mock_cloud_log_streamer_class = Mock(
+            return_value=self.mock_cloud_log_streamer
+        )
         self.mock_get_algorithms = Mock(
             return_value=[{"id": "test-algorithm-id", "name": "test-algorithm"}]
         )
@@ -158,6 +166,14 @@ class MainTestSetup:
         self.monkeypatch.setattr(
             "neuracore.ml.train.AlgorithmStorageHandler",
             self.mock_storage_handler_class,
+        )
+        self.monkeypatch.setattr(
+            "neuracore.ml.train.TrainingStorageHandler",
+            self.mock_training_storage_handler_class,
+        )
+        self.monkeypatch.setattr(
+            "neuracore.ml.train.CloudLogStreamer",
+            self.mock_cloud_log_streamer_class,
         )
         self.monkeypatch.setattr(
             "neuracore.ml.train.convert_cross_embodiment_description_names_to_ids",
@@ -1957,6 +1973,46 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
 
         mock_setup_logging.assert_called_once_with(cfg.local_output_dir)
 
+    def test_main_sets_up_logging_before_login(self, monkeypatch, temp_output_dir):
+        cfg = OmegaConf.create({
+            "algorithm_id": "test-algorithm-id",
+            "dataset_id": "test-dataset-id",
+            "dataset_name": None,
+            "org_id": None,
+            "device": None,
+            "local_output_dir": str(temp_output_dir),
+            "batch_size": 8,
+            "input_data_types": {},
+            "output_data_types": {},
+            "input_cross_embodiment_description": INPUT_CROSS_EMBODIMENT_SPEC,
+            "output_cross_embodiment_description": OUTPUT_CROSS_EMBODIMENT_SPEC,
+            "output_prediction_horizon": 5,
+            "frequency": 30,
+            "algorithm_params": None,
+            "max_prefetch_workers": 4,
+            "max_delay_s": 0.5,
+            "allow_duplicates": True,
+            "trim_start_end": True,
+        })
+
+        setup = MainTestSetup(monkeypatch)
+        setup.setup_mocks()
+
+        call_order: list[str] = []
+
+        def record_setup_logging(*args, **kwargs):
+            call_order.append("setup_logging")
+
+        def record_login(*args, **kwargs):
+            call_order.append("login")
+
+        monkeypatch.setattr("neuracore.ml.train.setup_logging", record_setup_logging)
+        setup.mock_login.side_effect = record_login
+
+        main(cfg)
+
+        assert call_order.index("setup_logging") < call_order.index("login")
+
     def test_main_saves_local_metadata_for_local_runs(
         self, monkeypatch, temp_output_dir
     ):
@@ -2254,6 +2310,40 @@ class TestMainErrorReporting:
         mock_report.assert_called_once()
         _, reported_error_msg = mock_report.call_args[0]
         assert "dataset not found" in reported_error_msg
+        setup.mock_cloud_log_streamer.start.assert_called_once()
+        setup.mock_cloud_log_streamer.close.assert_called_once()
+
+    def test_cloud_log_streamer_starts_before_dataset_loading(
+        self, monkeypatch, temp_output_dir
+    ):
+        cfg = self._cloud_cfg(temp_output_dir, training_id="cloud-job-id")
+        setup = MainTestSetup(monkeypatch)
+        setup.setup_mocks()
+
+        call_order: list[str] = []
+
+        def record_streamer_start():
+            call_order.append("streamer_start")
+
+        def record_get_dataset(*args, **kwargs):
+            call_order.append("get_dataset")
+            return setup.mock_dataset
+
+        setup.mock_cloud_log_streamer.start.side_effect = record_streamer_start
+        setup.mock_get_dataset.side_effect = record_get_dataset
+
+        main(cfg)
+
+        setup.mock_training_storage_handler_class.assert_called_once_with(
+            local_dir=cfg.local_output_dir,
+            training_job_id="cloud-job-id",
+        )
+        setup.mock_cloud_log_streamer_class.assert_called_once_with(
+            storage_handler=setup.mock_training_storage_handler,
+            output_dir=Path(cfg.local_output_dir),
+        )
+        assert call_order.index("streamer_start") < call_order.index("get_dataset")
+        setup.mock_cloud_log_streamer.close.assert_called_once()
 
     def test_reported_error_message_contains_full_traceback(
         self, monkeypatch, temp_output_dir


### PR DESCRIPTION
## Summary
- Configure training file logging immediately after Hydra config resolution so setup logs such as the run directory and resolved config are written to `train.log`.
- Move `CloudLogStreamer` ownership to `_main()` so cloud runs start uploading logs before dataset loading, validation, synchronization, and other pre-training setup work.
- Keep `run_training()` focused on training execution and metric logging, avoiding a second later log streamer.
- Add regression tests for logging-before-login, cloud log streaming before dataset loading, and streamer cleanup after pre-training failures.
