### PR TITLE
fix: align production integration tests with release tags

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
@@ -9,18 +9,71 @@ jobs:
   discover-algorithms:
     runs-on: ubuntu-latest
     outputs:
-      algorithms: ${{ steps.list.outputs.algorithms }}
+      latest_release_tag: ${{ steps.release-tag.outputs.latest_release_tag }}
+      matrix: ${{ steps.list.outputs.matrix }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Resolve latest release tag
+      id: release-tag
+      run: |
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        if [ -z "$latest_release_tag" ]; then
+          echo "::error::No release tag matching v* found"
+          exit 1
+        fi
+        echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag: $latest_release_tag"
     - name: List algorithm names
       id: list
+      env:
+        LATEST_RELEASE_TAG: ${{ steps.release-tag.outputs.latest_release_tag }}
       run: |
         pip install pyyaml -q
         python3 << 'EOF' >> $GITHUB_OUTPUT
-        import yaml, json
-        with open('tests/integration/ml/algorithm_configs.yaml') as f:
-            c = yaml.safe_load(f)
-        print('algorithms=' + json.dumps([a['name'] for a in c['algorithms']]))
+        import json
+        import os
+        import subprocess
+
+        import yaml
+
+        latest_release_tag = os.environ["LATEST_RELEASE_TAG"]
+
+        with open("tests/integration/ml/algorithm_configs.yaml") as f:
+            staging_config = yaml.safe_load(f)
+
+        production_config = yaml.safe_load(
+            subprocess.check_output(
+                [
+                    "git",
+                    "show",
+                    f"{latest_release_tag}:tests/integration/ml/algorithm_configs.yaml",
+                ],
+                text=True,
+            )
+        )
+
+        matrix = [
+            {
+                "algorithm": algorithm["name"],
+                "environment": "staging",
+                "python-version": "3.11",
+                "test-harness-ref": "main",
+            }
+            for algorithm in staging_config["algorithms"]
+        ]
+        matrix.extend(
+            {
+                "algorithm": algorithm["name"],
+                "environment": "production",
+                "python-version": "3.11",
+                "test-harness-ref": latest_release_tag,
+            }
+            for algorithm in production_config["algorithms"]
+        )
+
+        print("matrix=" + json.dumps(matrix))
         EOF
 
   evaluate:
@@ -29,9 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
-        algorithm: ${{ fromJson(needs.discover-algorithms.outputs.algorithms) }}
-        environment: [staging, production]
+        include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
     - name: Checkout code
@@ -43,10 +94,7 @@ jobs:
       if: ${{ matrix.environment == 'production' }}
       uses: actions/checkout@v4
       with:
-        ref: main
-        sparse-checkout: |
-          tests/integration/ml
-          examples/common
+        ref: ${{ needs.discover-algorithms.outputs.latest_release_tag }}
     - name: Pull LFS objects
       run: git lfs pull
 
@@ -55,9 +103,9 @@ jobs:
       with:
         path: training_job_id.txt
         # No exact key match is expected; restore-keys picks the most recent run.
-        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-never-exact
+        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-never-exact
         restore-keys: |
-          training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-
+          training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-
 
     - name: Read training job ID
       run: |
@@ -69,19 +117,34 @@ jobs:
         echo "Training job ID: $(cat training_job_id.txt)"
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ matrix.environment != 'production' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ matrix.environment == 'production' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
       run: |
         python -m pip install --no-cache-dir --upgrade pip
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          pip install --no-cache-dir "neuracore[dev,ml,examples]"
-        else
-          pip install --no-cache-dir ".[dev,ml,examples]"
-        fi
+        pip install --no-cache-dir ".[dev,ml,examples]"
+
+    - name: Resolve test harness
+      run: |
+        echo "TEST_HARNESS_PATH=tests/integration/ml/test_algorithm_performance.py" >> "$GITHUB_ENV"
+        echo "Test harness environment: ${{ matrix.environment }}"
+        echo "Test harness ref: ${{ matrix.test-harness-ref }}"
+        echo "Test harness commit: $(git rev-parse HEAD)"
+        echo "Test harness path: tests/integration/ml/test_algorithm_performance.py"
+        python - << 'EOF'
+        import neuracore
+
+        print(f"Installed neuracore version: {neuracore.__version__}")
+        EOF
 
     - name: Run Evaluation
       env:
@@ -95,4 +158,4 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
-        pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate tests/integration/ml/test_algorithm_performance.py
+        pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate "$TEST_HARNESS_PATH"

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate.yaml
@@ -85,36 +85,57 @@ jobs:
         include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
-    - name: Checkout code
-      if: ${{ matrix.environment != 'production' }}
-      uses: actions/checkout@v4
-      with:
-        ref: main
-    - name: Checkout production test harness
-      if: ${{ matrix.environment == 'production' }}
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ needs.discover-algorithms.outputs.latest_release_tag }}
-    - name: Pull LFS objects
-      run: git lfs pull
-
-    - name: Restore training job ID from cache
+    - name: Restore training metadata from cache
       uses: actions/cache/restore@v4
       with:
