### PR TITLE
feat: add mcap dataset import support

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -413,4 +413,11 @@ memfd
 CLOEXEC
 ftruncate
 RDWR
-
+bgra
+bigendian
+byteswap
+elems
+itemsize
+mcap
+MCAP
+newbyteorder

--- a/neuracore/importer/config/example.yaml
+++ b/neuracore/importer/config/example.yaml
@@ -1,5 +1,5 @@
 input_dataset_name: example_input_dataset
-dataset_type: RLDS # RLDS | LEROBOT | TFDS, can be left blank and we will detect based on file structure
+dataset_type: RLDS # MCAP | RLDS | LEROBOT | TFDS, can be left blank and we will detect based on file structure
 
 output_dataset:
   name: example_output_dataset

--- a/neuracore/importer/core/base.py
+++ b/neuracore/importer/core/base.py
@@ -1260,7 +1260,7 @@ class NeuracoreDatasetImporter(ABC):
             TimeElapsedColumn(),
             TimeRemainingColumn(),
             refresh_per_second=10,
-            transient=True,
+            transient=False,
             console=get_shared_console(),
         ) as progress:
             overall_task = progress.add_task("Importing episodes", total=total_items)

--- a/neuracore/importer/core/exceptions.py
+++ b/neuracore/importer/core/exceptions.py
@@ -35,3 +35,7 @@ class DatasetDetectionError(ImporterError):
 
 class DatasetOperationError(ImporterError):
     """Raised when dataset CRUD operations fail."""
+
+
+class UploaderError(ImporterError):
+    """Raised when upload setup or worker execution fails."""

--- a/neuracore/importer/importer.py
+++ b/neuracore/importer/importer.py
@@ -35,6 +35,7 @@ from neuracore.importer.core.validation import (
     validate_dataset_config_against_robot_model,
 )
 from neuracore.importer.lerobot_importer import LeRobotDatasetImporter
