### PR TITLE
test: daemon data integrity test bug and improvements

### DIFF
--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
@@ -112,7 +112,7 @@ def test_cancel_recording_produces_no_data(
                     case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
                     label="nc.cancel_recording",
                     always_log=True,
-                    assert_limit=False,
+                    assert_deadline=False,
                 ):
                     nc.cancel_recording(robot_name=robot_name)
 
@@ -122,7 +122,7 @@ def test_cancel_recording_produces_no_data(
                     MAX_TIME_TO_START_S,
                     label="nc.get_dataset",
                     always_log=True,
-                    assert_limit=False,
+                    assert_deadline=False,
                 ):
                     dataset = nc.get_dataset(dataset_name)
                 assert (
@@ -196,7 +196,7 @@ def test_cancel_then_start_new_recording(
                     case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
                     label="nc.cancel_recording",
                     always_log=True,
-                    assert_limit=False,
+                    assert_deadline=False,
                 ):
                     nc.cancel_recording(robot_name=robot_name)
 
@@ -219,7 +219,7 @@ def test_cancel_then_start_new_recording(
                     case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
                     label="nc.stop_recording",
                     always_log=True,
-                    assert_limit=False,
+                    assert_deadline=False,
                 ):
                     nc.stop_recording(robot_name=robot_name, wait=True)
                 wall_stopped_at = time.time()

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -1,5 +1,3 @@
-from dataclasses import replace
-
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
 )
@@ -12,7 +10,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     TIMESTAMP_MODE_STOCHASTIC,
 )
 
