### PR TITLE
feat: check batch size is valid before training

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -339,25 +339,20 @@ def setup_logging(output_dir: str, rank: int = 0) -> None:
     """Setup logging configuration."""
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
+    stream_handler = logging.StreamHandler()
 
     if rank == 0:
         file_handler = logging.FileHandler(output_path / "train.log")
-        file_handler.setFormatter(JsonLineLogFormatter())
-        handlers: list[logging.Handler] = [file_handler]
-        logging.basicConfig(
-            level=logging.INFO,
-            handlers=handlers,
-            force=True,
-        )
     else:
         file_handler = logging.FileHandler(output_path / f"train-rank{rank}.log")
-        file_handler.setFormatter(JsonLineLogFormatter())
-        handlers = [file_handler]
-        logging.basicConfig(
-            level=logging.INFO,
-            handlers=handlers,
-            force=True,
-        )
+    file_handler.setFormatter(JsonLineLogFormatter())
+
+    handlers: list[logging.Handler] = [file_handler, stream_handler]
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=handlers,
+        force=True,
+    )
 
 
 def get_model_and_algorithm_config(
@@ -451,6 +446,9 @@ def assert_valid_batch_size(
             batch_size=batch_size,
             device=device,
         )
+    except Exception:
+        logger.error("Batch size validation failed", exc_info=True)
+        raise
     finally:
         del model
         del assert_dataset
@@ -502,19 +500,23 @@ def determine_optimal_batch_size(
         cfg, model_init_description
     )
 
-    optimal_batch_size = find_optimal_batch_size(
-        cfg=cfg,
-        model=model,
-        dataset=autotuning_dataset,
-        device=device,
-    )
-
-    # Clean up
-    del model
-    del autotuning_dataset
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-    gc.collect()
+    try:
+        optimal_batch_size = find_optimal_batch_size(
+            cfg=cfg,
+            model=model,
+            dataset=autotuning_dataset,
+            device=device,
+        )
+    except Exception:
+        logger.error("Batch size autotuning failed", exc_info=True)
+        raise
+    finally:
+        # Clean up
+        del model
+        del autotuning_dataset
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
 
     logger.info(
         f"Autotuning complete. Optimal batch size per GPU: {optimal_batch_size}"

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -48,7 +48,10 @@ from neuracore.ml.logging.cloud_log_streamer import CloudLogStreamer
 from neuracore.ml.logging.cloud_training_logger import CloudTrainingLogger
 from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 from neuracore.ml.logging.tensorboard_training_logger import TensorboardTrainingLogger
-from neuracore.ml.trainers.batch_autotuner import find_optimal_batch_size
+from neuracore.ml.trainers.batch_autotuner import (
+    find_optimal_batch_size,
+    is_valid_batch_size,
+)
 from neuracore.ml.trainers.distributed_trainer import (
     DistributedTrainer,
     cleanup_distributed,
@@ -396,6 +399,74 @@ def get_model_and_algorithm_config(
             "must be provided in the configuration"
         )
     return model, algorithm_config
+
+
+def assert_valid_batch_size(
+    batch_size: int,
+    cfg: DictConfig,
+    dataset: PytorchSynchronizedDataset,
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+    device: torch.device | None = None,
+) -> None:
+    """Assert that a user-selected batch size fits in GPU memory.
+
+    The check is skipped on CPU (or when CUDA is unavailable). The user-selected
+    batch size is trusted in that case.
+
+    Raises:
+        ValueError: If ``batch_size`` does not fit in GPU memory.
+    """
+    if not torch.cuda.is_available() or (
+        device is not None and "cuda" not in device.type
+    ):
+        logger.warning("Skipping batch size memory check: GPU not available.")
+        return
+
+    if device is None:
+        device = get_default_device()
+
+    logger.info(f"Validating batch size {batch_size} on {device}...")
+
+    # Avoid altering the original dataset
+    assert_dataset = copy.deepcopy(dataset)
+
+    dataset_statistics_by_role = assert_dataset.dataset_statistics
+    model_init_description = ModelInitDescription(
+        input_dataset_statistics=dataset_statistics_by_role["input"],
+        output_dataset_statistics=dataset_statistics_by_role["output"],
+        input_data_types=extract_data_types(input_cross_embodiment_description),
+        output_data_types=extract_data_types(output_cross_embodiment_description),
+        output_prediction_horizon=cfg.output_prediction_horizon,
+    )
+    model, _algorithm_config = get_model_and_algorithm_config(
+        cfg, model_init_description
+    )
+
+    try:
+        valid = is_valid_batch_size(
+            cfg=cfg,
+            model=model,
+            dataset=assert_dataset,
+            batch_size=batch_size,
+            device=device,
+        )
+    finally:
+        del model
+        del assert_dataset
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    if not valid:
+        raise ValueError(
+            f"Batch size {batch_size} is not valid: it does not fit in "
+            "memory for the current algorithm, dataset, and GPU type. "
+            "Try a smaller batch size, or use batch_size='auto' to automatically "
+            "find the largest batch size that fits."
+        )
+
+    logger.info(f"Batch size {batch_size} is valid.")
 
 
 def determine_optimal_batch_size(
@@ -913,6 +984,7 @@ def _main(cfg: DictConfig) -> None:
 
         # Handle batch size configuration
         if isinstance(batch_size, str) and batch_size.lower() == "auto":
+            # Find the largest batch size that fits in RAM and GPU memory
             optimal_batch_size = determine_optimal_batch_size(
                 cfg=cfg,
                 dataset=pytorch_dataset,
@@ -923,6 +995,16 @@ def _main(cfg: DictConfig) -> None:
 
             batch_size = optimal_batch_size
         else:
+            # Check if the specified batch size fits in RAM and GPU memory
+            assert_valid_batch_size(
+                batch_size=int(batch_size),
+                cfg=cfg,
+                dataset=pytorch_dataset,
+                input_cross_embodiment_description=input_cross_embodiment_description,
+                output_cross_embodiment_description=output_cross_embodiment_description,
+                device=device,
+            )
+
             batch_size = int(batch_size)
 
         if world_size > 1:

--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -144,6 +144,19 @@ class BatchSizeAutotuner:
             device=str(self.device),
         )
 
+    def is_valid_batch_size(self, batch_size: int) -> bool:
+        """Check if a specific batch size fits in GPU memory without OOM.
+
+        Args:
+            batch_size: Batch size to validate.
+
+        Returns:
+            True if the batch size fits in GPU memory, False if it causes OOM.
+        """
+        is_valid = self._test_batch_size(batch_size)
+        self._cleanup()
+        return is_valid
+
     def _test_batch_size(self, batch_size: int) -> bool:
         """Test if a specific batch size works.
 
@@ -420,4 +433,71 @@ def find_optimal_batch_size(
 
     except Exception:
         logger.error("Batch size autotuning failed", exc_info=True)
+        raise
+
+
+def is_valid_batch_size(
+    cfg: DictConfig,
+    model: NeuracoreModel,
+    dataset: PytorchSynchronizedDataset,
+    batch_size: int,
+    device: torch.device,
+) -> bool:
+    """Check whether a specific batch size fits in RAM and GPU memory."""
+    # Split dataset into train and validation sets
+    dataset_size = len(dataset)
+    train_split = 1 - cfg.validation_split
+    train_size = int(train_split * dataset_size)
+    val_size = dataset_size - train_size
+    generator = torch.Generator().manual_seed(cfg.seed)
+    train_dataset, val_dataset = random_split(
+        dataset, [train_size, val_size], generator=generator
+    )
+
+    try:
+        if batch_size > len(train_dataset):
+            logger.info(
+                "Batch size %d exceeds train dataset size %d; treating as invalid.",
+                batch_size,
+                len(train_dataset),
+            )
+            return False
+
+        model = model.to(device)
+
+        num_train_workers = min(cfg.num_train_workers, cpu_count())
+        num_val_workers = min(cfg.num_val_workers, cpu_count())
+
+        logger.info(
+            f"Validating batch_size: {batch_size}, "
+            f"num_train_workers: {num_train_workers}, "
+            f"num_val_workers: {num_val_workers}"
+        )
+
+        autotuner = BatchSizeAutotuner(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={
+                "collate_fn": dataset.collate_fn,
+                "num_workers": num_train_workers,
+                "persistent_workers": num_train_workers > 0,
+                "pin_memory": True,
+            },
+            val_dataloader_kwargs={
+                "collate_fn": dataset.collate_fn,
+                "num_workers": num_val_workers,
+                "persistent_workers": num_val_workers > 0,
+                "pin_memory": True,
+            },
+            min_batch_size=batch_size,
+            max_batch_size=batch_size,
+        )
+
+        valid = autotuner.is_valid_batch_size(batch_size)
+
+        return valid
+
+    except Exception:
+        logger.error("Batch size validation failed", exc_info=True)
         raise

--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -2,6 +2,8 @@
 
 import gc
 import logging
+import multiprocessing
+import queue as queue_module
 import time
 from typing import Any
 
@@ -17,6 +19,348 @@ from neuracore.ml.utils.device_utils import cpu_count
 from neuracore.ml.utils.memory_monitor import MemoryMonitor, OutOfMemoryError
 
 logger = logging.getLogger(__name__)
+
+
+# Helpers for validator subprocess worker.
+_WORKER_RESULT_SUCCESS = "ok"
+_WORKER_RESULT_FAILURE = "fail"
+_SUBPROCESS_TERMINATE_TIMEOUT_S = 5.0
+
+
+class BatchSizeValidator:
+    """Validator for batch size given a model and dataset.
+
+    Each test constructs train and validation dataloaders, performs a
+    brief training pass, then a short validation pass in a spawned subprocess.
+    This approach ensures that CUDA out-of-memory errors (or any fatal state the
+    CUDA allocator cannot recover from) do not affect the parent process.
+    """
+
+    def __init__(
+        self,
+        model: NeuracoreModel,
+        train_dataset: Dataset,
+        val_dataset: Dataset,
+        train_dataloader_kwargs: dict[str, Any],
+        val_dataloader_kwargs: dict[str, Any],
+        num_iterations: int = 2,
+    ):
+        """Initialize a batch-size validator for a specific model and datasets."""
+        self.device = model.device
+
+        if not torch.cuda.is_available() or "cuda" not in self.device.type:
+            raise ValueError("Batch size testing is only supported on GPUs.")
+
+        # Keep the parent-side copy on CPU to avoid unnecessary VRAM usage.
+        self.model = model.to("cpu")
+        self.train_dataset = train_dataset
+        self.val_dataset = val_dataset
+        self.train_dataloader_kwargs = train_dataloader_kwargs
+        self.val_dataloader_kwargs = val_dataloader_kwargs
+        self.num_iterations = num_iterations
+
+    def test_batch_size(self, batch_size: int) -> bool:
+        """Test if a specific batch size works.
+
+        The actual probing (dataloader construction, forward/backward, etc.) is
+        executed in a subprocess. Anything that leaves the subprocess in a bad
+        state due to memory pressure (CUDA OOM, RAM OOM, process killed by the
+        OS) is surfaced here as ``False``. Unexpected probe errors are raised to
+        the caller to avoid misclassifying logic/data bugs as batch-size issues.
+
+        Args:
+            batch_size: Batch size to test
+
+        Returns:
+            True if the batch size works, False if it causes an OOM-related
+            failure.
+        """
+        logger.info(f"Testing batch size: {batch_size}")
+
+        # Ensure the parent GPU state is clean so the child has maximum room.
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
+
+        return self._run_in_subprocess(batch_size)
+
+    def _run_in_subprocess(self, batch_size: int) -> bool:
+        """Spawn a subprocess that probes batch_size and return the result."""
+        ctx = multiprocessing.get_context("spawn")
+        result_queue: Any = ctx.Queue()
+
+        proc = ctx.Process(
+            target=_run_batch_size_test_worker,
+            args=(
+                result_queue,
+                self.model,
+                self.train_dataset,
+                self.val_dataset,
+                self.train_dataloader_kwargs,
+                self.val_dataloader_kwargs,
+                self.num_iterations,
+                batch_size,
+                str(self.device),
+            ),
+        )
+
+        try:
+            proc.start()
+            proc.join()
+
+            if proc.exitcode != 0:
+                logger.info(
+                    "Batch size %s subprocess exited with code %s; "
+                    "treating as failure.",
+                    batch_size,
+                    proc.exitcode,
+                )
+                return False
+
+            try:
+                status, payload = result_queue.get_nowait()
+            except queue_module.Empty:
+                logger.warning(
+                    "No result received from batch-size subprocess for "
+                    "batch size %s; treating as failure.",
+                    batch_size,
+                )
+                return False
+
+            if status == _WORKER_RESULT_SUCCESS:
+                success = bool(payload)
+                if success:
+                    logger.info("Batch size %s test succeeded", batch_size)
+                else:
+                    logger.info("Batch size %s test failed", batch_size)
+                return success
+
+            raise RuntimeError(
+                f"Unexpected failure while probing batch size {batch_size}: {payload}"
+            )
+        finally:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=_SUBPROCESS_TERMINATE_TIMEOUT_S)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join()
+            try:
+                result_queue.close()
+                result_queue.join_thread()
+            except Exception:
+                pass
+
+
+def _run_batch_size_test_worker(
+    result_queue: Any,
+    model: NeuracoreModel,
+    train_dataset: Dataset,
+    val_dataset: Dataset,
+    train_dataloader_kwargs: dict[str, Any],
+    val_dataloader_kwargs: dict[str, Any],
+    num_iterations: int,
+    batch_size: int,
+    device_str: str,
+) -> None:
+    """Subprocess entrypoint that probes a single batch size."""
+    logging.basicConfig(level=logging.INFO)
+    worker_logger = logging.getLogger(__name__)
+
+    try:
+        device = torch.device(device_str)
+        model = model.to(device)
+
+        success = _probe_batch_size(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs=train_dataloader_kwargs,
+            val_dataloader_kwargs=val_dataloader_kwargs,
+            num_iterations=num_iterations,
+            batch_size=batch_size,
+            device=device,
+        )
+        result_queue.put((_WORKER_RESULT_SUCCESS, success))
+    except BaseException as exc:  # noqa: BLE001 - forward anything to parent
+        worker_logger.error(
+            "Unhandled exception while probing batch size %s: %s",
+            batch_size,
+            exc,
+            exc_info=True,
+        )
+        try:
+            result_queue.put((_WORKER_RESULT_FAILURE, repr(exc)))
+        except Exception:
+            pass
+
+
+def _probe_batch_size(
+    model: NeuracoreModel,
+    train_dataset: Dataset,
+    val_dataset: Dataset,
+    train_dataloader_kwargs: dict[str, Any],
+    val_dataloader_kwargs: dict[str, Any],
+    num_iterations: int,
+    batch_size: int,
+    device: torch.device,
+) -> bool:
+    """Run the actual batch-size probe (executed inside the subprocess)."""
+    try:
+        memory_monitor = MemoryMonitor(
+            max_ram_utilization=0.8, max_gpu_utilization=0.95
+        )
+
+        train_loader = DataLoader(
+            train_dataset,
+            **{
+                **train_dataloader_kwargs,
+                "batch_size": batch_size,
+                "shuffle": False,
+                "drop_last": False,  # make sure at least one batch is loaded
+            },
+        )
+        val_loader = DataLoader(
+            val_dataset,
+            **{
+                **val_dataloader_kwargs,
+                "batch_size": batch_size,
+                "shuffle": False,
+                "drop_last": False,  # make sure at least one batch is loaded
+            },
+        )
+
+        optimizers = model.configure_optimizers()
+        torch.cuda.reset_peak_memory_stats(device)
+
+        _train_probe(
+            model, train_loader, optimizers, memory_monitor, num_iterations, device
+        )
+        with torch.no_grad():
+            _validate_probe(model, val_loader, memory_monitor, num_iterations, device)
+
+        peak_mem_bytes = torch.cuda.max_memory_allocated(device)
+        peak_memory_gb = peak_mem_bytes / (1024**3)
+        logger.info(
+            "Batch size %s succeeded (peak GPU memory: %.2f GB)",
+            batch_size,
+            peak_memory_gb,
+        )
+        return True
+
+    except (torch.cuda.OutOfMemoryError, RuntimeError) as e:
+        if (
+            isinstance(e, torch.cuda.OutOfMemoryError)
+            or "out of memory" in str(e).lower()
+        ):
+            if torch.cuda.is_available():
+                torch.cuda.synchronize(device)
+            logger.error("Batch size %s failed due to OOM error", batch_size)
+            return False
+
+        logger.error(
+            "RuntimeError while probing batch size %s: %s",
+            batch_size,
+            e,
+            exc_info=True,
+        )
+        raise
+
+    except OutOfMemoryError as e:
+        logger.error("Batch size %s failed due to RAM OOM error: %s", batch_size, e)
+        return False
+
+    except Exception as e:  # noqa: BLE001
+        logger.error(
+            "Unexpected exception while probing batch size %s: %s",
+            batch_size,
+            e,
+            exc_info=True,
+        )
+        raise
+
+    finally:
+        if torch.cuda.is_available():
+            try:
+                torch.cuda.synchronize(device)
+            except Exception:
+                pass
+            torch.cuda.empty_cache()
+        gc.collect()
+
+
+def _train_probe(
+    model: NeuracoreModel,
+    data_loader: DataLoader,
+    optimizers: list[torch.optim.Optimizer],
+    memory_monitor: MemoryMonitor,
+    num_iterations: int,
+    device: torch.device,
+) -> None:
+    """Run a short training loop for memory profiling."""
+    model.train()
+
+    for optimizer in optimizers:
+        optimizer.zero_grad()
+
+    i = 0
+    while i < num_iterations:
+        for batch in data_loader:
+            memory_monitor.check_memory(log=True)
+
+            batch = batch.to(device)
+
+            outputs: BatchedTrainingOutputs = model.training_step(batch)
+            loss = sum(outputs.losses.values()).mean()
+
+            loss.backward()
+
+            for optimizer in optimizers:
+                optimizer.step()
+
+            # Check again before freeing up gradients
+            memory_monitor.check_memory(log=True)
+
+            # Free-up GPU during validation or before next forward pass
+            for optimizer in optimizers:
+                optimizer.zero_grad()
+
+            del batch, outputs, loss
+
+            i += 1
+            if i >= num_iterations:
+                break
+
+
+def _validate_probe(
+    model: NeuracoreModel,
+    val_loader: DataLoader,
+    memory_monitor: MemoryMonitor,
+    num_iterations: int,
+    device: torch.device,
+) -> None:
+    """Run a short validation loop for memory profiling."""
+    assert len(val_loader) > 0, "Validation loader must have at least one batch"
+    model.train()  # Keep in train mode to get losses
+
+    j = 0
+    while j < num_iterations:
+        for v_batch in val_loader:
+            memory_monitor.check_memory(log=True)
+
+            v_batch = v_batch.to(device)
+
+            outputs: BatchedTrainingOutputs = model.training_step(v_batch)
+            _ = outputs  # load outputs in memory to force GPU usage
+
+            # Check again after forward pass
+            memory_monitor.check_memory(log=True)
+
+            del v_batch, outputs
+
+            j += 1
+            if j >= num_iterations:
+                break
 
 
 class BatchSizeAutotuner:
@@ -59,11 +403,12 @@ class BatchSizeAutotuner:
         self.num_iterations = num_iterations
         self.safety_factor = safety_factor
         self.device = model.device
-        self.last_peak_memory_gb: float | None = None
-        self.last_gpu_memory_gb: float | None = None
 
         if not torch.cuda.is_available() or "cuda" not in self.device.type:
             raise ValueError("Autotuning batch size is only supported on GPUs.")
+
+        if safety_factor < 0.0 or safety_factor > 1.0:
+            raise ValueError("safety_factor must be between 0.0 and 1.0")
 
         # Validate batch size ranges
         if min_batch_size > max_batch_size:
@@ -79,17 +424,21 @@ class BatchSizeAutotuner:
                 f"than min_batch_size ({min_batch_size})"
             )
 
+        self.validator = BatchSizeValidator(
+            model=self.model,
+            train_dataset=self.train_dataset,
+            val_dataset=self.val_dataset,
+            train_dataloader_kwargs=self.train_dataloader_kwargs,
+            val_dataloader_kwargs=self.val_dataloader_kwargs,
+            num_iterations=self.num_iterations,
+        )
+
     def find_optimal_batch_size(self) -> int:
         """Find the optimal batch size using binary search.
 
         Returns:
             The optimal batch size
         """
-        logger.info(
-            "Finding optimal batch size between "
-            f"{self.min_batch_size} and {self.max_batch_size}"
-        )
-
         # Initialize binary search range
         low = self.min_batch_size
         high = self.max_batch_size
@@ -105,7 +454,7 @@ class BatchSizeAutotuner:
             mid = (low + high) // 2
             search_step += 1
 
-            success = self._test_batch_size(mid)
+            success = self.validator.test_batch_size(mid)
 
             if success:
                 # This batch size works, enter the upper half of the search range
@@ -115,21 +464,18 @@ class BatchSizeAutotuner:
                 # This batch size failed, enter the lower half of the search range
                 high = mid - 1
 
-            self._cleanup()
-
         # Reduce by self.safety_factor to be safe (e.g. 0.7 for 30% reduction)
         reduced_batch_size = int(optimal_batch_size * self.safety_factor)
         msg = (
-            f"Optimal batch size found {optimal_batch_size}, "
-            f"Reducing it by {self.safety_factor * 100}% to {reduced_batch_size}"
+            f"Optimal batch size found: {optimal_batch_size}, "
+            f"Reducing by {(1 - self.safety_factor) * 100:.1f}% to {reduced_batch_size}"
         )
         logger.info(msg)
 
         # Re-test the reduced size and, if it fails, keep shrinking until it fits
         candidate = reduced_batch_size
         while candidate >= self.min_batch_size:
-            if self._test_batch_size(candidate):
-                self._cleanup()
+            if self.validator.test_batch_size(candidate):
                 return candidate
 
             logger.info(
@@ -144,226 +490,6 @@ class BatchSizeAutotuner:
             device=str(self.device),
         )
 
-    def is_valid_batch_size(self, batch_size: int) -> bool:
-        """Check if a specific batch size fits in GPU memory without OOM.
-
-        Args:
-            batch_size: Batch size to validate.
-
-        Returns:
-            True if the batch size fits in GPU memory, False if it causes OOM.
-        """
-        is_valid = self._test_batch_size(batch_size)
-        self._cleanup()
-        return is_valid
-
-    def _test_batch_size(self, batch_size: int) -> bool:
-        """Test if a specific batch size works.
-
-        Args:
-            batch_size: Batch size to test
-
-        Returns:
-            True if the batch size works, False if it causes OOM error
-        """
-        logger.info(f"Testing batch size: {batch_size}")
-
-        if not torch.cuda.is_available() or "cuda" not in self.device.type:
-            raise ValueError("Batch size testing is only supported on GPUs.")
-
-        base_state = None
-        train_loader: DataLoader | None = None
-        val_loader: DataLoader | None = None
-        try:
-            memory_monitor = MemoryMonitor(
-                max_ram_utilization=0.8, max_gpu_utilization=0.95
-            )
-
-            # Snapshot model weights for next tuning iteration
-            base_state = {
-                k: v.detach().cpu().clone() for k, v in self.model.state_dict().items()
-            }
-
-            # Create train dataloader
-            train_dataloader_kwargs = {
-                **self.train_dataloader_kwargs,
-                "batch_size": batch_size,
-                "shuffle": False,
-                "drop_last": False,  # make sure at least one batch is loaded
-            }
-            train_loader = DataLoader(self.train_dataset, **train_dataloader_kwargs)
-
-            # Create val dataloader
-            val_dataloader_kwargs = {
-                **self.val_dataloader_kwargs,
-                "batch_size": batch_size,
-                "shuffle": False,
-                "drop_last": False,  # make sure at least one batch is loaded
-            }
-            val_loader = DataLoader(self.val_dataset, **val_dataloader_kwargs)
-
-            # Fresh optimizers each trial
-            optimizers = self.model.configure_optimizers()
-
-            # Track peak memory for this test
-            torch.cuda.reset_peak_memory_stats(self.device)
-
-            # Train the model for "self.num_iterations" batches
-            self._train(
-                train_loader,
-                optimizers,
-                memory_monitor,
-            )
-
-            # Validate the model for "self.num_iterations" batches
-            with torch.no_grad():
-                self._validate(
-                    val_loader,
-                    memory_monitor,
-                )
-
-            peak_mem_bytes = torch.cuda.max_memory_allocated(self.device)
-            self.last_peak_memory_gb = peak_mem_bytes / (1024**3)
-            self.last_gpu_memory_gb = self.last_peak_memory_gb
-            msg = (
-                f"Batch size {batch_size} succeeded (peak GPU memory: "
-                f"{self.last_peak_memory_gb:.2f} GB)"
-            )
-            logger.info(msg)
-
-            return True
-
-        except (torch.cuda.OutOfMemoryError, RuntimeError) as e:
-            if (
-                isinstance(e, torch.cuda.OutOfMemoryError)
-                or "out of memory" in str(e).lower()
-            ):
-                torch.cuda.synchronize(self.device)
-                logger.info(f"Batch size {batch_size} failed due to OOM error")
-                return False
-
-            logger.error(f"_test_batch_size RuntimeError: {e}", exc_info=True)
-            return False
-
-        except OutOfMemoryError as e:
-            logger.info(f"Batch size {batch_size} failed due to RAM OOM error: {e}")
-            return False
-
-        except Exception as e:
-            logger.error(f"_test_batch_size unexpected exception: {e}", exc_info=True)
-            return False
-
-        finally:
-            # Restore model weights for next tuning iteration
-            if base_state is not None:
-                try:
-                    self.model.load_state_dict(base_state)
-                except Exception:
-                    logger.exception(
-                        "Failed to restore model weights after tuning trial."
-                    )
-            self.model.zero_grad()
-
-            # Drop references and clean CUDA allocator
-            try:
-                del optimizers
-            except Exception:
-                pass
-            try:
-                del train_loader, val_loader
-            except Exception:
-                pass
-
-            self._cleanup()
-
-    def _train(
-        self,
-        data_loader: DataLoader,
-        optimizers: list[torch.optim.Optimizer],
-        memory_monitor: MemoryMonitor,
-    ) -> None:
-        """Run a short training loop for memory profiling during autotuning.
-
-        Args:
-            data_loader: DataLoader to use for training
-            optimizers: List of optimizers to use for training
-            memory_monitor: MemoryMonitor to use for monitoring memory usage
-        """
-        self.model.train()
-
-        for optimizer in optimizers:
-            optimizer.zero_grad()
-
-        i = 0
-        while i < self.num_iterations:
-            for batch in data_loader:
-                memory_monitor.check_memory(log=True)
-
-                batch = batch.to(self.device)
-
-                # Forward pass
-                outputs: BatchedTrainingOutputs = self.model.training_step(batch)
-                loss = sum(outputs.losses.values()).mean()
-
-                # Backward pass
-                loss.backward()
-
-                for optimizer in optimizers:
-                    optimizer.step()
-
-                # Check again before freeing up gradients
-                memory_monitor.check_memory(log=True)
-
-                # Free-up GPU during validation or before next forward pass
-                for optimizer in optimizers:
-                    optimizer.zero_grad()
-
-                del batch, outputs, loss
-
-                i += 1
-                if i >= self.num_iterations:
-                    break
-
-    def _validate(
-        self,
-        val_loader: DataLoader,
-        memory_monitor: MemoryMonitor,
-    ) -> None:
-        """Run a short validation loop for memory profiling during autotuning.
-
-        Args:
-            val_loader: DataLoader to use for validation
-            memory_monitor: MemoryMonitor to use for monitoring memory usage
-        """
-        assert len(val_loader) > 0, "Validation loader must have at least one batch"
-        self.model.train()  # Keep in train mode to get losses
-
-        j = 0
-        while j < self.num_iterations:
-            for v_batch in val_loader:
-                memory_monitor.check_memory(log=True)
-
-                v_batch = v_batch.to(self.device)
-
-                outputs: BatchedTrainingOutputs = self.model.training_step(v_batch)
-                _ = outputs  # load outputs in memory to force GPU usage
-
-                # Check again after forward pass
-                memory_monitor.check_memory(log=True)
-
-                del v_batch, outputs
-
-                j += 1
-                if j >= self.num_iterations:
-                    break
-
-    def _cleanup(self) -> None:
-        """Clean up the autotuner."""
-        if torch.cuda.is_available():
-            torch.cuda.synchronize(self.device)
-            torch.cuda.empty_cache()
-        gc.collect()
-
 
 def find_optimal_batch_size(
     cfg: DictConfig,
@@ -372,68 +498,54 @@ def find_optimal_batch_size(
     device: torch.device,
 ) -> int:
     """Tune the batch size automatically via binary search."""
-    # Split dataset into train and validation sets
-    dataset_size = len(dataset)
-    train_split = 1 - cfg.validation_split
-    train_size = int(train_split * dataset_size)
-    val_size = dataset_size - train_size
-    generator = torch.Generator().manual_seed(cfg.seed)
-    train_dataset, val_dataset = random_split(
-        dataset, [train_size, val_size], generator=generator
+    train_dataset, val_dataset = _split_train_val_dataset(cfg, dataset)
+    model = model.to(device)
+
+    max_batch_size = (
+        cfg.max_batch_size if "max_batch_size" in cfg else len(train_dataset)
+    )
+    max_batch_size = min(max_batch_size, len(train_dataset))  # Clamp to train len
+    min_batch_size = cfg.min_batch_size if "min_batch_size" in cfg else 2
+
+    num_train_workers = min(cfg.num_train_workers, cpu_count())
+    num_val_workers = min(cfg.num_val_workers, cpu_count())
+
+    logger.info(
+        f"Autotuning batch size with max_batch_size: {max_batch_size}, "
+        f"min_batch_size: {min_batch_size}, "
+        f"num_train_workers: {num_train_workers}, "
+        f"num_val_workers: {num_val_workers}"
     )
 
-    try:
-        model = model.to(device)
+    start_time = time.perf_counter()
 
-        max_batch_size = (
-            cfg.max_batch_size if "max_batch_size" in cfg else len(train_dataset)
-        )
-        max_batch_size = min(max_batch_size, len(train_dataset))  # Clamp to train len
-        min_batch_size = cfg.min_batch_size if "min_batch_size" in cfg else 2
+    autotuner = BatchSizeAutotuner(
+        model=model,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        train_dataloader_kwargs={
+            "collate_fn": dataset.collate_fn,
+            "num_workers": num_train_workers,
+            "persistent_workers": num_train_workers > 0,
+            "pin_memory": True,
+        },
+        val_dataloader_kwargs={
+            "collate_fn": dataset.collate_fn,
+            "num_workers": num_val_workers,
+            "persistent_workers": num_val_workers > 0,
+            "pin_memory": True,
+        },
+        min_batch_size=min_batch_size,
+        max_batch_size=max_batch_size,
+    )
 
-        num_train_workers = min(cfg.num_train_workers, cpu_count())
-        num_val_workers = min(cfg.num_val_workers, cpu_count())
+    # Perform binary search to find the optimal batch size
+    optimal_batch_size = autotuner.find_optimal_batch_size()
 
-        logger.info(
-            f"using max_batch_size: {max_batch_size}, "
-            f"min_batch_size: {min_batch_size}, "
-            f"num_train_workers: {num_train_workers}, "
-            f"num_val_workers: {num_val_workers}"
-        )
+    elapsed_time = time.perf_counter() - start_time
+    logger.info("Autotune batch_size took %.3fs", elapsed_time)
 
-        start_time = time.perf_counter()
-
-        autotuner = BatchSizeAutotuner(
-            model=model,
-            train_dataset=train_dataset,
-            val_dataset=val_dataset,
-            train_dataloader_kwargs={
-                "collate_fn": dataset.collate_fn,
-                "num_workers": num_train_workers,
-                "persistent_workers": num_train_workers > 0,
-                "pin_memory": True,
-            },
-            val_dataloader_kwargs={
-                "collate_fn": dataset.collate_fn,
-                "num_workers": num_val_workers,
-                "persistent_workers": num_val_workers > 0,
-                "pin_memory": True,
-            },
-            min_batch_size=min_batch_size,
-            max_batch_size=max_batch_size,
-        )
-
-        # Perform binary search to find the optimal batch size
-        optimal_batch_size = autotuner.find_optimal_batch_size()
-
-        elapsed_time = time.perf_counter() - start_time
-        logger.info("Autotune batch_size took %.3fs", elapsed_time)
-
-        return optimal_batch_size
-
-    except Exception:
-        logger.error("Batch size autotuning failed", exc_info=True)
-        raise
+    return optimal_batch_size
 
 
 def is_valid_batch_size(
@@ -444,7 +556,53 @@ def is_valid_batch_size(
     device: torch.device,
 ) -> bool:
     """Check whether a specific batch size fits in RAM and GPU memory."""
-    # Split dataset into train and validation sets
+    train_dataset, val_dataset = _split_train_val_dataset(cfg, dataset)
+    model = model.to(device)
+
+    if batch_size > len(train_dataset):
+        batch_size = len(train_dataset)
+        logger.info(
+            f"Batch size {batch_size} exceeds train dataset size {len(train_dataset)}; "
+            "clamping to train dataset size"
+        )
+
+    num_train_workers = min(cfg.num_train_workers, cpu_count())
+    num_val_workers = min(cfg.num_val_workers, cpu_count())
+
+    logger.info(
+        f"Validating batch_size: {batch_size}, "
+        f"num_train_workers: {num_train_workers}, "
+        f"num_val_workers: {num_val_workers}"
+    )
+
+    validator = BatchSizeValidator(
+        model=model,
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        train_dataloader_kwargs={
+            "collate_fn": dataset.collate_fn,
+            "num_workers": num_train_workers,
+            "persistent_workers": num_train_workers > 0,
+            "pin_memory": True,
+        },
+        val_dataloader_kwargs={
+            "collate_fn": dataset.collate_fn,
+            "num_workers": num_val_workers,
+            "persistent_workers": num_val_workers > 0,
+            "pin_memory": True,
+        },
+    )
+
+    valid = validator.test_batch_size(batch_size)
+
+    return valid
+
+
+def _split_train_val_dataset(
+    cfg: DictConfig,
+    dataset: PytorchSynchronizedDataset,
+) -> tuple[Dataset, Dataset]:
+    """Split dataset into deterministic train and validation subsets."""
     dataset_size = len(dataset)
     train_split = 1 - cfg.validation_split
     train_size = int(train_split * dataset_size)
@@ -453,51 +611,4 @@ def is_valid_batch_size(
     train_dataset, val_dataset = random_split(
         dataset, [train_size, val_size], generator=generator
     )
-
-    try:
-        if batch_size > len(train_dataset):
-            logger.info(
-                "Batch size %d exceeds train dataset size %d; treating as invalid.",
-                batch_size,
-                len(train_dataset),
-            )
-            return False
-
-        model = model.to(device)
-
-        num_train_workers = min(cfg.num_train_workers, cpu_count())
-        num_val_workers = min(cfg.num_val_workers, cpu_count())
-
-        logger.info(
-            f"Validating batch_size: {batch_size}, "
-            f"num_train_workers: {num_train_workers}, "
-            f"num_val_workers: {num_val_workers}"
-        )
-
-        autotuner = BatchSizeAutotuner(
-            model=model,
-            train_dataset=train_dataset,
-            val_dataset=val_dataset,
-            train_dataloader_kwargs={
-                "collate_fn": dataset.collate_fn,
-                "num_workers": num_train_workers,
-                "persistent_workers": num_train_workers > 0,
-                "pin_memory": True,
-            },
-            val_dataloader_kwargs={
-                "collate_fn": dataset.collate_fn,
-                "num_workers": num_val_workers,
-                "persistent_workers": num_val_workers > 0,
-                "pin_memory": True,
-            },
-            min_batch_size=batch_size,
-            max_batch_size=batch_size,
-        )
-
-        valid = autotuner.is_valid_batch_size(batch_size)
-
-        return valid
-
-    except Exception:
-        logger.error("Batch size validation failed", exc_info=True)
-        raise
+    return train_dataset, val_dataset

--- a/tests/unit/ml/test_batch_autotuner.py
+++ b/tests/unit/ml/test_batch_autotuner.py
@@ -15,6 +15,7 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 from neuracore.ml.trainers.batch_autotuner import (
     BatchSizeAutotuner,
     find_optimal_batch_size,
+    is_valid_batch_size,
 )
 
 
@@ -167,3 +168,146 @@ def test_find_optimal_batch_size_passes_default_min_max_to_batch_size_autotuner(
     kwargs = mock_autotuner_cls.call_args.kwargs
     assert kwargs["min_batch_size"] == 2
     assert kwargs["max_batch_size"] == 80  # clamp to train dataset length
+
+
+def test_autotuner_is_valid_batch_size_delegates_to_test_batch_size():
+    """Instance method delegates to _test_batch_size and propagates its result."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        autotuner = BatchSizeAutotuner(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            min_batch_size=2,
+            max_batch_size=4,
+            num_iterations=2,
+        )
+
+    with (
+        patch.object(
+            BatchSizeAutotuner, "_test_batch_size", return_value=True
+        ) as mock_test,
+        patch.object(BatchSizeAutotuner, "_cleanup") as mock_cleanup,
+    ):
+        result = autotuner.is_valid_batch_size(batch_size=4)
+
+    assert result is True
+    mock_test.assert_called_once_with(4)
+    mock_cleanup.assert_called_once()
+
+
+def test_autotuner_is_valid_batch_size_returns_false_on_oom():
+    """When _test_batch_size reports OOM, is_valid_batch_size propagates False."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        autotuner = BatchSizeAutotuner(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            min_batch_size=2,
+            max_batch_size=4,
+            num_iterations=2,
+        )
+
+    with (
+        patch.object(BatchSizeAutotuner, "_test_batch_size", return_value=False),
+        patch.object(BatchSizeAutotuner, "_cleanup"),
+    ):
+        result = autotuner.is_valid_batch_size(batch_size=4)
+
+    assert result is False
+
+
+def test_module_is_valid_batch_size_returns_false_when_batch_size_exceeds_train_len():
+    """If batch_size > len(train_dataset) we must return False."""
+    cfg = OmegaConf.create({
+        "validation_split": 0.2,
+        "seed": 42,
+        "num_train_workers": 0,
+        "num_val_workers": 0,
+    })
+
+    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
+    mock_dataset.__len__ = Mock(return_value=100)  # train split -> 80
+    mock_dataset.collate_fn = lambda x: x
+
+    device = torch.device("cuda:0")
+    model = cast(NeuracoreModel, DummyModel(device=device))
+
+    def fake_random_split(dataset, lengths, generator=None):
+        return (DummyDataset(80), DummyDataset(20))
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(model, "to", return_value=model),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.random_split",
+            side_effect=fake_random_split,
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeAutotuner",
+        ) as mock_autotuner_cls,
+    ):
+        result = is_valid_batch_size(
+            cfg=cfg,
+            model=model,
+            dataset=mock_dataset,
+            batch_size=128,  # > 80 train samples
+            device=device,
+        )
+
+    assert result is False
+    mock_autotuner_cls.assert_not_called()
+
+
+def test_module_is_valid_batch_size_returns_false_when_autotuner_reports_oom():
+    """When the autotuner reports OOM the helper returns False."""
+    cfg = OmegaConf.create({
+        "validation_split": 0.2,
+        "seed": 42,
+        "num_train_workers": 0,
+        "num_val_workers": 0,
+    })
+
+    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
+    mock_dataset.__len__ = Mock(return_value=100)
+    mock_dataset.collate_fn = lambda x: x
+
+    device = torch.device("cuda:0")
+    model = cast(NeuracoreModel, DummyModel(device=device))
+
+    def fake_random_split(dataset, lengths, generator=None):
+        return (DummyDataset(80), DummyDataset(20))
+
+    mock_autotuner_instance = MagicMock()
+    mock_autotuner_instance.is_valid_batch_size.return_value = False
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(model, "to", return_value=model),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.random_split",
+            side_effect=fake_random_split,
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeAutotuner",
+            return_value=mock_autotuner_instance,
+        ),
+    ):
+        result = is_valid_batch_size(
+            cfg=cfg,
+            model=model,
+            dataset=mock_dataset,
+            batch_size=32,
+            device=device,
+        )
+
+    assert result is False

--- a/tests/unit/ml/test_batch_autotuner.py
+++ b/tests/unit/ml/test_batch_autotuner.py
@@ -1,9 +1,9 @@
 """Tests for batch size autotuner."""
 
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 import torch
 from omegaconf import OmegaConf
 from torch.utils.data import Dataset
@@ -14,6 +14,8 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 )
 from neuracore.ml.trainers.batch_autotuner import (
     BatchSizeAutotuner,
+    BatchSizeValidator,
+    _probe_batch_size,
     find_optimal_batch_size,
     is_valid_batch_size,
 )
@@ -56,44 +58,6 @@ class DummyModel(torch.nn.Module):
         return [torch.optim.SGD(self.parameters(), lr=0.1)]
 
 
-def test_autotuner_records_gpu_usage():
-    train_dataset = DummyDataset(length=16)
-    val_dataset = DummyDataset(length=16)
-    device = torch.device("cuda:0")
-
-    with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
-        autotuner = BatchSizeAutotuner(
-            model=model,
-            train_dataset=train_dataset,
-            val_dataset=val_dataset,
-            train_dataloader_kwargs={},
-            val_dataloader_kwargs={},
-            min_batch_size=2,
-            max_batch_size=4,
-            num_iterations=2,
-        )
-
-    # Patch CUDA helpers and MemoryMonitor behavior
-    with (
-        patch("torch.cuda.is_available", return_value=True),
-        patch("torch.cuda.synchronize", return_value=None),
-        patch("torch.cuda.reset_peak_memory_stats", return_value=None),
-        patch("torch.cuda.max_memory_allocated", return_value=1024**3),
-        patch("torch.cuda.memory_reserved", return_value=1024**3),  # 1 GB
-        patch(
-            "torch.cuda.get_device_properties",
-            return_value=SimpleNamespace(total_memory=2 * 1024**3),
-        ),
-        patch("neuracore.ml.utils.memory_monitor.MemoryMonitor.check_memory"),
-        patch("torch.Tensor.to", lambda self, device=None: self),
-    ):
-        success = autotuner._test_batch_size(batch_size=2)
-
-    assert success is True
-    assert autotuner.last_peak_memory_gb == 1.0
-
-
 def test_find_optimal_runs_probe_batch():
     train_dataset = DummyDataset(length=400)
     val_dataset = DummyDataset(length=100)
@@ -112,9 +76,13 @@ def test_find_optimal_runs_probe_batch():
             num_iterations=2,
         )
 
-    with patch.object(
-        BatchSizeAutotuner, "_test_batch_size", return_value=True
-    ) as mock_test:
+    with (
+        patch.object(
+            BatchSizeValidator, "test_batch_size", return_value=True
+        ) as mock_test,
+        patch("torch.cuda.reset_peak_memory_stats", return_value=None),
+        patch("torch.cuda.max_memory_allocated", return_value=1024**3),
+    ):
         autotuner.find_optimal_batch_size()
 
     # After reduction, the final validation probes int(safety_factor * optimal).
@@ -170,106 +138,312 @@ def test_find_optimal_batch_size_passes_default_min_max_to_batch_size_autotuner(
     assert kwargs["max_batch_size"] == 80  # clamp to train dataset length
 
 
-def test_autotuner_is_valid_batch_size_delegates_to_test_batch_size():
-    """Instance method delegates to _test_batch_size and propagates its result."""
+def test_batch_size_validator_test_batch_size_success():
+    """BatchSizeValidator returns True when the subprocess reports success."""
     train_dataset = DummyDataset(length=16)
     val_dataset = DummyDataset(length=16)
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
         model = cast(NeuracoreModel, DummyModel(device=device))
-        autotuner = BatchSizeAutotuner(
+        validator = BatchSizeValidator(
             model=model,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
-            min_batch_size=2,
-            max_batch_size=4,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
             num_iterations=2,
         )
 
-    with (
-        patch.object(
-            BatchSizeAutotuner, "_test_batch_size", return_value=True
-        ) as mock_test,
-        patch.object(BatchSizeAutotuner, "_cleanup") as mock_cleanup,
-    ):
-        result = autotuner.is_valid_batch_size(batch_size=4)
+    with patch.object(
+        BatchSizeValidator, "_run_in_subprocess", return_value=True
+    ) as mock_run:
+        result = validator.test_batch_size(batch_size=4)
 
     assert result is True
-    mock_test.assert_called_once_with(4)
-    mock_cleanup.assert_called_once()
+    mock_run.assert_called_once_with(4)
 
 
-def test_autotuner_is_valid_batch_size_returns_false_on_oom():
-    """When _test_batch_size reports OOM, is_valid_batch_size propagates False."""
+def test_batch_size_validator_test_batch_size_returns_false_on_subprocess_failure():
+    """BatchSizeValidator returns False when the subprocess reports failure."""
     train_dataset = DummyDataset(length=16)
     val_dataset = DummyDataset(length=16)
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
         model = cast(NeuracoreModel, DummyModel(device=device))
-        autotuner = BatchSizeAutotuner(
+        validator = BatchSizeValidator(
             model=model,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
-            min_batch_size=2,
-            max_batch_size=4,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
             num_iterations=2,
         )
 
-    with (
-        patch.object(BatchSizeAutotuner, "_test_batch_size", return_value=False),
-        patch.object(BatchSizeAutotuner, "_cleanup"),
+    with patch.object(
+        BatchSizeValidator, "_run_in_subprocess", return_value=False
+    ) as mock_run:
+        result = validator.test_batch_size(batch_size=4)
+
+    assert result is False
+    mock_run.assert_called_once_with(4)
+
+
+def test_batch_size_validator_spawns_subprocess_and_returns_worker_result():
+    """BatchSizeValidator spawns a subprocess and uses the queued result."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        validator = BatchSizeValidator(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+    fake_queue = MagicMock()
+    fake_queue.get_nowait.return_value = ("ok", True)
+
+    fake_proc = MagicMock()
+    fake_proc.exitcode = 0
+    fake_proc.is_alive.return_value = False
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue.return_value = fake_queue
+    fake_ctx.Process.return_value = fake_proc
+
+    with patch(
+        "neuracore.ml.trainers.batch_autotuner.multiprocessing.get_context",
+        return_value=fake_ctx,
+    ) as mock_get_ctx:
+        result = validator.test_batch_size(batch_size=4)
+
+    assert result is True
+    mock_get_ctx.assert_called_once_with("spawn")
+    fake_ctx.Process.assert_called_once()
+    fake_proc.start.assert_called_once()
+    fake_proc.join.assert_called()
+
+
+def test_batch_size_validator_treats_nonzero_exit_code_as_failure():
+    """A subprocess that exits abnormally is treated as a batch-size failure."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        validator = BatchSizeValidator(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+    fake_queue = MagicMock()
+    fake_proc = MagicMock()
+    fake_proc.exitcode = -9  # e.g. killed by SIGKILL (OOM killer)
+    fake_proc.is_alive.return_value = False
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue.return_value = fake_queue
+    fake_ctx.Process.return_value = fake_proc
+
+    with patch(
+        "neuracore.ml.trainers.batch_autotuner.multiprocessing.get_context",
+        return_value=fake_ctx,
     ):
-        result = autotuner.is_valid_batch_size(batch_size=4)
+        result = validator.test_batch_size(batch_size=4)
+
+    assert result is False
+    fake_queue.get_nowait.assert_not_called()
+
+
+def test_batch_size_validator_raises_on_worker_failure_result():
+    """Unexpected worker failures should propagate as RuntimeError."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        validator = BatchSizeValidator(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+    fake_queue = MagicMock()
+    fake_queue.get_nowait.return_value = ("fail", "ValueError('shape mismatch')")
+
+    fake_proc = MagicMock()
+    fake_proc.exitcode = 0
+    fake_proc.is_alive.return_value = False
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue.return_value = fake_queue
+    fake_ctx.Process.return_value = fake_proc
+
+    with patch(
+        "neuracore.ml.trainers.batch_autotuner.multiprocessing.get_context",
+        return_value=fake_ctx,
+    ):
+        with pytest.raises(
+            RuntimeError, match="Unexpected failure while probing batch size 4"
+        ):
+            validator.test_batch_size(batch_size=4)
+
+
+def test_batch_size_validator_returns_false_on_worker_oom_failure():
+    """Worker-reported OOM remains a normal batch-size failure signal."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    with patch("torch.cuda.is_available", return_value=True):
+        model = cast(NeuracoreModel, DummyModel(device=device))
+        validator = BatchSizeValidator(
+            model=model,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+    fake_queue = MagicMock()
+    fake_queue.get_nowait.return_value = ("ok", False)
+
+    fake_proc = MagicMock()
+    fake_proc.exitcode = 0
+    fake_proc.is_alive.return_value = False
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue.return_value = fake_queue
+    fake_ctx.Process.return_value = fake_proc
+
+    with patch(
+        "neuracore.ml.trainers.batch_autotuner.multiprocessing.get_context",
+        return_value=fake_ctx,
+    ):
+        result = validator.test_batch_size(batch_size=4)
 
     assert result is False
 
 
-def test_module_is_valid_batch_size_returns_false_when_batch_size_exceeds_train_len():
-    """If batch_size > len(train_dataset) we must return False."""
-    cfg = OmegaConf.create({
-        "validation_split": 0.2,
-        "seed": 42,
-        "num_train_workers": 0,
-        "num_val_workers": 0,
-    })
-
-    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
-    mock_dataset.__len__ = Mock(return_value=100)  # train split -> 80
-    mock_dataset.collate_fn = lambda x: x
-
-    device = torch.device("cuda:0")
-    model = cast(NeuracoreModel, DummyModel(device=device))
-
-    def fake_random_split(dataset, lengths, generator=None):
-        return (DummyDataset(80), DummyDataset(20))
+def test_batch_size_validator_requires_cuda_device():
+    """BatchSizeValidator rejects non-CUDA devices."""
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    model = cast(NeuracoreModel, DummyModel(device=torch.device("cpu")))
 
     with (
-        patch("torch.cuda.is_available", return_value=True),
-        patch.object(model, "to", return_value=model),
-        patch(
-            "neuracore.ml.trainers.batch_autotuner.random_split",
-            side_effect=fake_random_split,
-        ),
-        patch(
-            "neuracore.ml.trainers.batch_autotuner.BatchSizeAutotuner",
-        ) as mock_autotuner_cls,
+        patch("torch.cuda.is_available", return_value=False),
+        pytest.raises(ValueError, match="only supported on GPUs"),
     ):
-        result = is_valid_batch_size(
-            cfg=cfg,
+        BatchSizeValidator(
             model=model,
-            dataset=mock_dataset,
-            batch_size=128,  # > 80 train samples
-            device=device,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+
+def test_probe_batch_size_returns_false_on_torch_cuda_oom():
+    """CUDA OOM is treated as an expected batch-size failure."""
+    model = MagicMock()
+    model.configure_optimizers.return_value = []
+
+    with (
+        patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
+        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
+        patch("torch.cuda.reset_peak_memory_stats"),
+        patch("torch.cuda.max_memory_allocated", return_value=0),
+        patch("torch.cuda.is_available", return_value=False),
+    ):
+        mock_train_probe.side_effect = torch.cuda.OutOfMemoryError("OOM")
+        result = _probe_batch_size(
+            model=model,
+            train_dataset=DummyDataset(length=8),
+            val_dataset=DummyDataset(length=8),
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=1,
+            batch_size=4,
+            device=torch.device("cuda:0"),
         )
 
     assert result is False
-    mock_autotuner_cls.assert_not_called()
 
 
-def test_module_is_valid_batch_size_returns_false_when_autotuner_reports_oom():
-    """When the autotuner reports OOM the helper returns False."""
+def test_probe_batch_size_raises_on_non_oom_runtime_error():
+    """Runtime errors unrelated to OOM should abort probing."""
+    model = MagicMock()
+    model.configure_optimizers.return_value = []
+
+    with (
+        patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
+        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
+        patch("torch.cuda.reset_peak_memory_stats"),
+        patch("torch.cuda.is_available", return_value=False),
+    ):
+        mock_train_probe.side_effect = RuntimeError("shape mismatch in model head")
+        with pytest.raises(RuntimeError, match="shape mismatch in model head"):
+            _probe_batch_size(
+                model=model,
+                train_dataset=DummyDataset(length=8),
+                val_dataset=DummyDataset(length=8),
+                train_dataloader_kwargs={},
+                val_dataloader_kwargs={},
+                num_iterations=1,
+                batch_size=4,
+                device=torch.device("cuda:0"),
+            )
+
+
+def test_probe_batch_size_raises_on_generic_exception():
+    """Non-runtime unexpected exceptions should also abort probing."""
+    model = MagicMock()
+    model.configure_optimizers.return_value = []
+
+    with (
+        patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
+        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
+        patch("torch.cuda.reset_peak_memory_stats"),
+        patch("torch.cuda.is_available", return_value=False),
+    ):
+        mock_train_probe.side_effect = ValueError("bad data shape")
+        with pytest.raises(ValueError, match="bad data shape"):
+            _probe_batch_size(
+                model=model,
+                train_dataset=DummyDataset(length=8),
+                val_dataset=DummyDataset(length=8),
+                train_dataloader_kwargs={},
+                val_dataloader_kwargs={},
+                num_iterations=1,
+                batch_size=4,
+                device=torch.device("cuda:0"),
+            )
+
+
+def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
+    """is_valid_batch_size clamps oversized batch_size to train dataset length."""
     cfg = OmegaConf.create({
         "validation_split": 0.2,
         "seed": 42,
@@ -285,10 +459,8 @@ def test_module_is_valid_batch_size_returns_false_when_autotuner_reports_oom():
     model = cast(NeuracoreModel, DummyModel(device=device))
 
     def fake_random_split(dataset, lengths, generator=None):
+        assert lengths == [80, 20]
         return (DummyDataset(80), DummyDataset(20))
-
-    mock_autotuner_instance = MagicMock()
-    mock_autotuner_instance.is_valid_batch_size.return_value = False
 
     with (
         patch("torch.cuda.is_available", return_value=True),
@@ -298,16 +470,17 @@ def test_module_is_valid_batch_size_returns_false_when_autotuner_reports_oom():
             side_effect=fake_random_split,
         ),
         patch(
-            "neuracore.ml.trainers.batch_autotuner.BatchSizeAutotuner",
-            return_value=mock_autotuner_instance,
-        ),
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.test_batch_size",
+            return_value=True,
+        ) as mock_test_batch_size,
     ):
         result = is_valid_batch_size(
             cfg=cfg,
             model=model,
             dataset=mock_dataset,
-            batch_size=32,
+            batch_size=256,
             device=device,
         )
 
-    assert result is False
+    assert result is True
+    mock_test_batch_size.assert_called_once_with(80)

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -39,6 +39,7 @@ from neuracore.ml.train import (
     _resolve_cross_embodiment_description,
     _resolve_output_dir,
     _resolve_recording_cache_dir,
+    assert_valid_batch_size,
     determine_optimal_batch_size,
     get_model_and_algorithm_config,
     main,
@@ -161,6 +162,11 @@ class MainTestSetup:
         )
         self.monkeypatch.setattr(
             "neuracore.ml.train.run_training", self.mock_run_training
+        )
+        self.mock_assert_valid_batch_size = Mock()
+        self.monkeypatch.setattr(
+            "neuracore.ml.train.assert_valid_batch_size",
+            self.mock_assert_valid_batch_size,
         )
         self.monkeypatch.setattr("torch.cuda.device_count", self.mock_cuda_device_count)
         self.monkeypatch.setattr(
@@ -926,6 +932,208 @@ class TestDetermineOptimalBatchSize:
                 mock_cfg_batch_size.output_cross_embodiment_description,
                 device=device,
             )
+
+
+class TestAssertValidBatchSize:
+    """Tests for assert_valid_batch_size function."""
+
+    @pytest.mark.skipif(SKIP_TEST, reason="Skipping test in CI environment")
+    def test_assert_valid_batch_size_returns_none_when_check_passes(
+        self,
+        mock_cfg_batch_size,
+        mock_dataset,
+        model_init_description,
+        mock_model_class,
+        monkeypatch,
+    ):
+        mock_get_device = Mock(return_value=torch.device("cuda:0"))
+        mock_is_valid = Mock(return_value=True)
+        mock_get_model_config = Mock(
+            return_value=(mock_model_class(model_init_description), {})
+        )
+
+        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
+        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
+        )
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+
+        result = assert_valid_batch_size(
+            batch_size=8,
+            cfg=mock_cfg_batch_size,
+            dataset=mock_dataset,
+            input_cross_embodiment_description=(
+                mock_cfg_batch_size.input_cross_embodiment_description
+            ),
+            output_cross_embodiment_description=(
+                mock_cfg_batch_size.output_cross_embodiment_description
+            ),
+        )
+
+        assert result is None
+        mock_is_valid.assert_called_once()
+        kwargs = mock_is_valid.call_args.kwargs
+        assert kwargs["batch_size"] == 8
+        assert kwargs["cfg"] is mock_cfg_batch_size
+
+    @pytest.mark.skipif(SKIP_TEST, reason="Skipping test in CI environment")
+    def test_assert_valid_batch_size_raises_when_check_fails(
+        self,
+        mock_cfg_batch_size,
+        mock_dataset,
+        model_init_description,
+        mock_model_class,
+        monkeypatch,
+    ):
+        mock_get_device = Mock(return_value=torch.device("cuda:0"))
+        mock_is_valid = Mock(return_value=False)
+        mock_get_model_config = Mock(
+            return_value=(mock_model_class(model_init_description), {})
+        )
+
+        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
+        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
+        )
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+
+        with pytest.raises(ValueError, match="Batch size 64 is not valid"):
+            assert_valid_batch_size(
+                batch_size=64,
+                cfg=mock_cfg_batch_size,
+                dataset=mock_dataset,
+                input_cross_embodiment_description=(
+                    mock_cfg_batch_size.input_cross_embodiment_description
+                ),
+                output_cross_embodiment_description=(
+                    mock_cfg_batch_size.output_cross_embodiment_description
+                ),
+            )
+
+        mock_is_valid.assert_called_once()
+
+    def test_assert_valid_batch_size_skips_check_on_cpu(
+        self, mock_cfg_batch_size, mock_dataset, monkeypatch
+    ):
+        """On CPU the memory check must be skipped without raising."""
+        mock_is_valid = Mock()
+        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+
+        result = assert_valid_batch_size(
+            batch_size=8,
+            cfg=mock_cfg_batch_size,
+            dataset=mock_dataset,
+            input_cross_embodiment_description=(
+                mock_cfg_batch_size.input_cross_embodiment_description
+            ),
+            output_cross_embodiment_description=(
+                mock_cfg_batch_size.output_cross_embodiment_description
+            ),
+        )
+
+        assert result is None
+        mock_is_valid.assert_not_called()
+
+    def test_assert_valid_batch_size_skips_check_when_cpu_device_provided(
+        self, mock_cfg_batch_size, mock_dataset, monkeypatch
+    ):
+        """Explicit CPU device should also skip the memory check."""
+        mock_is_valid = Mock()
+        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+
+        result = assert_valid_batch_size(
+            batch_size=8,
+            cfg=mock_cfg_batch_size,
+            dataset=mock_dataset,
+            input_cross_embodiment_description=(
+                mock_cfg_batch_size.input_cross_embodiment_description
+            ),
+            output_cross_embodiment_description=(
+                mock_cfg_batch_size.output_cross_embodiment_description
+            ),
+            device=torch.device("cpu"),
+        )
+
+        assert result is None
+        mock_is_valid.assert_not_called()
+
+    @pytest.mark.skipif(SKIP_TEST, reason="Skipping test in CI environment")
+    def test_assert_valid_batch_size_cleans_up_on_success_and_failure(
+        self,
+        mock_cfg_batch_size,
+        mock_dataset,
+        model_init_description,
+        mock_model_class,
+        monkeypatch,
+    ):
+        """Cleanup must run both when validation succeeds and when it fails."""
+        mock_get_device = Mock(return_value=torch.device("cuda:0"))
+        mock_is_valid = Mock()
+        mock_get_model_config = Mock(
+            return_value=(mock_model_class(model_init_description), {})
+        )
+
+        cleanup_call_counts = {"gc_collect": 0, "cuda_empty_cache": 0}
+
+        original_gc_collect = gc.collect
+        original_cuda_empty_cache = torch.cuda.empty_cache
+
+        def mock_gc_collect():
+            cleanup_call_counts["gc_collect"] += 1
+            return original_gc_collect()
+
+        def mock_cuda_empty_cache():
+            cleanup_call_counts["cuda_empty_cache"] += 1
+            return original_cuda_empty_cache()
+
+        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
+        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
+        )
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        monkeypatch.setattr("gc.collect", mock_gc_collect)
+        monkeypatch.setattr("torch.cuda.empty_cache", mock_cuda_empty_cache)
+
+        # Success path: is_valid_batch_size returns True, no raise, cleanup.
+        mock_is_valid.return_value = True
+        assert_valid_batch_size(
+            batch_size=8,
+            cfg=mock_cfg_batch_size,
+            dataset=mock_dataset,
+            input_cross_embodiment_description=(
+                mock_cfg_batch_size.input_cross_embodiment_description
+            ),
+            output_cross_embodiment_description=(
+                mock_cfg_batch_size.output_cross_embodiment_description
+            ),
+        )
+
+        assert cleanup_call_counts["gc_collect"] == 1
+        assert cleanup_call_counts["cuda_empty_cache"] == 1
+
+        # Failure path: is_valid_batch_size returns False, ValueError is raised,
+        # cleanup must run a second time before the exception propagates.
+        mock_is_valid.return_value = False
+        with pytest.raises(ValueError, match="is not valid"):
+            assert_valid_batch_size(
+                batch_size=16,
+                cfg=mock_cfg_batch_size,
+                dataset=mock_dataset,
+                input_cross_embodiment_description=(
+                    mock_cfg_batch_size.input_cross_embodiment_description
+                ),
+                output_cross_embodiment_description=(
+                    mock_cfg_batch_size.output_cross_embodiment_description
+                ),
+            )
+
+        assert cleanup_call_counts["gc_collect"] == 2
+        assert cleanup_call_counts["cuda_empty_cache"] == 2
 
 
 class TestRunTraining:
@@ -1784,7 +1992,45 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
         main(cfg)
 
         setup.mock_determine_optimal_batch_size.assert_not_called()
+        setup.mock_assert_valid_batch_size.assert_called_once()
+        assert setup.mock_assert_valid_batch_size.call_args.kwargs["batch_size"] == 16
         assert setup.mock_run_training.call_args[0][3] == 16
+
+    def test_main_propagates_invalid_batch_size_error(
+        self, monkeypatch, temp_output_dir
+    ):
+        """If assert_valid_batch_size raises ValueError, _main propagates it."""
+        cfg = OmegaConf.create({
+            "algorithm_id": "test-algorithm-id",
+            "dataset_id": "test-dataset-id",
+            "dataset_name": None,
+            "org_id": None,
+            "device": None,
+            "local_output_dir": str(temp_output_dir),
+            "batch_size": 64,
+            "input_data_types": {},
+            "output_data_types": {},
+            "input_cross_embodiment_description": INPUT_CROSS_EMBODIMENT_SPEC,
+            "output_cross_embodiment_description": OUTPUT_CROSS_EMBODIMENT_SPEC,
+            "output_prediction_horizon": 5,
+            "frequency": 30,
+            "algorithm_params": None,
+            "max_prefetch_workers": 4,
+            "max_delay_s": 0.5,
+            "allow_duplicates": True,
+            "trim_start_end": True,
+        })
+
+        setup = MainTestSetup(monkeypatch)
+        setup.setup_mocks()
+        setup.mock_assert_valid_batch_size.side_effect = ValueError(
+            "Batch size 64 is not valid."
+        )
+
+        with pytest.raises(ValueError, match="Batch size 64 is not valid"):
+            main(cfg)
+
+        setup.mock_run_training.assert_not_called()
 
     def test_main_loads_algorithm_by_id_when_algorithm_not_in_cfg_but_algorithm_id_provided(  # noqa: E501
         self, monkeypatch, temp_output_dir


### PR DESCRIPTION
### Features
 - When the user selects a specific batch size, this value is now checked using the BatchAutoTuner to make sure if fits into memory (GPU and RAM), before even starting training
 - This way the user gets a well described error
 
<img width="750" height="391" alt="image" src="https://github.com/user-attachments/assets/cdc9572d-6475-4864-9481-275eaea486a6" />

 - Perform batch size validation in subprocess to prevent CUDA OOM on main training process due to left over artefacts
 - Restore logging to console on train.py

 ### Notes:
 - In the future, we can run this check before even downloading the entire dataset, to save even more time for the user before finding out that the batch size was too high. Still, we need to download at least one sample on local disk to mimic the RAM and GPU memory usage.