### PR TITLE
fix: define output ordering for all-types validation fixture

### DIFF
--- a/tests/integration/ml/fixtures/all_types_model/model.py
+++ b/tests/integration/ml/fixtures/all_types_model/model.py
@@ -20,6 +20,23 @@ class AllTypesModel(NeuracoreModel):
     training treat every input as its own prediction.
     """
 
+    CANONICAL_OUTPUT_DATA_TYPE_ORDER = (
+        DataType.JOINT_TARGET_POSITIONS,
+        DataType.JOINT_POSITIONS,
+        DataType.JOINT_VELOCITIES,
+        DataType.JOINT_TORQUES,
+        DataType.VISUAL_JOINT_POSITIONS,
+        DataType.END_EFFECTOR_POSES,
+        DataType.PARALLEL_GRIPPER_TARGET_OPEN_AMOUNTS,
+        DataType.PARALLEL_GRIPPER_OPEN_AMOUNTS,
+        DataType.RGB_IMAGES,
+        DataType.DEPTH_IMAGES,
+        DataType.POINT_CLOUDS,
+        DataType.POSES,
+        DataType.LANGUAGE,
+        DataType.CUSTOM_1D,
+    )
+
     def __init__(self, model_init_description: ModelInitDescription):
         super().__init__(model_init_description)
         # Learnable offset ensures a non-zero gradient during the backward pass

--- a/tests/integration/ml/test_algorithm_validation.py
+++ b/tests/integration/ml/test_algorithm_validation.py
@@ -36,6 +36,18 @@ EXPECTED_VALIDATION_CHECKLIST = {
 }
 
 
+def _raise_for_status_with_detail(response: requests.Response) -> None:
+    """Raise HTTP errors with the backend response body attached."""
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise requests.HTTPError(
+            f"{exc}\nResponse body: {response.text}",
+            response=response,
+            request=response.request,
+        ) from exc
+
+
 def _zip_fixture_directory(fixture_directory: Path) -> bytes:
     """Pack a directory tree into a ZIP archive and return the raw bytes.
 
@@ -78,7 +90,7 @@ def _upload_algorithm(
             "description": "AllTypesModel integration test — tests all data types",
         },
     )
-    response.raise_for_status()
+    _raise_for_status_with_detail(response)
     return response.json()
 
 
@@ -89,7 +101,7 @@ def _get_algorithm(org_id: str, algorithm_id: str) -> dict:
         f"{API_URL}/org/{org_id}/algorithms/{algorithm_id}",
         headers=auth.get_headers(),
     )
-    response.raise_for_status()
+    _raise_for_status_with_detail(response)
     return response.json()
 
 
@@ -100,7 +112,7 @@ def _delete_algorithm(org_id: str, algorithm_id: str) -> None:
         f"{API_URL}/org/{org_id}/algorithms/{algorithm_id}",
         headers=auth.get_headers(),
     )
-    response.raise_for_status()
+    _raise_for_status_with_detail(response)
 
 
 def _poll_until_validation_complete(


### PR DESCRIPTION
## Summary
This fixes the `AllTypesModel` integration fixture so validation can initialize it when the model advertises all supported output data types.
