### PR TITLE
fix: provide recording name instead of id in error when training on uneven sensor names

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -389,12 +389,44 @@ class Dataset:
         )
         response.raise_for_status()
 
-    @staticmethod
-    def _format_failure_summary(failed_recording_ids: list[str]) -> str:
-        summary = ", ".join(failed_recording_ids[:3])
-        if len(failed_recording_ids) > 3:
-            summary += ", ..."
-        return summary
+    def _format_failure_summary(self, failed_recording_ids: list[str]) -> str:
+        id_to_name = {r.id: r.name for r in self._recordings_cache}
+        auth_headers = get_auth().get_headers()
+        for recording_id in failed_recording_ids:
+            if recording_id not in id_to_name:
+                try:
+                    response = requests.get(
+                        f"{API_URL}/org/{self.org_id}/recording/{recording_id}",
+                        headers=auth_headers,
+                    )
+                    response.raise_for_status()
+                    recording_model = RecordingModel.model_validate(response.json())
+                    id_to_name[recording_id] = recording_model.metadata.name
+                except Exception:
+                    logger.debug("Failed to fetch name for recording %s", recording_id)
+                    id_to_name[recording_id] = recording_id
+        return "".join(
+            f"\n{id_to_name[recording_id]}" for recording_id in failed_recording_ids
+        )
+
+    def _raise_sync_failure(
+        self,
+        failed_recording_ids: list[str],
+        processed: int | None = None,
+        total: int | None = None,
+    ) -> None:
+        recording_names = self._format_failure_summary(failed_recording_ids)
+        progress_line = (
+            f"\n({processed}/{total} recordings synchronized)."
+            if processed is not None and total is not None
+            else ""
+        )
+        raise DatasetError(
+            f"Synchronization failed for dataset '{self.name}'.\n\n"
+            f"Problematic recordings:\n{recording_names}\n\n"
+            "These recordings might have missing or extra sensor data or "
+            f"invalid synchronization parameters were provided.{progress_line}"
+        )
 
     def _synchronize(
         self,
@@ -453,8 +485,16 @@ class Dataset:
             headers=get_auth().get_headers(),
         )
         if response.status_code == 409:
-            detail = extract_error_detail(response)
-            raise DatasetError(detail or "Synchronization failed.")
+            detail = extract_error_detail(response) or "Synchronization failed."
+            prefix = "Synchronization failed for recording(s): "
+            if prefix in detail:
+                failed_ids = [
+                    rid.strip()
+                    for rid in detail.split(prefix, 1)[1].split(",")
+                    if rid.strip()
+                ]
+                self._raise_sync_failure(failed_ids)
+            raise DatasetError(detail)
         response.raise_for_status()
         return SynchronizationProgress.model_validate(response.json())
 
@@ -496,16 +536,12 @@ class Dataset:
             cross_embodiment_union=cross_embodiment_union,
         )
 
-        synchronization_progress = self._get_synchronization_progress(synced_dataset.id)
         total = synced_dataset.num_demonstrations
+        synchronization_progress = self._get_synchronization_progress(synced_dataset.id)
         processed = synchronization_progress.num_synchronized_demonstrations
         if synchronization_progress.has_failures:
-            failure_summary = self._format_failure_summary(
-                synchronization_progress.failed_recording_ids
-            )
-            raise DatasetError(
-                "Synchronization failed for recording(s): "
-                f"{failure_summary} ({processed}/{total} recordings synchronized)."
+            self._raise_sync_failure(
+                synchronization_progress.failed_recording_ids, processed, total
             )
         if total != processed:
             pbar = tqdm(total=total, desc="Synchronizing dataset", unit="recording")
@@ -518,13 +554,8 @@ class Dataset:
                 )
                 if synchronization_progress.has_failures:
                     pbar.close()
