### PR TITLE
fix: preserve local server embodiment ordering

### DIFF
--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -42,6 +42,14 @@ logger = logging.getLogger(__name__)
 PREDICTION_WAIT_TIME = 0.1
 
 
+def _parse_embodiment_description(raw_description: dict) -> EmbodimentDescription:
+    """Parse an API embodiment description, restoring typed keys."""
+    return {
+        DataType(data_type): {int(index): name for index, name in indexed_names.items()}
+        for data_type, indexed_names in raw_description.items()
+    }
+
+
 class Policy:
     """Base class for all policies."""
 
@@ -208,6 +216,7 @@ class ServerPolicy(Policy):
         self,
         base_url: str,
         headers: dict[str, str] | None = None,
+        input_embodiment_description: EmbodimentDescription | None = None,
     ):
         """Initialize the server policy with connection details.
 
@@ -215,10 +224,13 @@ class ServerPolicy(Policy):
             robot: Robot instance for accessing sensor streams.
             base_url: Base URL of the server.
             headers: Optional HTTP headers for authentication.
+            input_embodiment_description: Optional input spec used to project
+                local sync points before sending them to the server.
         """
         super().__init__()
         self._base_url = base_url
         self._headers = headers or {}
+        self._input_embodiment_description = input_embodiment_description
         self._is_local = "localhost" in base_url or "127.0.0.1" in base_url
 
     def set_checkpoint(
@@ -287,6 +299,13 @@ class ServerPolicy(Policy):
 
         if sync_point is None:
             sync_point = get_latest_sync_point()
+        if self._input_embodiment_description is not None:
+            filtered_data = {
+                data_type: sync_point.data[data_type]
+                for data_type in self._input_embodiment_description.keys()
+                if data_type in sync_point.data
+            }
+            sync_point.data = filtered_data
         response = None
         try:
             response = requests.post(
@@ -361,7 +380,10 @@ class LocalServerPolicy(ServerPolicy):
             host: Host to bind to
             endpoint_id: Optional deployed endpoint ID used for cloud log uploads.
         """
-        super().__init__(f"http://{host}:{port}")
+        super().__init__(
+            f"http://{host}:{port}",
+            input_embodiment_description=input_embodiment_description,
+        )
         self.input_embodiment_description = input_embodiment_description
         self.output_embodiment_description = output_embodiment_description
         self.org_id = org_id
@@ -551,14 +573,25 @@ class LocalServerPolicy(ServerPolicy):
 class RemoteServerPolicy(ServerPolicy):
     """Policy for connecting to remote endpoints on the Neuracore platform."""
 
-    def __init__(self, base_url: str, headers: dict[str, str]):
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str],
+        input_embodiment_description: EmbodimentDescription | None = None,
+    ):
         """Initialize the remote server policy.
 
         Args:
             base_url: Base URL of the remote server.
             headers: HTTP headers for authentication.
+            input_embodiment_description: Optional input spec used to project
+                local sync points before sending them to the server.
         """
-        super().__init__(base_url, headers)
+        super().__init__(
+            base_url,
+            headers,
+            input_embodiment_description=input_embodiment_description,
+        )
 
 
 def policy(
@@ -695,10 +728,16 @@ def policy_remote_server(
                 f"Multiple active endpoints found with name {endpoint_name} "
             )
         endpoint = active_endpoints[0]
+        input_embodiment_description = None
+        if endpoint.get("input_embodiment_description"):
+            input_embodiment_description = _parse_embodiment_description(
+                endpoint["input_embodiment_description"]
+            )
 
         return RemoteServerPolicy(
             base_url=f"{API_URL}/org/{org_id}/models/endpoints/{endpoint['id']}",
             headers=auth.get_headers(),
+            input_embodiment_description=input_embodiment_description,
         )
     except requests.exceptions.ConnectionError:
         raise EndpointError(

--- a/neuracore/core/utils/server.py
+++ b/neuracore/core/utils/server.py
@@ -32,6 +32,14 @@ from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 logger = logging.getLogger(__name__)
 
 
+def _parse_embodiment_description(raw_description: str) -> EmbodimentDescription:
+    """Parse a JSON CLI embodiment description, restoring typed keys."""
+    return {
+        DataType(data_type): {int(index): name for index, name in indexed_names.items()}
+        for data_type, indexed_names in json.loads(raw_description).items()
+    }
+
+
 class CheckpointRequest(BaseModel):
     """Request model for setting checkpoints."""
 
@@ -274,14 +282,12 @@ if __name__ == "__main__":
     try:
         args = parser.parse_args()
 
-        input_embodiment_description = {
-            DataType(k): v
-            for k, v in json.loads(str(args.input_embodiment_description)).items()
-        }
-        output_embodiment_description = {
-            DataType(k): v
-            for k, v in json.loads(str(args.output_embodiment_description)).items()
-        }
+        input_embodiment_description = _parse_embodiment_description(
+            args.input_embodiment_description
+        )
+        output_embodiment_description = _parse_embodiment_description(
+            args.output_embodiment_description
+        )
         start_server(
             input_embodiment_description=input_embodiment_description,
             output_embodiment_description=output_embodiment_description,

--- a/tests/unit/core/utils/test_server.py
+++ b/tests/unit/core/utils/test_server.py
@@ -1,0 +1,26 @@
+import json
+
+from neuracore_types import DataType, JointData, SynchronizedPoint
+
+from neuracore.core.utils.server import _parse_embodiment_description
+
+
+def test_parse_embodiment_description_restores_numeric_indices():
+    joint_names = [f"joint{i}" for i in range(12)]
+    raw_description = json.dumps(
+        {DataType.JOINT_POSITIONS.value: dict(enumerate(joint_names))}
+    )
+
+    embodiment_description = _parse_embodiment_description(raw_description)
+    sync_point = SynchronizedPoint(
+        data={
+            DataType.JOINT_POSITIONS: {
+                name: JointData(value=float(index))
+                for index, name in enumerate(joint_names)
+            }
+        }
+    )
+
+    ordered = sync_point.order(embodiment_description)
+
+    assert list(ordered.data[DataType.JOINT_POSITIONS]) == joint_names

--- a/tests/unit/ml/test_endpoints.py
+++ b/tests/unit/ml/test_endpoints.py
@@ -112,6 +112,56 @@ def test_connect_endpoint(
     assert np.array_equal(pred_values, expected_values)
 
 
+def test_remote_endpoint_filters_sync_point_from_endpoint_input_description(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Remote endpoints should only receive data types declared in metadata."""
+    nc.login("test_api_key")
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json={"robot_id": "mock_robot_id", "has_urdf": True},
+        status_code=200,
+    )
+    nc.connect_robot("test_robot")
+
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/models/endpoints",
+        json=[{
+            "id": "test_endpoint_id",
+            "name": "test_endpoint",
+            "status": "active",
+            "input_embodiment_description": {
+                "JOINT_POSITIONS": {
+                    "0": "joint1",
+                    "1": "joint2",
+                    "2": "joint3",
+                }
+            },
+        }],
+        status_code=200,
+    )
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/models/endpoints/test_endpoint_id/predict",
+        json=FAKE_PREDICTED_DATA_JSON,
+        status_code=200,
+    )
+
+    endpoint = nc.policy_remote_server("test_endpoint")
+
+    nc.log_joint_positions(positions={"joint1": 0.5, "joint2": 0.5, "joint3": 0.5})
+    nc.log_rgb("top_camera", np.zeros((100, 100, 3), dtype=np.uint8))
+
+    endpoint.predict()
+
+    request_body = mock_auth_requests.request_history[-1].json()
+    assert set(request_body["data"]) == {"JOINT_POSITIONS"}
+    assert set(request_body["data"]["JOINT_POSITIONS"]) == {
+        "joint1",
+        "joint2",
+        "joint3",
+    }
+
+
 def test_connect_nonexistent_endpoint(
     temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
 ):


### PR DESCRIPTION
## Summary
- Restore integer indices when the local model server parses JSON embodiment descriptions so joint/action ordering stays numeric after subprocess launch.
- Filter local server prediction sync-point data types to the declared input embodiment, matching direct `nc.policy` behavior.
- Add a regression test covering 12 indexed joints so string sorting would fail.