-        path: training_job_id.txt
+        path: |
+          training_job_id.txt
+          test_harness_ref.txt
         # No exact key match is expected; restore-keys picks the most recent run.
-        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-never-exact
+        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-never-exact
         restore-keys: |
-          training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-
+          training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-
 
-    - name: Read training job ID
+    - name: Read training metadata
+      id: training-metadata
       run: |
         if [ ! -f training_job_id.txt ]; then
           echo "::error::No cached training job ID found for ${{ matrix.algorithm }}/${{ matrix.environment }}. Did the Start Training workflow succeed?"
           exit 1
         fi
-        echo "TRAINING_JOB_ID=$(cat training_job_id.txt)" >> $GITHUB_ENV
+        echo "TRAINING_JOB_ID=$(cat training_job_id.txt)" >> "$GITHUB_ENV"
+
+        if [ "${{ matrix.environment }}" = "production" ]; then
+          if [ ! -f test_harness_ref.txt ]; then
+            echo "::error::No cached test harness ref found for production ${{ matrix.algorithm }}. Did the Start Training workflow write metadata?"
+            exit 1
+          fi
+          test_harness_ref="$(cat test_harness_ref.txt)"
+        else
+          test_harness_ref="main"
+        fi
+
+        echo "TEST_HARNESS_REF=$test_harness_ref" >> "$GITHUB_ENV"
+        echo "test_harness_ref=$test_harness_ref" >> "$GITHUB_OUTPUT"
         echo "Training job ID: $(cat training_job_id.txt)"
+        echo "Test harness ref: $test_harness_ref"
+
+    - name: Checkout test harness
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.training-metadata.outputs.test_harness_ref }}
+        fetch-depth: 0
+    - name: Pull LFS objects
+      run: git lfs pull
+
+    - name: Verify production test harness ref
+      if: ${{ matrix.environment == 'production' }}
+      run: |
+        checked_out_ref="$(git describe --tags --exact-match HEAD)"
+        if [ "$checked_out_ref" != "$TEST_HARNESS_REF" ]; then
+          echo "::error::Expected production test harness ref $TEST_HARNESS_REF, got $checked_out_ref"
+          exit 1
+        fi
 
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ matrix.environment != 'production' }}
@@ -137,7 +158,7 @@ jobs:
       run: |
         echo "TEST_HARNESS_PATH=tests/integration/ml/test_algorithm_performance.py" >> "$GITHUB_ENV"
         echo "Test harness environment: ${{ matrix.environment }}"
-        echo "Test harness ref: ${{ matrix.test-harness-ref }}"
+        echo "Test harness ref: $TEST_HARNESS_REF"
         echo "Test harness commit: $(git rev-parse HEAD)"
         echo "Test harness path: tests/integration/ml/test_algorithm_performance.py"
         python - << 'EOF'

--- a/.github/workflows/integration-ml-algorithm-performance-start.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start.yaml
@@ -9,18 +9,71 @@ jobs:
   discover-algorithms:
     runs-on: ubuntu-latest
     outputs:
