### PR TITLE
fix: pass model factory to batch size validator subprocess instead of…

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -9,6 +9,7 @@ import re
 import sys
 import time
 import traceback
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -396,6 +397,14 @@ def get_model_and_algorithm_config(
     return model, algorithm_config
 
 
+def _create_model_for_batch_validation(
+    cfg: DictConfig, model_init_description: ModelInitDescription
+) -> NeuracoreModel:
+    """Create a model instance for batch size validation (called inside subprocess)."""
+    model, _ = get_model_and_algorithm_config(cfg, model_init_description)
+    return model
+
+
 def assert_valid_batch_size(
     batch_size: int,
     cfg: DictConfig,
@@ -434,14 +443,14 @@ def assert_valid_batch_size(
         output_data_types=extract_data_types(output_cross_embodiment_description),
         output_prediction_horizon=cfg.output_prediction_horizon,
     )
-    model, _algorithm_config = get_model_and_algorithm_config(
-        cfg, model_init_description
+    model_factory = partial(
+        _create_model_for_batch_validation, cfg, model_init_description
     )
 
     try:
         valid = is_valid_batch_size(
             cfg=cfg,
-            model=model,
+            model_factory=model_factory,
             dataset=assert_dataset,
             batch_size=batch_size,
             device=device,
@@ -450,7 +459,6 @@ def assert_valid_batch_size(
         logger.error("Batch size validation failed", exc_info=True)
         raise
     finally:
-        del model
         del assert_dataset
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
@@ -496,14 +504,14 @@ def determine_optimal_batch_size(
         output_data_types=extract_data_types(output_cross_embodiment_description),
         output_prediction_horizon=cfg.output_prediction_horizon,
     )
-    model, algorithm_config = get_model_and_algorithm_config(
-        cfg, model_init_description
+    model_factory = partial(
+        _create_model_for_batch_validation, cfg, model_init_description
     )
 
     try:
         optimal_batch_size = find_optimal_batch_size(
             cfg=cfg,
-            model=model,
+            model_factory=model_factory,
             dataset=autotuning_dataset,
             device=device,
         )
@@ -512,7 +520,6 @@ def determine_optimal_batch_size(
         raise
     finally:
         # Clean up
-        del model
         del autotuning_dataset
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 import queue as queue_module
 import time
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -38,21 +39,21 @@ class BatchSizeValidator:
 
     def __init__(
         self,
-        model: NeuracoreModel,
+        model_factory: Callable[[], NeuracoreModel],
+        device: torch.device,
         train_dataset: Dataset,
         val_dataset: Dataset,
         train_dataloader_kwargs: dict[str, Any],
         val_dataloader_kwargs: dict[str, Any],
         num_iterations: int = 2,
     ):
-        """Initialize a batch-size validator for a specific model and datasets."""
-        self.device = model.device
+        """Initialize a batch-size validator."""
+        self.device = device
 
         if not torch.cuda.is_available() or "cuda" not in self.device.type:
             raise ValueError("Batch size testing is only supported on GPUs.")
 
-        # Keep the parent-side copy on CPU to avoid unnecessary VRAM usage.
-        self.model = model.to("cpu")
+        self.model_factory = model_factory
         self.train_dataset = train_dataset
         self.val_dataset = val_dataset
         self.train_dataloader_kwargs = train_dataloader_kwargs
@@ -93,7 +94,7 @@ class BatchSizeValidator:
             target=_run_batch_size_test_worker,
             args=(
                 result_queue,
-                self.model,
+                self.model_factory,
                 self.train_dataset,
                 self.val_dataset,
                 self.train_dataloader_kwargs,
@@ -154,7 +155,7 @@ class BatchSizeValidator:
 
 def _run_batch_size_test_worker(
     result_queue: Any,
-    model: NeuracoreModel,
+    model_factory: Callable[[], NeuracoreModel],
     train_dataset: Dataset,
     val_dataset: Dataset,
     train_dataloader_kwargs: dict[str, Any],
@@ -169,7 +170,7 @@ def _run_batch_size_test_worker(
 
     try:
         device = torch.device(device_str)
-        model = model.to(device)
+        model = model_factory().to(device)
 
         success = _probe_batch_size(
             model=model,
@@ -368,7 +369,8 @@ class BatchSizeAutotuner:
 
     def __init__(
         self,
-        model: NeuracoreModel,
+        model_factory: Callable[[], NeuracoreModel],
+        device: torch.device,
         train_dataset: Dataset,
         val_dataset: Dataset,
         train_dataloader_kwargs: dict[str, Any] | None = None,
@@ -381,7 +383,8 @@ class BatchSizeAutotuner:
         """Initialize the batch size auto-tuner.
 
         Args:
-            model: Model to use for testing
+            model_factory: Callable that constructs a fresh model for testing
+            device: CUDA device to test on
             train_dataset: Dataset to use for training
             val_dataset: Dataset to use for validation
             train_dataloader_kwargs: Additional arguments for the train DataLoader
@@ -393,7 +396,6 @@ class BatchSizeAutotuner:
         """
         assert num_iterations >= 2, "At least two consecutive batches must be loaded"
 
-        self.model = model
         self.train_dataset = train_dataset
         self.train_dataloader_kwargs = train_dataloader_kwargs or {}
         self.val_dataset = val_dataset
@@ -402,7 +404,7 @@ class BatchSizeAutotuner:
         self.max_batch_size = max_batch_size
         self.num_iterations = num_iterations
         self.safety_factor = safety_factor
-        self.device = model.device
+        self.device = device
 
         if not torch.cuda.is_available() or "cuda" not in self.device.type:
             raise ValueError("Autotuning batch size is only supported on GPUs.")
@@ -425,7 +427,8 @@ class BatchSizeAutotuner:
             )
 
         self.validator = BatchSizeValidator(
-            model=self.model,
+            model_factory=model_factory,
+            device=self.device,
             train_dataset=self.train_dataset,
             val_dataset=self.val_dataset,
             train_dataloader_kwargs=self.train_dataloader_kwargs,
@@ -493,13 +496,12 @@ class BatchSizeAutotuner:
 
 def find_optimal_batch_size(
     cfg: DictConfig,
-    model: NeuracoreModel,
+    model_factory: Callable[[], NeuracoreModel],
     dataset: PytorchSynchronizedDataset,
     device: torch.device,
 ) -> int:
     """Tune the batch size automatically via binary search."""
     train_dataset, val_dataset = _split_train_val_dataset(cfg, dataset)
-    model = model.to(device)
 
     max_batch_size = (
         cfg.max_batch_size if "max_batch_size" in cfg else len(train_dataset)
@@ -520,7 +522,8 @@ def find_optimal_batch_size(
     start_time = time.perf_counter()
 
     autotuner = BatchSizeAutotuner(
-        model=model,
+        model_factory=model_factory,
+        device=device,
         train_dataset=train_dataset,
         val_dataset=val_dataset,
         train_dataloader_kwargs={
@@ -550,14 +553,13 @@ def find_optimal_batch_size(
 
 def is_valid_batch_size(
     cfg: DictConfig,
-    model: NeuracoreModel,
+    model_factory: Callable[[], NeuracoreModel],
     dataset: PytorchSynchronizedDataset,
     batch_size: int,
     device: torch.device,
 ) -> bool:
     """Check whether a specific batch size fits in RAM and GPU memory."""
     train_dataset, val_dataset = _split_train_val_dataset(cfg, dataset)
-    model = model.to(device)
 
     if batch_size > len(train_dataset):
         batch_size = len(train_dataset)
@@ -576,7 +578,8 @@ def is_valid_batch_size(
     )
 
     validator = BatchSizeValidator(
-        model=model,
+        model_factory=model_factory,
+        device=device,
         train_dataset=train_dataset,
         val_dataset=val_dataset,
         train_dataloader_kwargs={

--- a/tests/unit/ml/test_batch_autotuner.py
+++ b/tests/unit/ml/test_batch_autotuner.py
@@ -1,6 +1,7 @@
 """Tests for batch size autotuner."""
 
-from typing import cast
+import functools
+import pickle
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -8,7 +9,7 @@ import torch
 from omegaconf import OmegaConf
 from torch.utils.data import Dataset
 
-from neuracore.ml import BatchedTrainingOutputs, NeuracoreModel
+from neuracore.ml import BatchedTrainingOutputs
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
 )
@@ -42,6 +43,8 @@ class DummyModel(torch.nn.Module):
         super().__init__()
         self.device = device
         self.weight = torch.nn.Parameter(torch.tensor(1.0))
+        # Simulate transformer models (e.g. GemmaConfig) that are not picklable.
+        self._non_picklable = lambda: None
 
     def forward(self, batch):
         return batch
@@ -64,9 +67,9 @@ def test_find_optimal_runs_probe_batch():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         autotuner = BatchSizeAutotuner(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -107,7 +110,7 @@ def test_find_optimal_batch_size_passes_default_min_max_to_batch_size_autotuner(
     mock_dataset.collate_fn = lambda x: x
 
     device = torch.device("cuda:0")
-    model = cast(NeuracoreModel, DummyModel(device=device))
+    model_factory = functools.partial(DummyModel, device=device)
 
     def fake_random_split(dataset, lengths, generator=None):
         assert len(dataset) == 100
@@ -119,7 +122,6 @@ def test_find_optimal_batch_size_passes_default_min_max_to_batch_size_autotuner(
 
     with (
         patch("torch.cuda.is_available", return_value=True),
-        patch.object(model, "to", return_value=model),
         patch(
             "neuracore.ml.trainers.batch_autotuner.random_split",
             side_effect=fake_random_split,
@@ -129,7 +131,7 @@ def test_find_optimal_batch_size_passes_default_min_max_to_batch_size_autotuner(
             return_value=mock_autotuner_instance,
         ) as mock_autotuner_cls,
     ):
-        result = find_optimal_batch_size(cfg, model, mock_dataset, device)
+        result = find_optimal_batch_size(cfg, model_factory, mock_dataset, device)
 
     assert result == 4
     mock_autotuner_cls.assert_called_once()
@@ -145,9 +147,9 @@ def test_batch_size_validator_test_batch_size_success():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -171,9 +173,9 @@ def test_batch_size_validator_test_batch_size_returns_false_on_subprocess_failur
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -197,9 +199,9 @@ def test_batch_size_validator_spawns_subprocess_and_returns_worker_result():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -238,9 +240,9 @@ def test_batch_size_validator_treats_nonzero_exit_code_as_failure():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -274,9 +276,9 @@ def test_batch_size_validator_raises_on_worker_failure_result():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -312,9 +314,9 @@ def test_batch_size_validator_returns_false_on_worker_oom_failure():
     device = torch.device("cuda:0")
 
     with patch("torch.cuda.is_available", return_value=True):
-        model = cast(NeuracoreModel, DummyModel(device=device))
         validator = BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -346,14 +348,15 @@ def test_batch_size_validator_requires_cuda_device():
     """BatchSizeValidator rejects non-CUDA devices."""
     train_dataset = DummyDataset(length=16)
     val_dataset = DummyDataset(length=16)
-    model = cast(NeuracoreModel, DummyModel(device=torch.device("cpu")))
+    device = torch.device("cpu")
 
     with (
         patch("torch.cuda.is_available", return_value=False),
         pytest.raises(ValueError, match="only supported on GPUs"),
     ):
         BatchSizeValidator(
-            model=model,
+            model_factory=functools.partial(DummyModel, device=device),
+            device=device,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             train_dataloader_kwargs={},
@@ -442,6 +445,62 @@ def test_probe_batch_size_raises_on_generic_exception():
             )
 
 
+def test_batch_size_validator_handles_non_picklable_model_attributes():
+    """test_batch_size succeeds even when model instances have non-picklable attributes.
+
+    Simulates a transformer model where instance attributes (e.g. GemmaConfig)
+    are not picklable. The subprocess receives a picklable factory callable rather
+    than a model instance, so the pickling error never occurs.
+    """
+    train_dataset = DummyDataset(length=16)
+    val_dataset = DummyDataset(length=16)
+    device = torch.device("cuda:0")
+
+    # DummyModel has self._non_picklable = lambda: None — instances are not picklable.
+    # However, functools.partial(DummyModel, device=device) is picklable because
+    # it holds only the class reference and a plain torch.device, never an instance.
+    model_factory = functools.partial(DummyModel, device=device)
+
+    with patch("torch.cuda.is_available", return_value=True):
+        validator = BatchSizeValidator(
+            model_factory=model_factory,
+            device=device,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            train_dataloader_kwargs={},
+            val_dataloader_kwargs={},
+            num_iterations=2,
+        )
+
+    fake_queue = MagicMock()
+    fake_queue.get_nowait.return_value = ("ok", True)
+    fake_proc = MagicMock()
+    fake_proc.exitcode = 0
+    fake_proc.is_alive.return_value = False
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue.return_value = fake_queue
+    fake_ctx.Process.return_value = fake_proc
+
+    def start_that_pickles_args():
+        # Reproduce what spawn does: pickle-serialize every arg before sending to
+        # the subprocess. Skip args[0] (the result_queue IPC object) since it is
+        # always an OS primitive, not a plain Python value. Check all remaining
+        # args: none of them should be a model instance.
+        for arg in fake_ctx.Process.call_args.kwargs["args"][1:]:
+            pickle.dumps(arg)
+
+    fake_proc.start.side_effect = start_that_pickles_args
+
+    with patch(
+        "neuracore.ml.trainers.batch_autotuner.multiprocessing.get_context",
+        return_value=fake_ctx,
+    ):
+        result = validator.test_batch_size(batch_size=4)
+
+    assert result is True
+
+
 def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
     """is_valid_batch_size clamps oversized batch_size to train dataset length."""
     cfg = OmegaConf.create({
@@ -456,7 +515,7 @@ def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
     mock_dataset.collate_fn = lambda x: x
 
     device = torch.device("cuda:0")
-    model = cast(NeuracoreModel, DummyModel(device=device))
+    model_factory = functools.partial(DummyModel, device=device)
 
     def fake_random_split(dataset, lengths, generator=None):
         assert lengths == [80, 20]
@@ -464,7 +523,6 @@ def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
 
     with (
         patch("torch.cuda.is_available", return_value=True),
-        patch.object(model, "to", return_value=model),
         patch(
             "neuracore.ml.trainers.batch_autotuner.random_split",
             side_effect=fake_random_split,
@@ -476,7 +534,7 @@ def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
     ):
         result = is_valid_batch_size(
             cfg=cfg,
-            model=model,
+            model_factory=model_factory,
             dataset=mock_dataset,
             batch_size=256,
             device=device,


### PR DESCRIPTION
## fix: resolve pickling error in batch size validator for transformer models

Fixes: https://github.com/NeuracoreAI/neuracore/pull/557

Fixes a `_pickle.PicklingError` that occurred when `BatchSizeValidator` tried to serialize transformer models (e.g. Pi0/Pi05) into a `spawn` subprocess. These models store `GemmaConfig` instances as attributes, which fail pickling due to a class identity mismatch across import paths in the transformers library.

`BatchSizeValidator._run_in_subprocess` passed the model instance directly as a `ctx.Process` arg. The `spawn` start method pickles all args before sending them to the subprocess, causing the error for any model with non-picklable attributes.                                                                                                                                 
                                                            
### Fix                                                                                                                                                                                                           
                                                            
Instead of passing a model instance, callers now pass a `model_factory:  Callable[[], NeuracoreModel]` + explicit `device`.  The subprocess constructs the model fresh by calling `model_factory()`. No model instance ever crosses the process boundary.

In `train.py`, the factory is `functools.partial(_create_model_for_batch_validation, cfg, model_init_description)`, a module-level function with picklable args, which uses the same Hydra instantiation path as the main training loop, including all algorithm-specific kwargs.  