### PR TITLE
fix: stop polling finalized recording durations

### DIFF
--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -726,30 +726,12 @@ def verify_cloud_results(
         poll_interval_s=2.0,
     )
 
-    # Compute duration bounds (mirrors _verify_recording_structure) so we can
-    # wait until the backend has finalized end_time for every recording before
-    # performing the structural pass.
-    base_duration_s = float(case.duration_sec)
-    clock_tolerance_s = 2.0
-    if case.context_duration_mode == DURATION_MODE_VARIABLE:
-        finalized_min_s = (
-            base_duration_s * DURATION_VARIABLE_MIN_FACTOR - clock_tolerance_s
-        )
-        finalized_max_s = (
-            base_duration_s * DURATION_VARIABLE_MAX_FACTOR + clock_tolerance_s
-        )
-    else:
-        finalized_min_s = base_duration_s - clock_tolerance_s
-        finalized_max_s = base_duration_s + clock_tolerance_s
-
     all_recording_ids = {
         str(rec_id) for result in results for rec_id in result.recording_ids
     }
     wait_for_recordings_finalized(
         dataset_name,
         all_recording_ids,
-        min_duration_s=finalized_min_s,
-        max_duration_s=finalized_max_s,
         timeout_s=case_timeout_seconds(case),
         poll_interval_s=2.0,
     )

--- a/tests/integration/platform/data_daemon/shared/db_helpers.py
+++ b/tests/integration/platform/data_daemon/shared/db_helpers.py
@@ -532,24 +532,20 @@ def wait_for_recordings_finalized(
     dataset_name: str,
     recording_ids: set[str],
     *,
-    min_duration_s: float,
-    max_duration_s: float,
     timeout_s: float = 120.0,
     poll_interval_s: float = 2.0,
 ) -> None:
     """Block until every recording in ``recording_ids`` has a finalized end_time.
 
-    The backend updates a recording's ``end_time`` asynchronously as traces are
-    ingested.  This helper re-fetches the dataset on each poll and returns only
-    once every expected recording has ``end_time - start_time`` within the
-    supplied duration bounds, signalling that the backend has finished processing
-    all trace data for those recordings.
+    The backend updates a recording's ``end_time`` asynchronously.  This helper
+    re-fetches the dataset on each poll and returns once every expected
+    recording exists and has a non-null ``end_time``.  Duration correctness is
+    checked later by the structural verification pass so failures surface
+    immediately instead of polling for a duration value that is already final.
 
     Args:
         dataset_name: Name of the dataset to poll.
         recording_ids: Set of recording IDs that must all be finalized.
-        min_duration_s: Minimum acceptable ``end_time - start_time`` in seconds.
-        max_duration_s: Maximum acceptable ``end_time - start_time`` in seconds.
         timeout_s: Maximum time to wait before raising.
         poll_interval_s: Seconds between successive polls.
 
@@ -557,7 +553,8 @@ def wait_for_recordings_finalized(
         TimeoutError: If not all recordings are finalized within ``timeout_s``.
     """
     deadline = time.monotonic() + timeout_s
-    last_bad: dict[str, float] = {}
+    last_missing = set(recording_ids)
+    last_without_end_time: set[str] = set()
 
     while time.monotonic() < deadline:
         try:
@@ -566,25 +563,28 @@ def wait_for_recordings_finalized(
             time.sleep(poll_interval_s)
             continue
 
-        bad: dict[str, float] = {}
+        seen: set[str] = set()
+        without_end_time: set[str] = set()
         for recording in dataset:
             rec_id = str(recording.id)
             if rec_id not in recording_ids:
                 continue
-            duration = float(recording.end_time) - float(recording.start_time)
-            if not (min_duration_s <= duration <= max_duration_s):
-                bad[rec_id] = duration
+            seen.add(rec_id)
+            if recording.end_time is None:
+                without_end_time.add(rec_id)
 
-        if not bad:
+        missing = recording_ids - seen
+        if not missing and not without_end_time:
             return
 
-        last_bad = bad
+        last_missing = missing
+        last_without_end_time = without_end_time
         time.sleep(min(poll_interval_s, max(0.0, deadline - time.monotonic())))
 
     raise TimeoutError(
-        f"Recordings in dataset '{dataset_name}' did not reach expected duration "
-        f"[{min_duration_s:.1f}s, {max_duration_s:.1f}s] within {timeout_s}s. "
-        f"Still outside range: {last_bad}"
+        f"Recordings in dataset '{dataset_name}' did not finalize within "
+        f"{timeout_s}s. Missing: {sorted(last_missing)}. "
+        f"Without end_time: {sorted(last_without_end_time)}"
     )
 
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - This fixes the cloud data integrity wait logic. Before, the test kept polling until a recording cloud duration matched the expected test duration. But once the backend sets end_time, that value does not change, so waiting longer cannot fix a bad duration.
 
The test now only waits until each recording has an end_time. After that, the normal duration check runs and fails right away if the duration is wrong

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-928](https://neuracore.atlassian.net/browse/NCP-928)


<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
