### PR TITLE
fix: add set -o pipefail on git workflow to avoid slient unit test failure

### DIFF
--- a/.github/workflows/pr-pre-commit-and-test.yaml
+++ b/.github/workflows/pr-pre-commit-and-test.yaml
@@ -91,7 +91,9 @@ jobs:
 
       - name: Run non-ML unit tests
         if: env.SHOULD_RUN == 'true'
+        shell: bash
         run: |
+          set -euo pipefail
           if [ "${SHOULD_RUN_COVERAGE}" = "true" ]; then
             uv run pytest tests/unit \
               --ignore=tests/unit/ml \


### PR DESCRIPTION
By adding this line, the pipeline returns the first non-zero exit code in the chain instead of the last, this fixes the silent fail from the non-ml unit test