### PR TITLE
feat: save training cross embodiment description for inference

### DIFF
--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -28,14 +28,30 @@ from neuracore.core.get_latest_sync_point import (
     get_latest_sync_point as _get_latest_sync_point,
 )
 from neuracore.core.utils.http_session import get_session
+from neuracore.core.utils.robot_data_spec_utils import (
+    resolve_embodiment_descriptions_with_override,
+)
+
+
+def _resolve_robot_id(
+    robot_id: str | None, robot_name: str | None, instance: int
+) -> str | None:
+    """Resolve robot_id from explicit id or robot name."""
+    if robot_name is not None:
+        assert robot_id is None, "Specify only one of robot_id or robot_name."
+        return _get_robot(robot_name, instance).id
+    return robot_id
 
 
 def policy(
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
+    robot_id: str | None = None,
+    robot_name: str | None = None,
+    instance: int = 0,
 ) -> DirectPolicy:
     """Launch a direct policy that runs the model in-process without any server.
 
@@ -48,6 +64,10 @@ def policy(
         train_run_name: Name of the training run to load the model from.
         model_file: Path to the model file to load.
         device: Torch device to run the model on (CPU or GPU, or MPS).
+        robot_id: Robot ID used to select embodiments from the model archive when
+            input/output embodiments are not provided.
+        robot_name: Robot name to resolve to robot_id before model loading.
+        instance: Robot instance number used with robot_name resolution.
 
     Returns:
         DirectPolicy object that provides direct in-process model inference.
@@ -56,23 +76,29 @@ def policy(
         EndpointError: If the model download or initialization fails.
         ConfigError: If there is an error trying to get the current org.
     """
+    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+
     return _policy(
         input_embodiment_description=input_embodiment_description,
         output_embodiment_description=output_embodiment_description,
         train_run_name=train_run_name,
         model_file=model_file,
         device=device,
+        robot_id=robot_id,
     )
 
 
 def policy_local_server(
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
     port: int = 8080,
     host: str = "127.0.0.1",
+    robot_id: str | None = None,
+    robot_name: str | None = None,
+    instance: int = 0,
 ) -> LocalServerPolicy:
     """Launch and connect to a local server policy.
 
@@ -86,6 +112,10 @@ def policy_local_server(
         device: Torch device to run the model on (CPU or GPU, or MPS).
         port: TCP port number where the local server will run.
         host: Host address to bind the server to. Defaults to localhost.
+        robot_id: Robot ID used to select embodiments from the model archive when
+            input/output embodiments are not provided.
+        robot_name: Robot name to resolve to robot_id before model loading.
+        instance: Robot instance number used with robot_name resolution.
 
     Returns:
         LocalServerPolicy object that manages a local FastAPI server.
@@ -94,6 +124,8 @@ def policy_local_server(
         EndpointError: If the server startup or model initialization fails.
         ConfigError: If there is an error trying to get the current org.
     """