-      algorithms: ${{ steps.list.outputs.algorithms }}
+      latest_release_tag: ${{ steps.release-tag.outputs.latest_release_tag }}
+      matrix: ${{ steps.list.outputs.matrix }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Resolve latest release tag
+      id: release-tag
+      run: |
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        if [ -z "$latest_release_tag" ]; then
+          echo "::error::No release tag matching v* found"
+          exit 1
+        fi
+        echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag: $latest_release_tag"
     - name: List algorithm names
       id: list
+      env:
+        LATEST_RELEASE_TAG: ${{ steps.release-tag.outputs.latest_release_tag }}
       run: |
         pip install pyyaml -q
         python3 << 'EOF' >> $GITHUB_OUTPUT
-        import yaml, json
-        with open('tests/integration/ml/algorithm_configs.yaml') as f:
-            c = yaml.safe_load(f)
-        print('algorithms=' + json.dumps([a['name'] for a in c['algorithms']]))
+        import json
+        import os
+        import subprocess
+
+        import yaml
+
+        latest_release_tag = os.environ["LATEST_RELEASE_TAG"]
+
+        with open("tests/integration/ml/algorithm_configs.yaml") as f:
+            staging_config = yaml.safe_load(f)
+
+        production_config = yaml.safe_load(
+            subprocess.check_output(
+                [
+                    "git",
+                    "show",
+                    f"{latest_release_tag}:tests/integration/ml/algorithm_configs.yaml",
+                ],
+                text=True,
+            )
+        )
+
+        matrix = [
+            {
+                "algorithm": algorithm["name"],
+                "environment": "staging",
+                "python-version": "3.11",
+                "test-harness-ref": "main",
+            }
+            for algorithm in staging_config["algorithms"]
+        ]
+        matrix.extend(
+            {
+                "algorithm": algorithm["name"],
+                "environment": "production",
+                "python-version": "3.11",
+                "test-harness-ref": latest_release_tag,
+            }
+            for algorithm in production_config["algorithms"]
+        )
+
+        print("matrix=" + json.dumps(matrix))
         EOF
 
   start-training:
@@ -29,9 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
-        algorithm: ${{ fromJson(needs.discover-algorithms.outputs.algorithms) }}
-        environment: [staging, production]
+        include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
     - name: Checkout code
@@ -43,27 +94,39 @@ jobs:
       if: ${{ matrix.environment == 'production' }}
       uses: actions/checkout@v4
       with:
-        ref: main
-        sparse-checkout: |
-          tests/integration/ml
-          examples/common
+        ref: ${{ needs.discover-algorithms.outputs.latest_release_tag }}
     - name: Pull LFS objects
       run: git lfs pull
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ matrix.environment != 'production' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ matrix.environment == 'production' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
       run: |
         python -m pip install --no-cache-dir --upgrade pip
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          pip install --no-cache-dir "neuracore[dev,ml,examples]"
-        else
-          pip install --no-cache-dir ".[dev,ml,examples]"
-        fi
+        pip install --no-cache-dir ".[dev,ml,examples]"
+
+    - name: Resolve test harness
+      run: |
+        echo "TEST_HARNESS_PATH=tests/integration/ml/test_algorithm_performance.py" >> "$GITHUB_ENV"
+        echo "Test harness environment: ${{ matrix.environment }}"
+        echo "Test harness ref: ${{ matrix.test-harness-ref }}"
+        echo "Test harness commit: $(git rev-parse HEAD)"
+        echo "Test harness path: tests/integration/ml/test_algorithm_performance.py"
+        python - << 'EOF'
+        import neuracore
+
+        print(f"Installed neuracore version: {neuracore.__version__}")
+        EOF
 
     - name: Start training job
       id: start-training
@@ -72,7 +135,7 @@ jobs:
         NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
         NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
         ALGORITHM_NAME: ${{ matrix.algorithm }}
-      run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training tests/integration/ml/test_algorithm_performance.py
+      run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training "$TEST_HARNESS_PATH"
 
     - name: Write job ID to file
       run: echo "${{ steps.start-training.outputs.training_job_id }}" > training_job_id.txt
@@ -81,4 +144,4 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: training_job_id.txt
-        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ github.run_number }}
+        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-${{ github.run_number }}

--- a/.github/workflows/integration-ml-algorithm-performance-start.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start.yaml
@@ -95,8 +95,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ needs.discover-algorithms.outputs.latest_release_tag }}
+        fetch-depth: 0
     - name: Pull LFS objects
       run: git lfs pull