-                    failure_summary = self._format_failure_summary(
-                        synchronization_progress.failed_recording_ids
-                    )
-                    raise DatasetError(
-                        "Synchronization failed for recording(s): "
-                        f"{failure_summary} "
-                        f"({processed}/{total} recordings synchronized)."
+                    self._raise_sync_failure(
+                        synchronization_progress.failed_recording_ids, processed, total
                     )
 
                 new_processed = synchronization_progress.num_synchronized_demonstrations

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -15,6 +15,7 @@ from neuracore_types import (
     DataType,
     JointData,
     Recording,
+    RecordingMetadata,
     RGBCameraData,
     SynchronizationProgress,
     SynchronizedDataset,
@@ -153,25 +154,23 @@ def recordings_list():
     return [
         Recording(
             id="rec1",
-            name="recording1",
             robot_id=TEST_ROBOT_ID_1,
             instance=1,
             org_id="test-org-id",
             start_time=0.0,
             end_time=10.0,
             total_bytes=512,
-            created_at="2023-01-01T00:00:00Z",
+            metadata=RecordingMetadata(name="recording1"),
         ).model_dump(mode="json"),
         Recording(
             id="rec2",
-            name="recording2",
             robot_id=TEST_ROBOT_ID_2,
             instance=1,
             org_id="test-org-id",
             start_time=0.0,
             end_time=8.0,
             total_bytes=512,
-            created_at="2023-01-02T00:00:00Z",
+            metadata=RecordingMetadata(name="recording2"),
         ).model_dump(mode="json"),
     ]
 

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -894,7 +894,7 @@ class TestDatasetSynchronization:
                 num_synchronized_demonstrations=0,
                 has_failures=True,
                 num_failed_recordings=1,
-                failed_recording_ids=["rec-1"],
+                failed_recording_ids=["rec1"],
             )
 
         monkeypatch.setattr(
@@ -903,11 +903,95 @@ class TestDatasetSynchronization:
             failed_progress,
         )
 
-        with pytest.raises(
-            DatasetError, match="Synchronization failed for recording\\(s\\): rec-1"
-        ):
+        with pytest.raises(DatasetError, match="Problematic recordings"):
             dataset.synchronize(frequency=30)
 
+    @pytest.mark.usefixtures("mock_login")
+    def test_synchronize_error_shows_recording_name_from_cache(
+        self, mock_data_requests, dataset_dict, recordings_list, monkeypatch
+    ):
+        """Error message shows recording name when recording is in cache."""
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+
+        def failed_progress(_: str) -> SynchronizationProgress:
+            return SynchronizationProgress(
+                synchronized_dataset_id="synced_dataset_123",
+                num_synchronized_demonstrations=0,
+                has_failures=True,
+                num_failed_recordings=1,
+                failed_recording_ids=["rec1"],
+            )
+
+        monkeypatch.setattr(dataset, "_get_synchronization_progress", failed_progress)
+
+        with pytest.raises(DatasetError) as exc_info:
+            dataset.synchronize(frequency=30)
+
+        assert "recording1" in str(exc_info.value)
+
+    @pytest.mark.usefixtures("mock_login")
+    def test_synchronize_error_fetches_recording_name_on_cache_miss(
+        self,
+        mock_data_requests,
+        dataset_dict,
+        recordings_list,
+        mocked_org_id,
+        monkeypatch,
+    ):
+        """Error message fetches recording name via API when not in cache."""
+        dataset = Dataset(**dataset_dict)
+
+        mock_data_requests.get(
+            f"{API_URL}/org/{mocked_org_id}/recording/rec1",
+            json=recordings_list[0],
+            status_code=200,
+        )
+
+        def failed_progress(_: str) -> SynchronizationProgress:
+            return SynchronizationProgress(
+                synchronized_dataset_id="synced_dataset_123",
+                num_synchronized_demonstrations=0,
+                has_failures=True,
+                num_failed_recordings=1,
+                failed_recording_ids=["rec1"],
+            )
+
+        monkeypatch.setattr(dataset, "_get_synchronization_progress", failed_progress)
+
+        with pytest.raises(DatasetError) as exc_info:
+            dataset.synchronize(frequency=30)
+
+        assert "recording1" in str(exc_info.value)
+
+    @pytest.mark.usefixtures("mock_login")
+    def test_synchronize_error_falls_back_to_id_when_name_fetch_fails(
+        self, mock_data_requests, dataset_dict, mocked_org_id, monkeypatch
+    ):
+        """Error message falls back to recording ID when name API call fails."""
+        dataset = Dataset(**dataset_dict)
+
+        mock_data_requests.get(
+            f"{API_URL}/org/{mocked_org_id}/recording/unknown-rec",
+            status_code=404,
+        )
+
+        def failed_progress(_: str) -> SynchronizationProgress:
+            return SynchronizationProgress(
+                synchronized_dataset_id="synced_dataset_123",
+                num_synchronized_demonstrations=0,
+                has_failures=True,
+                num_failed_recordings=1,
+                failed_recording_ids=["unknown-rec"],
+            )
+
+        monkeypatch.setattr(dataset, "_get_synchronization_progress", failed_progress)
+
+        with pytest.raises(DatasetError) as exc_info:
+            dataset.synchronize(frequency=30)
+
+        assert "unknown-rec" in str(exc_info.value)
+
+    @pytest.mark.usefixtures("mock_login")
     def test_get_synchronization_progress_raises_dataset_error_on_409(
         self, mock_data_requests, dataset_dict, recordings_list, mocked_org_id
     ):
@@ -916,17 +1000,37 @@ class TestDatasetSynchronization:
             f"{API_URL}/org/{mocked_org_id}/synchronize/synchronization-progress/synced_dataset_123",
             json={
                 "detail": {
-                    "error": "Synchronization failed for recording(s): rec-1",
+                    "error": "Synchronization failed for recording(s): rec1",
                     "status": 409,
                 }
             },
             status_code=409,
         )
 