-INTEGRITY_CASES = (
+PRE_NETWORK_INTEGRITY_CASES = (
     DataDaemonTestCase(
         duration_sec=10,
         joint_count=7,
@@ -93,8 +91,85 @@ INTEGRITY_CASES = (
     ),
 )
 
-PRE_NETWORK_INTEGRITY_CASES = INTEGRITY_CASES
-NETWORK_INTEGRITY_CASES = INTEGRITY_CASES + (
+NETWORK_INTEGRITY_CASES = (
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        parallel_contexts=1,
+        recording_count=1,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        recording_count=1,
+        video_count=1,
+        image_height=64,
+        image_width=64,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        recording_count=1,
+        video_count=1,
+        image_height=64,
+        image_width=64,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        joint_fps=15,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        recording_count=4,
+        video_count=1,
+        image_height=64,
+        image_width=64,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        joint_fps=15,
+        producer_channels=PRODUCER_PER_THREAD,
+        parallel_contexts=2,
+        mode=MODE_STAGGERED,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        recording_count=4,
+        video_count=1,
+        image_height=64,
+        image_width=64,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        joint_fps=15,
+        producer_channels=PRODUCER_PER_THREAD,
+        parallel_contexts=2,
+        mode=MODE_STAGGERED,
+        timestamp_mode=TIMESTAMP_MODE_REAL,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=1,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=1000,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_REAL,
+        wait=False,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=4,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=500,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        wait=False,
+    ),
     DataDaemonTestCase(
         duration_sec=5,
         joint_count=7,
@@ -185,12 +260,174 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         joint_fps=15,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
     ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=1,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=1000,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_REAL,
+        wait=False,
+    ),
 )
 
 NETWORK_PERFORMANCE_CASES = (
-    *[
-        c
-        for pair in PRE_NETWORK_PERFORMANCE_CASES
-        for c in (pair, replace(pair, wait=True))
-    ],
+    # High frequency robot control at 210Hz joint data
+    # Tests: high-frequency sampling, temporal jitter, joint-only streaming
+    DataDaemonTestCase(
+        duration_sec=60,
+        joint_count=7,
+        video_count=0,
+        parallel_contexts=1,
+        recording_count=5,
+        context_duration_mode=DURATION_MODE_FIXED,
+        joint_fps=210,
+    ),
+    DataDaemonTestCase(
+        duration_sec=60,
+        joint_count=7,
+        video_count=0,
+        parallel_contexts=1,
+        recording_count=5,
+        context_duration_mode=DURATION_MODE_FIXED,
+        joint_fps=210,
+        wait=True,
+    ),
+    # High number of medium-throughput robots with synchronized
+    # recordings. Tests: multi-robot contention, mixed data types,
+    # moderate-res cameras (256x256),
+    # one producer thread per robot, back-to-back recordings
+    DataDaemonTestCase(
+        duration_sec=20,
+        joint_count=7,
+        video_count=1,
+        image_width=256,
+        image_height=256,
+        parallel_contexts=8,
+        recording_count=16,
+        joint_fps=80,
+        producer_channels=PRODUCER_PER_THREAD,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+    ),
+    DataDaemonTestCase(
+        duration_sec=20,
+        joint_count=7,
+        video_count=1,
+        image_width=256,
+        image_height=256,
+        parallel_contexts=8,
+        recording_count=16,
+        joint_fps=80,
+        producer_channels=PRODUCER_PER_THREAD,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        wait=True,
+    ),
+    # Large number of joints without cameras (1000 joints)
+    # Tests: high joint dimensionality, memory efficiency, sensor-only workload
+    DataDaemonTestCase(
+        duration_sec=30,
+        joint_count=1000,
+        video_count=0,
+        parallel_contexts=1,
+        recording_count=3,
+    ),
+    DataDaemonTestCase(
+        duration_sec=30,
+        joint_count=1000,
+        video_count=0,
+        parallel_contexts=1,
+        recording_count=3,
+        wait=True,
+    ),
+    # 3x longer duration recordings
+    # Tests: long-running stability, memory leak detection, large dataset
+    # accumulation
+    DataDaemonTestCase(
+        duration_sec=300,
+        joint_count=10,
+        video_count=1,
+        image_width=1920,
+        image_height=1080,
+        parallel_contexts=2,
+        recording_count=16,
+        context_duration_mode=DURATION_MODE_FIXED,
+    ),
+    DataDaemonTestCase(
+        duration_sec=300,
+        joint_count=10,
+        video_count=1,
+        image_width=1920,
+        image_height=1080,
+        parallel_contexts=2,
+        recording_count=16,
+        context_duration_mode=DURATION_MODE_FIXED,
+        wait=True,
+    ),
+    DataDaemonTestCase(
+        duration_sec=300,
+        joint_count=10,
+        video_count=1,
+        image_width=1920,
+        image_height=1080,
+        parallel_contexts=2,
+        recording_count=16,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        joint_fps=15,
+        timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+    ),
+    DataDaemonTestCase(
+        duration_sec=300,
+        joint_count=10,
+        video_count=1,
+        image_width=1920,
+        image_height=1080,
+        parallel_contexts=2,
+        recording_count=16,
+        context_duration_mode=DURATION_MODE_VARIABLE,
+        video_fps=30,
+        joint_fps=15,
+        timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        wait=True,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=1,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=1000,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_REAL,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=1,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=1000,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_REAL,
+        wait=True,
+    ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        recording_count=4,
+        video_count=1,
+        image_height=120,
+        image_width=120,
+        video_fps=120,
+        joint_fps=500,
+        producer_channels=PRODUCER_PER_THREAD,
+        timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        wait=False,
+    ),
 )

--- a/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
@@ -76,12 +76,11 @@ def test_disk_db_data_integrity(
     results: list[ContextResult] = []
     dataset_name = create_testing_dataset_name(case)
     test_wall_start = time.perf_counter()
-
+    specs = build_context_specs(case, dataset_name=dataset_name)
     with scoped_storage_state(case, dataset_name=dataset_name):
         try:
             with offline_daemon_running():
                 assert_exactly_one_daemon_pid()
-                specs = build_context_specs(case, dataset_name=dataset_name)
                 results = run_case_contexts(case, specs=specs)
                 wait_for_all_traces_written(results=results)
                 assert_disk_recording_properties(results)

--- a/tests/integration/platform/data_daemon/performance/test_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_network.py
@@ -63,7 +63,7 @@ def test_cloud_upload_and_readiness_performance(
             " or a saved current organization."
         )
     dataset_name = create_testing_dataset_name(case)
-    specs = build_context_specs(case, dataset_name=dataset_name)
+    specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=True)
     results: list[ContextResult] = []
     with scoped_storage_state(case, dataset_name=dataset_name):
         try:

--- a/tests/integration/platform/data_daemon/performance/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_pre_network.py
@@ -15,6 +15,7 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     case_ids,
 )
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case_context import (  # noqa: E501
+    build_context_specs,
     create_testing_dataset_name,
     run_case_contexts,
 )
@@ -49,11 +50,12 @@ def test_disk_db_write_performance(
     """
 
     dataset_name = create_testing_dataset_name(case)
+    specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=True)
     with scoped_storage_state(case, dataset_name=dataset_name):
         with offline_daemon_running():
             results = []
             try:
                 assert_exactly_one_daemon_pid()
-                results = run_case_contexts(case, wait_for_traces=True)
+                results = run_case_contexts(case, specs=specs, wait_for_traces=True)
             finally:
                 log_run_analysis_on_teardown(case, results)

--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -100,7 +100,6 @@ def assert_context_mode(case: DataDaemonTestCase, results: list[ContextResult]) 
     tolerance_s = 0.1
     if case.mode == MODE_SEQUENTIAL:
         assert abs(second.timestamp_start_s - first.timestamp_start_s) < tolerance_s
-        assert abs(first.timestamp_end_s - second.timestamp_end_s) < tolerance_s
         assert second.wall_started_at is not None
         assert first.wall_stopped_at > second.wall_started_at
         return

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -77,7 +77,7 @@ class Timer:
             ``max_time``.
         log_threshold: Log at INFO level when elapsed time meets or exceeds
             this value.  ``None`` disables.
-        assert_limit: When ``True`` (default), raise ``AssertionError`` if
+        assert_deadline: When ``True`` (default), raise ``AssertionError`` if
             the block exceeds ``max_time``.  Set to ``False`` to log only.
     """
 
@@ -89,17 +89,13 @@ class Timer:
         label: str | None = None,
         always_log: bool = False,
         log_threshold: float | None = None,
-        assert_limit: bool = True,
-        deadline: float | None = None,
-        timing_tolerance: float | None = None,
+        assert_deadline: bool = True,
     ) -> None:
         self.max_time = max_time
         self.label = label
         self.always_log = always_log
         self.log_threshold = log_threshold
-        self.assert_limit = assert_limit
-        self.deadline = deadline
-        self.timing_tolerance = timing_tolerance
+        self.assert_deadline = assert_deadline
 
     def __enter__(self) -> Timer:
         self.wall_start = time.time()
@@ -139,14 +135,7 @@ class Timer:
         if had_exception:
             return False
 
-        if self.assert_limit:
-            if self.deadline is not None and self.timing_tolerance is not None:
-                lateness = self.wall_start - self.deadline
-                assert abs(lateness) <= self.timing_tolerance, (
-                    f"{self.label or 'Function'} logged at wrong moment: "
-                    f"lateness={lateness:+.3f}s, "
-                    f"tolerance=±{self.timing_tolerance:.3f}s"
-                )
+        if self.assert_deadline:
             assert self.interval < self.max_time, (
                 f"{self.label or 'Function'} took too long: "
                 f"{self.interval:.3f}s >= {self.max_time:.3f}s"
@@ -163,6 +152,19 @@ class Timer:
             existing["count"] += incoming["count"]
             existing["total"] += incoming["total"]
             existing["max"] = max(existing["max"], incoming["max"])
+
+
+def assert_on_schedule(deadline: float, tolerance: float, label: str) -> None:
+    """Assert the producer fired at the intended wall-clock moment.
+
+    Independent of any duration check: bounds *when* a logging call started,
+    not how long it took.
+    """
+    lateness = time.time() - deadline
+    assert abs(lateness) <= tolerance, (
+        f"{label} fired at wrong moment: "
+        f"lateness={lateness:+.3f}s, tolerance=±{tolerance:.3f}s"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +245,7 @@ def _wait_and_escalate(candidate_pids: set[int], *, graceful_timeout_s: float) -
         if not pid_is_running(pid):
             continue
         if not wait_for_exit(pid, timeout_s=graceful_timeout_s):
-            with Timer(5.0, label="stop_daemon_escalated", assert_limit=False):
+            with Timer(5.0, label="stop_daemon_escalated", assert_deadline=False):
                 force_kill(pid)
                 wait_for_exit(pid, timeout_s=5.0)
 
@@ -274,7 +276,7 @@ def stop_daemon(
         graceful_timeout_s: Seconds to wait for graceful exit before escalating
             to SIGKILL.  Ignored when ``method="sigkill"``.
     """
-    with Timer(15.0, label=f"stop_daemon[{method}]", assert_limit=False):
+    with Timer(15.0, label=f"stop_daemon[{method}]", assert_deadline=False):
         candidate_pids = _collect_candidate_pids()
         _send_initial_stop(method, candidate_pids)
         if method == STOP_METHOD_SIGKILL:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -270,9 +270,9 @@ def case_id(case: DataDaemonTestCase) -> str:
         f"{case.duration_sec}s",
         f"{case.recording_count}recs",
         *(["variable"] if case.context_duration_mode == DURATION_MODE_VARIABLE else []),
-        f"{case.parallel_contexts}ctx",
     ]
     if case.parallel_contexts > DataDaemonTestCase.parallel_contexts:
+        parts.append(f"{case.parallel_contexts}ctx")
         parts.append(mode_short)
     parts.append(f"{case.joint_count}joints")
     if case.joint_fps != DataDaemonTestCase.joint_fps:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -23,6 +23,7 @@ from tests.integration.platform.data_daemon.shared.assertions import assert_cont
 from tests.integration.platform.data_daemon.shared.process_control import (
     MAX_TIME_TO_LOG_S,
     Timer,
+    assert_on_schedule,
 )
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
@@ -45,6 +46,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     MAX_TIME_TO_START_S,
     MODE_STAGGERED,
     PRODUCER_PER_THREAD,
+    SCHEDULER_TOLERANCE_S,
     STOCHASTIC_JITTER_S,
     STOP_RECORDING_OVERHEAD_PER_SEC,
     TIMESTAMP_MODE_REAL,
@@ -309,7 +311,6 @@ def log_synchronous_frames(
     Joint and video frames are interleaved in a single loop using a wall-clock
     deadline scheduler, so both streams advance together in time order.
     """
-    timing_tolerance = STOCHASTIC_JITTER_S if use_stochastic_timestamps else None
     recording_wall_start = time.time()
     joint_index = 0
     video_index = 0
@@ -336,6 +337,10 @@ def log_synchronous_frames(
             remaining = joint_deadline - time.time()
             if remaining > 0:
                 time.sleep(remaining)
+            if assert_deadline and use_stochastic_timestamps:
+                assert_on_schedule(
+                    joint_deadline, SCHEDULER_TOLERANCE_S, label="joint frame"
+                )
             if use_real_timestamps:
                 timestamp = None
             else:
@@ -345,8 +350,7 @@ def log_synchronous_frames(
             with Timer(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_positions",
-                deadline=joint_deadline if assert_deadline else None,
-                timing_tolerance=timing_tolerance,
+                assert_deadline=assert_deadline,
             ):
                 nc.log_joint_positions(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -354,8 +358,7 @@ def log_synchronous_frames(
             with Timer(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_velocities",
-                deadline=joint_deadline if assert_deadline else None,
-                timing_tolerance=timing_tolerance,
+                assert_deadline=assert_deadline,
             ):
                 nc.log_joint_velocities(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -363,8 +366,7 @@ def log_synchronous_frames(
             with Timer(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_torques",
-                deadline=joint_deadline if assert_deadline else None,
-                timing_tolerance=timing_tolerance,
+                assert_deadline=assert_deadline,
             ):
                 nc.log_joint_torques(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -372,8 +374,7 @@ def log_synchronous_frames(
             with Timer(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_custom_1d",
-                deadline=joint_deadline if assert_deadline else None,
-                timing_tolerance=timing_tolerance,
+                assert_deadline=assert_deadline,
             ):
                 nc.log_custom_1d(
                     marker_name,
@@ -386,6 +387,10 @@ def log_synchronous_frames(
             remaining = video_deadline - time.time()
             if remaining > 0:
                 time.sleep(remaining)
+            if assert_deadline and use_stochastic_timestamps:
+                assert_on_schedule(
+                    video_deadline, SCHEDULER_TOLERANCE_S, label="video frame"
+                )
             if use_real_timestamps:
                 timestamp = None
             else:
@@ -403,8 +408,7 @@ def log_synchronous_frames(
                 with Timer(
                     MAX_TIME_TO_LOG_S,
                     label="nc.log_rgb",
-                    deadline=video_deadline if assert_deadline else None,
-                    timing_tolerance=timing_tolerance,
+                    assert_deadline=assert_deadline,
                 ):
                     nc.log_rgb(
                         camera_name,
@@ -472,15 +476,18 @@ def run_threaded_logging(
             frame_count = video_frame_count if is_rgb else joint_frame_count
             fps = video_fps if is_rgb else joint_fps
             thread_wall_start = time.time()
-            jitter = get_jitter(use_stochastic_timestamps)
-            timing_tolerance = (
-                STOCHASTIC_JITTER_S if use_stochastic_timestamps else None
-            )
             for frame_index in range(frame_count):
-                frame_deadline = thread_wall_start + (frame_index / fps)
+                jitter = get_jitter(use_stochastic_timestamps)
+                frame_deadline = thread_wall_start + (frame_index / fps) + jitter
                 remaining = frame_deadline - time.time()
                 if remaining > 0:
                     time.sleep(remaining)
+                if assert_deadline and use_stochastic_timestamps:
+                    assert_on_schedule(
+                        frame_deadline,
+                        SCHEDULER_TOLERANCE_S,
+                        label=f"{role_name} frame",
+                    )
                 if use_real_timestamps:
                     timestamp = None
                 else:
@@ -504,8 +511,7 @@ def run_threaded_logging(
                         with Timer(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_rgb",
-                            deadline=frame_deadline if assert_deadline else None,
-                            timing_tolerance=timing_tolerance,
+                            assert_deadline=assert_deadline,
                         ):
                             nc.log_rgb(
                                 camera_id,
@@ -522,8 +528,7 @@ def run_threaded_logging(
                         with Timer(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_positions",
-                            deadline=frame_deadline if assert_deadline else None,
-                            timing_tolerance=timing_tolerance,
+                            assert_deadline=assert_deadline,
                         ):
                             nc.log_joint_positions(
                                 joint_values,
@@ -534,8 +539,7 @@ def run_threaded_logging(
                         with Timer(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_velocities",
-                            deadline=frame_deadline if assert_deadline else None,
-                            timing_tolerance=timing_tolerance,
+                            assert_deadline=assert_deadline,
                         ):
                             nc.log_joint_velocities(
                                 joint_values,
@@ -546,8 +550,7 @@ def run_threaded_logging(
                         with Timer(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_torques",
-                            deadline=frame_deadline if assert_deadline else None,
-                            timing_tolerance=timing_tolerance,
+                            assert_deadline=assert_deadline,
                         ):
                             nc.log_joint_torques(
                                 joint_values,
@@ -557,8 +560,7 @@ def run_threaded_logging(
                 with Timer(
                     MAX_TIME_TO_LOG_S,
                     label="nc.log_custom_1d",
-                    deadline=frame_deadline if assert_deadline else None,
-                    timing_tolerance=timing_tolerance,
+                    assert_deadline=assert_deadline,
                 ):
                     nc.log_custom_1d(
                         marker_name,
@@ -667,9 +669,12 @@ def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     On Linux, Pool uses fork so workers inherit a copy of the parent's
     Timer._stats. Clearing it here ensures workers only capture their own
     timers and the parent's pre-fork timers (e.g. nc.login) are not
-    double-counted when stats are merged back.
+    double-counted when stats are merged back. The stochastic-timestamp RNG
+    is reseeded per-context so parallel workers produce independent jitter
+    sequences instead of replaying the parent's seed.
     """
     Timer._stats.clear()
+    STOCHASTIC_TIMESTAMP_RANDOM.seed(1 + spec.context_index)
     return context_worker(spec)
 
 
@@ -707,6 +712,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                 MAX_TIME_TO_START_S,
                 label="nc.start_recording",
                 always_log=True,
+                assert_deadline=spec.assert_deadline,
             ):
                 nc.start_recording(robot_name=spec.robot_name)
             if wall_started_at is None:
@@ -770,7 +776,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                 case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
                 label="nc.stop_recording",
                 always_log=True,
-                assert_limit=False,
+                assert_deadline=spec.assert_deadline,
             ):
                 nc.stop_recording(robot_name=spec.robot_name, wait=case.wait)
             wall_stopped_at = time.time()
@@ -822,7 +828,6 @@ def run_case_contexts(
     case: DataDaemonTestCase,
     *,
     specs: list[ContextSpec] | None = None,
-    assert_deadline: bool = False,
     assert_mode: bool = True,
     wait_for_traces: bool = False,
 ) -> list[ContextResult]:
@@ -836,8 +841,6 @@ def run_case_contexts(
         case: The test case defining parallelism level and context matrix.
         specs: Pre-built context specs to run. If None, built from ``case``
             via :func:`build_context_specs`.
-        assert_deadline: Passed through to :func:`build_context_specs` when
-            ``specs`` is ``None``.
         assert_mode: When ``True`` (default), calls :func:`assert_context_mode`
             after running to verify expected parallelization behaviour.
         wait_for_traces: When ``True``, waits for all traces to be written to
@@ -847,7 +850,7 @@ def run_case_contexts(
         List of result dicts from each context worker, one per spec.
     """
     if specs is None:
-        specs = build_context_specs(case, assert_deadline=assert_deadline)
+        specs = build_context_specs(case)
 
     if specs:
         with Timer(MAX_TIME_TO_START_S, label="nc.create_dataset", always_log=True):

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -35,6 +35,8 @@ TIMESTAMP_MODE_MANUAL = "manual"
 TIMESTAMP_MODE_REAL = "real"
 TIMESTAMP_MODE_STOCHASTIC = "stochastic"
 STOCHASTIC_JITTER_S = 0.05
+# OS-scheduler slack budget for the deadline-lateness assertion in stochastic mode.
+SCHEDULER_TOLERANCE_S = 0.05
 
 # ---------------------------------------------------------------------------
 # Value sets (tuples for static validation)


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Explicit test cases rather than programmatic
 - Context number hidden in id unless more than one
 - Separated concepts of deadlines for perf tests and scheduled log times for stochastic perf tests

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Data integrity cases asserting deadlines when they shouldn't be
 - Fixed bug where stochastic timestamps are only creating jitter constant once per worker
 - Removed overly strict assertion for sequential mode where we checking the end times were within a tolerance (Thanks to @muneebneura for revealing this bug)