+
+    - name: Verify production test harness ref
+      if: ${{ matrix.environment == 'production' }}
+      run: |
+        checked_out_ref="$(git describe --tags --exact-match HEAD)"
+        expected_ref="${{ matrix.test-harness-ref }}"
+        if [ "$checked_out_ref" != "$expected_ref" ]; then
+          echo "::error::Expected production test harness ref $expected_ref, got $checked_out_ref"
+          exit 1
+        fi
 
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ matrix.environment != 'production' }}
@@ -137,11 +148,15 @@ jobs:
         ALGORITHM_NAME: ${{ matrix.algorithm }}
       run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training "$TEST_HARNESS_PATH"
 
-    - name: Write job ID to file
-      run: echo "${{ steps.start-training.outputs.training_job_id }}" > training_job_id.txt
+    - name: Write training metadata to files
+      run: |
+        echo "${{ steps.start-training.outputs.training_job_id }}" > training_job_id.txt
+        echo "${{ matrix.test-harness-ref }}" > test_harness_ref.txt
 
-    - name: Cache training job ID
+    - name: Cache training metadata
       uses: actions/cache/save@v4
       with:
-        path: training_job_id.txt
-        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ matrix.test-harness-ref }}-${{ github.run_number }}
+        path: |
+          training_job_id.txt
+          test_harness_ref.txt
+        key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ github.run_number }}

--- a/.github/workflows/integration-ml-algorithm-validation.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation.yaml
@@ -15,10 +15,37 @@ jobs:
         environment: [staging, production]
 
     steps:
-    - name: Checkout code
+    - name: Checkout repository metadata
       uses: actions/checkout@v4
       with:
-        ref: main
+        fetch-depth: 0
+
+    - name: Resolve latest release tag
+      id: release-tag
+      run: |
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        if [ -z "$latest_release_tag" ]; then
+          echo "::error::No release tag matching v* found"
+          exit 1
+        fi
+        echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag: $latest_release_tag"
+
+    - name: Checkout test harness
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}
+        fetch-depth: 0
+
+    - name: Verify production test harness ref
+      if: ${{ matrix.environment == 'production' }}
+      run: |
+        checked_out_ref="$(git describe --tags --exact-match HEAD)"
+        expected_ref="${{ steps.release-tag.outputs.latest_release_tag }}"
+        if [ "$checked_out_ref" != "$expected_ref" ]; then
+          echo "::error::Expected production test harness ref $expected_ref, got $checked_out_ref"
+          exit 1
+        fi
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -29,11 +56,19 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --no-cache-dir --upgrade pip
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          pip install --no-cache-dir "neuracore[dev]"
-        else
-          pip install --no-cache-dir ".[dev]"
-        fi
+        pip install --no-cache-dir ".[dev]"
+
+    - name: Resolve test harness
+      run: |
+        echo "Test harness environment: ${{ matrix.environment }}"
+        echo "Test harness ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}"
+        echo "Test harness commit: $(git rev-parse HEAD)"
+        echo "Test harness path: tests/integration/ml/test_algorithm_validation.py"
+        python - << 'EOF'
+        import neuracore
+
+        print(f"Installed neuracore version: {neuracore.__version__}")
+        EOF
 
     - name: Run Algorithm Validation Integration Test
       env:

--- a/.github/workflows/integration-ml-training-flow.yaml
+++ b/.github/workflows/integration-ml-training-flow.yaml
@@ -38,12 +38,39 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Checkout code
+    - name: Checkout repository metadata
       uses: actions/checkout@v4
       with:
-        ref: main
+        fetch-depth: 0
+
+    - name: Resolve latest release tag
+      id: release-tag
+      run: |
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        if [ -z "$latest_release_tag" ]; then
+          echo "::error::No release tag matching v* found"
+          exit 1
+        fi
+        echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag: $latest_release_tag"
+
+    - name: Checkout test harness
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}
+        fetch-depth: 0
     - name: Pull LFS objects
       run: git lfs pull