+    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+
     return _policy_local_server(
         input_embodiment_description=input_embodiment_description,
         output_embodiment_description=output_embodiment_description,
@@ -102,6 +134,7 @@ def policy_local_server(
         device=device,
         port=port,
         host=host,
+        robot_id=robot_id,
     )
 
 
@@ -129,10 +162,13 @@ def policy_remote_server(endpoint_name: str) -> RemoteServerPolicy:
 def deploy_model(
     job_id: str,
     name: str,
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     ttl: int | None = None,
     gpu_type: GPUType = GPUType.NVIDIA_TESLA_V100,
+    robot_id: str | None = None,
+    robot_name: str | None = None,
+    instance: int = 0,
 ) -> dict:
     """Deploy a trained model to a managed endpoint.
 
@@ -151,6 +187,10 @@ def deploy_model(
         ttl: Optional time-to-live in seconds for the endpoint. If provided,
             the endpoint will be automatically deleted after this duration.
         gpu_type: Type of GPU to use for deployment.
+        robot_id: Robot ID used to select embodiments from the model archive when
+            input/output embodiments are not provided.
+        robot_name: Robot name to resolve to robot_id before model loading.
+        instance: Robot instance number used with robot_name resolution.
 
     Returns:
         Deployment response containing endpoint details and deployment status.
@@ -166,12 +206,24 @@ def deploy_model(
     """
     auth = get_auth()
     org_id = get_current_org()
+    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+
+    (
+        resolved_input_embodiment_description,
+        resolved_output_embodiment_description,
+    ) = resolve_embodiment_descriptions_with_override(
+        input_embodiment_description=input_embodiment_description,
+        output_embodiment_description=output_embodiment_description,
+        robot_id=robot_id,
+        job_id=job_id,
+    )
+
     payload = DeploymentRequest(
         training_id=job_id,
         name=name,
         ttl=ttl,
-        input_embodiment_description=input_embodiment_description,
-        output_embodiment_description=output_embodiment_description,
+        input_embodiment_description=resolved_input_embodiment_description,
+        output_embodiment_description=resolved_output_embodiment_description,
         config=DeploymentConfig(gpu_type=gpu_type),
     ).model_dump(mode="json")
     try:

--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -143,12 +143,13 @@ class DirectPolicy(Policy):
 
     def __init__(
         self,
-        input_embodiment_description: EmbodimentDescription,
-        output_embodiment_description: EmbodimentDescription,
         model_path: Path,
         org_id: str,
+        input_embodiment_description: EmbodimentDescription | None = None,
+        output_embodiment_description: EmbodimentDescription | None = None,
         job_id: str | None = None,
         device: str | None = None,
+        robot_id: str | None = None,
     ):
         """Initialize the direct policy with a robot instance."""
         super().__init__()
@@ -162,6 +163,7 @@ class DirectPolicy(Policy):
             job_id=job_id,
             model_file=model_path,
             device=device,
+            robot_id=robot_id,
         )
 
     def set_checkpoint(
@@ -357,15 +359,16 @@ class LocalServerPolicy(ServerPolicy):
 
     def __init__(
         self,
-        input_embodiment_description: EmbodimentDescription,
-        output_embodiment_description: EmbodimentDescription,
         org_id: str,
         model_path: Path,
+        input_embodiment_description: EmbodimentDescription | None = None,
+        output_embodiment_description: EmbodimentDescription | None = None,
         device: str | None = None,
         job_id: str | None = None,
         port: int = 8080,
         host: str = "127.0.0.1",
         endpoint_id: str | None = None,
+        robot_id: str | None = None,
     ):
         """Initialize the local server policy.
 
@@ -381,6 +384,8 @@ class LocalServerPolicy(ServerPolicy):
             port: Port to run the server on
             host: Host to bind to
             endpoint_id: Optional deployed endpoint ID used for cloud log uploads.
+            robot_id: Optional robot ID used to resolve embodiments from model
+                metadata when explicit embodiments are omitted.
         """
         super().__init__(
             f"http://{host}:{port}",
@@ -388,6 +393,7 @@ class LocalServerPolicy(ServerPolicy):
         )
         self.input_embodiment_description = input_embodiment_description
         self.output_embodiment_description = output_embodiment_description
+        self.robot_id = robot_id
         self.org_id = org_id
         self.job_id = job_id
         self.endpoint_id = endpoint_id
@@ -424,20 +430,10 @@ class LocalServerPolicy(ServerPolicy):
     def _start_server(self) -> None:
         """Start the FastAPI server in a subprocess using module execution."""
         # Start the server process using module execution
-        input_embodiment_description_str = json.dumps(
-            {k.value: v for k, v in self.input_embodiment_description.items()}
-        )
-        output_embodiment_description_str = json.dumps(
-            {k.value: v for k, v in self.output_embodiment_description.items()}
-        )
         cmd = [
             sys.executable,
             "-m",
             "neuracore.core.utils.server",
-            "--input-embodiment-description",
-            f"{input_embodiment_description_str}",
-            "--output-embodiment-description",
-            f"{output_embodiment_description_str}",
             "--model-file",
             str(self.model_path),
             "--org-id",
@@ -449,6 +445,24 @@ class LocalServerPolicy(ServerPolicy):
             "--log-level",
             "info",
         ]
+        if self.input_embodiment_description is not None:
+            input_embodiment_description_str = json.dumps(
+                {k.value: v for k, v in self.input_embodiment_description.items()}
+            )
+            cmd.extend([
+                "--input-embodiment-description",
+                f"{input_embodiment_description_str}",
+            ])
+        if self.output_embodiment_description is not None:
+            output_embodiment_description_str = json.dumps(
+                {k.value: v for k, v in self.output_embodiment_description.items()}
+            )
+            cmd.extend([
+                "--output-embodiment-description",
+                f"{output_embodiment_description_str}",
+            ])
+        if self.robot_id is not None:
+            cmd.extend(["--robot-id", self.robot_id])
         if self.device:
             cmd.extend(["--device", self.device])
         if self.job_id:
@@ -597,11 +611,12 @@ class RemoteServerPolicy(ServerPolicy):
 
 
 def policy(
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
+    robot_id: str | None = None,
 ) -> DirectPolicy:
     """Launch a direct policy that runs the model in-process.
 
@@ -613,6 +628,8 @@ def policy(
         train_run_name: Name of the training run to load the model from.
         model_file: Path to the model file to load.
         device: Torch device to run the model on (CPU or GPU, or MPS).
+        robot_id: Robot ID used to select embodiments from the model archive
+            when embodiment descriptions are not explicitly provided.
 
     Returns:
         DirectPolicy instance for direct model inference.
@@ -634,12 +651,13 @@ def policy(
         job_id=job_id,
         model_path=model_path,
         device=device,
+        robot_id=robot_id,
     )
 
 
 def policy_local_server(
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     train_run_name: str | None = None,
     model_file: str | None = None,
     device: str | None = None,
@@ -647,6 +665,7 @@ def policy_local_server(
     host: str = "127.0.0.1",
     job_id: str | None = None,
     endpoint_id: str | None = None,
+    robot_id: str | None = None,
 ) -> LocalServerPolicy:
     """Launch a local server policy with a FastAPI server.
 
@@ -662,6 +681,8 @@ def policy_local_server(
         host: Host to bind to.
         job_id: Optional job ID to associate with the server.
         endpoint_id: Optional endpoint ID used for endpoint log streaming.
+        robot_id: Robot ID used to select embodiments from the model archive
+            when embodiment descriptions are not explicitly provided.
 
     Returns:
         LocalServerPolicy instance managing a local FastAPI server.
@@ -684,15 +705,16 @@ def policy_local_server(
         raise ValueError("Must specify either train_run_name or model_file")
 
     return LocalServerPolicy(
-        input_embodiment_description=input_embodiment_description,
-        output_embodiment_description=output_embodiment_description,
         org_id=org_id,
         model_path=model_path,
+        input_embodiment_description=input_embodiment_description,
+        output_embodiment_description=output_embodiment_description,
         device=device,
         job_id=job_id,
         port=port,
         host=host,
         endpoint_id=endpoint_id,
+        robot_id=robot_id,
     )
 
 

--- a/neuracore/core/utils/robot_data_spec_utils.py
+++ b/neuracore/core/utils/robot_data_spec_utils.py
@@ -8,12 +8,25 @@ would be the natural home for these shared utilities.
 
 import re
 from collections.abc import Mapping
+from pathlib import Path
 
-from neuracore_types import CrossEmbodimentDescription, CrossEmbodimentUnion, DataType
+import requests
+from neuracore_types import (
+    CrossEmbodimentDescription,
+    CrossEmbodimentUnion,
+    DataType,
+    EmbodimentDescription,
+)
 from omegaconf import DictConfig
 from ordered_set import OrderedSet
 
+from neuracore.core.auth import get_auth
+from neuracore.core.config.get_current_org import get_current_org
+from neuracore.core.const import API_URL
 from neuracore.core.robot import get_robot_id_from_name
+from neuracore.ml.utils.nc_archive import (
+    load_cross_embodiment_descriptions_from_nc_archive,
+)
 
 ID_REGEX = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
@@ -177,3 +190,133 @@ def extract_data_types(
     for data_types in robot_id_to_data_types.values():
         unique_data_types.update(data_types.keys())
     return unique_data_types
+
+
+def normalize_embodiment_description(
+    embodiment_description: dict[DataType | str, object],
+) -> EmbodimentDescription:
+    """Normalize embodiment description keys to DataType enum values."""
+    return {
+        data_type if isinstance(data_type, DataType) else DataType(data_type): names
+        for data_type, names in embodiment_description.items()
+    }
+
+
+def resolve_embodiment_descriptions(
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+    robot_id: str,
+) -> tuple[EmbodimentDescription, EmbodimentDescription]:
+    """Resolve concrete input/output embodiments for a specific robot."""
+    if robot_id not in input_cross_embodiment_description:
+        raise ValueError(
+            f"Robot ID '{robot_id}' not found in input cross-embodiment description."
+        )
+    if robot_id not in output_cross_embodiment_description:
+        raise ValueError(
+            f"Robot ID '{robot_id}' not found in output cross-embodiment description."
+        )
+    return (
+        normalize_embodiment_description(input_cross_embodiment_description[robot_id]),
+        normalize_embodiment_description(output_cross_embodiment_description[robot_id]),
+    )
+
+
+def resolve_embodiment_descriptions_with_override(
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
+    robot_id: str | None = None,
+    job_id: str | None = None,
+    model_file: Path | None = None,
+    input_cross_embodiment_description: CrossEmbodimentDescription | None = None,
+    output_cross_embodiment_description: CrossEmbodimentDescription | None = None,
+) -> tuple[EmbodimentDescription, EmbodimentDescription]:
+    """Resolve embodiments from archive/cross-specs and apply explicit overrides.
+
+    1. Prioritize explicit overrides of embodiment descriptions.
+    2. If no explicit overrides, resolve using robot ID from
+       cross-embodiment descriptions.
+    3. If no cross-embodiment descriptions, resolve from training metadata
+       or model archive.
+    """
+    resolved_input_embodiment_description = None
+    resolved_output_embodiment_description = None
+
+    if (
+        input_embodiment_description is not None
+        and output_embodiment_description is not None
+    ):
+        return input_embodiment_description, output_embodiment_description
+
+    # Retrieve cross-embodiment descriptions and resolve embodiments from them
+    if robot_id is not None:
+        if (
+            not input_cross_embodiment_description
+            or not output_cross_embodiment_description
+        ):
+            if job_id is not None:
+                auth = get_auth()
+                org_id = get_current_org()
+                response = requests.get(
+                    f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
+                    headers=auth.get_headers(),
+                    timeout=30,
+                )
+                if response.status_code == 200:
+                    training_job = response.json()
+                    input_cross_embodiment_description = training_job.get(
+                        "input_cross_embodiment_description"
+                    )
+                    output_cross_embodiment_description = training_job.get(
+                        "output_cross_embodiment_description"
+                    )
+
+            elif model_file is not None:
+                (
+                    archive_input_cross_embodiment_description,
+                    archive_output_cross_embodiment_description,
+                ) = load_cross_embodiment_descriptions_from_nc_archive(model_file)
+                if input_cross_embodiment_description is None:
+                    input_cross_embodiment_description = (
+                        archive_input_cross_embodiment_description
+                    )
+                if output_cross_embodiment_description is None:
+                    output_cross_embodiment_description = (
+                        archive_output_cross_embodiment_description
+                    )
+
+        if (
+            input_cross_embodiment_description is None
+            or output_cross_embodiment_description is None
+        ):
+            raise ValueError(
+                "Must provide both input_cross_embodiment_description and "
+                "output_cross_embodiment_description, or provide robot_id "
+                "with job_id or model_file to load them from training "
+                "metadata or the model archive."
+            )
+
+        (
+            resolved_input_embodiment_description,
+            resolved_output_embodiment_description,
+        ) = resolve_embodiment_descriptions(
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            robot_id=robot_id,
+        )
+
+    if input_embodiment_description is not None:
+        resolved_input_embodiment_description = input_embodiment_description
+    if output_embodiment_description is not None:
+        resolved_output_embodiment_description = output_embodiment_description
+
+    if (
+        resolved_input_embodiment_description is None
+        or resolved_output_embodiment_description is None
+    ):
+        raise ValueError(
+            "Must provide both input_embodiment_description and "
+            "output_embodiment_description, or provide robot_id with job_id/model_file "
+            "to load them from training metadata or the model archive."
+        )
+    return resolved_input_embodiment_description, resolved_output_embodiment_description

--- a/neuracore/core/utils/server.py
+++ b/neuracore/core/utils/server.py
@@ -82,22 +82,25 @@ class ModelServer:
 
     def __init__(
         self,
-        input_embodiment_description: EmbodimentDescription,
-        output_embodiment_description: EmbodimentDescription,
         model_file: Path,
         org_id: str,
+        input_embodiment_description: EmbodimentDescription | None = None,
+        output_embodiment_description: EmbodimentDescription | None = None,
         job_id: str | None = None,
         device: str | None = None,
+        robot_id: str | None = None,
     ):
         """Initialize the model server.
 
         Args:
-            input_embodiment_description: Model input data order
-            output_embodiment_description: Model output data order
             model_file: Path to the .nc.zip model archive
             org_id: Organization ID for the model
+            input_embodiment_description: Input mapping per supported robot type.
+            output_embodiment_description: Output mapping per supported robot type.
             job_id: Job ID for the model
             device: Device the model loaded on
+            robot_id: Robot ID used to select embodiments from the model
+                archive or training metadata.
         """
         # Import here to avoid the need for pytorch unless the user uses this policy
         from neuracore.ml.utils.policy_inference import PolicyInference
@@ -109,6 +112,7 @@ class ModelServer:
             job_id=job_id,
             model_file=model_file,
             device=device,
+            robot_id=robot_id,
         )
         self.app = self._create_app()
         logger.info(
@@ -196,10 +200,10 @@ class ModelServer:
 
 
 def start_server(
-    input_embodiment_description: EmbodimentDescription,
-    output_embodiment_description: EmbodimentDescription,
     model_file: Path,
     org_id: str,
+    input_embodiment_description: EmbodimentDescription | None = None,
+    output_embodiment_description: EmbodimentDescription | None = None,
     job_id: str | None = None,
     host: str = "0.0.0.0",
     port: int = 8080,
@@ -207,6 +211,7 @@ def start_server(
     log_file_path: str | None = None,
     startup_status_file_path: str | None = None,
     device: str | None = None,
+    robot_id: str | None = None,
 ) -> ModelServer:
     """Start a model server instance.
 
@@ -214,12 +219,16 @@ def start_server(
         model_file: Path to the .nc.zip model archive
         org_id: Organization ID
         job_id: Job ID
+        input_embodiment_description: Input mapping per supported robot type.
+        output_embodiment_description: Output mapping per supported robot type.
         host: Host to bind to
         port: Port to bind to
         log_level: Logging level
         log_file_path: Optional log file path for structured server logs.
         startup_status_file_path: Optional file path used to report startup status.
         device: Device model loaded on
+        robot_id: Robot ID used to select embodiments from the model archive
+            or training metadata.
 
     Returns:
         ModelServer instance
@@ -233,6 +242,7 @@ def start_server(
         org_id=org_id,
         job_id=job_id,
         device=device,
+        robot_id=robot_id,
     )
     write_startup_status(startup_status_file_path, status="ready")
     server.run(host, port, log_level)
@@ -245,18 +255,22 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Start Neuracore Model Server")
     parser.add_argument(
         "--input-embodiment-description",
-        required=True,
+        required=False,
         help=(
             "Input embodiment description consisting of json dump of "
-            "dict mapping DataType to list of strings"
+            "dict mapping DataType to list of strings. If not provided, "
+            "the robot ID will be used to select embodiments from the model "
+            "archive or training metadata."
         ),
     )
     parser.add_argument(
         "--output-embodiment-description",
-        required=True,
+        required=False,
         help=(
             "Output embodiment description consisting of json dump of "
-            "dict mapping DataType to list of strings"
+            "dict mapping DataType to list of strings. If not provided, "
+            "the robot ID will be used to select embodiments from the model "
+            "archive or training metadata."
         ),
     )
     parser.add_argument(
@@ -278,16 +292,28 @@ if __name__ == "__main__":
         help="Optional path to write startup status for parent process.",
     )
     parser.add_argument("--device", help="Device to load model on (cpu, cuda, etc.)")
+    parser.add_argument(
+        "--robot-id",
+        required=False,
+        help=(
+            "Robot ID used to select embodiments from the model archive or "
+            "training metadata."
+        ),
+    )
 
     try:
         args = parser.parse_args()
 
-        input_embodiment_description = _parse_embodiment_description(
-            args.input_embodiment_description
-        )
-        output_embodiment_description = _parse_embodiment_description(
-            args.output_embodiment_description
-        )
+        input_embodiment_description = None
+        if args.input_embodiment_description is not None:
+            input_embodiment_description = _parse_embodiment_description(
+                args.input_embodiment_description
+            )
+        output_embodiment_description = None
+        if args.output_embodiment_description is not None:
+            output_embodiment_description = _parse_embodiment_description(
+                args.output_embodiment_description
+            )
         start_server(
             input_embodiment_description=input_embodiment_description,
             output_embodiment_description=output_embodiment_description,
@@ -300,6 +326,7 @@ if __name__ == "__main__":
             log_file_path=args.log_file_path,
             startup_status_file_path=args.startup_status_file_path,
             device=args.device,
+            robot_id=args.robot_id,
         )
     except Exception as exc:
         write_startup_status(

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -661,6 +661,8 @@ def run_training(
             local_dir=cfg.local_output_dir,
             training_job_id=cfg.training_id,
             algorithm_config=algorithm_config,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
         )
 
         logger.info(

--- a/neuracore/ml/utils/nc_archive.py
+++ b/neuracore/ml/utils/nc_archive.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
-from neuracore_types import ModelInitDescription
+from neuracore_types import CrossEmbodimentDescription, ModelInitDescription
 
 from neuracore.ml.core.neuracore_model import NeuracoreModel
 from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
@@ -47,7 +47,11 @@ def _build_archive_metadata() -> dict[str, str | None]:
 
 
 def create_nc_archive(
-    model: NeuracoreModel, output_dir: Path, algorithm_config: dict = {}
+    model: NeuracoreModel,
+    output_dir: Path,
+    algorithm_config: dict = {},
+    input_cross_embodiment_description: dict[str, Any] = {},
+    output_cross_embodiment_description: dict[str, Any] = {},
 ) -> Path:
     """Create a Neuracore model archive (NC.ZIP) file from a Neuracore model.
 
@@ -59,6 +63,8 @@ def create_nc_archive(
         model: Trained Neuracore model instance to package for deployment.
         output_dir: Directory path where the NC.ZIP file will be created.
         algorithm_config: Custom configuration for the algorithm.
+        input_cross_embodiment_description: Input embodiment mapping.
+        output_cross_embodiment_description: Output embodiment mapping.
 
     Returns:
         Path to the created NC.ZIP file.
@@ -90,6 +96,12 @@ def create_nc_archive(
         with open(temp_path / "algorithm_config.json", "w") as f:
             json.dump(algorithm_config, f, indent=2)
 
+        # Save cross-embodiment descriptions
+        with open(temp_path / "input_cross_embodiment_description.json", "w") as f:
+            json.dump(input_cross_embodiment_description, f, indent=2)
+        with open(temp_path / "output_cross_embodiment_description.json", "w") as f:
+            json.dump(output_cross_embodiment_description, f, indent=2)
+
         # Save archive metadata
         with open(temp_path / "metadata", "w") as f:
             json.dump(_build_archive_metadata(), f, indent=2)
@@ -107,6 +119,16 @@ def create_nc_archive(
 
             # Add algorithm config (always present)
             zip_file.write(temp_path / "algorithm_config.json", "algorithm_config.json")
+
+            # Add cross-embodiment descriptions
+            zip_file.write(
+                temp_path / "input_cross_embodiment_description.json",
+                "input_cross_embodiment_description.json",
+            )
+            zip_file.write(
+                temp_path / "output_cross_embodiment_description.json",
+                "output_cross_embodiment_description.json",
+            )
 
             # Add archive metadata
             zip_file.write(temp_path / "metadata", "metadata")
@@ -166,6 +188,10 @@ def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
                 extracted_files["model_init_description"] = file_path
             elif file_info.filename == "algorithm_config.json":
                 extracted_files["algorithm_config"] = file_path
+            elif file_info.filename == "input_cross_embodiment_description.json":
+                extracted_files["input_cross_embodiment_description"] = file_path
+            elif file_info.filename == "output_cross_embodiment_description.json":
+                extracted_files["output_cross_embodiment_description"] = file_path
             elif file_info.filename == "metadata":
                 extracted_files["metadata"] = file_path
             elif file_info.filename == "algorithm/requirements.txt":
@@ -178,9 +204,54 @@ def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
     return extracted_files
 
 
+def load_cross_embodiment_descriptions_from_nc_archive(
+    archive_file: Path,
+    extract_to: Path | None = None,
+) -> tuple[CrossEmbodimentDescription, CrossEmbodimentDescription]:
+    """Load cross-embodiment descriptions from a Neuracore model archive.
+
+    Args:
+        archive_file: Path to the NC.ZIP file.
+        extract_to: Optional directory to extract files to.
+            If None, uses a temporary directory.
+
+    Returns:
+        Tuple of input and output cross-embodiment descriptions.
+    """
+    use_temp_dir = extract_to is None
+
+    if use_temp_dir:
+        temp_dir_context = tempfile.TemporaryDirectory()
+        extract_to = Path(temp_dir_context.__enter__())
+    else:
+        temp_dir_context = None
+
+    assert extract_to is not None
+
+    try:
+        extracted_files = extract_nc_archive(archive_file, extract_to)
+        if "input_cross_embodiment_description" not in extracted_files:
+            raise FileNotFoundError(
+                "input_cross_embodiment_description.json not found in archive"
+            )
+        if "output_cross_embodiment_description" not in extracted_files:
+            raise FileNotFoundError(
+                "output_cross_embodiment_description.json not found in archive"
+            )
+
+        with open(extracted_files["input_cross_embodiment_description"]) as f:
+            input_cross_embodiment_description = json.load(f)
+        with open(extracted_files["output_cross_embodiment_description"]) as f:
+            output_cross_embodiment_description = json.load(f)
+        return input_cross_embodiment_description, output_cross_embodiment_description
+    finally:
+        if use_temp_dir and temp_dir_context:
+            temp_dir_context.__exit__(None, None, None)
+
+
 def load_model_from_nc_archive(
     archive_file: Path, extract_to: Path | None = None, device: str | None = None
-) -> NeuracoreModel:
+) -> tuple[NeuracoreModel, CrossEmbodimentDescription, CrossEmbodimentDescription]:
     """Load a Neuracore model from a NC.ZIP archive file.
 
     Extracts the archive file and reconstructs the original Neuracore model instance
@@ -193,7 +264,10 @@ def load_model_from_nc_archive(
         device: Optional device model to be loaded on
 
     Returns:
-        NeuracoreModel: The reconstructed model instance ready for inference.
+        A tuple containing:
+          - The reconstructed model instance ready for inference.
+          - Input cross-embodiment description loaded from the archive (if present).
+          - Output cross-embodiment description loaded from the archive (if present).
     """
     use_temp_dir = extract_to is None
 
@@ -225,6 +299,16 @@ def load_model_from_nc_archive(
             with open(extracted_files["algorithm_config"]) as f:
                 algorithm_config = json.load(f)
 
+        # Load cross-embodiment descriptions if present
+        input_cross_embodiment_description = {}
+        if "input_cross_embodiment_description" in extracted_files:
+            with open(extracted_files["input_cross_embodiment_description"]) as f:
+                input_cross_embodiment_description = json.load(f)
+        output_cross_embodiment_description = {}
+        if "output_cross_embodiment_description" in extracted_files:
+            with open(extracted_files["output_cross_embodiment_description"]) as f:
+                output_cross_embodiment_description = json.load(f)
+
         # Find the algorithm directory
         algorithm_dir = extract_to / "algorithm"
         if not algorithm_dir.exists():
@@ -251,7 +335,11 @@ def load_model_from_nc_archive(
             )
             model.load_state_dict(state_dict)
 
-        return model
+        return (
+            model,
+            input_cross_embodiment_description,
+            output_cross_embodiment_description,
+        )
 
     finally:
         if use_temp_dir and temp_dir_context:

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -19,6 +19,9 @@ from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.utils.download import download_with_progress
 from neuracore.core.utils.http_session import get_session
+from neuracore.core.utils.robot_data_spec_utils import (
+    resolve_embodiment_descriptions_with_override,
+)
 from neuracore.ml import BatchedInferenceInputs
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.nc_archive import load_model_from_nc_archive
@@ -46,34 +49,52 @@ class PolicyInference:
 
     def __init__(
         self,
-        input_embodiment_description: EmbodimentDescription,
-        output_embodiment_description: EmbodimentDescription,
         model_file: Path,
         org_id: str,
+        input_embodiment_description: EmbodimentDescription | None = None,
+        output_embodiment_description: EmbodimentDescription | None = None,
         job_id: str | None = None,
         device: str | None = None,
+        robot_id: str | None = None,
     ) -> None:
         """Initialize the policy inference.
 
         Args:
-            input_embodiment_description: Input mapping per supported robot type.
-            output_embodiment_description: Output mapping per supported robot type.
             model_file: Path to the model file to load.
             org_id: ID of the organization for loading checkpoints.
+            input_embodiment_description: Input mapping per supported robot type.
+            output_embodiment_description: Output mapping per supported robot type.
             job_id: ID of the training job for loading checkpoints.
             device: Torch device to run the model inference on.
-            robot_to_output_mapping: Output mapping per supported robot type.
+            robot_id: Robot ID used to select embodiments from cross-embodiment
+                metadata in the model archive when explicit embodiments are not
+                provided.
         """
         self.org_id = org_id
         self.job_id = job_id
-        self.model = load_model_from_nc_archive(model_file, device=device)
+        (
+            self.model,
+            input_cross_embodiment_description,
+            output_cross_embodiment_description,
+        ) = load_model_from_nc_archive(model_file, device=device)
         self.model.eval()
         self.input_dataset_statistics = (
             self.model.model_init_description.input_dataset_statistics
         )
         self.device = torch.device(device) if device else get_default_device()
-        self.input_embodiment_description = input_embodiment_description
-        self.output_embodiment_description = output_embodiment_description
+        (
+            self.input_embodiment_description,
+            self.output_embodiment_description,
+        ) = resolve_embodiment_descriptions_with_override(
+            input_embodiment_description=input_embodiment_description,
+            output_embodiment_description=output_embodiment_description,
+            robot_id=robot_id,
+            job_id=job_id,
+            model_file=model_file,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+        )
+
         self.prediction_horizon = (
             self.model.model_init_description.output_prediction_horizon
         )

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -27,6 +27,8 @@ class TrainingStorageHandler(UploadStorageMixin):
         local_dir: str | None,
         training_job_id: str | None = None,
         algorithm_config: dict = {},
+        input_cross_embodiment_description: dict[str, Any] = {},
+        output_cross_embodiment_description: dict[str, Any] = {},
     ) -> None:
         """Initialize the storage handler.
 
@@ -34,10 +36,16 @@ class TrainingStorageHandler(UploadStorageMixin):
             local_dir: Local directory to save artifacts and checkpoints.
             training_job_id: Optional ID of the training job for cloud logging.
             algorithm_config: Optional configuration for the algorithm.
+            input_cross_embodiment_description: Input embodiment mapping
+                to persist with model artifacts.
+            output_cross_embodiment_description: Output embodiment mapping
+                to persist with model artifacts.
         """
         self.local_dir = Path(local_dir or "./output")
         self.training_job_id = training_job_id
         self.algorithm_config = algorithm_config
+        self.input_cross_embodiment_description = input_cross_embodiment_description
+        self.output_cross_embodiment_description = output_cross_embodiment_description
         self.log_to_cloud = self.training_job_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
@@ -225,6 +233,8 @@ class TrainingStorageHandler(UploadStorageMixin):
             model=model,
             output_dir=artifacts_dir,
             algorithm_config=self.algorithm_config,
+            input_cross_embodiment_description=self.input_cross_embodiment_description,
+            output_cross_embodiment_description=self.output_cross_embodiment_description,
         )
         if self.log_to_cloud:
             for file_path in artifacts_dir.glob("*"):

--- a/neuracore/ml/utils/validate.py
+++ b/neuracore/ml/utils/validate.py
@@ -250,7 +250,13 @@ def run_validation(
         with tempfile.TemporaryDirectory():
             try:
                 artifacts_dir = output_dir
-                create_nc_archive(model, artifacts_dir, algorithm_config)
+                create_nc_archive(
+                    model,
+                    artifacts_dir,
+                    algorithm_config,
+                    input_cross_embodiment_description,
+                    output_cross_embodiment_description,
+                )
 
                 algo_check.successfully_exported_model = True
                 logger.info("NC archive export successful")

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -694,6 +694,58 @@ def test_deploy_model_failure(
         )
 
 
+def test_deploy_model_loads_embodiments_from_job_metadata_for_robot_name(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id, monkeypatch
+):
+    """Deploy model should resolve robot_name and load job metadata embodiments."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/models/deploy",
+        json={"id": "endpoint_123", "name": "test_endpoint", "status": "deploying"},
+        status_code=200,
+    )
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123",
+        json={
+            "input_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_POSITIONS": {"0": "joint1"}}
+            },
+            "output_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
+            },
+        },
+        status_code=200,
+    )
+
+    nc.deploy_model(
+        job_id="job_123",
+        name="test_endpoint",
+        robot_name=TEST_ROBOT_ID,
+    )
+
+    request_body = mock_auth_requests.request_history[-1].json()
+    assert request_body["input_embodiment_description"]["JOINT_POSITIONS"] == {
+        "0": "joint1"
+    }
+    assert request_body["output_embodiment_description"]["JOINT_TARGET_POSITIONS"] == {
+        "0": "joint1"
+    }
+
+
+def test_deploy_model_raises_when_missing_embodiments_and_robot_selector(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Deploy model requires embodiments or a robot_id/robot_name."""
+    nc.login(TEST_API_KEY)
+    with pytest.raises(
+        ValueError, match="Must provide both input_embodiment_description"
+    ):
+        nc.deploy_model(
+            job_id="job_123",
+            name="test_endpoint",
+        )
+
+
 def test_connect_local_endpoint_with_train_run(
     temp_config_dir, mock_auth_requests, reset_neuracore, monkeypatch, mocked_org_id
 ):

--- a/tests/unit/ml/utils/test_policy_inference.py
+++ b/tests/unit/ml/utils/test_policy_inference.py
@@ -1,5 +1,6 @@
 """Tests for policy inference."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -240,3 +241,64 @@ def test_preprocess_raises_when_received_items_exceed_training_limit() -> None:
         match="Received 2 items for data type",
     ):
         policy_inference._preprocess(sync_point)
+
+
+def test_init_loads_embodiments_from_archive_when_robot_id_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_model = SimpleNamespace(
+        eval=lambda: None,
+        model_init_description=SimpleNamespace(
+            input_dataset_statistics={},
+            output_prediction_horizon=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "neuracore.ml.utils.policy_inference.load_model_from_nc_archive",
+        lambda model_file, device=None: (
+            fake_model,
+            {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
+            {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
+        ),
+    )
+
+    inference = PolicyInference(
+        input_embodiment_description=None,
+        output_embodiment_description=None,
+        model_file=Path("dummy.nc.zip"),
+        org_id="org",
+        robot_id="robot-1",
+    )
+
+    assert DataType.JOINT_POSITIONS in inference.input_embodiment_description
+    assert DataType.JOINT_TARGET_POSITIONS in inference.output_embodiment_description
+
+
+def test_init_raises_when_no_descriptions_and_no_robot_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_model = SimpleNamespace(
+        eval=lambda: None,
+        model_init_description=SimpleNamespace(
+            input_dataset_statistics={},
+            output_prediction_horizon=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "neuracore.ml.utils.policy_inference.load_model_from_nc_archive",
+        lambda model_file, device=None: (fake_model, {}, {}),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Must provide both input_embodiment_description and "
+            "output_embodiment_description"
+        ),
+    ):
+        PolicyInference(
+            input_embodiment_description=None,
+            output_embodiment_description=None,
+            model_file=Path("dummy.nc.zip"),
+            org_id="org",
+        )

--- a/tests/unit/ml/utils/test_robot_data_spec_utils.py
+++ b/tests/unit/ml/utils/test_robot_data_spec_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from neuracore_types import DataType
 
@@ -5,6 +7,7 @@ import neuracore as nc
 from neuracore.core.const import API_URL
 from neuracore.core.utils.robot_data_spec_utils import (
     convert_cross_embodiment_description_names_to_ids,
+    resolve_embodiment_descriptions_with_override,
 )
 
 TEST_ROBOT_ID = "20a621b7-2f9b-4699-a08e-7d080488a5a3"
@@ -55,3 +58,91 @@ def test_convert_robot_data_spec_names_to_ids_raises_on_name_id_collision(
     spec = {"robot_id_1": {DataType.RGB_IMAGES: _indexed_names("cam")}}
     with pytest.raises(Exception):
         convert_cross_embodiment_description_names_to_ids(spec)
+
+
+def test_resolve_embodiments_with_override_returns_explicit_descriptions() -> None:
+    input_emb = {DataType.JOINT_POSITIONS: _indexed_names("joint1")}
+    output_emb = {DataType.JOINT_TARGET_POSITIONS: _indexed_names("joint1")}
+
+    resolved_input, resolved_output = resolve_embodiment_descriptions_with_override(
+        input_embodiment_description=input_emb,
+        output_embodiment_description=output_emb,
+        robot_id=None,
+    )
+
+    assert resolved_input == input_emb
+    assert resolved_output == output_emb
+
+
+def test_resolve_embodiments_with_override_loads_from_job_metadata(
+    requests_mock, monkeypatch
+) -> None:
+    class _Auth:
+        def get_headers(self):
+            return {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_current_org",
+        lambda: "test-org-id",
+    )
+    requests_mock.get(
+        f"{API_URL}/org/test-org-id/training/jobs/job-123",
+        json={
+            "input_cross_embodiment_description": {
+                "robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}
+            },
+            "output_cross_embodiment_description": {
+                "robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
+            },
+        },
+        status_code=200,
+    )
+
+    resolved_input, resolved_output = resolve_embodiment_descriptions_with_override(
+        input_embodiment_description=None,
+        output_embodiment_description=None,
+        robot_id="robot-1",
+        job_id="job-123",
+    )
+
+    assert resolved_input == {DataType.JOINT_POSITIONS: {"0": "joint1"}}
+    assert resolved_output == {DataType.JOINT_TARGET_POSITIONS: {"0": "joint1"}}
+
+
+def test_resolve_embodiments_with_override_loads_from_model_archive(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.load_cross_embodiment_descriptions_from_nc_archive",
+        lambda model_file: (
+            {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
+            {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
+        ),
+    )
+
+    resolved_input, resolved_output = resolve_embodiment_descriptions_with_override(
+        input_embodiment_description=None,
+        output_embodiment_description=None,
+        robot_id="robot-1",
+        model_file=Path("dummy.nc.zip"),
+    )
+
+    assert resolved_input == {DataType.JOINT_POSITIONS: {"0": "joint1"}}
+    assert resolved_output == {DataType.JOINT_TARGET_POSITIONS: {"0": "joint1"}}
+
+
+def test_resolve_embodiments_with_override_raises_when_incomplete() -> None:
+    with pytest.raises(
+        ValueError, match="Must provide both input_embodiment_description"
+    ):
+        resolve_embodiment_descriptions_with_override(
+            input_embodiment_description={
+                DataType.JOINT_POSITIONS: _indexed_names("j1")
+            },
+            output_embodiment_description=None,
+            robot_id=None,
+        )

--- a/tests/unit/ml/utils/test_training_storage_handler.py
+++ b/tests/unit/ml/utils/test_training_storage_handler.py
@@ -14,6 +14,8 @@ ORG_ID = "test-org-id"
 JOB_ID = "test-job-id"
 BASE_JOB_URL = f"{API_URL}/org/{ORG_ID}/training/jobs/{JOB_ID}"
 SIGNED_URL = "https://storage.example.com/signed-url"
+INPUT_CROSS_EMBODIMENT_DESCRIPTION = {"robot": {"joints": {"0": {"name": "j0"}}}}
+OUTPUT_CROSS_EMBODIMENT_DESCRIPTION = {"robot": {"actions": {"0": {"name": "a0"}}}}
 
 
 @pytest.fixture
@@ -42,13 +44,19 @@ def handler(tmp_path, requests_mock, mock_auth, mock_org):
     return TrainingStorageHandler(
         local_dir=str(tmp_path),
         training_job_id=JOB_ID,
+        input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+        output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
     )
 
 
 @pytest.fixture
 def local_handler(tmp_path, mock_auth, mock_org):
     """Create a local-only TrainingStorageHandler (no cloud)."""
-    return TrainingStorageHandler(local_dir=str(tmp_path))
+    return TrainingStorageHandler(
+        local_dir=str(tmp_path),
+        input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+        output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
+    )
 
 
 class TestInit:
@@ -57,7 +65,10 @@ class TestInit:
     ):
         requests_mock.get(BASE_JOB_URL, json={}, status_code=200)
         cloud_handler = TrainingStorageHandler(
-            local_dir=str(tmp_path), training_job_id=JOB_ID
+            local_dir=str(tmp_path),
+            training_job_id=JOB_ID,
+            input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
         )
         assert cloud_handler.log_to_cloud is True
         assert cloud_handler.training_job_id == JOB_ID
@@ -68,17 +79,30 @@ class TestInit:
     ):
         requests_mock.get(BASE_JOB_URL, json={"detail": "Not found"}, status_code=404)
         with pytest.raises(ValueError, match=JOB_ID):
-            TrainingStorageHandler(local_dir=str(tmp_path), training_job_id=JOB_ID)
+            TrainingStorageHandler(
+                local_dir=str(tmp_path),
+                training_job_id=JOB_ID,
+                input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+                output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            )
 
     def test_init_without_job_id_disables_cloud_logging(
         self, tmp_path, mock_auth, mock_org
     ):
-        local_only_handler = TrainingStorageHandler(local_dir=str(tmp_path))
+        local_only_handler = TrainingStorageHandler(
+            local_dir=str(tmp_path),
+            input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
+        )
         assert local_only_handler.log_to_cloud is False
         assert local_only_handler.training_job_id is None
 
     def test_init_sets_local_dir_to_output_when_none_given(self, mock_auth, mock_org):
-        handler_with_default_dir = TrainingStorageHandler(local_dir=None)
+        handler_with_default_dir = TrainingStorageHandler(
+            local_dir=None,
+            input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
+        )
         assert handler_with_default_dir.local_dir == Path("./output")
 
 
@@ -314,6 +338,8 @@ class TestSaveModelArtifacts:
             model=mock_model,
             output_dir=artifacts_dir,
             algorithm_config={},
+            input_cross_embodiment_description=INPUT_CROSS_EMBODIMENT_DESCRIPTION,
+            output_cross_embodiment_description=OUTPUT_CROSS_EMBODIMENT_DESCRIPTION,
         )
 
     def test_save_model_artifacts_uploads_each_artifact_file_to_cloud(
@@ -327,7 +353,13 @@ class TestSaveModelArtifacts:
         )
         requests_mock.put(SIGNED_URL, status_code=200)
 
-        def fake_archive(model, output_dir, algorithm_config):
+        def fake_archive(
+            model,
+            output_dir,
+            algorithm_config,
+            input_cross_embodiment_description,
+            output_cross_embodiment_description,
+        ):
             (output_dir / "model.pt").write_bytes(b"model_data")
             (output_dir / "config.json").write_bytes(b"{}")
 


### PR DESCRIPTION
### Features
- Save cross embodiment description to nc archive during training
- Enable selection of embodiment description by robot ID during inference/deployment from nc archive or job description from backend if embodiment description is not explicitly provided 

### Items
 - [NCRL-404](https://neuracore.atlassian.net/browse/NCRL-404)

### Related PRs
- https://github.com/NeuracoreAI/neuracore_frontend/pull/308
- https://github.com/NeuracoreAI/neuracore_backend/pull/368