### PR TITLE
fix: retry stale keep-alive connections via shared HTTP session

### DIFF
--- a/neuracore/api/datasets.py
+++ b/neuracore/api/datasets.py
@@ -4,7 +4,6 @@ This module provides functions for creating and retrieving datasets
 for robot demonstrations.
 """
 
-import requests
 from neuracore_types import Dataset as DatasetModel
 
 from neuracore.api.globals import GlobalSingleton
@@ -13,6 +12,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.data.dataset import Dataset
 from neuracore.core.exceptions import DatasetError
+from neuracore.core.utils.http_session import get_session
 
 
 def get_dataset(name: str | None = None, id: str | None = None) -> Dataset:
@@ -66,7 +66,7 @@ def merge_datasets(name: str, dataset_names: list[str]) -> Dataset:
             raise DatasetError(f"Dataset '{dataset_name}' not found.")
         source_ids.append(ds.id)
 
-    response = requests.post(
+    response = get_session().post(
         f"{API_URL}/org/{org_id}/datasets/merge",
         headers=auth.get_headers(),
         json={"name": name, "sourceDatasetIds": source_ids},

--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -5,7 +5,6 @@ managing local model endpoints, and handling the lifecycle of model deployments
 including deployment, status monitoring, and deletion operations.
 """
 
