### PR TITLE
fix: call create dataset once per daemon test

### DIFF
--- a/tests/integration/platform/data_daemon/data_integrity/test_network.py
+++ b/tests/integration/platform/data_daemon/data_integrity/test_network.py
@@ -27,7 +27,7 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case_con
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STOP_METHOD_CLI,
-    STORAGE_STATE_PRESERVE,
+    STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
     scoped_storage_state,
@@ -36,7 +36,7 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 
 _CASES = DataDaemonTestBatch(
     cases=PRE_NETWORK_INTEGRITY_CASES,
-    storage_state_action=STORAGE_STATE_PRESERVE,
+    storage_state_action=STORAGE_STATE_DELETE,
     stop_method=STOP_METHOD_CLI,
 ).as_cases()
 

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -643,13 +643,8 @@ def log_frames(
     return [marker_name]
 
 
-def _bind_worker_dataset(*, dataset_name: str, create_dataset: bool) -> None:
-    """Ensure a worker is bound to the shared dataset before recording."""
-    if create_dataset:
-        with Timer(MAX_TIME_TO_START_S, label="nc.create_dataset", always_log=True):
-            nc.create_dataset(dataset_name)
-        return
-
+def _bind_worker_dataset(*, dataset_name: str) -> None:
+    """Poll until the worker pool-shared dataset is visible to this worker."""
     last_error: Exception | None = None
     deadline = time.time() + MAX_TIME_TO_START_S
     with Timer(MAX_TIME_TO_START_S, label="nc.get_dataset", always_log=True):
@@ -695,10 +690,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
     wall_stopped_at: float = 0.0
 
     try:
-        _bind_worker_dataset(
-            dataset_name=spec.dataset_name,
-            create_dataset=spec.context_index == 0,
-        )
+        _bind_worker_dataset(dataset_name=spec.dataset_name)
         with Timer(MAX_TIME_TO_START_S, label="nc.connect_robot", always_log=True):
             robot = nc.connect_robot(spec.robot_name, overwrite=False)
 
@@ -856,6 +848,10 @@ def run_case_contexts(
     """
     if specs is None:
         specs = build_context_specs(case, assert_deadline=assert_deadline)
+
+    if specs:
+        with Timer(MAX_TIME_TO_START_S, label="nc.create_dataset", always_log=True):
+            nc.create_dataset(specs[0].dataset_name)
 
     if case.parallel_contexts == 1:
         results = [context_worker(specs[0])]


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Per daemon test, create dataset was getting called once per worker. Due to the shared http session introduced recently, workers were in a race condition to read from the keep alive socket