+
+    - name: Verify production test harness ref
+      if: ${{ matrix.environment == 'production' }}
+      run: |
+        checked_out_ref="$(git describe --tags --exact-match HEAD)"
+        expected_ref="${{ steps.release-tag.outputs.latest_release_tag }}"
+        if [ "$checked_out_ref" != "$expected_ref" ]; then
+          echo "::error::Expected production test harness ref $expected_ref, got $checked_out_ref"
+          exit 1
+        fi
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -54,11 +81,19 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --no-cache-dir --upgrade pip
-        if [ "${{ matrix.environment }}" = "production" ]; then
-          pip install --no-cache-dir "neuracore[dev,ml,examples]"
-        else
-          pip install --no-cache-dir ".[dev,ml,examples]"
-        fi
+        pip install --no-cache-dir ".[dev,ml,examples]"
+
+    - name: Resolve test harness
+      run: |
+        echo "Test harness environment: ${{ matrix.environment }}"
+        echo "Test harness ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}"
+        echo "Test harness commit: $(git rev-parse HEAD)"
+        echo "Test harness path: tests/integration/ml/test_training_flow.py"
+        python - << 'EOF'
+        import neuracore
+
+        print(f"Installed neuracore version: {neuracore.__version__}")
+        EOF
 
     - name: Run Integration Test
       env:

--- a/.github/workflows/integration-platform.yaml
+++ b/.github/workflows/integration-platform.yaml
@@ -36,8 +36,37 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Checkout code
+    - name: Checkout repository metadata
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Resolve latest release tag
+      id: release-tag
+      run: |
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        if [ -z "$latest_release_tag" ]; then
+          echo "::error::No release tag matching v* found"
+          exit 1
+        fi
+        echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag: $latest_release_tag"
+
+    - name: Checkout test harness
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}
+        fetch-depth: 0
+
+    - name: Verify production test harness ref
+      if: ${{ matrix.environment == 'production' }}
+      run: |
+        checked_out_ref="$(git describe --tags --exact-match HEAD)"
+        expected_ref="${{ steps.release-tag.outputs.latest_release_tag }}"
+        if [ "$checked_out_ref" != "$expected_ref" ]; then
+          echo "::error::Expected production test harness ref $expected_ref, got $checked_out_ref"
+          exit 1
+        fi
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -55,6 +84,27 @@ jobs:
       run: |
         python -m pip install --no-cache-dir --upgrade pip
         pip install --no-cache-dir ".[dev,ml,examples]"
+
+    - name: Resolve test harness
+      run: |
+        echo "Test harness environment: ${{ matrix.environment }}"
+        echo "Test harness ref: ${{ matrix.environment == 'production' && steps.release-tag.outputs.latest_release_tag || 'main' }}"
+        echo "Test harness commit: $(git rev-parse HEAD)"
+        echo "Test harness paths:"
+        echo "  tests/integration/platform/test_runtime_data_flow.py"
+        echo "  tests/integration/platform/test_consume_stream.py"
+        python - << 'EOF'
+        import neuracore
+
+        print(f"Installed neuracore version: {neuracore.__version__}")
+        EOF
+
+    - name: Run Recording and Playback Integration Test
+      env:
+        NEURACORE_API_URL: ${{ matrix.environment == 'staging' && 'https://staging.api.neuracore.com/api' || 'https://api.neuracore.com/api' }}
+        NEURACORE_API_KEY: ${{ matrix.environment == 'staging' && secrets.STAGING_SERVICE_API_KEY || secrets.PROD_SERVICE_API_KEY }}
+        NEURACORE_ORG_ID: ${{ matrix.environment == 'staging' && vars.STAGING_SERVICE_ORG_ID || vars.PROD_SERVICE_ORG_ID }}
+      run: pytest -o log_cli=true --log-cli-level=INFO tests/integration/platform/test_runtime_data_flow.py
 
     - name: Run Consume Stream Integration Test
       env:


### PR DESCRIPTION
### Summary

This PR updates integration workflows so production tests run from the released source of truth, while staging continues to test `main`.

### Changes

- Production integration jobs now resolve the latest `v*` release tag and check out that tag for the test harness.
- Production integration jobs now install Neuracore from the checked-out release tag with `pip install .[...]`, instead of mixing a PyPI package with tests from `main`.
- Staging integration jobs continue to check out and install from `main`.
- Production jobs now verify that the checked-out commit exactly matches the expected release tag before running tests.
- Each integration workflow logs the environment, harness ref, checkout commit, test path, and installed `neuracore.__version__` for easier debugging.
- The split ML algorithm performance workflow now caches both the training job ID and the test harness ref, so the evaluate workflow uses the exact same release tag that started the training job.