-import requests
 from neuracore_types import (
     DeploymentConfig,
     DeploymentRequest,
@@ -28,6 +27,7 @@ from neuracore.core.get_latest_sync_point import (
 from neuracore.core.get_latest_sync_point import (
     get_latest_sync_point as _get_latest_sync_point,
 )
+from neuracore.core.utils.http_session import get_session
 
 
 def policy(
@@ -175,7 +175,7 @@ def deploy_model(
         config=DeploymentConfig(gpu_type=gpu_type),
     ).model_dump(mode="json")
     try:
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{org_id}/models/deploy",
             headers=auth.get_headers(),
             json=payload,
@@ -210,7 +210,7 @@ def get_endpoint_status(endpoint_id: str) -> str:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
             headers=auth.get_headers(),
         )
@@ -243,7 +243,7 @@ def delete_endpoint(endpoint_id: str) -> None:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        response = requests.delete(
+        response = get_session().delete(
             f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
             headers=auth.get_headers(),
         )

--- a/neuracore/api/orgs_fetch.py
+++ b/neuracore/api/orgs_fetch.py
@@ -1,14 +1,13 @@
 """Helpers for fetching the current user's organization IDs from the API."""
 
-import requests
-
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 
 
 def fetch_org_ids(access_token: str) -> set[str] | None:
     """Return the set of org IDs for the authenticated user."""
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org-management/my-orgs",
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=10,

--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -8,7 +8,6 @@ import concurrent
 import sys
 from typing import Any, cast
 
-import requests
 from neuracore_types import (
     CrossEmbodimentDescription,
     GPUType,
@@ -17,6 +16,7 @@ from neuracore_types import (
 )
 
 from neuracore.core.config.get_current_org import get_current_org
+from neuracore.core.utils.http_session import get_session
 from neuracore.core.utils.robot_data_spec_utils import (
     merge_cross_embodiment_description,
 )
@@ -76,13 +76,13 @@ def _get_algorithms() -> list[dict]:
     org_id = get_current_org()
     with concurrent.futures.ThreadPoolExecutor() as executor:
         org_alg_req = executor.submit(
-            requests.get,
+            get_session().get,
             f"{API_URL}/org/{org_id}/algorithms",
             headers=auth.get_headers(),
             params={"shared": False},
         )
         shared_alg_req = executor.submit(
-            requests.get,
+            get_session().get,
             f"{API_URL}/org/{org_id}/algorithms",
             headers=auth.get_headers(),
             params={"shared": True},
@@ -183,7 +183,7 @@ def start_training_run(
 
     auth = get_auth()
     org_id = get_current_org()
-    response = requests.post(
+    response = get_session().post(
         f"{API_URL}/org/{org_id}/training/jobs",
         headers=auth.get_headers(),
         json=data.model_dump(mode="json"),
@@ -213,7 +213,7 @@ def resume_training_run(job_id: str, additional_epochs: int) -> dict:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}/resume/{additional_epochs}",
             headers=auth.get_headers(),
         )
@@ -235,7 +235,7 @@ def get_training_jobs() -> list[dict]:
     """
     auth = get_auth()
     org_id = get_current_org()
-    response = requests.get(
+    response = get_session().get(
         f"{API_URL}/org/{org_id}/training/jobs",
         headers=auth.get_headers(),
     )
@@ -317,7 +317,7 @@ def get_training_job_logs(
         params["severity_filter"] = severity_filter
 
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}/logs",
             headers=auth.get_headers(),
             params=params,
@@ -343,7 +343,7 @@ def delete_training_job(job_id: str) -> None:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        response = requests.delete(
+        response = get_session().delete(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
             headers=auth.get_headers(),
         )

--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -13,6 +13,7 @@ import requests
 from neuracore.api.orgs_fetch import fetch_org_ids
 from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.config.get_api_key import get_api_key
+from neuracore.core.utils.http_session import get_session
 from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
 
 from .const import API_URL
@@ -56,7 +57,7 @@ class Auth(metaclass=SingletonMetaclass):
 
         # Verify API key with server and get access token
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/auth/verify-api-key",
                 json={"api_key": api_key},
             )
@@ -133,7 +134,7 @@ class Auth(metaclass=SingletonMetaclass):
         # Placeholder for version validation logic
         from neuracore_types import __version__ as nc_types_version
 
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/auth/verify-version",
             params={"version": nc_types_version},
         )

--- a/neuracore/core/cli/generate_api_key.py
+++ b/neuracore/core/cli/generate_api_key.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ValidationError
 from neuracore.core.cli.get_user_confirmation import get_user_confirmation
 from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.exceptions import AuthenticationError, InputError
+from neuracore.core.utils.http_session import get_session
 
 from ..const import API_URL, MAX_INPUT_ATTEMPTS
 
@@ -62,7 +63,7 @@ def generate_api_key(email: str | None = None, password: str | None = None) -> s
             if not password:
                 password = getpass("Enter your password: ")
 
-            auth_response = requests.post(
+            auth_response = get_session().post(
                 f"{API_URL}/auth/token",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 data={"username": email, "password": password},
@@ -103,7 +104,7 @@ def generate_api_key(email: str | None = None, password: str | None = None) -> s
     # Use the access token to request an API key
     try:
         headers = {"Authorization": f"Bearer {access_token}"}
-        api_key_response = requests.get(
+        api_key_response = get_session().get(
             f"{API_URL}/auth/api-key",
             headers=headers,
         )

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -27,6 +27,7 @@ from ..auth import Auth, get_auth
 from ..const import API_URL, DEFAULT_RECORDING_CACHE_DIR
 from ..exceptions import AuthenticationError, DatasetError
 from ..utils.http_errors import extract_error_detail
+from ..utils.http_session import get_session
 
 PAGE_SIZE = 30
 SYNC_PROGRESS_POLL_INTERVAL_S = 5.0
@@ -116,7 +117,7 @@ class Dataset:
     def _initialize_num_recordings(self) -> None:
         """Fetch total number of recordings without loading them."""
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
                 headers=get_auth().get_headers(),
                 params={"limit": 1, "is_shared": self.is_shared},
@@ -141,7 +142,7 @@ class Dataset:
         params = {"limit": PAGE_SIZE, "is_shared": self.is_shared}
         payload = self._start_after or None
 
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
             headers=get_auth().get_headers(),
             params=params,
@@ -231,7 +232,7 @@ class Dataset:
         """
         auth: Auth = get_auth()
         org_id = get_current_org()
-        req = requests.get(
+        req = get_session().get(
             f"{API_URL}/org/{org_id}/datasets/{id}",
             headers=auth.get_headers(),
         )
@@ -272,7 +273,7 @@ class Dataset:
         auth: Auth = get_auth()
         org_id = get_current_org()
         try:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{org_id}/datasets/search/by-name",
                 params={"name": name},
                 headers=auth.get_headers(),
@@ -354,7 +355,7 @@ class Dataset:
         """
         auth: Auth = get_auth()
         org_id = get_current_org()
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{org_id}/datasets",
             headers=auth.get_headers(),
             json={
@@ -383,7 +384,7 @@ class Dataset:
 
     def delete(self) -> None:
         """Delete this dataset from Neuracore."""
-        response = requests.delete(
+        response = get_session().delete(
             f"{API_URL}/org/{self.org_id}/datasets/{self.id}",
             headers=get_auth().get_headers(),
         )
@@ -395,7 +396,7 @@ class Dataset:
         for recording_id in failed_recording_ids:
             if recording_id not in id_to_name:
                 try:
-                    response = requests.get(
+                    response = get_session().get(
                         f"{API_URL}/org/{self.org_id}/recording/{recording_id}",
                         headers=auth_headers,
                     )
@@ -455,7 +456,7 @@ class Dataset:
             requests.HTTPError: If the API request fails.
             DatasetError: If frequency is not greater than 0.
         """
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{self.org_id}/synchronize/synchronize-dataset",
             headers=get_auth().get_headers(),
             json=SynchronizeDatasetRequest(
@@ -480,7 +481,7 @@ class Dataset:
         Returns:
             Synchronization progress for the dataset.
         """
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.org_id}/synchronize/synchronization-progress/{synchronized_dataset_id}",
             headers=get_auth().get_headers(),
         )
@@ -586,7 +587,7 @@ class Dataset:
         """
         # Best-effort resolution without additional network calls.
         # If we can resolve a robot_name to an ID, do so; otherwise delegate to server.
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.org_id}/datasets/{self.id}/full-embodiment-description/{robot_id}",
             headers=get_auth().get_headers(),
         )
@@ -607,7 +608,7 @@ class Dataset:
             List of robot IDs in the synchronized dataset.
         """
         if self._robot_ids is None:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robot_ids",
                 headers=get_auth().get_headers(),
             )
@@ -688,7 +689,7 @@ class Dataset:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            req = requests.get(
+            req = get_session().get(
                 f"{API_URL}/org/{org_id}/datasets/{self.id}",
                 headers=auth.get_headers(),
             )
@@ -722,7 +723,7 @@ class Dataset:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            response = requests.put(
+            response = get_session().put(
                 f"{API_URL}/org/{org_id}/datasets/{self.id}",
                 headers=auth.get_headers(),
                 json=dataset_metadata.model_dump(mode="json"),

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-import requests
 from neuracore_types import CrossEmbodimentUnion, DataType
 from neuracore_types import Recording as RecordingModel
 from neuracore_types import RecordingMetadata, RecordingStatus
@@ -12,6 +11,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.data.synced_recording import SynchronizedRecording
 from neuracore.core.exceptions import AuthenticationError, SynchronizationError
+from neuracore.core.utils.http_session import get_session
 from neuracore.core.utils.robot_data_spec_utils import extract_data_types
 
 if TYPE_CHECKING:
@@ -138,7 +138,7 @@ class Recording:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{org_id}/recording/{self.id}",
                 headers=auth.get_headers(),
             )
@@ -165,7 +165,7 @@ class Recording:
         org_id = get_current_org()
         try:
 
-            response = requests.put(
+            response = get_session().put(
                 f"{API_URL}/org/{org_id}/recording/{self.id}/metadata",
                 headers=auth.get_headers(),
                 json=recording_metadata.model_dump(mode="json"),

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -4,7 +4,6 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Union, cast
 
-import requests
 from neuracore_types import (
     CrossEmbodimentDescription,
     CrossEmbodimentUnion,
@@ -16,6 +15,7 @@ from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.data.recording import Recording
 from neuracore.core.data.synced_recording import SynchronizedRecording
+from neuracore.core.utils.http_session import get_session
 
 if TYPE_CHECKING:
     from neuracore.core.data.dataset import Dataset
@@ -208,7 +208,7 @@ class SynchronizedDataset:
         Returns:
             SynchronizedDatasetStatistics containing the calculated statistics.
         """
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset/calculate-dataset-statistics",
             json=SynchronizedDatasetStatistics(
                 synchronized_dataset_id=self.id,

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
-import requests
 import wget
 from neuracore_types import (
     CameraData,
@@ -25,6 +24,7 @@ from PIL import Image
 
 from neuracore.core.data.cache_manager import CacheManager
 from neuracore.core.utils.depth_utils import rgb_to_depth_storage
+from neuracore.core.utils.http_session import get_session
 
 from ..auth import get_auth
 from ..const import API_URL
@@ -104,7 +104,7 @@ class SynchronizedRecording:
             requests.HTTPError: If the API request fails.
         """
         auth = get_auth()
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording",
             json=SynchronizeRecordingRequest(
                 recording_id=self.id,
@@ -134,7 +134,7 @@ class SynchronizedRecording:
             requests.HTTPError: If the API request fails.
         """
         auth = get_auth()
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.dataset.org_id}/recording/{self.id}/download_url",
             params={"filepath": f"{camera_type.value}/{camera_id}/lossless.mp4"},
             headers=auth.get_headers(),

--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 import requests
 from neuracore_types import DataType, EmbodimentDescription, SynchronizedPoint
 
+from neuracore.core.utils.http_session import get_session
+
 if TYPE_CHECKING:
     from neuracore_types import BatchedNCData
 
@@ -252,7 +254,7 @@ class ServerPolicy(Policy):
         if epoch < -1:
             raise ValueError("Epoch must be -1 (last) or a non-negative integer.")
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{self._base_url}{SET_CHECKPOINT_ENDPOINT}",
                 headers=self._headers,
                 json={"epoch": epoch},
@@ -308,7 +310,7 @@ class ServerPolicy(Policy):
             sync_point.data = filtered_data
         response = None
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{self._base_url}{PREDICT_ENDPOINT}",
                 headers=self._headers,
                 json=sync_point.model_dump(mode="json"),
@@ -502,7 +504,7 @@ class LocalServerPolicy(ServerPolicy):
             if self.server_process and self.server_process.poll() is not None:
                 raise EndpointError("Local server process terminated unexpectedly.")
             try:
-                response = requests.get(
+                response = get_session().get(
                     f"http://{self.host}:{self.port}{PING_ENDPOINT}", timeout=1
                 )
                 if response.status_code == 200:
@@ -710,7 +712,7 @@ def policy_remote_server(
 
     try:
         # Find endpoint by name
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/models/endpoints", headers=auth.get_headers()
         )
         response.raise_for_status()
@@ -759,7 +761,7 @@ def _download_model(job_id: str, org_id: str) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     print("Downloading model from training run...")
-    response = requests.get(
+    response = get_session().get(
         f"{API_URL}/org/{org_id}/training/jobs/{job_id}/model_url",
         headers=auth.get_headers(),
         timeout=30,
@@ -779,7 +781,7 @@ def _download_model(job_id: str, org_id: str) -> Path:
 def _get_job_id(train_run_name: str, org_id: str) -> str:
     """Get job ID from training run name."""
     auth = get_auth()
-    response = requests.get(
+    response = get_session().get(
         f"{API_URL}/org/{org_id}/training/jobs", headers=auth.get_headers()
     )
     response.raise_for_status()

--- a/neuracore/core/organizations.py
+++ b/neuracore/core/organizations.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ValidationError
 
 from neuracore.core.auth import get_auth
 from neuracore.core.exceptions import AuthenticationError, OrganizationError
+from neuracore.core.utils.http_session import get_session
 
 from .const import API_URL
 
@@ -34,7 +35,7 @@ def list_my_orgs() -> list[Organization]:
     """
     auth = get_auth()
     try:
-        org_response = requests.get(
+        org_response = get_session().get(
             f"{API_URL}/org-management/my-orgs", headers=auth.get_headers()
         )
         org_response.raise_for_status()

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -23,6 +23,7 @@ from neuracore_types import DataType, RobotInstanceIdentifier
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.streaming.data_stream import DataStream
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
+from neuracore.core.utils.http_session import get_session
 from neuracore.data_daemon.communications_management.producer_channel import (
     ProducerChannel,
 )
@@ -176,7 +177,7 @@ class Robot:
             )
 
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/robots?is_shared={self.shared}",
                 json={
                     "name": self.name,
@@ -269,7 +270,7 @@ class Robot:
 
         try:
 
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/recording/start",
                 headers=self._auth.get_headers(),
                 json={
@@ -331,7 +332,7 @@ class Robot:
         )
 
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/recording/stop?recording_id={recording_id}",
                 headers=self._auth.get_headers(),
             )
@@ -539,7 +540,7 @@ class Robot:
             )
 
         try:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
                 headers=self._auth.get_headers(),
             )
@@ -586,7 +587,7 @@ class Robot:
             files = self._package_urdf()
 
             # Upload the package
-            response = requests.put(
+            response = get_session().put(
                 f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
                 headers=self._auth.get_headers(),
                 files=files,
@@ -675,7 +676,7 @@ class Robot:
         self._get_daemon_recording_context().stop_recording(recording_id=recording_id)
 
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/recording/cancel?recording_id={recording_id}",
                 headers=self._auth.get_headers(),
             )
@@ -832,7 +833,7 @@ def update_robot_name(
         raise RobotError("No organization selected. Please call nc.select_org() first.")
     robot_id = _robot_name_id_mapping.get(robot_key, robot_key)
     try:
-        response = requests.post(
+        response = get_session().post(
             f"{API_URL}/org/{resolved_org_id}/robots?is_shared={shared}&robot_id={robot_id}",
             json={"name": new_robot_name, "instance": instance},
             headers=get_auth().get_headers(),
@@ -868,7 +869,7 @@ def list_organization_robots(
             "Invalid robot list mode. Please use 'current', 'archived', or 'mixed'."
         )
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/robots?is_shared={is_shared}&mode={mode}",
             headers=get_auth().get_headers(),
         )
@@ -902,13 +903,13 @@ def get_robot_id_from_name(robot_name: str, org_id: str | None = None) -> str:
     if org_id is None:
         org_id = get_current_org()
 
-    response_private = requests.get(
+    response_private = get_session().get(
         f"{API_URL}/org/{org_id}/robots",
         headers=get_auth().get_headers(),
         params={"is_shared": False},
     )
 
-    response_shared = requests.get(
+    response_shared = get_session().get(
         f"{API_URL}/org/{org_id}/robots",
         headers=get_auth().get_headers(),
         params={"is_shared": True},

--- a/neuracore/core/streaming/bucket_uploaders/bucket_uploader.py
+++ b/neuracore/core/streaming/bucket_uploaders/bucket_uploader.py
@@ -15,6 +15,7 @@ from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
+from neuracore.core.utils.http_session import get_session
 
 TRACE_FILE = "trace.json"
 
@@ -54,7 +55,7 @@ class BucketUploader(ABC):
 
         org_id = get_current_org()
         try:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces",
                 json={"data_type": data_type.value},
                 headers=get_auth().get_headers(),
@@ -94,7 +95,7 @@ class BucketUploader(ABC):
 
         org_id = get_current_org()
         try:
-            requests.put(
+            get_session().put(
                 f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces/{trace_id}",
                 json=data_trace_payload,
                 headers=get_auth().get_headers(),

--- a/neuracore/core/streaming/bucket_uploaders/resumable_upload.py
+++ b/neuracore/core/streaming/bucket_uploaders/resumable_upload.py
@@ -9,11 +9,10 @@ exponential backoff.
 import logging
 import time
 
-import requests
-
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +59,7 @@ class ResumableUpload:
             "content_type": self.content_type,
         }
         org_id = get_current_org()
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/recording/{self.recording_id}/resumable_upload_url",
             params=params,
             headers=auth.get_headers(),
@@ -112,7 +111,9 @@ class ResumableUpload:
 
         for attempt in range(self.max_retries):
             try:
-                response = requests.put(self.session_uri, headers=headers, data=data)
+                response = get_session().put(
+                    self.session_uri, headers=headers, data=data
+                )
                 status_code = response.status_code
 
                 if status_code == 200 or status_code == 201:
@@ -149,7 +150,7 @@ class ResumableUpload:
         """
         headers = {"Content-Length": "0", "Content-Range": "bytes */*"}
 
-        response = requests.put(self.session_uri, headers=headers)
+        response = get_session().put(self.session_uri, headers=headers)
         if response.status_code == 200 or response.status_code == 201:
             logger.debug("Upload complete")
             return self.total_bytes_uploaded

--- a/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
+++ b/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
@@ -25,6 +25,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import EncodingError
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
+from neuracore.core.utils.http_session import get_session
 
 from .bucket_uploader import TRACE_FILE, BucketUploader
 from .resumable_upload import ResumableUpload
@@ -393,7 +394,7 @@ class StreamingVideoUploader(BucketUploader):
         }
         org_id = get_current_org()
         try:
-            upload_url_response = requests.get(
+            upload_url_response = get_session().get(
                 f"{API_URL}/org/{org_id}/recording/{self.uploader.recording_id}/resumable_upload_url",
                 params=params,
                 headers=get_auth().get_headers(),
@@ -406,7 +407,7 @@ class StreamingVideoUploader(BucketUploader):
         for i in range(0, len(self.frame_metadatas)):
             self.frame_metadatas[i].frame_idx = i
         data = json.dumps([fm.model_dump(mode="json") for fm in self.frame_metadatas])
-        response = requests.put(
+        response = get_session().put(
             upload_url, headers={"Content-Length": str(len(data))}, data=data
         )
         response.raise_for_status()

--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -8,12 +8,12 @@ synchronized datasets.
 import base64
 import hashlib
 
-import requests
 from neuracore_types import DataType, RecordingDataTrace
 
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 
 
 def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
@@ -33,7 +33,7 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
         ConfigError: If there is an error trying to get the current org.
     """
     org_id = get_current_org()
-    response = requests.get(
+    response = get_session().get(
         f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/active",
         headers=get_auth().get_headers(),
     )

--- a/neuracore/core/utils/download.py
+++ b/neuracore/core/utils/download.py
@@ -3,8 +3,9 @@
 import tempfile
 from pathlib import Path
 
-import requests
 from tqdm import tqdm
+
+from neuracore.core.utils.http_session import get_session
 
 
 def download_with_progress(
@@ -21,7 +22,7 @@ def download_with_progress(
     Returns:
         Path to the downloaded file.
     """
-    response = requests.get(
+    response = get_session().get(
         url,
         timeout=120,
         stream=True,

--- a/neuracore/core/utils/http_session.py
+++ b/neuracore/core/utils/http_session.py
@@ -1,0 +1,39 @@
+"""Shared HTTP session with retry on connection/SSL failures.
+
+All Neuracore API calls should use ``get_session()`` rather than the bare
+``requests.*`` module-level functions so that stale keep-alive connections
+are retried transparently instead of raising SSLError.
+"""
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+_RETRY = Retry(
+    total=3,  # cap total retry attempts across all categories
+    connect=3,  # retry conn establishment failures (stale keep-alive reuse lands here)
+    read=0,  # never retry after bytes left the wire
+    status=0,  # no status-code retries; let 5xx raise immediately
+    backoff_factor=0.1,  # 0.1s, 0.2s, 0.4s between retries (~0.7s worst case)
+    allowed_methods=False,  # type: ignore[arg-type]  # False = retry all methods
+)
+
+
+def _build_session() -> requests.Session:
+    """Build a new requests Session with retry on connection/SSL failures."""
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=_RETRY)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_session: requests.Session | None = None
+
+
+def get_session() -> requests.Session:
+    """Return the shared, retry-configured requests Session."""
+    global _session
+    if _session is None or _session.adapters == {}:
+        _session = _build_session()
+    return _session

--- a/neuracore/core/utils/video_url_streamer.py
+++ b/neuracore/core/utils/video_url_streamer.py
@@ -14,6 +14,8 @@ import av
 import numpy as np
 import requests
 
+from neuracore.core.utils.http_session import get_session
+
 logger = logging.getLogger(__name__)
 
 CHUNK_SIZE = 256 * 1024  # Multiples of 256KB
@@ -206,7 +208,7 @@ class VideoStreamer:
                 streams, or if decoding fails.
         """
         # Start the streaming request
-        self.response = requests.get(self.video_url, stream=True)
+        self.response = get_session().get(self.video_url, stream=True)
 
         # Check if request was successful
         if self.response.status_code != 200:

--- a/neuracore/ml/cli/training_runs_cloud.py
+++ b/neuracore/ml/cli/training_runs_cloud.py
@@ -19,6 +19,7 @@ from neuracore.core.cli.training_display import RunDisplayRow, print_run_table
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError, ConfigError, TrainingRunError
+from neuracore.core.utils.http_session import get_session
 
 TRAINING_JOB_LIST_ADAPTER = TypeAdapter(list[TrainingJob])
 console = Console()
@@ -127,7 +128,7 @@ def _fetch_training_jobs(auth: Any, org_id: str) -> list[TrainingJob]:
         TrainingRunError: If the API request fails.
     """
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/training/jobs",
             headers=auth.get_headers(),
         )
@@ -164,7 +165,7 @@ def _fetch_training_job(auth: Any, org_id: str, job_id: str) -> TrainingJob:
         TrainingRunError: If the job is not found or API request fails.
     """
     try:
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
             headers=auth.get_headers(),
         )

--- a/neuracore/ml/logging/cloud_training_logger.py
+++ b/neuracore/ml/logging/cloud_training_logger.py
@@ -6,12 +6,12 @@ import time
 from typing import Any
 
 import numpy as np
-import requests
 import torch
 
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 from neuracore.ml.logging.training_logger import TrainingLogger
 
 logger = logging.getLogger(__name__)
@@ -177,7 +177,7 @@ class CloudTrainingLogger(TrainingLogger):
                 for name, step_map in self._store.items()
             }
         }
-        response = requests.put(
+        response = get_session().put(
             f"{API_URL}/org/{org_id}/training/jobs/{self.training_id}/metrics",
             headers=get_auth().get_headers(),
             json=metricsData,

--- a/neuracore/ml/utils/algorithm_storage_handler.py
+++ b/neuracore/ml/utils/algorithm_storage_handler.py
@@ -11,6 +11,7 @@ import wget
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 from neuracore.ml.utils.validate import AlgorithmCheck
 
@@ -31,7 +32,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         self.log_to_cloud = self.algorithm_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}",
                 headers=get_auth().get_headers(),
             )
@@ -47,7 +48,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
             error_message: Error message to save.
         """
         if self.log_to_cloud:
-            response = requests.post(
+            response = get_session().post(
                 f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/validation-error",
                 headers=get_auth().get_headers(),
                 json={"error_message": error_message},
@@ -63,7 +64,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         Args:
             extract_dir: Directory to extract algorithm code to.
         """
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.org_id}/algorithms/download_url/{self.algorithm_id}",
             headers=get_auth().get_headers(),
         )
@@ -105,7 +106,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         else:
             dict_to_save["validation_status"] = "validation_failed"
             dict_to_save["validation_message"] = error_message
-        response = requests.put(
+        response = get_session().put(
             f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/update-algorithm-validation",
             headers=get_auth().get_headers(),
             json=dict_to_save,
@@ -118,7 +119,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for algorithm artifacts/logs."""
         assert self.algorithm_id is not None, "Algorithm ID not provided"
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/upload-url",
             headers=get_auth().get_headers(),
             params={
@@ -138,7 +139,7 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         data: bytes | IO[bytes],
         content_type: str,
     ) -> requests.Response:
-        return requests.put(
+        return get_session().put(
             upload_url,
             data=data,
             headers={"Content-Type": content_type},

--- a/neuracore/ml/utils/endpoint_storage_handler.py
+++ b/neuracore/ml/utils/endpoint_storage_handler.py
@@ -8,6 +8,7 @@ import requests
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class EndpointStorageHandler(UploadStorageMixin):
         self.log_to_cloud = self.endpoint_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
-            response = requests.get(
+            response = get_session().get(
                 f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}",
                 headers=get_auth().get_headers(),
             )
@@ -38,7 +39,7 @@ class EndpointStorageHandler(UploadStorageMixin):
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for endpoint logs."""
         assert self.endpoint_id is not None, "Endpoint ID not provided"
-        response = requests.get(
+        response = get_session().get(
             f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/upload-url",
             headers=get_auth().get_headers(),
             params={"filepath": filepath, "content_type": content_type},
@@ -55,7 +56,7 @@ class EndpointStorageHandler(UploadStorageMixin):
         data: bytes | IO[bytes],
         content_type: str,
     ) -> requests.Response:
-        return requests.put(
+        return get_session().put(
             upload_url,
             data=data,
             headers={"Content-Type": content_type},
@@ -67,7 +68,7 @@ class EndpointStorageHandler(UploadStorageMixin):
             return
 
         assert self.endpoint_id is not None, "Endpoint ID not provided"
-        response = requests.put(
+        response = get_session().put(
             f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/update",
             headers=get_auth().get_headers(),
             json={"error": error},

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import cast
 
-import requests
 import torch
 from neuracore_types import (
     DATA_TYPE_TO_BATCHED_NC_DATA_CLASS,
@@ -19,6 +18,7 @@ from neuracore_types import (
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.utils.download import download_with_progress
+from neuracore.core.utils.http_session import get_session
 from neuracore.ml import BatchedInferenceInputs
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.nc_archive import load_model_from_nc_archive
@@ -151,7 +151,7 @@ class PolicyInference:
             )
             if not checkpoint_path.exists():
                 checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-                response = requests.get(
+                response = get_session().get(
                     f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}/checkpoint_url/{checkpoint_name}",
                     headers=get_auth().get_headers(),
                     timeout=30,

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -12,6 +12,7 @@ import neuracore as nc
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.utils.http_session import get_session
 from neuracore.ml.utils.nc_archive import create_nc_archive
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 
@@ -181,7 +182,7 @@ class TrainingStorageHandler(UploadStorageMixin):
         load_path = self.local_dir / checkpoint_name
         if self.log_to_cloud:
             download_url = self._get_checkpoint_download_url(checkpoint_name)
-            response = requests.get(download_url)
+            response = get_session().get(download_url)
             if response.status_code != 200:
                 raise ValueError(
                     f"Failed to download checkpoint {checkpoint_name}: {response.text}"
@@ -307,11 +308,11 @@ class TrainingStorageHandler(UploadStorageMixin):
             headers: Optional headers to include in the request.
         """
         headers = headers or get_auth().get_headers()
-        response = requests.put(url, headers=headers, json=json, data=data)
+        response = get_session().put(url, headers=headers, json=json, data=data)
         if response.status_code == 401:
             logger.warning("Unauthorized request. Token may have expired.")
             nc.login()
-            response = requests.put(url, headers=headers, json=json, data=data)
+            response = get_session().put(url, headers=headers, json=json, data=data)
         return response
 
     def _get_request(self, url: str, params: dict | None = None) -> requests.Response:
@@ -321,11 +322,13 @@ class TrainingStorageHandler(UploadStorageMixin):
             url: The URL to send the request to.
             params: Optional parameters to include in the request.
         """
-        response = requests.get(url, headers=get_auth().get_headers(), params=params)
+        response = get_session().get(
+            url, headers=get_auth().get_headers(), params=params
+        )
         if response.status_code == 401:
             logger.warning("Unauthorized request. Token may have expired.")
             nc.login()
-            response = requests.get(
+            response = get_session().get(
                 url, headers=get_auth().get_headers(), params=params
             )
         return response
@@ -336,9 +339,9 @@ class TrainingStorageHandler(UploadStorageMixin):
         Args:
             url: The URL to send the request to.
         """
-        response = requests.delete(url, headers=get_auth().get_headers())
+        response = get_session().delete(url, headers=get_auth().get_headers())
         if response.status_code == 401:
             logger.warning("Unauthorized request. Token may have expired.")
             nc.login()
-            response = requests.delete(url, headers=get_auth().get_headers())
+            response = get_session().delete(url, headers=get_auth().get_headers())
         return response

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import pathlib
 import re
 import tempfile
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests_mock
@@ -168,3 +168,8 @@ def reset_neuracore():
     yield
 
     nc.core.auth._auth = original_auth
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()

--- a/tests/unit/core/cli/test_training_runs.py
+++ b/tests/unit/core/cli/test_training_runs.py
@@ -321,13 +321,16 @@ class TestLibraryFunctions:
         mock_auth_requests,
         reset_neuracore,
         mocked_org_id,
+        mock_session,
     ):
         """Test handling of connection errors."""
         nc.login("test_api_key")
 
-        with patch("requests.get") as mock_get:
-            mock_get.side_effect = requests.exceptions.ConnectionError()
-
+        mock_session.get.side_effect = requests.exceptions.ConnectionError()
+        with patch(
+            "neuracore.ml.cli.training_runs_cloud.get_session",
+            return_value=mock_session,
+        ):
             with pytest.raises(TrainingRunError, match="connect"):
                 list_training_runs()
 

--- a/tests/unit/core/utils/test_http_session.py
+++ b/tests/unit/core/utils/test_http_session.py
@@ -1,0 +1,59 @@
+import pytest
+import requests
+import requests_mock
+from requests.adapters import HTTPAdapter
+
+import neuracore.core.utils.http_session as _mod
+from neuracore.core.utils.http_session import _build_session, get_session
+
+_URL = "https://api.neuracore.com"
+
+
+@pytest.fixture(autouse=True)
+def reset_session():
+    _mod._session = None
+    yield
+    _mod._session = None
+
+
+def test_get_session_returns_session():
+    assert isinstance(get_session(), requests.Session)
+
+
+def test_get_session_is_singleton():
+    assert get_session() is get_session()
+
+
+def test_get_session_rebuilds_when_adapters_cleared():
+    s1 = get_session()
+    s1.adapters.clear()
+    s2 = get_session()
+    assert s2 is not s1
+    assert s2.adapters
+
+
+def test_session_mounts_http_and_https():
+    s = _build_session()
+    assert isinstance(s.get_adapter("https://"), HTTPAdapter)
+    assert isinstance(s.get_adapter("http://"), HTTPAdapter)
+
+
+def test_retry_config():
+    retry = _build_session().get_adapter(_URL).max_retries
+    assert retry.connect == 3
+    assert retry.read == 0
+    assert retry.status == 0
+    assert retry.total == 3
+
+
+def test_retry_allows_all_methods():
+    retry = _build_session().get_adapter(_URL).max_retries
+    assert retry.allowed_methods is False
+
+
+def test_no_retry_on_5xx():
+    with requests_mock.Mocker() as m:
+        m.get(f"{_URL}/health", status_code=500)
+        r = _build_session().get(f"{_URL}/health")
+    assert r.status_code == 500
+    assert m.call_count == 1

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -2,7 +2,7 @@
 
 import re
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -305,21 +305,19 @@ def test_set_checkpoint_raises_endpoint_error_for_non_200_response(
 
 
 def test_set_checkpoint_raises_endpoint_error_for_connection_error(
-    monkeypatch,
     temp_config_dir,
     mock_auth_requests,
     reset_neuracore,
     mocked_org_id,
+    mock_session,
 ):
     """set_checkpoint should wrap requests ConnectionError in EndpointError."""
     nc.login(TEST_API_KEY)
     endpoint = _connect_test_remote_endpoint(mock_auth_requests, mocked_org_id)
-    monkeypatch.setattr(
-        "neuracore.core.endpoint.requests.post",
-        MagicMock(side_effect=requests.exceptions.ConnectionError()),
-    )
-
-    with pytest.raises(
+    mock_session.post.side_effect = requests.exceptions.ConnectionError()
+    with patch(
+        "neuracore.core.endpoint.get_session", return_value=mock_session
+    ), pytest.raises(
         EndpointError,
         match=(
             "Failed to connect to endpoint, please check your internet "
@@ -330,21 +328,19 @@ def test_set_checkpoint_raises_endpoint_error_for_connection_error(
 
 
 def test_set_checkpoint_raises_endpoint_error_for_request_exception(
-    monkeypatch,
     temp_config_dir,
     mock_auth_requests,
     reset_neuracore,
     mocked_org_id,
+    mock_session,
 ):
     """set_checkpoint should wrap generic RequestException in EndpointError."""
     nc.login(TEST_API_KEY)
     endpoint = _connect_test_remote_endpoint(mock_auth_requests, mocked_org_id)
-    monkeypatch.setattr(
-        "neuracore.core.endpoint.requests.post",
-        MagicMock(side_effect=requests.exceptions.Timeout("timeout")),
-    )
-
-    with pytest.raises(EndpointError, match="Failed to set checkpoint: timeout"):
+    mock_session.post.side_effect = requests.exceptions.Timeout("timeout")
+    with patch(
+        "neuracore.core.endpoint.get_session", return_value=mock_session
+    ), pytest.raises(EndpointError, match="Failed to set checkpoint: timeout"):
         endpoint.set_checkpoint(epoch=1)
 
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Session backed by a HTTPAdapter so that stale keep-alive sockets are transparently retried instead of surfacing as an SSLError

### Bugfixes
- Data daemon tests are failing from depleted connection pool