-        with pytest.raises(
-            DatasetError, match="Synchronization failed for recording\\(s\\): rec-1"
-        ):
+        with pytest.raises(DatasetError, match="Problematic recordings"):
             dataset._get_synchronization_progress("synced_dataset_123")
+
+    @pytest.mark.usefixtures("mock_login")
+    def test_get_synchronization_progress_409_shows_recording_name(
+        self, mock_data_requests, dataset_dict, recordings_list, mocked_org_id
+    ):
+        """409 error message resolves recording name from cache."""
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.get(
+            f"{API_URL}/org/{mocked_org_id}/synchronize/synchronization-progress/synced_dataset_123",
+            json={
+                "detail": {
+                    "error": "Synchronization failed for recording(s): rec1",
+                    "status": 409,
+                }
+            },
+            status_code=409,
+        )
+
+        with pytest.raises(DatasetError) as exc_info:
+            dataset._get_synchronization_progress("synced_dataset_123")
+
+        assert "recording1" in str(exc_info.value)
 
 
 class TestDatasetMixedOperations:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- `_format_failure_summary`: resolve recording IDs to human-readable names — check cache first, fetch via API on miss, fall back to ID on error
- `_raise_sync_failure`: centralize duplicate error-raise logic; `processed`/`total` default to `None` so 409 path doesn't pass explicit `None, None`
- 409 handler: parse failed recording IDs from error string and resolve names via `_raise_sync_failure`
- Error message now includes dataset name and lists `name (id)` per failed recording
- `synced_dataset.py`: gate `_perform_synced_data_prefetch` behind `_prefetch_videos_needed` to fix `ValueError: max_workers must be greater than 0` when `prefetch_videos=False`
- Tests: 4 new tests covering name-from-cache, name-from-API, ID-fallback, and 409 name resolution

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-420](https://neuracore.atlassian.net/browse/NCRL-420)