+from neuracore.importer.mcap.mcap_importer import MCAPDatasetImporter
 from neuracore.importer.rlds_tfds_importer import (
     RLDSDatasetImporter,
     TFDSDatasetImporter,
@@ -85,7 +86,7 @@ def cli_args_validation(args: SimpleNamespace) -> None:
 
 
 def detect_dataset_type(dataset_dir: Path) -> DatasetTypeConfig:
-    """Detect whether the dataset is TFDS, RLDS, or LeRobot."""
+    """Detect whether the dataset is MCAP, TFDS, RLDS, or LeRobot."""
     detector = DatasetDetector()
     try:
         return detector.detect(dataset_dir)
@@ -240,9 +241,9 @@ def _run_import(
         searched_locations = (
             ", ".join(search_hints) if search_hints else "none provided"
         )
-        raise CLIError(
-            "Could not find a robot description file (.urdf or .xml/.mjcf). "
-            f"Searched: {searched_locations}."
+        logger.warning(
+            f"No robot description files found. Searched: {searched_locations}. "
+            "Robot information will not be populated in the dataset.",
         )
 
     if urdf_path is not None and mjcf_path is not None:
@@ -287,10 +288,34 @@ def _run_import(
     logger.info("Setup complete; beginning import.")
 
     skip_on_error = args.skip_on_error
-    importer: TFDSDatasetImporter | RLDSDatasetImporter | LeRobotDatasetImporter
+    importer: (
+        TFDSDatasetImporter
+        | RLDSDatasetImporter
+        | LeRobotDatasetImporter
+        | MCAPDatasetImporter
+    )
     if dataset_type == DatasetTypeConfig.TFDS:
         logger.info("Starting TFDS dataset import from %s", args.dataset_dir)
         importer = TFDSDatasetImporter(
+            input_dataset_name=dataconfig.input_dataset_name,
+            output_dataset_name=dataconfig.output_dataset.name,
+            dataset_dir=args.dataset_dir,
+            dataset_config=dataconfig,
+            joint_info=robot.joint_info,
+            urdf_path=urdf_path,
+            ik_init_config=ik_init_config,
+            dry_run=args.dry_run,
+            suppress_warnings=args.no_validation_warnings,
+            max_workers=args.max_workers,
+            skip_on_error=skip_on_error,
+            random_sample=args.random_sample,
+            storage_limit=args.storage_limit,
+            shared=args.shared,
+        )
+        importer.import_all()
+    elif dataset_type == DatasetTypeConfig.MCAP:
+        logger.info(f"Starting MCAP dataset import from {args.dataset_dir}")
+        importer = MCAPDatasetImporter(
             input_dataset_name=dataconfig.input_dataset_name,
             output_dataset_name=dataconfig.output_dataset.name,
             dataset_dir=args.dataset_dir,

--- a/neuracore/importer/mcap/__init__.py
+++ b/neuracore/importer/mcap/__init__.py
@@ -1,0 +1,1 @@
+"""MCAP importer package."""

--- a/neuracore/importer/mcap/mcap_importer.py
+++ b/neuracore/importer/mcap/mcap_importer.py
@@ -1,0 +1,270 @@
+"""MCAP dataset importer."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from mcap.decoder import DecoderFactory
+from mcap.reader import make_reader
+from neuracore_types import DataType
+from neuracore_types.nc_data import DatasetImportConfig
+
+import neuracore as nc
+from neuracore.core.robot import JointInfo
+from neuracore.importer.core.base import ImportItem, NeuracoreDatasetImporter
+from neuracore.importer.core.exceptions import ImportError
+from neuracore.importer.mcap.utils import (
+    build_topic_map,
+    clip_depth,
+    convert_decoded_mcap_data,
+    estimate_total_messages,
+    get_mcap_topics,
+    iter_decoded_mcap_messages,
+    iter_mcap_source_events,
+    list_decoder_factories,
+    log_mcap_header,
+    log_mcap_summary_details,
+    read_mcap_header,
+    read_mcap_summary,
+    validate_channel_decoder_support,
+    validate_requested_topics,
+)
+
+
+class MCAPDatasetImporter(NeuracoreDatasetImporter):
+    """Importer for MCAP datasets."""
+
+    def __init__(
+        self,
+        input_dataset_name: str,
+        output_dataset_name: str,
+        dataset_dir: Path,
+        dataset_config: DatasetImportConfig,
+        joint_info: dict[str, JointInfo] = {},
+        urdf_path: str | None = None,
+        ik_init_config: list[float] | None = None,
+        dry_run: bool = False,
+        suppress_warnings: bool = False,
+        max_workers: int | None = 1,
+        skip_on_error: str = "episode",
+        storage_limit: int = 5 * 1024**3,
+        random_sample: int | None = None,
+        shared: bool = False,
+    ) -> None:
+        """Initialize the MCAP dataset importer."""
+        super().__init__(
+            dataset_dir=dataset_dir,
+            dataset_config=dataset_config,
+            output_dataset_name=output_dataset_name,
+            max_workers=max_workers,
+            skip_on_error=skip_on_error,
+            joint_info=joint_info,
+            urdf_path=urdf_path,
+            ik_init_config=ik_init_config,
+            dry_run=dry_run,
+            suppress_warnings=suppress_warnings,
+            storage_limit=storage_limit,
+            random_sample=random_sample,
+            shared=shared,
+        )
+        if max_workers is not None and max_workers > 1:
+            self.logger.warning(
+                f"MCAP import is configured with {max_workers} workers. Each MCAP "
+                "file is streamed as one episode, so memory use remains bounded per "
+                "worker.",
+            )
+
+        self.dataset_name = input_dataset_name
+        self.dataset_dir = Path(dataset_dir)
+        self.topic_map = build_topic_map(dataset_config=dataset_config)
+        self.mcap_files = self._discover_mcap_files(dataset_dir=self.dataset_dir)
+        self._decoder_factories: list[DecoderFactory] | None = None
+        self._init_runtime_components()
+
+        self.logger.info(
+            f"Initialized MCAP importer for '{self.dataset_name}' "
+            f"(files={len(self.mcap_files)}, "
+            f"topics={len(get_mcap_topics(topic_map=self.topic_map))}, "
+            f"root={self.dataset_dir})"
+        )
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return picklable state with decoder factories cleared."""
+        # TODO: Replace this with lazy worker-local decoder factory initialization
+        # so runtime decoder state is never stored on the importer before forking.
+        state = self.__dict__.copy()
+        state["_decoder_factories"] = None
+        return state
+
+    def build_work_items(self) -> Sequence[ImportItem]:
+        """Return one work item per discovered MCAP file."""
+        return [
+            ImportItem(index=i, description=path.name, metadata={"path": str(path)})
+            for i, path in enumerate(self.mcap_files)
+        ]
+
+    def prepare_worker(
+        self,
+        worker_id: int,
+        chunk: Sequence[ImportItem] | None = None,
+    ) -> None:
+        """Initialize per-worker decoder factories after forking."""
+        super().prepare_worker(worker_id=worker_id, chunk=chunk)
+        self._init_runtime_components()
+
+    def import_item(self, item: ImportItem) -> None:
+        """Import one MCAP file."""
+        self._ensure_runtime_components()
+        self._reset_episode_state()
+
+        file_path_raw = (item.metadata or {}).get("path")
+        file_path = Path(file_path_raw) if file_path_raw else None
+        if file_path is None or not file_path.exists():
+            raise ImportError(f"MCAP file not found for item {item.index}.")
+
+        label = item.description or file_path.name
+        instance = max(0, self._worker_id)
+        self.logger.info(
+            f"Importing MCAP file {label} ({item.index + 1}/{len(self.mcap_files)})"
+        )
+
+        if not self.dry_run:
+            nc.start_recording(robot_name=self.robot_name, instance=instance)
+        try:
+            message_count = self._stream_episode_file(
+                episode_file_path=file_path,
+                item=item,
+                label=label,
+            )
+        finally:
+            if not self.dry_run:
+                nc.stop_recording(
+                    robot_name=self.robot_name, instance=instance, wait=True
+                )
+
+        self.logger.info(f"Completed MCAP file {label} | messages={message_count}")
+
+    def _record_step(self, step: dict, timestamp: float) -> None:
+        """Log decoded data from each MCAP source topic in this step."""
+        for topic, decoded_data in step.items():
+            for event in iter_mcap_source_events(
+                topic=topic,
+                decoded_data=decoded_data,
+                topic_map=self.topic_map,
+                logger=self.logger,
+                timestamp=timestamp,
+            ):
+                self._log_data(
+                    data_type=event.data_type,
+                    source_data=event.source_data,
+                    item=event.item,
+                    format=event.format,
+                    timestamp=event.timestamp,
+                )
+
+    def _stream_episode_file(
+        self, episode_file_path: Path, item: ImportItem, label: str
+    ) -> int:
+        """Stream messages from one MCAP episode file."""
+        topics = get_mcap_topics(topic_map=self.topic_map)
+        factories = list(self._decoder_factories or [])
+        base_timestamp: float | None = None
+        message_count = 0
+
+        with episode_file_path.open("rb") as stream:
+            reader = make_reader(stream=stream, decoder_factories=factories)
+            header = read_mcap_header(reader=reader)
+            log_mcap_header(header=header, logger=self.logger)
+            summary = read_mcap_summary(reader=reader)
+            log_mcap_summary_details(summary=summary, logger=self.logger)
+            validate_requested_topics(summary=summary, topics=topics)
+            validate_channel_decoder_support(
+                summary=summary,
+                topics=topics,
+                decoder_factories=factories,
+                logger=self.logger,
+            )
+            total = estimate_total_messages(summary=summary, topics=topics)
+
+            for decoded_message in iter_decoded_mcap_messages(
+                reader=reader,
+                topics=topics,
+            ):
+                if base_timestamp is None:
+                    base_timestamp = decoded_message.timestamp_seconds
+                timestamp = max(0.0, decoded_message.timestamp_seconds - base_timestamp)
+                decoded_data = convert_decoded_mcap_data(
+                    decoded_data=decoded_message.data
+                )
+                self._record_step(
+                    step={decoded_message.topic: decoded_data},
+                    timestamp=timestamp,
+                )
+                message_count += 1
+                if message_count % 100 == 0:
+                    self._emit_progress(
+                        item_index=item.index,
+                        step=message_count,
+                        total_steps=total,
+                        episode_label=label,
+                    )
+
+        self._emit_progress(
+            item_index=item.index,
+            step=message_count,
+            total_steps=total,
+            episode_label=label,
+        )
+        return message_count
+
+    def _log_transformed_data(
+        self,
+        data_type: DataType,
+        transformed_data: Any,
+        name: str,
+        timestamp: float,
+        *,
+        extrinsics: np.ndarray | None = None,
+        intrinsics: np.ndarray | None = None,
+    ) -> None:
+        """Clip depth arrays before delegating to the base logging path."""
+        if data_type == DataType.DEPTH_IMAGES:
+            transformed_data = clip_depth(data=transformed_data, logger=self.logger)
+        super()._log_transformed_data(
+            data_type=data_type,
+            transformed_data=transformed_data,
+            name=name,
+            timestamp=timestamp,
+            extrinsics=extrinsics,
+            intrinsics=intrinsics,
+        )
+
+    def _init_runtime_components(self) -> None:
+        self._decoder_factories = list_decoder_factories(logger=self.logger)
+
+    def _ensure_runtime_components(self) -> None:
+        if self._decoder_factories is None:
+            self._init_runtime_components()
+
+    @staticmethod
+    def _discover_mcap_files(dataset_dir: Path) -> list[Path]:
+        if dataset_dir.is_file():
+            if dataset_dir.suffix.lower() != ".mcap":
+                raise ImportError(
+                    f"Expected an MCAP file, got '{dataset_dir.name}' instead."
+                )
+            return [dataset_dir]
+
+        if not dataset_dir.exists():
+            raise ImportError(f"Dataset path does not exist: {dataset_dir}")
+
+        mcap_files = sorted(dataset_dir.rglob("*.mcap"))
+        if not mcap_files:
+            raise ImportError(
+                f"No MCAP files found under '{dataset_dir}'. "
+                "Provide a .mcap file or a directory containing MCAP files."
+            )
+        return mcap_files

--- a/neuracore/importer/mcap/utils.py
+++ b/neuracore/importer/mcap/utils.py
@@ -1,0 +1,1014 @@
+"""MCAP reader utilities for the Neuracore importer.
+
+Thin adapter over Foxglove's ``mcap`` package: decodes messages and normalises
+them into the shape expected by Neuracore's mapping pipeline.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import importlib
+import importlib.metadata as importlib_metadata
+import io
+import json
+import logging
+import pkgutil
+import time
+from collections.abc import Iterator
+from copy import copy
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from mcap.decoder import DecoderFactory
+from mcap.reader import McapReader
+from mcap.well_known import MessageEncoding
+from neuracore_types import DataType
+from neuracore_types.importer.config import LanguageConfig
+from neuracore_types.importer.data_config import DataFormat
+from neuracore_types.nc_data import DatasetImportConfig
+from neuracore_types.nc_data.nc_data import MappingItem
+
+from neuracore.core.utils.depth_utils import MAX_DEPTH
+from neuracore.importer.core.exceptions import ImportError
+
+
+def split_topic_path(source: str) -> tuple[str, list[str]]:
+    """Split a source path into topic and nested field components."""
+    value = source.strip()
+    if not value:
+        raise ImportError("Source must include a topic.")
+
+    topic, sep, subpath = value.partition(".")
+    if not topic:
+        raise ImportError(f"Invalid source '{source}': topic segment is empty.")
+
+    path = [part for part in subpath.split(".") if part] if sep else []
+    return topic, path
+
+
+def resolve_path(data: Any, path: list[str]) -> Any:
+    """Resolve a nested path against dict/object/list payloads."""
+    current = data
+    for part in path:
+        current = _resolve_path_part(current, part)
+    return current
+
+
+def _resolve_path_part(data: Any, part: str) -> Any:
+    """Resolve one path segment from dicts, objects, or indexable containers."""
+    if isinstance(data, dict):
+        if part in data:
+            return data[part]
+        if part.isdigit():
+            numeric_key = int(part)
+            if numeric_key in data:
+                return data[numeric_key]
+        raise ImportError(f"Key '{part}' not found while resolving message path.")
+
+    if hasattr(data, part):
+        return getattr(data, part)
+
+    if part.isdigit():
+        index = int(part)
+        try:
+            return data[index]
+        except Exception as exc:  # noqa: BLE001
+            raise ImportError(
+                f"Index {index} is unavailable while resolving message path: {exc}"
+            ) from exc
+
+    try:
+        return data[part]
+    except Exception as exc:  # noqa: BLE001
+        raise ImportError(f"Failed to resolve '{part}' from payload: {exc}") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class TopicConfig:
+    """Resolved topic configuration for one mapping entry group."""
+
+    data_type: DataType
+    import_config: Any
+    source_path: list[str]
+    mapping_item: MappingItem | None = None
+    item_base_path: list[str] | None = None
+
+
+TopicMap = dict[str, list[TopicConfig]]
+
+
+def build_topic_map(dataset_config: DatasetImportConfig) -> TopicMap:
+    """Build topic lookup tables from dataset mapping configuration."""
+    topic_map: TopicMap = {}
+
+    for data_type, import_config in dataset_config.data_import_config.items():
+        source = (import_config.source or "").strip()
+        mapping = list(import_config.mapping)
+
+        absolute_items = [
+            item
+            for item in mapping
+            if item.source_name and item.source_name.startswith("/")
+        ]
+        relative_items = [
+            item
+            for item in mapping
+            if not (item.source_name and item.source_name.startswith("/"))
+        ]
+
+        if relative_items:
+            if not source:
+                raise ImportError(
+                    f"Missing source for data type '{data_type.value}'. "
+                    "Relative mapping entries require a base source path."
+                )
+            topic, subpath = split_topic_path(source)
+            topic_map.setdefault(topic, []).append(
+                TopicConfig(
+                    data_type=data_type,
+                    import_config=_copy_import_config_with_mapping(
+                        import_config,
+                        relative_items,
+                    ),
+                    source_path=subpath,
+                )
+            )
+
+        for item in absolute_items:
+            item_topic, item_subpath = split_topic_path(item.source_name)
+            topic_map.setdefault(item_topic, []).append(
+                TopicConfig(
+                    data_type=data_type,
+                    import_config=import_config,
+                    source_path=[],
+                    mapping_item=item,
+                    item_base_path=item_subpath,
+                )
+            )
+
+    if not topic_map:
+        raise ImportError("No data_import_config entries found for MCAP import.")
+
+    return topic_map
+
+
+def _copy_import_config_with_mapping(
+    import_config: Any,
+    mapping: list[MappingItem],
+) -> Any:
+    """Clone an import config while replacing mapping entries."""
+    mapping_copy = list(mapping)
+    if hasattr(import_config, "model_copy"):
+        return import_config.model_copy(update={"mapping": mapping_copy})
+    cloned = copy(import_config)
+    setattr(cloned, "mapping", mapping_copy)
+    return cloned
+
+
+def get_mcap_topics(topic_map: TopicMap) -> list[str]:
+    """Return all configured MCAP topics in deterministic order."""
+    return sorted(topic_map)
+
+
+@dataclass(frozen=True, slots=True)
+class MCAPSourceEvent:
+    """One extracted MCAP source message ready for _log_data."""
+
+    data_type: DataType
+    source_data: Any
+    item: MappingItem
+    format: DataFormat
+    timestamp: float
+    source_topic: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedMCAPMessage:
+    """Decoded MCAP message plus the metadata needed by Neuracore.
+
+    topic: MCAP channel topic name. In Neuracore importer config this is the
+        source topic used to select mapping rules.
+    log_time_ns: MCAP message log timestamp in nanoseconds.
+    publish_time_ns: MCAP message publish timestamp in nanoseconds.
+    timestamp_seconds: Resolved timestamp in seconds, preferring log time.
+    data: Decoded message data returned by the MCAP decoder factory. This is
+        the source object Neuracore mappings read from.
+    """
+
+    topic: str
+    log_time_ns: int
+    publish_time_ns: int
+    timestamp_seconds: float
+    data: Any
+
+
+def read_mcap_header(reader: McapReader) -> Any | None:
+    """Return the MCAP header when available."""
+    try:
+        return reader.get_header()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def read_mcap_summary(reader: McapReader) -> Any | None:
+    """Return the MCAP summary when available."""
+    try:
+        return reader.get_summary()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def log_mcap_header(header: Any | None, logger: logging.Logger) -> None:
+    """Log basic MCAP header details for diagnostics."""
+    if header is None:
+        return
+    profile = getattr(header, "profile", "") or "<empty>"
+    library = getattr(header, "library", "") or "<empty>"
+    logger.debug(
+        f"MCAP header | profile={profile} | library={library}",
+    )
+
+
+def log_mcap_summary_details(summary: Any | None, logger: logging.Logger) -> None:
+    """Log non-message record counts that this importer does not process."""
+    if summary is None:
+        return
+    attachment_count = len(getattr(summary, "attachment_indexes", []) or [])
+    metadata_count = len(getattr(summary, "metadata_indexes", []) or [])
+    if attachment_count > 0 or metadata_count > 0:
+        logger.debug(
+            f"MCAP includes {attachment_count} attachment(s) and {metadata_count} "
+            "metadata record(s); the importer currently processes message records "
+            "only.",
+        )
+
+
+def resolve_timestamp_seconds(
+    *,
+    log_time_ns: int,
+    publish_time_ns: int,
+) -> float:
+    """Resolve message timestamp from log/publish time nanoseconds."""
+    if log_time_ns > 0:
+        return log_time_ns / 1e9
+    if publish_time_ns > 0:
+        return publish_time_ns / 1e9
+    return time.time()
+
+
+def iter_decoded_mcap_messages(
+    reader: McapReader,
+    topics: list[str],
+) -> Iterator[DecodedMCAPMessage]:
+    """Yield decoded MCAP messages in log-time order for configured topics.
+
+    The MCAP reader yields:
+    schema: message type information used by the decoder.
+    channel: topic metadata such as topic name, message encoding, and schema id.
+    raw_message: the MCAP message record with timestamps and serialized bytes.
+    decoded_data: raw_message.data after the decoder factory has decoded it.
+    """
+    for _schema, channel, raw_message, decoded_data in reader.iter_decoded_messages(
+        topics=topics,
+        log_time_order=True,
+    ):
+        log_time_ns = int(getattr(raw_message, "log_time", 0) or 0)
+        publish_time_ns = int(getattr(raw_message, "publish_time", 0) or 0)
+        yield DecodedMCAPMessage(
+            topic=str(getattr(channel, "topic", "") or ""),
+            log_time_ns=log_time_ns,
+            publish_time_ns=publish_time_ns,
+            timestamp_seconds=resolve_timestamp_seconds(
+                log_time_ns=log_time_ns,
+                publish_time_ns=publish_time_ns,
+            ),
+            data=decoded_data,
+        )
+
+
+def estimate_total_messages(summary: Any | None, topics: list[str]) -> int | None:
+    """Estimate total message count from MCAP summary statistics."""
+    if (
+        summary is None
+        or not getattr(summary, "statistics", None)
+        or not summary.statistics.channel_message_counts
+    ):
+        return None
+
+    counts = summary.statistics.channel_message_counts
+    total = 0
+    for channel_id, channel in summary.channels.items():
+        if channel.topic in topics:
+            total += int(counts.get(channel_id, 0))
+    return total if total > 0 else None
+
+
+def validate_requested_topics(summary: Any | None, topics: list[str]) -> None:
+    """Validate configured topics against the MCAP summary when available."""
+    if summary is None or not getattr(summary, "channels", None) or not topics:
+        return
+
+    available_topics = {channel.topic for channel in summary.channels.values()}
+    missing = sorted(topic for topic in topics if topic not in available_topics)
+    if not missing:
+        return
+
+    shown_available = ", ".join(sorted(available_topics)[:20])
+    raise ImportError(
+        "Configured topic(s) not present in MCAP: "
+        f"{', '.join(missing)}. "
+        f"Available topics include: {shown_available}"
+    )
+
+
+try:
+    import cbor2
+
+    HAS_CBOR = True
+except Exception:  # noqa: BLE001
+    cbor2 = None
+    HAS_CBOR = False
+
+try:
+    from google.protobuf.json_format import MessageToDict
+    from google.protobuf.message import Message as ProtobufMessage
+
+    HAS_PROTOBUF_RUNTIME = True
+except Exception:  # noqa: BLE001
+    MessageToDict = None
+    ProtobufMessage = None
+    HAS_PROTOBUF_RUNTIME = False
+
+try:
+    from mcap_protobuf.decoder import DecoderFactory as ProtobufDecoderFactory
+
+    HAS_PROTOBUF_FACTORY = True
+except Exception:  # noqa: BLE001
+    ProtobufDecoderFactory = None
+    HAS_PROTOBUF_FACTORY = False
+
+try:
+    from mcap_ros1.decoder import DecoderFactory as Ros1DecoderFactory
+
+    HAS_ROS1_FACTORY = True
+except Exception:  # noqa: BLE001
+    Ros1DecoderFactory = None
+    HAS_ROS1_FACTORY = False
+
+try:
+    from mcap_ros2.decoder import DecoderFactory as Ros2DecoderFactory
+
+    HAS_ROS2_FACTORY = True
+except Exception:  # noqa: BLE001
+    Ros2DecoderFactory = None
+    HAS_ROS2_FACTORY = False
+
+try:
+    from PIL import Image
+
+    HAS_PIL = True
+except Exception:  # noqa: BLE001
+    Image = None
+    HAS_PIL = False
+
+_DISCOVERED_DECODER_FACTORY_CLASSES: list[type[DecoderFactory]] | None = None
+
+
+def _to_bytes(data: Any) -> bytes:
+    if isinstance(data, memoryview):
+        return data.tobytes()
+    if isinstance(data, bytearray):
+        return bytes(data)
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return data.encode("utf-8")
+    return bytes(data)
+
+
+class JSONDecoderFactory(DecoderFactory):
+    """Decode ``json`` message-encoded payloads."""
+
+    def decoder_for(self, message_encoding: str, schema: Any | None) -> Any | None:
+        """Return a decoder when the channel encoding is JSON."""
+        if (message_encoding or "").lower() != MessageEncoding.JSON.lower():
+            return None
+
+        def _decode(data: bytes) -> Any:
+            return json.loads(_to_bytes(data).decode("utf-8"))
+
+        return _decode
+
+
+class TextDecoderFactory(DecoderFactory):
+    """Decode UTF-8 text payloads."""
+
+    def decoder_for(self, message_encoding: str, schema: Any | None) -> Any | None:
+        """Return a decoder for common UTF-8 text encodings."""
+        if (message_encoding or "").lower() not in {"text", "utf-8", "utf8"}:
+            return None
+
+        def _decode(data: bytes) -> str:
+            return _to_bytes(data).decode("utf-8")
+
+        return _decode
+
+
+class CborDecoderFactory(DecoderFactory):
+    """Decode ``cbor`` payloads when ``cbor2`` is installed."""
+
+    def decoder_for(self, message_encoding: str, schema: Any | None) -> Any | None:
+        """Return a decoder when CBOR is available and requested."""
+        if (message_encoding or "").lower() != MessageEncoding.CBOR.lower():
+            return None
+        if not HAS_CBOR or cbor2 is None:
+            return None
+
+        def _decode(data: bytes) -> Any:
+            return cbor2.loads(_to_bytes(data))
+
+        return _decode
+
+
+class RawPassthroughDecoderFactory(DecoderFactory):
+    """Final fallback factory that returns raw bytes.
+
+    Register this last so all format-specific factories get first chance.
+    """
+
+    def decoder_for(self, message_encoding: str, schema: Any | None) -> Any | None:
+        """Return a fallback decoder that passes bytes through unchanged."""
+
+        def _decode(data: bytes) -> bytes:
+            return _to_bytes(data)
+
+        return _decode
+
+
+def _iter_candidate_decoder_modules() -> set[str]:
+    modules = {
+        module.name
+        for module in pkgutil.iter_modules()
+        if module.name.startswith("mcap_")
+    }
+    try:
+        for distribution in importlib_metadata.distributions():
+            name = (distribution.metadata["Name"] or "").strip().lower()
+            if name.startswith("mcap-"):
+                modules.add(name.replace("-", "_"))
+    except Exception:  # noqa: BLE001
+        pass
+    return modules
+
+
+def _load_decoder_factory_class(module_name: str) -> type[DecoderFactory] | None:
+    try:
+        decoder_module = importlib.import_module(f"{module_name}.decoder")
+    except Exception:  # noqa: BLE001
+        return None
+
+    decoder_factory_cls = getattr(decoder_module, "DecoderFactory", None)
+    if (
+        decoder_factory_cls is None
+        or not isinstance(decoder_factory_cls, type)
+        or not issubclass(decoder_factory_cls, DecoderFactory)
+    ):
+        return None
+    return decoder_factory_cls
+
+
+def _discover_decoder_factory_classes(
+    logger: logging.Logger | None = None,
+) -> list[type[DecoderFactory]]:
+    global _DISCOVERED_DECODER_FACTORY_CLASSES
+
+    if _DISCOVERED_DECODER_FACTORY_CLASSES is not None:
+        return list(_DISCOVERED_DECODER_FACTORY_CLASSES)
+
+    classes: list[type[DecoderFactory]] = []
+    for module_name in sorted(_iter_candidate_decoder_modules()):
+        factory_cls = _load_decoder_factory_class(module_name)
+        if factory_cls is None:
+            continue
+        classes.append(factory_cls)
+
+    _DISCOVERED_DECODER_FACTORY_CLASSES = classes
+
+    if logger is not None:
+        logger.info(f"Discovered {len(classes)} MCAP decoder plugin class(es).")
+
+    return list(_DISCOVERED_DECODER_FACTORY_CLASSES)
+
+
+def discover_decoder_factories(
+    logger: logging.Logger | None = None,
+) -> list[DecoderFactory]:
+    """Discover and instantiate optional MCAP decoder factories."""
+    factories: list[DecoderFactory] = []
+    for factory_cls in _discover_decoder_factory_classes(logger=logger):
+        try:
+            factories.append(factory_cls())
+        except Exception as exc:  # noqa: BLE001
+            if logger is not None:
+                logger.debug(
+                    "Failed to instantiate discovered MCAP decoder factory "
+                    f"'{factory_cls}': {exc}",
+                    exc_info=True,
+                )
+    return factories
+
+
+def list_decoder_factories(
+    *,
+    enable_discovery: bool = False,
+    include_raw_fallback: bool = True,
+    logger: logging.Logger | None = None,
+) -> list[DecoderFactory]:
+    """Build decoder factories used by ``make_reader(..., decoder_factories=...)``."""
+    factories: list[DecoderFactory] = [
+        JSONDecoderFactory(),
+        TextDecoderFactory(),
+        CborDecoderFactory(),
+    ]
+
+    if HAS_PROTOBUF_FACTORY and ProtobufDecoderFactory is not None:
+        factories.append(ProtobufDecoderFactory())
+    if HAS_ROS1_FACTORY and Ros1DecoderFactory is not None:
+        factories.append(Ros1DecoderFactory())
+    if HAS_ROS2_FACTORY and Ros2DecoderFactory is not None:
+        factories.append(Ros2DecoderFactory())
+
+    if enable_discovery:
+        seen = {factory.__class__ for factory in factories}
+        for factory in discover_decoder_factories(logger=logger):
+            if factory.__class__ in seen:
+                continue
+            factories.append(factory)
+            seen.add(factory.__class__)
+
+    if include_raw_fallback:
+        factories.append(RawPassthroughDecoderFactory())
+
+    if logger is not None:
+        factory_names = [
+            f"{factory.__class__.__module__}.{factory.__class__.__qualname__}"
+            for factory in factories
+        ]
+        logger.debug(
+            f"Configured MCAP decoder factories: {factory_names}",
+        )
+
+    return factories
+
+
+def _channel_has_decoder_support(
+    message_encoding: str,
+    schema: Any | None,
+    decoder_factories: list[DecoderFactory],
+) -> bool:
+    for factory in decoder_factories:
+        if isinstance(factory, RawPassthroughDecoderFactory):
+            continue
+        try:
+            if factory.decoder_for(message_encoding, schema) is not None:
+                return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
+
+
+def validate_channel_decoder_support(
+    summary: Any | None,
+    topics: list[str],
+    decoder_factories: list[DecoderFactory],
+    logger: logging.Logger,
+) -> None:
+    """Warn when configured topics lack non-raw decoder support."""
+    if summary is None or not getattr(summary, "channels", None):
+        return
+
+    schemas = getattr(summary, "schemas", {}) or {}
+    for channel in summary.channels.values():
+        if channel.topic not in topics:
+            continue
+
+        encoding = str(channel.message_encoding or "")
+        schema = schemas.get(getattr(channel, "schema_id", 0), None)
+
+        if encoding.lower() == MessageEncoding.CBOR.lower() and not HAS_CBOR:
+            logger.warning(
+                f"MCAP topic '{channel.topic}' uses CBOR but cbor2 is unavailable.",
+            )
+
+        if _channel_has_decoder_support(encoding, schema, decoder_factories):
+            continue
+
+        logger.warning(
+            f"No structured decoder available for topic '{channel.topic}' "
+            f"(encoding={encoding or '<empty>'}). Using raw-byte fallback.",
+        )
+
+
+def _read_field(data: Any, name: str) -> Any:
+    """Read a field from mapping-like or object-like message payloads."""
+    if isinstance(data, dict):
+        return data.get(name)
+    if hasattr(data, name):
+        return getattr(data, name)
+    return None
+
+
+def _is_byte_list(data: Any) -> bool:
+    """Return True for integer sequences that likely represent bytes."""
+    return isinstance(data, (list, tuple)) and bool(data) and isinstance(data[0], int)
+
+
+def _is_raw_image_message(message: Any) -> bool:
+    """Check whether a message payload exposes raw image metadata fields."""
+    return (
+        _read_field(message, "height") is not None
+        and _read_field(message, "width") is not None
+        and _read_field(message, "encoding") is not None
+    )
+
+
+def _is_compressed_image_message(message: Any) -> bool:
+    """Check whether a message payload exposes compressed image bytes."""
+    return _read_field(message, "data") is not None
+
+
+def _decode_raw_image(
+    data_type: DataType,
+    data: Any,
+    message: Any,
+    *,
+    logger: logging.Logger,
+) -> np.ndarray:
+    """Decode ``sensor_msgs/Image``-style payloads."""
+    height = _read_field(message, "height")
+    width = _read_field(message, "width")
+    encoding = _read_field(message, "encoding")
+    step = _read_field(message, "step")
+    is_bigendian = _read_field(message, "is_bigendian")
+
+    if height is None or width is None or encoding is None:
+        raise ImportError(
+            "Raw image decoding requires height, width, and encoding fields."
+        )
+
+    encoding_name = str(encoding).lower().split(";", maxsplit=1)[0].strip()
+    enc_map = {
+        "rgb8": (np.uint8, 3),
+        "bgr8": (np.uint8, 3),
+        "rgba8": (np.uint8, 4),
+        "bgra8": (np.uint8, 4),
+        "mono8": (np.uint8, 1),
+        "8uc1": (np.uint8, 1),
+        "mono16": (np.uint16, 1),
+        "16uc1": (np.uint16, 1),
+        "32fc1": (np.float32, 1),
+        "64fc1": (np.float64, 1),
+    }
+    if encoding_name not in enc_map:
+        raise ImportError(f"Unsupported image encoding '{encoding_name}'.")
+
+    dtype, channels = enc_map[encoding_name]
+    buffer = _read_bytes(data)
+
+    bytes_per_pixel = np.dtype(dtype).itemsize * channels
+    row_step = int(step) if step else int(width) * bytes_per_pixel
+    row_elements = row_step // np.dtype(dtype).itemsize
+    expected_len = row_step * int(height)
+    actual_len = len(buffer)
+    if actual_len != expected_len:
+        relation = "too small" if actual_len < expected_len else "too large"
+        raise ImportError(
+            "Image buffer size mismatch "
+            f"({relation}: expected {expected_len} bytes, got {actual_len})."
+        )
+
+    array = np.frombuffer(buffer[:expected_len], dtype=dtype).reshape(
+        int(height), row_elements
+    )
+    if channels == 1:
+        array = array[:, : int(width)]
+    else:
+        array = array[:, : int(width) * channels].reshape(
+            int(height),
+            int(width),
+            channels,
+        )
+
+    if is_bigendian and np.dtype(dtype).itemsize > 1:
+        array = array.byteswap()
+
+    return _drop_alpha_channel(data_type, array, logger=logger)
+
+
+def _decode_compressed_image(
+    data_type: DataType,
+    message: Any,
+    *,
+    logger: logging.Logger,
+) -> np.ndarray:
+    """Decode ``sensor_msgs/CompressedImage`` payloads."""
+    raw = _read_field(message, "data")
+    if raw is None:
+        raise ImportError("Compressed image decoding requires data field.")
+    return __decode_compressed_image_bytes(data_type, raw, logger=logger)
+
+
+def read_image_data(
+    data_type: DataType,
+    data: Any,
+    message: Any,
+    *,
+    logger: logging.Logger,
+) -> Any:
+    """Read image payloads as arrays; keep non-image values untouched."""
+    if data_type not in {DataType.RGB_IMAGES, DataType.DEPTH_IMAGES}:
+        return data
+
+    if isinstance(data, np.ndarray):
+        return _drop_alpha_channel(data_type, data, logger=logger)
+
+    if _is_raw_image_message(message):
+        return _decode_raw_image(data_type, data, message, logger=logger)
+
+    if _is_compressed_image_message(message):
+        return _decode_compressed_image(data_type, message, logger=logger)
+
+    if isinstance(data, (list, tuple)) and data and not _is_byte_list(data):
+        array = np.array(data)
+        if array.ndim >= 2:
+            return _drop_alpha_channel(data_type, array, logger=logger)
+
+    if isinstance(data, (bytes, bytearray, memoryview, str)) or _is_byte_list(data):
+        try:
+            return __decode_compressed_image_bytes(data_type, data, logger=logger)
+        except ImportError:
+            pass
+
+    raise ImportError(
+        "Image mapping resolved to unsupported payload type "
+        f"{type(data).__name__}. Configure mapping to point to image bytes/data."
+    )
+
+
+def __decode_compressed_image_bytes(
+    data_type: DataType,
+    data: Any,
+    *,
+    logger: logging.Logger,
+    has_pil: bool = HAS_PIL,
+    image_module: Any = Image,
+) -> np.ndarray:
+    """Decode compressed image bytes into a numpy array."""
+    if not has_pil or image_module is None:
+        raise ImportError(
+            "Compressed image decoding requires pillow. "
+            "Install with `pip install neuracore[import]`."
+        )
+
+    buffer = _read_bytes(data)
+    try:
+        with image_module.open(io.BytesIO(buffer)) as image:
+            if data_type == DataType.RGB_IMAGES and image.mode != "RGB":
+                image = image.convert("RGB")
+            array = np.array(image)
+    except Exception as exc:  # noqa: BLE001
+        raise ImportError(f"Failed decoding compressed image: {exc}") from exc
+
+    return _drop_alpha_channel(data_type, array, logger=logger)
+
+
+def _read_bytes(data: Any) -> bytes:
+    """Read bytes from bytes-like values, base64 strings, or integer lists."""
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return bytes(data)
+    if isinstance(data, str):
+        return _decode_base64_bytes(data)
+    if _is_byte_list(data):
+        return bytes(data)
+    raise ImportError("Image payload is not a byte buffer.")
+
+
+def _drop_alpha_channel(
+    data_type: DataType,
+    array: np.ndarray,
+    *,
+    logger: logging.Logger,
+) -> np.ndarray:
+    """Normalize image arrays into Neuracore-friendly shape and dtype."""
+    if data_type == DataType.RGB_IMAGES and array.ndim == 3 and array.shape[2] == 4:
+        logger.warning("Dropping alpha channel for RGB image import.")
+        array = array[:, :, :3]
+
+    if data_type == DataType.DEPTH_IMAGES and array.dtype not in (
+        np.float16,
+        np.float32,
+        np.float64,
+    ):
+        array = array.astype(np.float32, copy=False)
+
+    return array
+
+
+def _decode_base64_bytes(value: str) -> bytes:
+    """Decode a base64 string into bytes."""
+    try:
+        return base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ImportError(
+            "Image payload is a string but not valid base64-encoded bytes."
+        ) from exc
+
+
+def convert_decoded_mcap_data(decoded_data: Any) -> Any:
+    """Convert decoded MCAP data into values the importer can read.
+
+    Protobuf objects are kept as-is to preserve ``bytes`` fields used by image
+    extraction. Non-protobuf decoded data is converted recursively.
+    """
+    if (
+        HAS_PROTOBUF_RUNTIME
+        and ProtobufMessage is not None
+        and isinstance(decoded_data, ProtobufMessage)
+    ):
+        return decoded_data
+    return to_python_types(decoded_data)
+
+
+def iter_mcap_source_events(
+    topic: str,
+    decoded_data: Any,
+    *,
+    topic_map: TopicMap,
+    logger: logging.Logger,
+    timestamp: float,
+) -> Iterator[MCAPSourceEvent]:
+    """Yield source events for each mapping config, ready for _log_data."""
+    configs = topic_map.get(topic, [])
+    if not configs:
+        return
+
+    for config in configs:
+        if config.mapping_item is not None:
+            base = decoded_data
+            if config.item_base_path:
+                base = resolve_path(base, config.item_base_path)
+
+            source_data = read_image_data(
+                config.data_type,
+                base,
+                decoded_data,
+                logger=logger,
+            )
+            if not _is_language_text(config.data_type, config.import_config):
+                source_data = to_numpy(source_data)
+
+            yield MCAPSourceEvent(
+                data_type=config.data_type,
+                source_data=source_data,
+                item=config.mapping_item,
+                format=config.import_config.format,
+                timestamp=timestamp,
+                source_topic=topic,
+            )
+            continue
+
+        base = resolve_path(decoded_data, config.source_path)
+        for item in config.import_config.mapping:
+            if item.source_name:
+                source_data = resolve_path(base, item.source_name.split("."))
+            elif item.index is not None:
+                source_data = base[item.index]
+            elif item.index_range is not None:
+                source_data = base[item.index_range.start : item.index_range.end]
+            else:
+                source_data = base
+
+            source_data = read_image_data(
+                config.data_type,
+                source_data,
+                decoded_data,
+                logger=logger,
+            )
+            if not _is_language_text(config.data_type, config.import_config):
+                source_data = to_numpy(source_data)
+
+            yield MCAPSourceEvent(
+                data_type=config.data_type,
+                source_data=source_data,
+                item=item,
+                format=config.import_config.format,
+                timestamp=timestamp,
+                source_topic=topic,
+            )
+
+
+_PRIMITIVE_PYTHON_TYPES = frozenset(
+    {bool, int, float, str, bytes, bytearray, type(None)}
+)
+
+
+def to_python_types(value: Any) -> Any:
+    """Recursively convert message payload objects to plain Python values."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, np.ndarray):
+        return value
+
+    if (
+        HAS_PROTOBUF_RUNTIME
+        and ProtobufMessage is not None
+        and isinstance(value, ProtobufMessage)
+    ):
+        if MessageToDict is None:
+            return repr(value)
+        return to_python_types(MessageToDict(value, preserving_proto_field_name=True))
+
+    if isinstance(value, dict):
+        if all(type(v) in _PRIMITIVE_PYTHON_TYPES for v in value.values()):
+            return value
+        return {str(key): to_python_types(item) for key, item in value.items()}
+
+    if isinstance(value, (list, tuple, set)):
+        lst = value if isinstance(value, list) else list(value)
+        if lst and all(type(e) in _PRIMITIVE_PYTHON_TYPES for e in lst):
+            return lst
+        return [to_python_types(item) for item in lst]
+
+    if hasattr(value, "__dict__"):
+        attrs = {
+            name: getattr(value, name)
+            for name in vars(value)
+            if not str(name).startswith("_")
+        }
+        if attrs:
+            return {key: to_python_types(item) for key, item in attrs.items()}
+
+    slots = getattr(type(value), "__slots__", None)
+    if slots:
+        names = [slots] if isinstance(slots, str) else list(slots)
+        out: dict[str, Any] = {}
+        for name in names:
+            if not isinstance(name, str) or name.startswith("_"):
+                continue
+            try:
+                out[name] = to_python_types(getattr(value, name))
+            except Exception:  # noqa: BLE001
+                continue
+        if out:
+            return out
+
+    return repr(value)
+
+
+def to_numpy(data: Any) -> Any:
+    """Convert numeric Python values to numpy values for transform compatibility."""
+    if hasattr(data, "numpy"):
+        return data.numpy()
+    if isinstance(data, np.ndarray):
+        return data
+    if isinstance(data, (list, tuple)):
+        return np.array(data)
+    if isinstance(data, (int, float)) and not isinstance(data, bool):
+        return np.float64(data)
+    return data
+
+
+def clip_depth(
+    data: Any,
+    logger: logging.Logger | None = None,
+) -> Any:
+    """Clip depth arrays to the backend-accepted meter range."""
+    if not isinstance(data, np.ndarray):
+        return data
+    float32 = data.astype(np.float32, copy=False)
+    needs_clip = (
+        np.any(np.isnan(float32))
+        or np.any(np.isinf(float32))
+        or float32.size > 0
+        and (float(float32.min()) < 0.0 or float(float32.max()) > MAX_DEPTH)
+    )
+    if needs_clip and logger is not None:
+        logger.warning(
+            f"Depth values outside valid range [0, {MAX_DEPTH:.1f} m] — clipping."
+        )
+    clipped = np.nan_to_num(float32, nan=0.0, posinf=MAX_DEPTH, neginf=0.0)
+    return np.clip(clipped, 0.0, MAX_DEPTH).astype(np.float16, copy=False)
+
+
+def _is_language_text(data_type: DataType, import_config: Any) -> bool:
+    """Return True when the mapping describes plain language text."""
+    return bool(
+        data_type == DataType.LANGUAGE
+        and import_config.format.language_type == LanguageConfig.STRING
+    )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "greenlet",
         "filelock>=3.0.0",
         "omegaconf",
-        "msgpack",
+        "msgpack>=1.0.8",
     ],
     extras_require={
         "examples": [
@@ -120,6 +120,10 @@ setup(
             "tensorflow-datasets>=4.9.9",
             "tensorflow>=2.20.0",
             "pin-pink>=4",
+            "mcap>=1.3.1,<2",
+            "mcap-protobuf-support>=0.5.4,<0.6",
+            "mcap-ros1-support>=0.7.4,<0.8",
+            "mcap-ros2-support>=0.5.7,<0.6",
         ],
     },
     entry_points={

--- a/tests/unit/importer/test_dataset_detection.py
+++ b/tests/unit/importer/test_dataset_detection.py
@@ -81,6 +81,26 @@ def test_detect_tfds_case_insensitive_markers(
         assert detector(dataset_dir) == DatasetTypeConfig.TFDS
 
 
+def test_detect_mcap_file(tmp_path: Path, detectors: list[tuple[str, DetectorFn]]):
+    file_path = tmp_path / "example.mcap"
+    file_path.touch()
+
+    for _, detector in detectors:
+        assert detector(file_path) == DatasetTypeConfig.MCAP
+
+
+def test_detect_mcap_in_directory(
+    tmp_path: Path, detectors: list[tuple[str, DetectorFn]]
+):
+    dataset_dir = _create_files(
+        tmp_path / "mcap_dataset",
+        ["session/example.mcap"],
+    )
+
+    for _, detector in detectors:
+        assert detector(dataset_dir) == DatasetTypeConfig.MCAP
+
+
 def test_detect_rlds_by_directory_name(
     tmp_path: Path, detectors: list[tuple[str, DetectorFn]]
 ):

--- a/tests/unit/importer/test_mcap_importer.py
+++ b/tests/unit/importer/test_mcap_importer.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import pytest
+from neuracore_types import DataType
+from neuracore_types.nc_data import DatasetImportConfig
+from PIL import Image
+
+from neuracore.core.utils.depth_utils import MAX_DEPTH
+from neuracore.importer.core.base import ImportItem
+from neuracore.importer.core.exceptions import ImportError
+from neuracore.importer.mcap.mcap_importer import MCAPDatasetImporter
+from neuracore.importer.mcap.utils import (
+    JSONDecoderFactory,
+    MCAPSourceEvent,
+    RawPassthroughDecoderFactory,
+    build_topic_map,
+    clip_depth,
+    convert_decoded_mcap_data,
+    estimate_total_messages,
+    get_mcap_topics,
+    iter_mcap_source_events,
+    list_decoder_factories,
+    read_image_data,
+    resolve_path,
+    resolve_timestamp_seconds,
+    split_topic_path,
+    to_numpy,
+    to_python_types,
+    validate_requested_topics,
+)
+
+
+def _make_mapping_item(
+    name: str,
+    *,
+    source_name: str | None = None,
+    index=None,
+    index_range=None,
+):
+    return SimpleNamespace(
+        name=name,
+        source_name=source_name,
+        index=index,
+        index_range=index_range,
+        transforms=lambda value: value,
+    )
+
+
+def _make_import_config(source: str, mapping: list[SimpleNamespace]):
+    return SimpleNamespace(
+        source=source,
+        mapping=mapping,
+        format=SimpleNamespace(language_type=None),
+    )
+
+
+def _make_dataset_config(data_import_config: dict) -> DatasetImportConfig:
+    return cast(
+        DatasetImportConfig,
+        SimpleNamespace(
+            data_import_config=data_import_config,
+            robot=SimpleNamespace(name="test_robot"),
+            frequency=30,
+        ),
+    )
+
+
+def test_split_topic_path_and_resolve_path():
+    topic, path = split_topic_path("/camera/color.image.data")
+    assert topic == "/camera/color"
+    assert path == ["image", "data"]
+
+    payload = {
+        "outer": {
+            "values": [
+                {"x": 1},
+                {"x": 2},
+            ]
+        }
+    }
+    value = resolve_path(payload, ["outer", "values", "1", "x"])
+    assert value == 2
+
+
+def test_topic_mapper_builds_mixed_absolute_and_relative_topics():
+    topic_map = build_topic_map(
+        _make_dataset_config({
+            DataType.RGB_IMAGES: _make_import_config(
+                source="/camera/color",
+                mapping=[
+                    _make_mapping_item(
+                        "cam_left",
+                        source_name="/camera/color/image_cam1.data",
+                    ),
+                    _make_mapping_item("color_main", source_name="image"),
+                ],
+            )
+        })
+    )
+
+    topics = get_mcap_topics(topic_map)
+    assert topics == ["/camera/color", "/camera/color/image_cam1"]
+
+    relative_cfg = topic_map["/camera/color"][0]
+    absolute_cfg = topic_map["/camera/color/image_cam1"][0]
+
+    assert [item.name for item in relative_cfg.import_config.mapping] == ["color_main"]
+    assert absolute_cfg.mapping_item.name == "cam_left"
+    assert absolute_cfg.item_base_path == ["data"]
+
+
+def test_topic_mapper_requires_source_for_relative_items():
+    with pytest.raises(ImportError, match="Relative mapping entries require"):
+        build_topic_map(
+            _make_dataset_config({
+                DataType.RGB_IMAGES: _make_import_config(
+                    source="",
+                    mapping=[_make_mapping_item("cam", source_name="image")],
+                )
+            })
+        )
+
+
+def test_json_decoder_factory_decodes_json():
+    decoder = JSONDecoderFactory().decoder_for("json", None)
+    assert decoder is not None
+    assert decoder(b'{"a": 1}') == {"a": 1}
+
+
+def test_raw_passthrough_decoder_factory_decodes_unknown_payload():
+    decoder = RawPassthroughDecoderFactory().decoder_for("custom", None)
+    assert decoder is not None
+    assert decoder(b"\x01\x02") == b"\x01\x02"
+
+
+def test_list_decoder_factories_has_raw_fallback_last():
+    factories = list_decoder_factories(
+        enable_discovery=False, include_raw_fallback=True
+    )
+    assert factories
+    assert isinstance(factories[-1], RawPassthroughDecoderFactory)
+
+
+def test_preprocessor_estimate_total_messages():
+    summary = SimpleNamespace(
+        statistics=SimpleNamespace(channel_message_counts={1: 10, 2: 5}),
+        channels={
+            1: SimpleNamespace(topic="/a"),
+            2: SimpleNamespace(topic="/b"),
+        },
+    )
+    assert estimate_total_messages(summary, ["/a", "/b"]) == 15
+
+
+def test_image_decoder_handles_base64_compressed_payload():
+    import base64
+    import io
+
+    image = Image.fromarray(np.array([[1000, 2000]], dtype=np.uint16))
+    with io.BytesIO() as buf:
+        image.save(buf, format="PNG")
+        raw_png = buf.getvalue()
+
+    message = {
+        "data": base64.b64encode(raw_png).decode("ascii"),
+        "format": "png",
+    }
+    image_data = read_image_data(
+        DataType.DEPTH_IMAGES,
+        message["data"],
+        message,
+        logger=logging.getLogger(__name__),
+    )
+    assert isinstance(image_data, np.ndarray)
+    assert image_data.shape == (1, 2)
+
+
+def _make_importer(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    dry_run: bool = False,
+    skip_on_error: str = "episode",
+) -> MCAPDatasetImporter:
+    """Build a minimally patched MCAPDatasetImporter for testing."""
+    mcap_path = tmp_path / "episode_001.mcap"
+    mcap_path.write_bytes(b"mcap")
+
+    monkeypatch.setattr(
+        MCAPDatasetImporter,
+        "_discover_mcap_files",
+        staticmethod(lambda dataset_dir: [mcap_path]),
+    )
+    monkeypatch.setattr(
+        MCAPDatasetImporter,
+        "_init_runtime_components",
+        lambda self: setattr(self, "_decoder_factories", []),
+    )
+
+    return MCAPDatasetImporter(
+        input_dataset_name="in",
+        output_dataset_name="out",
+        dataset_dir=tmp_path,
+        dataset_config=_make_dataset_config({
+            DataType.CUSTOM_1D: _make_import_config(
+                source="/topic",
+                mapping=[_make_mapping_item("value")],
+            )
+        }),
+        dry_run=dry_run,
+        skip_on_error=skip_on_error,
+    )
+
+
+def test_mcap_importer_build_work_items(monkeypatch, tmp_path: Path):
+    importer = _make_importer(monkeypatch, tmp_path)
+    items = list(importer.build_work_items())
+    assert len(items) == 1
+    assert items[0].description == "episode_001.mcap"
+    assert items[0].metadata["path"].endswith("episode_001.mcap")
+
+
+def test_mcap_importer_import_item_starts_and_stops_recording(
+    monkeypatch, tmp_path: Path
+):
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.nc.start_recording",
+        lambda robot_name, instance: calls.append("start"),
+    )
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.nc.stop_recording",
+        lambda robot_name, instance, wait: calls.append("stop"),
+    )
+
+    importer = _make_importer(monkeypatch, tmp_path)
+    monkeypatch.setattr(importer, "_stream_episode_file", lambda *_args, **_kwargs: 3)
+
+    importer.import_item(importer.build_work_items()[0])
+
+    assert calls == ["start", "stop"]
+
+
+def test_mcap_importer_dry_run_skips_recording(monkeypatch, tmp_path: Path):
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("dry-run must not call start/stop recording")
+
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.nc.start_recording", _unexpected
+    )
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.nc.stop_recording", _unexpected
+    )
+
+    importer = _make_importer(monkeypatch, tmp_path, dry_run=True)
+    monkeypatch.setattr(importer, "_stream_episode_file", lambda *_args, **_kwargs: 0)
+
+    importer.import_item(importer.build_work_items()[0])
+
+
+def test_mcap_importer_record_step_logs_each_event(monkeypatch, tmp_path: Path):
+    logged: list[tuple[DataType, str]] = []
+
+    importer = _make_importer(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        importer,
+        "_log_data",
+        lambda data_type, source_data, item, format, timestamp: logged.append(
+            (data_type, item.name)
+        ),
+    )
+
+    topic_map = build_topic_map(
+        _make_dataset_config({
+            DataType.CUSTOM_1D: _make_import_config(
+                source="/topic.values",
+                mapping=[
+                    _make_mapping_item("a"),
+                    _make_mapping_item("b"),
+                ],
+            )
+        })
+    )
+    importer.topic_map = topic_map
+
+    importer._record_step(  # noqa: SLF001
+        step={"/topic": {"values": {"a": 1.0, "b": 2.0}}},
+        timestamp=0.5,
+    )
+
+    assert len(logged) == 2
+    assert {name for _, name in logged} == {"a", "b"}
+
+
+@pytest.mark.parametrize(
+    "source,match",
+    [
+        ("", "Source must include a topic"),
+        (".field", "topic segment is empty"),
+    ],
+)
+def test_split_topic_path_raises(source, match):
+    with pytest.raises(ImportError, match=match):
+        split_topic_path(source)
+
+
+def test_split_topic_path_no_subpath():
+    topic, path = split_topic_path("/joint_states")
+    assert topic == "/joint_states"
+    assert path == []
+
+
+def test_resolve_path_numeric_string_as_integer_dict_key():
+    assert resolve_path({0: "zero"}, ["0"]) == "zero"
+
+
+def test_resolve_path_attribute_access_on_object():
+    assert resolve_path(SimpleNamespace(x=42), ["x"]) == 42
+
+
+def test_resolve_path_index_on_list():
+    assert resolve_path({"items": [10, 20, 30]}, ["items", "2"]) == 30
+
+
+def test_resolve_path_missing_key_raises():
+    with pytest.raises(ImportError, match="Key 'missing' not found"):
+        resolve_path({"a": 1}, ["missing"])
+
+
+@pytest.mark.parametrize(
+    "log_ns,pub_ns,expected",
+    [
+        (2_000_000_000, 0, 2.0),
+        (0, 1_000_000_000, 1.0),
+    ],
+)
+def test_resolve_timestamp_seconds(log_ns, pub_ns, expected):
+    assert resolve_timestamp_seconds(
+        log_time_ns=log_ns, publish_time_ns=pub_ns
+    ) == pytest.approx(expected)
+
+
+def test_resolve_timestamp_falls_back_to_wall_clock():
+    before = time.time()
+    ts = resolve_timestamp_seconds(log_time_ns=0, publish_time_ns=0)
+    assert before <= ts <= time.time()
+
+
+def test_validate_requested_topics_raises_on_missing():
+    summary = SimpleNamespace(channels={1: SimpleNamespace(topic="/present")})
+    with pytest.raises(ImportError, match="/missing"):
+        validate_requested_topics(summary, ["/missing"])
+
+
+def test_validate_requested_topics_passes_when_all_present():
+    summary = SimpleNamespace(
+        channels={1: SimpleNamespace(topic="/a"), 2: SimpleNamespace(topic="/b")}
+    )
+    validate_requested_topics(summary, ["/a", "/b"])  # must not raise
+
+
+@pytest.mark.parametrize("value", [None, True, 42, 3.14, "hello"])
+def test_to_python_types_primitives_passthrough(value):
+    assert to_python_types(value) == value
+
+
+def test_to_python_types_numpy_scalar_becomes_python():
+    result = to_python_types(np.float32(1.5))
+    assert isinstance(result, float)
+    assert result == pytest.approx(1.5)
+
+
+def test_to_python_types_bytearray_becomes_bytes():
+    assert to_python_types(bytearray(b"\x01\x02")) == b"\x01\x02"
+
+
+def test_to_python_types_numpy_array_passthrough():
+    arr = np.array([1, 2, 3])
+    assert to_python_types(arr) is arr
+
+
+def test_to_python_types_dict_all_primitive_same_object():
+    d = {"a": 1, "b": "x"}
+    assert to_python_types(d) is d
+
+
+def test_to_python_types_dict_with_nested_recurses():
+    result = to_python_types({"a": SimpleNamespace(x=1)})
+    assert result == {"a": {"x": 1}}
+
+
+def test_to_python_types_list_all_primitive_same_object():
+    lst = [1, 2, 3]
+    assert to_python_types(lst) is lst
+
+
+def test_to_python_types_list_with_nested_recurses():
+    result = to_python_types([SimpleNamespace(x=1)])
+    assert result == [{"x": 1}]
+
+
+def test_to_python_types_object_with_dict_attrs():
+    result = to_python_types(SimpleNamespace(a=1, b="hello"))
+    assert result == {"a": 1, "b": "hello"}
+
+
+def test_to_python_types_unknown_falls_back_to_repr():
+    class _Opaque:
+        __slots__ = ()
+
+        def __repr__(self):
+            return "opaque"
+
+    assert to_python_types(_Opaque()) == "opaque"
+
+
+def test_to_numpy_list_becomes_ndarray():
+    result = to_numpy([1, 2, 3])
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, [1, 2, 3])
+
+
+@pytest.mark.parametrize("value", [5, 2.5])
+def test_to_numpy_scalar_becomes_float64(value):
+    assert isinstance(to_numpy(value), np.float64)
+
+
+def test_to_numpy_bool_passthrough():
+    assert to_numpy(True) is True
+
+
+def test_to_numpy_ndarray_passthrough():
+    arr = np.array([1.0])
+    assert to_numpy(arr) is arr
+
+
+def test_to_numpy_tensor_with_numpy_method():
+    class _FakeTensor:
+        def numpy(self):
+            return np.array([7.0])
+
+    np.testing.assert_array_equal(to_numpy(_FakeTensor()), [7.0])
+
+
+@pytest.mark.parametrize("value", ["not an array", 42, None, [1, 2, 3]])
+def test_clip_depth_non_array_passthrough(value):
+    assert clip_depth(value) == value
+
+
+def test_read_image_data_non_image_type_passthrough():
+    data = {"position": 1.0}
+    assert (
+        read_image_data(
+            DataType.JOINT_POSITIONS, data, data, logger=logging.getLogger(__name__)
+        )
+        is data
+    )
+
+
+def test_read_image_data_decodes_raw_rgb8():
+    h, w = 2, 3
+    raw = np.zeros((h, w, 3), dtype=np.uint8)
+    raw[0, 0] = [255, 0, 0]
+    message = SimpleNamespace(
+        height=h,
+        width=w,
+        encoding="rgb8",
+        step=w * 3,
+        is_bigendian=False,
+        data=raw.tobytes(),
+    )
+    result = read_image_data(
+        DataType.RGB_IMAGES, message.data, message, logger=logging.getLogger(__name__)
+    )
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (h, w, 3)
+
+
+def test_read_image_data_decodes_bigendian_mono16():
+    raw = np.array([[1000, 2000]], dtype=">u2")
+    message = SimpleNamespace(
+        height=1,
+        width=2,
+        encoding="mono16",
+        step=4,
+        is_bigendian=True,
+        data=raw.tobytes(),
+    )
+
+    result = read_image_data(
+        DataType.DEPTH_IMAGES,
+        message.data,
+        message,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result, np.array([[1000, 2000]], dtype=np.float32))
+
+
+def test_read_image_data_raises_on_unsupported_encoding():
+    message = SimpleNamespace(
+        height=1,
+        width=1,
+        encoding="yuv422",
+        step=2,
+        is_bigendian=False,
+        data=b"\x00\x00",
+    )
+    with pytest.raises(ImportError, match="Unsupported image encoding"):
+        read_image_data(
+            DataType.RGB_IMAGES,
+            message.data,
+            message,
+            logger=logging.getLogger(__name__),
+        )
+
+
+def test_convert_decoded_mcap_data_converts_non_protobuf():
+    result = convert_decoded_mcap_data({"a": SimpleNamespace(x=1)})
+    assert result == {"a": {"x": 1}}
+
+
+def test_convert_decoded_mcap_data_plain_dict_passthrough():
+    d = {"a": 1}
+    assert convert_decoded_mcap_data(d) is d
+
+
+def test_mcap_importer_getstate_clears_decoder_factories(monkeypatch, tmp_path):
+    importer = _make_importer(monkeypatch, tmp_path)
+    importer._decoder_factories = [RawPassthroughDecoderFactory()]
+    state = importer.__getstate__()
+    assert state["_decoder_factories"] is None
+
+
+def test_mcap_importer_prepare_worker_re_initializes_factories(monkeypatch, tmp_path):
+    from neuracore.importer.core.base import NeuracoreDatasetImporter
+
+    importer = _make_importer(monkeypatch, tmp_path)
+    importer._decoder_factories = None
+    inited = []
+    monkeypatch.setattr(
+        NeuracoreDatasetImporter,
+        "prepare_worker",
+        lambda self, worker_id, chunk=None: None,
+    )
+    monkeypatch.setattr(importer, "_init_runtime_components", lambda: inited.append(1))
+    importer.prepare_worker(0)
+    assert inited
+
+
+def test_mcap_importer_import_item_missing_file_raises(monkeypatch, tmp_path):
+    importer = _make_importer(monkeypatch, tmp_path)
+    bad_item = ImportItem(
+        index=0, description="gone.mcap", metadata={"path": str(tmp_path / "gone.mcap")}
+    )
+    with pytest.raises(ImportError, match="MCAP file not found"):
+        importer.import_item(bad_item)
+
+
+def test_discover_mcap_files_single_mcap_file(tmp_path):
+    f = tmp_path / "episode.mcap"
+    f.write_bytes(b"mcap")
+    assert MCAPDatasetImporter._discover_mcap_files(f) == [f]
+
+
+def test_discover_mcap_files_rejects_non_mcap_file(tmp_path):
+    f = tmp_path / "data.bag"
+    f.write_bytes(b"bag")
+    with pytest.raises(ImportError, match="Expected an MCAP file"):
+        MCAPDatasetImporter._discover_mcap_files(f)
+
+
+def test_discover_mcap_files_raises_on_nonexistent_path(tmp_path):
+    with pytest.raises(ImportError, match="does not exist"):
+        MCAPDatasetImporter._discover_mcap_files(tmp_path / "nonexistent")
+
+
+def test_discover_mcap_files_raises_when_no_mcap_in_dir(tmp_path):
+    (tmp_path / "data.txt").write_text("hello")
+    with pytest.raises(ImportError, match="No MCAP files found"):
+        MCAPDatasetImporter._discover_mcap_files(tmp_path)
+
+
+def test_iter_mcap_source_events_yields_source_event():
+    topic_map = build_topic_map(
+        _make_dataset_config({
+            DataType.JOINT_POSITIONS: _make_import_config(
+                source="/joint.position",
+                mapping=[_make_mapping_item("joint_1")],
+            )
+        })
+    )
+
+    decoded_data = {"position": [1, 2, 3]}
+    events = list(
+        iter_mcap_source_events(
+            "/joint",
+            decoded_data,
+            topic_map=topic_map,
+            logger=logging.getLogger(__name__),
+            timestamp=1.0,
+        )
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], MCAPSourceEvent)
+    assert events[0].data_type == DataType.JOINT_POSITIONS
+    assert events[0].item.name == "joint_1"
+    np.testing.assert_array_equal(events[0].source_data, np.array([1, 2, 3]))
+
+
+def test_iter_mcap_source_events_unknown_topic_yields_nothing():
+    topic_map = build_topic_map(
+        _make_dataset_config({
+            DataType.JOINT_POSITIONS: _make_import_config(
+                source="/joint.position",
+                mapping=[_make_mapping_item("j1")],
+            )
+        })
+    )
+
+    events = list(
+        iter_mcap_source_events(
+            "/unknown",
+            {},
+            topic_map=topic_map,
+            logger=logging.getLogger(__name__),
+            timestamp=0.0,
+        )
+    )
+
+    assert events == []
+
+
+def test_mcap_importer_log_transformed_clips_depth(monkeypatch, tmp_path):
+    importer = _make_importer(monkeypatch, tmp_path)
+    logged = []
+    monkeypatch.setattr(
+        type(importer).__mro__[1],
+        "_log_transformed_data",
+        lambda self, data_type, transformed_data, name, timestamp, **kw: logged.append(
+            (data_type, transformed_data)
+        ),
+    )
+    oversized = np.array([[MAX_DEPTH + 100.0]], dtype=np.float32)
+    importer._log_transformed_data(  # noqa: SLF001
+        data_type=DataType.DEPTH_IMAGES,
+        transformed_data=oversized,
+        name="depth",
+        timestamp=0.0,
+    )
+    assert len(logged) == 1
+    assert float(np.max(logged[0][1])) <= MAX_DEPTH


### PR DESCRIPTION
### Features                                                                                           
  - Adds MCAP dataset import support (handles JSON, protobuf, ROS1, and ROS2 data)
  - Discovers MCAP files, maps configured topics/fields to Neuracore data types, and streams decoded messages directly into Neuracore recordings.                                                                                      
                                                                 
  ### Items                                   
  - [NCRL-303](https://neuracore.atlassian.net/browse/NCRL-303)
                                                                                                         
  ### Related PRs
  - https://github.com/NeuracoreAI/neuracore_types/pull/81 should go in first.                           
 