### PR TITLE
fix: training config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ MUJOCO_LOG.TXT
 *.nc.zip
 
 logs/
+outputs/
 examples/logs/
 *.log
 *.log.gz

--- a/docs/training.md
+++ b/docs/training.md
@@ -99,23 +99,75 @@ neuracore/
 ```
 
 ## Training Command Examples
-**Note**: Passing `run_name` is optional. If you don't pass the `run_name`, the system will generate a random name. To better track the training experiment, we highly recommend you to pass a `run_name`. If a run with the same name already exists, training fails by default; set `run_name_auto_increment=true` to use an incremented name (e.g. `my_experiment_1`) instead.
+**Note**: Passing `training_name` is optional. If you don't pass the `training_name`, the system will generate a random name. To better track the training experiment, we highly recommend you to pass a `training_name`. If a training with the same name already exists, training fails by default; set `training_name_auto_increment=true` to use an incremented name (e.g. `my_experiment_1`) instead.
 ```bash
 # Basic training with Diffusion Policy
-python -m neuracore.ml.train algorithm=diffusion_policy dataset_name="my_dataset" run_name="my_experiment"
+python -m neuracore.ml.train algorithm=diffusion_policy dataset_name="my_dataset" training_name="my_experiment"
 
 # Train ACT with custom algorithm hyperparameters
-python -m neuracore.ml.train algorithm=act algorithm.lr=5e-4 algorithm.hidden_dim=1024 dataset_name="my_dataset" run_name="my_experiment"
+python -m neuracore.ml.train algorithm=act algorithm.lr=5e-4 algorithm.hidden_dim=1024 dataset_name="my_dataset" training_name="my_experiment"
 
 # Auto-tune batch size
-python -m neuracore.ml.train algorithm=diffusion_policy batch_size=auto dataset_name="my_dataset" run_name="my_experiment"
+python -m neuracore.ml.train algorithm=diffusion_policy batch_size=auto dataset_name="my_dataset" training_name="my_experiment"
 
 # Hyperparameter sweeps
-python -m neuracore.ml.train --multirun algorithm=cnnmlp algorithm.lr=1e-4,5e-4,1e-3 algorithm.hidden_dim=256,512,1024 dataset_name="my_dataset" run_name="my_experiment"
+python -m neuracore.ml.train --multirun algorithm=cnnmlp algorithm.lr=1e-4,5e-4,1e-3 algorithm.hidden_dim=256,512,1024 dataset_name="my_dataset" training_name="my_experiment"
 
 # Training with specified modalities
 python -m neuracore.ml.train algorithm=pi0 dataset_name="my_multimodal_dataset" input_cross_embodiment_description={"my_robot": {"JOINT_POSITIONS": ["joint_1", "joint_2", ...], "RGB_IMAGES": ["wrist_camera"], "LANGUAGE": ["task_instruction"]}}
-output_cross_embodiment_description={"my_robot": {"JOINT_TARGET_POSITIONS": ["joint_1", "joint_2", ...]}} run_name="my_experiment"
+output_cross_embodiment_description={"my_robot": {"JOINT_TARGET_POSITIONS": ["joint_1", "joint_2", ...]}} training_name="my_experiment"
+```
+
+### Using a config file for training arguments
+
+Instead of passing every option on the command line, you can put your run arguments in a YAML file and ask Hydra to compose it with the default Neuracore training config.
+
+Create a config file in the `user` config group, for example `neuracore/ml/config/user/my_experiment.yaml`:
+
+```yaml
+# @package _global_
+
+training_name: my_experiment
+training_name_auto_increment: true
+
+dataset_name: my_dataset
+algorithm_name: diffusion_policy
+
+epochs: 100
+batch_size: auto
+frequency: 10
+validation_split: 0.2
+
+input_data_types:
+  - JOINT_POSITIONS
+  - RGB_IMAGES
+
+output_data_types:
+  - JOINT_TARGET_POSITIONS
+
+algorithm:
+  lr: 0.0005
+  hidden_dim: 1024
+```
+
+Then run training with:
+
+```bash
+python -m neuracore.ml.train user=my_experiment
+```
+
+You can still override any value from the command line. Command-line overrides take precedence over values in the YAML file:
+
+```bash
+python -m neuracore.ml.train user=my_experiment epochs=50 batch_size=32
+```
+
+If you want to keep config files outside the package directory, add the directory to Hydra's search path. The directory should contain a `user/` subdirectory:
+
+```bash
+mkdir -p configs/user
+# write configs/user/my_experiment.yaml
+python -m neuracore.ml.train --config-dir configs user=my_experiment
 ```
 
 ### Configuration management

--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -4,7 +4,7 @@ This module provides functions for starting and monitoring training jobs,
 including algorithm discovery, dataset resolution, and job status tracking.
 """
 
-import concurrent
+import concurrent.futures
 import sys
 from typing import Any, cast
 
@@ -60,37 +60,39 @@ def _resolve_next_name(base_name: str, existing_names: set[str]) -> str:
 
 
 def _get_algorithms() -> list[dict]:
-    """Retrieve all available algorithms from the API.
-
-    Fetches both organization-specific and shared algorithms concurrently.
-
-    Returns:
-        list[dict]: List of algorithm dictionaries containing algorithm metadata
-
-    Raises:
-        requests.exceptions.HTTPError: If the API request fails
-        requests.exceptions.RequestException: If there is a network problem
-        ConfigError: If there is an error trying to get the current org
-    """
+    """Retrieve all available algorithms from the API."""
     auth = get_auth()
     org_id = get_current_org()
-    with Session() as session, concurrent.futures.ThreadPoolExecutor() as executor:
-        org_alg_req = executor.submit(
-            session.get,
-            f"{API_URL}/org/{org_id}/algorithms",
+
+    with Session() as session:
+
+        def fetch_algorithms(shared: bool) -> list[dict]:
+            response = session.get(
+                f"{API_URL}/org/{org_id}/algorithms",
+                headers=auth.get_headers(),
+                params={"shared": shared},
+            )
+            response.raise_for_status()
+            return response.json()
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            org_algorithms, shared_algorithms = executor.map(
+                fetch_algorithms, (False, True)
+            )
+    return org_algorithms + shared_algorithms
+
+
+def get_algorithm(algorithm_id: str) -> dict:
+    """Retrieve a single algorithm by ID from the API."""
+    auth = get_auth()
+    org_id = get_current_org()
+    with Session() as session:
+        response = session.get(
+            f"{API_URL}/org/{org_id}/algorithms/{algorithm_id}",
             headers=auth.get_headers(),
-            params={"shared": False},
         )
-        shared_alg_req = executor.submit(
-            session.get,
-            f"{API_URL}/org/{org_id}/algorithms",
-            headers=auth.get_headers(),
-            params={"shared": True},
-        )
-        org_alg, shared_alg = org_alg_req.result(), shared_alg_req.result()
-    org_alg.raise_for_status()
-    shared_alg.raise_for_status()
-    return org_alg.json() + shared_alg.json()
+    response.raise_for_status()
+    return response.json()
 
 
 def start_training_run(

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -92,6 +92,7 @@ class Dataset:
         self._num_recordings: int | None = len(recordings) if recordings else None
         self._start_after: dict | None = None
         self._robot_ids: list[str] | None = None
+        self._robot_names: dict[str, str] | None = None
 
     def _wrap_raw_recording(self, raw_recording: dict) -> Recording:
         """Wrap a raw recording dict into a Recording object.
@@ -625,8 +626,21 @@ class Dataset:
                 )
             response.raise_for_status()
             self._robot_ids = response.json()
-            # Populate names to keep order consistent with IDs
         return self._robot_ids
+
+    def get_robot_names(self) -> dict[str, str]:
+        """Get robot names keyed by robot ID for this dataset."""
+        if self._robot_names is None:
+            with Session() as session:
+                response = session.get(
+                    f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robots",
+                    headers=get_auth().get_headers(),
+                )
+            response.raise_for_status()
+            robots = response.json()
+            self._robot_names = {robot["id"]: robot["name"] for robot in robots}
+            self._robot_ids = list(self._robot_names)
+        return self._robot_names
 
     def __iter__(self) -> Iterator[Recording]:
         """Yield recordings one by one, fetching pages lazily."""

--- a/neuracore/core/utils/robot_data_spec_utils.py
+++ b/neuracore/core/utils/robot_data_spec_utils.py
@@ -17,7 +17,6 @@ from neuracore_types import (
     DataType,
     EmbodimentDescription,
 )
-from omegaconf import DictConfig
 from ordered_set import OrderedSet
 
 from neuracore.core.auth import get_auth
@@ -37,39 +36,6 @@ def is_robot_id(string: str) -> bool:
         True if the identifier matches UUID format, False otherwise.
     """
     return bool(ID_REGEX.match(string))
-
-
-def convert_omegaconf_to_cross_embodiment_description(
-    cross_embodiment_cfg: DictConfig,
-) -> CrossEmbodimentDescription:
-    """Converts string representations of data types to DataType enums.
-
-    Takes a dictionary mapping robot names to dictionaries of
-    data type strings and their associated item names,
-    and converts the data type strings to DataType enums.
-
-    Args:
-        cross_embodiment_cfg: A dictionary where keys are robot names and
-            values are dictionaries mapping data type strings to lists of item names.
-
-    Returns:
-        A dictionary where keys are robot ids/name and values are dictionaries
-            mapping DataType
-        to a dict of index to item name.
-    """
-    result: CrossEmbodimentDescription = {}
-    for embodiment, embodiment_values in cross_embodiment_cfg.items():
-        result[embodiment] = {}
-        for data_type_str, item_names in embodiment_values.items():
-            try:
-                data_type_enum = DataType(data_type_str)
-            except ValueError:
-                raise ValueError(
-                    f"Invalid data type '{data_type_str}' for robot '{embodiment}'. "
-                    f"Expected one of {[data_type.value for data_type in DataType]}."
-                )
-            result[embodiment][data_type_enum] = dict(item_names)
-    return result
 
 
 def convert_cross_embodiment_description_names_to_ids(

--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -1,17 +1,49 @@
 defaults:
   - _self_
+  - optional user: null
   - algorithm: null
   - override hydra/launcher: basic
-  
+
+training_name:
+training_name_auto_increment: false
+training_id: null
+
+org_id: null
+
+# Only one of the below needs to be provided.
+dataset_name:
+dataset_id:
+
+# Only one of the below needs to be provided.
+algorithm_name:
+algorithm_id:
+
+algorithm_params: null
 
 # Core training parameters
 seed: 42
 epochs: 100
 output_prediction_horizon: 100
 validation_split: 0.2
+frequency: 10
+allow_duplicates: true
+
+# Resume training
+resume_checkpoint_path: null  # Path to checkpoint to resume from
+
 logging_frequency: 50
-keep_last_n_checkpoints: 2 
+keep_last_n_checkpoints: 2
 device: null  # e.g., "cuda:0", "mps", "cpu"
+
+input_data_types:
+output_data_types:
+
+input_cross_embodiment_description: {
+
+}
+output_cross_embodiment_description: {
+
+}
 
 # Batch size (can be "auto" for automatic tuning or an integer)
 batch_size: "auto"
@@ -22,31 +54,8 @@ num_val_workers: 1
 # Maximum number of workers to use for prefetching recordings
 max_prefetch_workers: 4
 
-# Dataset synchronization
-dataset_name: null
-dataset_id: null
-frequency: 10
-allow_duplicates: true
 max_delay_s: null
 trim_start_end: true
-
-# You can either specify input_data_types/output_data_types or
-# input_cross_embodiment_description/output_cross_embodiment_description
-input_data_types:
-  - "JOINT_POSITIONS"
-  - "RGB_IMAGES"
-
-output_data_types:
-  - "JOINT_TARGET_POSITIONS"
-
-# Dict[str, Dict[DataType, List[str]], e.g., {"my_robot": {"JOINT_POSITIONS": ["joint_1", "joint_2", ...]}}
-# You can also pass in an empty dict {} to use all available data for all robots
-input_cross_embodiment_description: {
-
-}
-output_cross_embodiment_description: {
-
-}
 
 # Dict[str, Dict[DataType, List[MethodConfig]]], e.g.:
 # for images, we must have a resize step to reshape all images from different sources to the same size.
@@ -66,22 +75,8 @@ preprocessing:
       - _target_: neuracore.ml.preprocessing.methods.resize_pad.ResizePad
         size: [224, 224]
 
-# Paths and IDs (for cloud vs local training)
-algorithm_id: null    # For cloud training
-training_id: null     # For cloud training
-org_id: null          # For cloud training
-run_name: null        # Optional name for the training run. If not provided, a two-word random name will be generated.
-run_name_auto_increment: false  # If true, when run_name already exists use run_name_1, run_name_2, etc. If false (default), fail when run_name exists.
-
 # Output directory (generated dynamically with the resolver)
-local_output_dir: ${resolve_output_dir:${run_name},${run_name_auto_increment}}
-
-# Custom algorithm parameters (used when algorithm_id is provided)
-# These will be passed directly to the algorithm constructor
-algorithm_params: null
-
-# Resume training
-resume_checkpoint_path: null  # Path to checkpoint to resume from
+local_output_dir: ${resolve_output_dir:${training_name},${training_name_auto_increment}}
 
 # Hydra configuration
 hydra:

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -29,6 +29,7 @@ from neuracore.core.utils.training_input_args_validation import (
 )
 from neuracore.ml import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_neuracore_dataset import PytorchNeuracoreDataset
+from neuracore.ml.utils.json_serialization import JsonValue, to_json_serializable
 from neuracore.ml.utils.memory_monitor import MemoryMonitor
 from neuracore.ml.utils.preprocessing_utils import (
     PreprocessingConfiguration,
@@ -42,12 +43,10 @@ CHECK_MEMORY_INTERVAL = 100
 
 
 def _cacheable_cross_embodiment_description(
-    description: CrossEmbodimentDescription,
-) -> CrossEmbodimentDescription:
+    description: object,
+) -> JsonValue:
     """Return a JSON-serializable cross-embodiment description."""
-    if hasattr(description, "model_dump"):
-        return description.model_dump(mode="json")
-    return description
+    return to_json_serializable(description)
 
 
 class PytorchSynchronizedDataset(PytorchNeuracoreDataset):

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -23,23 +23,14 @@ from neuracore_types import (
     CrossEmbodimentUnion,
     ModelInitDescription,
 )
-from neuracore_types.nc_data import DataType
 from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader, DistributedSampler, random_split
 
 import neuracore as nc
-from neuracore.api.training import _get_algorithms
 from neuracore.core.const import DEFAULT_CACHE_DIR, DEFAULT_RECORDING_CACHE_DIR
 from neuracore.core.utils.robot_data_spec_utils import (
-    convert_cross_embodiment_description_names_to_ids,
-    convert_omegaconf_to_cross_embodiment_description,
     extract_data_types,
     merge_cross_embodiment_description,
-)
-from neuracore.core.utils.training_input_args_validation import (
-    _get_data_types_for_algorithms,
-    get_algorithm_name,
-    validate_training_params,
 )
 from neuracore.ml import BatchedTrainingSamples, NeuracoreModel
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
@@ -65,6 +56,11 @@ from neuracore.ml.utils.preprocessing_utils import (
     PreprocessingConfiguration,
     resolve_preprocessing_config,
 )
+from neuracore.ml.utils.training_config import (
+    resolve_to_complete_config,
+    resolve_user_input_config,
+    validate_complete_config,
+)
 from neuracore.ml.utils.training_storage_handler import TrainingStorageHandler
 
 # Environment setup
@@ -85,77 +81,80 @@ def _resolve_recording_cache_dir(cfg: DictConfig) -> Path:
 
 
 def _resolve_output_dir(
-    run_name: str | None = None,
-    run_name_auto_increment: bool | str = False,
+    training_name: str | None = None,
+    training_name_auto_increment: bool | str = False,
 ) -> str:
     """Hydra resolver to generate the output directory path.
 
-    This resolver generates a unique output directory based on run_name.
+    This resolver generates a unique output directory based on training_name.
     It's called during Hydra initialization, so the directory is available before
     the main function runs.
 
-    When run_name_auto_increment is False (default), if a directory for the given
+    When training_name_auto_increment is False (default), if a directory for the given
     run name already exists, resolution fails with FileExistsError. Set
-    run_name_auto_increment=true to automatically use run_name_1, run_name_2, etc.
+    training_name_auto_increment=true to automatically use name_1, name_2, etc.
 
     Args:
-        run_name: Optional run name. If None or "null", a random name will be generated.
-        run_name_auto_increment: If True (or "true"), append _1, _2, ... when the
-            name already exists. If False (default), fail when the name exists.
+        training_name: Optional training name. If None or "null", a random name
+            will be generated.
+        training_name_auto_increment: If True (or "true"), append _1, _2, ...
+            when the name already exists. If False (default), fail when the name
+            exists.
 
     Returns:
         Full path to the output directory.
 
     Raises:
-        FileExistsError: When run_name_auto_increment is False and a directory
-            for run_name (or run_name_N) already exists.
+        FileExistsError: When training_name_auto_increment is False and a
+            directory for training_name (or training_name_N) already exists.
     """
     # Handle None, empty string, or string "null"
     if (
-        not run_name
-        or run_name == "null"
-        or (isinstance(run_name, str) and run_name.strip() == "")
+        not training_name
+        or training_name == "null"
+        or (isinstance(training_name, str) and training_name.strip() == "")
     ):
         # Generate name with hyphens instead of underscores
-        run_name = generate_name(style="underscore").replace("_", "-")
+        training_name = generate_name(style="underscore").replace("_", "-")
     else:
-        run_name = _sanitize_run_name(str(run_name))
+        training_name = _sanitize_run_name(str(training_name))
 
     auto_increment = (
-        str(run_name_auto_increment).lower() == "true"
-        if not isinstance(run_name_auto_increment, bool)
-        else run_name_auto_increment
+        str(training_name_auto_increment).lower() == "true"
+        if not isinstance(training_name_auto_increment, bool)
+        else training_name_auto_increment
     )
 
     base_dir = DEFAULT_CACHE_DIR / "runs"
 
-    final_run_name = run_name
+    final_training_name = training_name
     if base_dir.exists():
         taken = {
             p.name
             for p in base_dir.iterdir()
-            if p.is_dir() and (p.name == run_name or p.name.startswith(f"{run_name}_"))
+            if p.is_dir()
+            and (p.name == training_name or p.name.startswith(f"{training_name}_"))
         }
-        if run_name in taken:
+        if training_name in taken:
             if not auto_increment:
-                existing = base_dir / run_name
+                existing = base_dir / training_name
                 raise FileExistsError(
-                    f"A run named {run_name!r} already exists at {existing}. "
-                    "Either use a different run_name, "
-                    "or set run_name_auto_increment=true "
-                    "to use an incremented name (e.g. run_name_1)."
+                    f"A training named {training_name!r} already exists at "
+                    f"{existing}. Either use a different training_name, or set "
+                    "training_name_auto_increment=true to use an incremented "
+                    "name (e.g. training_name_1)."
                 )
             suffix = 1
-            while f"{run_name}_{suffix}" in taken:
+            while f"{training_name}_{suffix}" in taken:
                 suffix += 1
-            final_run_name = f"{run_name}_{suffix}"
+            final_training_name = f"{training_name}_{suffix}"
             logger.warning(
-                f"A run named {run_name} already exists. "
-                f"Using {final_run_name} for this run."
+                f"A training named {training_name} already exists. "
+                f"Using {final_training_name} for this run."
             )
 
     # Build full path
-    return str(base_dir / final_run_name)
+    return str(base_dir / final_training_name)
 
 
 def _sanitize_run_name(name: str) -> str:
@@ -224,60 +223,6 @@ def _serialize_cross_embodiment_union(
             key = data_type.name if hasattr(data_type, "name") else str(data_type)
             serializable[robot_id][key] = list(names)
     return serializable
-
-
-def _resolve_cross_embodiment_description(
-    cross_embodiment_description_cfg: DictConfig | None,
-    data_types_cfg: list[str],
-    dataset: Any,
-    field_name: str,
-) -> CrossEmbodimentDescription:
-    """Resolve a cross-embodiment description from config or dataset.
-
-    Args:
-        cross_embodiment_description_cfg: Optional configuration for the
-            cross-embodiment description.
-        data_types_cfg: Data types to include if
-            ``cross_embodiment_description_cfg`` is not provided.
-        dataset: The dataset to extract data specifications from if needed.
-        field_name: Name of the field being resolved, used in errors.
-
-    Returns:
-        A cross-embodiment description resolved from configuration or
-        constructed from the dataset.
-
-    Raises:
-        ValueError: If ``cross_embodiment_description_cfg`` is invalid.
-    """
-    # if cross_embodiment_description is provided
-    if cross_embodiment_description_cfg is not None and len(
-        cross_embodiment_description_cfg
-    ):
-        if not isinstance(cross_embodiment_description_cfg, DictConfig):
-            raise ValueError(
-                f"'{field_name}' must either be None or a dictionary mapping robot "
-                "names to dictionaries of data types to lists of data names."
-            )
-        return convert_omegaconf_to_cross_embodiment_description(
-            cross_embodiment_description_cfg
-        )
-
-    if data_types_cfg is not None:
-        data_types = [DataType(data_type) for data_type in data_types_cfg]
-        cross_embodiment_description: CrossEmbodimentDescription = {}
-
-        for robot_id in dataset.robot_ids:
-            robot_full_spec = dataset.get_full_embodiment_description(robot_id)
-            cross_embodiment_description[robot_id] = {
-                data_type: dict(robot_full_spec.get(data_type, {}))
-                for data_type in data_types
-            }
-        return cross_embodiment_description
-
-    raise ValueError(
-        f"Either '{field_name}' or the corresponding data_types "
-        "configuration must be provided."
-    )
 
 
 def _save_local_training_metadata(
@@ -663,9 +608,10 @@ def run_training(
             cfg, model_init_description
         )
 
+        training_id = getattr(cfg, "training_id", None)
         training_storage_handler = TrainingStorageHandler(
             local_dir=cfg.local_output_dir,
-            training_job_id=cfg.training_id,
+            training_job_id=training_id,
             algorithm_config=algorithm_config,
             input_cross_embodiment_description=input_cross_embodiment_description,
             output_cross_embodiment_description=output_cross_embodiment_description,
@@ -679,13 +625,13 @@ def run_training(
         )
 
         training_logger: TensorboardTrainingLogger | CloudTrainingLogger
-        if cfg.training_id is None:
+        if training_id is None:
             training_logger = TensorboardTrainingLogger(
                 log_dir=Path(cfg.local_output_dir) / "tensorboard",
             )
         else:
             training_logger = CloudTrainingLogger(
-                training_id=cfg.training_id,
+                training_id=training_id,
             )
 
         trainer = DistributedTrainer(
@@ -766,64 +712,6 @@ def _try_report_error_to_cloud(cfg: DictConfig, error_msg: str) -> None:
         logger.error("Failed to report training error to cloud.", exc_info=True)
 
 
-def _resolve_algorithm_name_and_supported_data_types(
-    cfg: DictConfig, algorithms_jsons: list[dict]
-) -> tuple[str, set[DataType], set[DataType]]:
-    """Resolve algorithm name and supported input and output data types.
-
-    If ``algorithm_id`` is provided (cloud case), use the algorithm ID to get
-    the algorithm name and supported data types. If ``algorithm_id`` is not
-    provided (local case), use the algorithm class to get the supported data
-    types.
-
-    Args:
-        cfg: Hydra configuration.
-        algorithms_jsons: List of algorithm metadata dictionaries.
-
-    Returns:
-        A tuple containing:
-          - Algorithm name.
-          - Supported input data types.
-          - Supported output data types.
-
-    Raises:
-        ValueError: If the algorithm does not have supported input or output data types.
-    """
-    if cfg.algorithm_id is not None:
-        algorithm_name = get_algorithm_name(
-            algorithm_id=cfg.algorithm_id,
-            algorithm_jsons=algorithms_jsons,
-        )
-        (
-            supported_input_data_types,
-            supported_output_data_types,
-        ) = _get_data_types_for_algorithms(
-            algorithm_name=algorithm_name,
-            algorithm_jsons=algorithms_jsons,
-        )
-        return (
-            algorithm_name,
-            supported_input_data_types,
-            supported_output_data_types,
-        )
-
-    # Local case: use the algorithm class to get the supported data types.
-    algorithm_name = cfg.algorithm._target_.rsplit(".", 1)[-1]
-    algorithm_cls = hydra.utils.get_object(cfg.algorithm._target_)
-    supported_input_data_types = algorithm_cls.get_supported_input_data_types()
-    supported_output_data_types = algorithm_cls.get_supported_output_data_types()
-    if (
-        supported_input_data_types is not None
-        and supported_output_data_types is not None
-    ):
-        return algorithm_name, supported_input_data_types, supported_output_data_types
-
-    raise ValueError(
-        f"Algorithm {algorithm_name} does not have supported input or output "
-        "data types, please check the algorithm class."
-    )
-
-
 def _main(cfg: DictConfig) -> None:
     """Inner implementation of main.
 
@@ -833,46 +721,22 @@ def _main(cfg: DictConfig) -> None:
     Args:
         cfg: Fully resolved Hydra configuration.
     """
-    # Resolve the configuration
-    OmegaConf.resolve(cfg)
-    setup_logging(cfg.local_output_dir)
+    # Merge Config with the base config from the algorithm
+    cfg = resolve_user_input_config(cfg)
 
+    setup_logging(cfg.local_output_dir)
     log_streamer: CloudLogStreamer | None = None
 
     try:
-        logger.info(f"Training run directory: {cfg.local_output_dir}")
-
-        # Print configuration
-        logger.info("Training configuration:")
-        logger.info(OmegaConf.to_yaml(cfg, resolve=True))
-
-        # Validate algorithm
-        if "algorithm" in cfg and cfg.algorithm_id is not None:
-            raise ValueError(
-                "Both 'algorithm' and 'algorithm_id' are provided. "
-                "Please specify only one."
-            )
-        if "algorithm" not in cfg and cfg.algorithm_id is None:
-            raise ValueError(
-                "Neither 'algorithm' nor 'algorithm_id' is provided. "
-                "Please specify one."
-            )
-
-        # Validate dataset specification
-        if cfg.dataset_id is None and cfg.dataset_name is None:
-            raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
-        if cfg.dataset_id is not None and cfg.dataset_name is not None:
-            raise ValueError(
-                "Both 'dataset_id' and 'dataset_name' are provided. "
-                "Please specify only one."
-            )
+        # Checks all parameters are valid inputs
+        validate_complete_config(cfg)
 
         # Login before constructing cloud storage so org/auth state is available.
         nc.login()
         if cfg.org_id is not None:
             nc.set_organization(cfg.org_id)
 
-        training_id = getattr(cfg, "training_id", None)
+        training_id = cfg.get("training_id")
         # If a training ID is provided,
         # We assume it is a Cloud Training Run
         if training_id is not None:
@@ -886,63 +750,27 @@ def _main(cfg: DictConfig) -> None:
             )
             log_streamer.start()
 
-        # Dataset retrieval and preparation
-        if cfg.dataset_id is not None:
-            dataset = nc.get_dataset(id=cfg.dataset_id)
-        elif cfg.dataset_name is not None:
+        if cfg.dataset_name is not None:
             dataset = nc.get_dataset(name=cfg.dataset_name)
         else:
-            raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
+            dataset = nc.get_dataset(id=cfg.dataset_id)
+
+        cfg = resolve_to_complete_config(cfg, dataset=dataset)
+        logger.info("Training configuration:")
+        logger.info(OmegaConf.to_yaml(cfg, resolve=False))
+        logger.info(f"Training run directory: {cfg.local_output_dir}")
+
         dataset.cache_dir = _resolve_recording_cache_dir(cfg)
         dataset.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        # Convert data_types to the final cross_embodiment_description
-        input_cross_embodiment_description = _resolve_cross_embodiment_description(
-            cross_embodiment_description_cfg=cfg.input_cross_embodiment_description,
-            data_types_cfg=cfg.input_data_types,
-            dataset=dataset,
-            field_name="input_cross_embodiment_description",
-        )
-        output_cross_embodiment_description = _resolve_cross_embodiment_description(
-            cross_embodiment_description_cfg=cfg.output_cross_embodiment_description,
-            data_types_cfg=cfg.output_data_types,
-            dataset=dataset,
-            field_name="output_cross_embodiment_description",
-        )
-
-        input_cross_embodiment_description = (
-            convert_cross_embodiment_description_names_to_ids(
-                input_cross_embodiment_description
-            )
-        )
-        output_cross_embodiment_description = (
-            convert_cross_embodiment_description_names_to_ids(
-                output_cross_embodiment_description
-            )
-        )
-
+        input_cross_embodiment_description = cfg.input_cross_embodiment_description
+        output_cross_embodiment_description = cfg.output_cross_embodiment_description
         # =========================================================
         # From here onwards we only deal with robot IDs, not names
         # =========================================================
-
         batch_size = cfg.batch_size
 
-        # Get algorithm JSONs parameters
-        algorithms_jsons = _get_algorithms()
-        algorithm_name, supported_input_data_types, supported_output_data_types = (
-            _resolve_algorithm_name_and_supported_data_types(cfg, algorithms_jsons)
-        )
-
         # Validate that the provided parameters are consistent and sufficient
-        validate_training_params(
-            dataset,
-            dataset_name=cfg.dataset_name if cfg.dataset_name is not None else "",
-            algorithm_name=algorithm_name,
-            input_cross_embodiment_description=input_cross_embodiment_description,
-            output_cross_embodiment_description=output_cross_embodiment_description,
-            supported_input_data_types=supported_input_data_types,
-            supported_output_data_types=supported_output_data_types,
-        )
 
         # Prepare data types for synchronization
         cross_embodiment_union: CrossEmbodimentUnion = (
@@ -954,7 +782,7 @@ def _main(cfg: DictConfig) -> None:
         # Save local metadata so CLI can inspect local runs without cloud access
         _save_local_training_metadata(
             cfg,
-            algorithm_name=algorithm_name,
+            algorithm_name=cfg.algorithm_name,
             input_cross_embodiment_description=input_cross_embodiment_description,
             output_cross_embodiment_description=output_cross_embodiment_description,
             cross_embodiment_union=cross_embodiment_union,

--- a/neuracore/ml/utils/json_serialization.py
+++ b/neuracore/ml/utils/json_serialization.py
@@ -1,0 +1,52 @@
+"""Helpers for converting config objects before JSON serialization."""
+
+from collections.abc import Mapping
+from enum import Enum
+from typing import Protocol, TypeAlias, runtime_checkable
+
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+JsonKey: TypeAlias = str | int | float | bool | None
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[JsonKey, "JsonValue"]
+
+
+@runtime_checkable
+class SupportsModelDump(Protocol):
+    """Protocol for Pydantic-like objects that can dump JSON-compatible data."""
+
+    def model_dump(self, *, mode: str) -> object:
+        """Return a serializable representation of the object."""
+
+
+def _to_json_key(key: object) -> JsonKey:
+    if isinstance(key, (str, int, float, bool)) or key is None:
+        return key
+    if isinstance(key, Enum):
+        return _to_json_key(key.value)
+    return str(key)
+
+
+def to_json_serializable(value: object) -> JsonValue:
+    """Convert OmegaConf and Pydantic-style objects into JSON-safe containers."""
+    if isinstance(value, SupportsModelDump):
+        return to_json_serializable(value.model_dump(mode="json"))
+
+    if isinstance(value, (DictConfig, ListConfig)):
+        return to_json_serializable(OmegaConf.to_container(value, resolve=True))
+
+    if isinstance(value, Mapping):
+        return {
+            _to_json_key(key): to_json_serializable(item) for key, item in value.items()
+        }
+
+    if isinstance(value, (list, tuple)):
+        return [to_json_serializable(item) for item in value]
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+
+    if isinstance(value, Enum):
+        return to_json_serializable(value.value)
+
+    return str(value)

--- a/neuracore/ml/utils/nc_archive.py
+++ b/neuracore/ml/utils/nc_archive.py
@@ -12,7 +12,6 @@ import tempfile
 import zipfile
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any
 
 import torch
 from neuracore_types import CrossEmbodimentDescription, ModelInitDescription
@@ -21,12 +20,23 @@ from omegaconf import OmegaConf
 from neuracore.ml.core.neuracore_model import NeuracoreModel
 from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
 from neuracore.ml.utils.device_utils import get_default_device
+from neuracore.ml.utils.json_serialization import to_json_serializable
 from neuracore.ml.utils.preprocessing_utils import (
     PreprocessingConfiguration,
     resolve_preprocessing_config,
 )
 
 logger = logging.getLogger(__name__)
+
+ArchiveEntry = Path | list[Path]
+
+
+def _archive_path(extracted_files: dict[str, ArchiveEntry], key: str) -> Path:
+    """Return a single extracted file path by key."""
+    value = extracted_files[key]
+    if isinstance(value, list):
+        raise ValueError(f"Archive entry {key!r} contains multiple files.")
+    return value
 
 
 def _build_archive_metadata() -> dict[str, str | None]:
@@ -54,11 +64,11 @@ def _build_archive_metadata() -> dict[str, str | None]:
 def create_nc_archive(
     model: NeuracoreModel,
     output_dir: Path,
-    algorithm_config: dict = {},
-    input_cross_embodiment_description: dict[str, Any] = {},
-    output_cross_embodiment_description: dict[str, Any] = {},
-    input_preprocessing_config: PreprocessingConfiguration = {},
-    output_preprocessing_config: PreprocessingConfiguration = {},
+    algorithm_config: object | None = None,
+    input_cross_embodiment_description: object | None = None,
+    output_cross_embodiment_description: object | None = None,
+    input_preprocessing_config: PreprocessingConfiguration | None = None,
+    output_preprocessing_config: PreprocessingConfiguration | None = None,
 ) -> Path:
     """Create a Neuracore model archive (NC.ZIP) file from a Neuracore model.
 
@@ -99,22 +109,30 @@ def create_nc_archive(
 
         # Save model initialization description
         with open(temp_path / "model_init_description.json", "w") as f:
-            json.dump(model.model_init_description.model_dump(mode="json"), f, indent=2)
+            json.dump(to_json_serializable(model.model_init_description), f, indent=2)
 
         # Save algorithm config (always create file, even if empty)
         with open(temp_path / "algorithm_config.json", "w") as f:
-            json.dump(algorithm_config, f, indent=2)
+            json.dump(to_json_serializable(algorithm_config or {}), f, indent=2)
 
         # Save cross-embodiment descriptions
         with open(temp_path / "input_cross_embodiment_description.json", "w") as f:
-            json.dump(input_cross_embodiment_description, f, indent=2)
+            json.dump(
+                to_json_serializable(input_cross_embodiment_description or {}),
+                f,
+                indent=2,
+            )
         with open(temp_path / "output_cross_embodiment_description.json", "w") as f:
-            json.dump(output_cross_embodiment_description, f, indent=2)
+            json.dump(
+                to_json_serializable(output_cross_embodiment_description or {}),
+                f,
+                indent=2,
+            )
         with open(temp_path / "input_preprocessing_config.json", "w") as f:
             json.dump(
                 {
                     data_type.value: [m.to_dict() for m in methods]
-                    for data_type, methods in input_preprocessing_config.items()
+                    for data_type, methods in (input_preprocessing_config or {}).items()
                 },
                 f,
                 indent=2,
@@ -123,7 +141,9 @@ def create_nc_archive(
             json.dump(
                 {
                     data_type.value: [m.to_dict() for m in methods]
-                    for data_type, methods in output_preprocessing_config.items()
+                    for data_type, methods in (
+                        output_preprocessing_config or {}
+                    ).items()
                 },
                 f,
                 indent=2,
@@ -185,7 +205,7 @@ def create_nc_archive(
     return archive_path
 
 
-def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
+def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, ArchiveEntry]:
     """Extract all contents from a Neuracore model archive (NC.ZIP) file.
 
     Extracts all files from a NC.ZIP archive including model weights, algorithm code,
@@ -206,7 +226,7 @@ def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
         raise FileNotFoundError(f"Archive file not found: {archive_file}")
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    extracted_files: dict[str, Any] = {}
+    extracted_files: dict[str, ArchiveEntry] = {}
 
     with zipfile.ZipFile(archive_file, "r") as zip_ref:
         # Extract all files
@@ -236,9 +256,13 @@ def extract_nc_archive(archive_file: Path, output_dir: Path) -> dict[str, Path]:
             elif file_info.filename == "algorithm/requirements.txt":
                 extracted_files["algorithm_requirements"] = file_path
             elif file_info.filename.startswith("algorithm/"):
-                extracted_files.setdefault("algorithm_files", []).append(file_path)
+                algorithm_files = extracted_files.setdefault("algorithm_files", [])
+                if isinstance(algorithm_files, list):
+                    algorithm_files.append(file_path)
             else:
-                extracted_files.setdefault("other_files", []).append(file_path)
+                other_files = extracted_files.setdefault("other_files", [])
+                if isinstance(other_files, list):
+                    other_files.append(file_path)
 
     return extracted_files
 
@@ -278,9 +302,13 @@ def load_cross_embodiment_descriptions_from_nc_archive(
                 "output_cross_embodiment_description.json not found in archive"
             )
 
-        with open(extracted_files["input_cross_embodiment_description"]) as f:
+        with open(
+            _archive_path(extracted_files, "input_cross_embodiment_description")
+        ) as f:
             input_cross_embodiment_description = json.load(f)
-        with open(extracted_files["output_cross_embodiment_description"]) as f:
+        with open(
+            _archive_path(extracted_files, "output_cross_embodiment_description")
+        ) as f:
             output_cross_embodiment_description = json.load(f)
         return input_cross_embodiment_description, output_cross_embodiment_description
     finally:
@@ -334,7 +362,7 @@ def load_model_from_nc_archive(
         if "model_init_description" not in extracted_files:
             raise FileNotFoundError("model_init_description.json not found in archive")
 
-        with open(extracted_files["model_init_description"]) as f:
+        with open(_archive_path(extracted_files, "model_init_description")) as f:
             model_init_description = json.load(f)
         model_init_description = ModelInitDescription.model_validate(
             model_init_description
@@ -343,21 +371,27 @@ def load_model_from_nc_archive(
         # Load algorithm config if present
         algorithm_config = {}
         if "algorithm_config" in extracted_files:
-            with open(extracted_files["algorithm_config"]) as f:
+            with open(_archive_path(extracted_files, "algorithm_config")) as f:
                 algorithm_config = json.load(f)
 
         # Load cross-embodiment descriptions if present
         input_cross_embodiment_description = {}
         if "input_cross_embodiment_description" in extracted_files:
-            with open(extracted_files["input_cross_embodiment_description"]) as f:
+            with open(
+                _archive_path(extracted_files, "input_cross_embodiment_description")
+            ) as f:
                 input_cross_embodiment_description = json.load(f)
         output_cross_embodiment_description = {}
         if "output_cross_embodiment_description" in extracted_files:
-            with open(extracted_files["output_cross_embodiment_description"]) as f:
+            with open(
+                _archive_path(extracted_files, "output_cross_embodiment_description")
+            ) as f:
                 output_cross_embodiment_description = json.load(f)
         input_preprocessing_config: PreprocessingConfiguration = {}
         if "input_preprocessing_config" in extracted_files:
-            with open(extracted_files["input_preprocessing_config"]) as f:
+            with open(
+                _archive_path(extracted_files, "input_preprocessing_config")
+            ) as f:
                 input_preprocessing_config_serialized = json.load(f)
                 if input_preprocessing_config_serialized:
                     input_preprocessing_config = resolve_preprocessing_config(
@@ -369,7 +403,9 @@ def load_model_from_nc_archive(
                     )
         output_preprocessing_config: PreprocessingConfiguration = {}
         if "output_preprocessing_config" in extracted_files:
-            with open(extracted_files["output_preprocessing_config"]) as f:
+            with open(
+                _archive_path(extracted_files, "output_preprocessing_config")
+            ) as f:
                 output_preprocessing_config_serialized = json.load(f)
                 if output_preprocessing_config_serialized:
                     output_preprocessing_config = resolve_preprocessing_config(

--- a/neuracore/ml/utils/training_config.py
+++ b/neuracore/ml/utils/training_config.py
@@ -1,0 +1,397 @@
+"""Utilities for normalizing Hydra training configuration."""
+
+import copy
+import re
+from pathlib import Path
+from typing import Any
+
+import hydra
+from neuracore_types import CrossEmbodimentDescription, DataType
+from omegaconf import DictConfig, OmegaConf
+
+import neuracore as nc
+from neuracore.api.training import _get_algorithms, get_algorithm
+from neuracore.core.data.dataset import Dataset
+from neuracore.core.utils.robot_data_spec_utils import (
+    convert_cross_embodiment_description_names_to_ids,
+    is_robot_id,
+)
+from neuracore.core.utils.training_input_args_validation import (
+    _get_data_types_for_algorithms,
+    get_algorithm_id,
+    get_algorithm_name,
+    validate_training_params,
+)
+
+ALGORITHM_CONFIG_DIR = Path(__file__).resolve().parents[1] / "config" / "algorithm"
+
+
+def _normalize_algorithm_name(name: str) -> str:
+    """Normalize algorithm names for config lookup."""
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _load_algorithm_config_from_name(algorithm_name: str) -> DictConfig:
+    """Load a packaged algorithm config from a file stem or target class name."""
+    requested_name = _normalize_algorithm_name(algorithm_name)
+    available_names: list[str] = []
+
+    for config_path in sorted(ALGORITHM_CONFIG_DIR.glob("*.yaml")):
+        algorithm_cfg = OmegaConf.load(config_path)
+        cfg_algorithm = algorithm_cfg.get("algorithm")
+        if cfg_algorithm is None or "_target_" not in cfg_algorithm:
+            continue
+
+        target_name = str(cfg_algorithm._target_).rsplit(".", 1)[-1]
+        candidate_names = {
+            _normalize_algorithm_name(config_path.stem),
+            _normalize_algorithm_name(target_name),
+        }
+        available_names.extend(sorted(candidate_names))
+
+        if requested_name in candidate_names:
+            return algorithm_cfg
+
+    available = ", ".join(sorted(set(available_names)))
+    raise ValueError(
+        f"Unknown algorithm {algorithm_name!r}. Expected one of: {available}."
+    )
+
+
+def _resolve_algorithm_name_config(cfg: DictConfig) -> DictConfig:
+    """Resolve algorithm_name shorthand into a full Hydra algorithm config."""
+    if isinstance(cfg.get("algorithm"), str):
+        raise ValueError(
+            "'algorithm' as a string is not supported. Use 'algorithm_name' "
+            "for packaged algorithms or 'algorithm_id' for custom algorithms."
+        )
+
+    if not isinstance(cfg.get("algorithm_name"), str):
+        return cfg
+
+    if cfg.get("algorithm_id") is not None:
+        raise ValueError(
+            "Both 'algorithm_name' and 'algorithm_id' are provided. "
+            "Please specify only one."
+        )
+
+    algorithm_cfg = _load_algorithm_config_from_name(cfg.algorithm_name)
+    cfg_with_overrides = copy.deepcopy(cfg)
+    if "algorithm" in cfg_with_overrides and cfg_with_overrides.algorithm is None:
+        del cfg_with_overrides.algorithm
+    return OmegaConf.merge(algorithm_cfg, cfg_with_overrides)
+
+
+def resolve_to_merged_config(cfg: DictConfig) -> DictConfig:
+    """Resolve a potentially incomplete training config to a complete one."""
+    # Merge with the default config to ensure all expected keys are present,
+    # even if the user provided a custom config that may not include all the
+    # default values.
+    default_cfg = OmegaConf.load(
+        Path(__file__).resolve().parents[1] / "config" / "config.yaml"
+    )
+    cfg = OmegaConf.merge(default_cfg, cfg)
+
+    return _resolve_algorithm_name_config(cfg)
+
+
+def _is_provided(value: Any) -> bool:
+    """Return whether a config value is present and non-empty."""
+    if value is None:
+        return False
+    try:
+        return len(value) > 0
+    except TypeError:
+        return True
+
+
+def validate_complete_config(cfg: DictConfig) -> None:
+    """Validate mutually exclusive and required top-level training config fields."""
+    algorithm = cfg.get("algorithm")
+    algorithm_id = cfg.get("algorithm_id")
+    if algorithm is not None and algorithm_id is not None:
+        raise ValueError(
+            "Both 'algorithm' and 'algorithm_id' are provided. "
+            "Please specify only one."
+        )
+    if algorithm is None and algorithm_id is None:
+        raise ValueError(
+            "Neither 'algorithm' nor 'algorithm_id' is provided. " "Please specify one."
+        )
+
+    dataset_id = cfg.get("dataset_id")
+    dataset_name = cfg.get("dataset_name")
+    if dataset_id is None and dataset_name is None:
+        raise ValueError("Either 'dataset_id' or 'dataset_name' must be provided.")
+    if dataset_id is not None and dataset_name is not None:
+        raise ValueError(
+            "Both 'dataset_id' and 'dataset_name' are provided. "
+            "Please specify only one."
+        )
+
+    input_data_types = cfg.get("input_data_types")
+    input_cross_embodiment_description = cfg.get("input_cross_embodiment_description")
+    if _is_provided(input_data_types) and _is_provided(
+        input_cross_embodiment_description
+    ):
+        raise ValueError(
+            "Both 'input_data_types' and 'input_cross_embodiment_description' "
+            "are provided. Please specify only one."
+        )
+    if not _is_provided(input_data_types) and not _is_provided(
+        input_cross_embodiment_description
+    ):
+        raise ValueError(
+            "Neither 'input_data_types' nor 'input_cross_embodiment_description' "
+            "is provided. Please specify one."
+        )
+
+    output_data_types = cfg.get("output_data_types")
+    output_cross_embodiment_description = cfg.get("output_cross_embodiment_description")
+    if _is_provided(output_data_types) and _is_provided(
+        output_cross_embodiment_description
+    ):
+        raise ValueError(
+            "Both 'output_data_types' and 'output_cross_embodiment_description' "
+            "are provided. Please specify only one."
+        )
+    if not _is_provided(output_data_types) and not _is_provided(
+        output_cross_embodiment_description
+    ):
+        raise ValueError(
+            "Neither 'output_data_types' nor 'output_cross_embodiment_description' "
+            "is provided. Please specify one."
+        )
+
+
+def _resolve_local_output_dir(cfg: DictConfig) -> None:
+    """Resolve the generated output directory without resolving Hydra internals."""
+    if "local_output_dir" in cfg:
+        cfg.local_output_dir = str(cfg.local_output_dir)
+
+
+def resolve_user_input_config(cfg: DictConfig) -> DictConfig:
+    """Resolve user-facing shorthand while preserving runtime-only settings."""
+    cfg = resolve_to_merged_config(cfg)
+    _resolve_local_output_dir(cfg)
+    return cfg
+
+
+def _resolve_algorithm_name_and_supported_data_types(
+    cfg: DictConfig, algorithms_jsons: list[dict]
+) -> tuple[str, set[DataType], set[DataType]]:
+    """Resolve algorithm name and supported input and output data types.
+
+    If ``algorithm_id`` is provided (cloud case), use the algorithm ID to get
+    the algorithm name and supported data types. If ``algorithm_id`` is not
+    provided (local case), use the algorithm class to get the supported data
+    types.
+
+    Args:
+        cfg: Hydra configuration.
+        algorithms_jsons: List of algorithm metadata dictionaries.
+
+    Returns:
+        A tuple containing:
+          - Algorithm name.
+          - Supported input data types.
+          - Supported output data types.
+
+    Raises:
+        ValueError: If the algorithm does not have supported input or output data types.
+    """
+    if cfg.algorithm_id is not None:
+        if algorithms_jsons:
+            algorithm_name = get_algorithm_name(
+                algorithm_id=cfg.algorithm_id,
+                algorithm_jsons=algorithms_jsons,
+            )
+            (
+                supported_input_data_types,
+                supported_output_data_types,
+            ) = _get_data_types_for_algorithms(
+                algorithm_name=algorithm_name,
+                algorithm_jsons=algorithms_jsons,
+            )
+        else:
+            algorithm_json = get_algorithm(cfg.algorithm_id)
+            algorithm_name = algorithm_json["name"]
+            (
+                supported_input_data_types,
+                supported_output_data_types,
+            ) = _get_data_types_for_algorithms(
+                algorithm_name=algorithm_name,
+                algorithm_jsons=[algorithm_json],
+            )
+        return (
+            algorithm_name,
+            supported_input_data_types,
+            supported_output_data_types,
+        )
+
+    # Local case: use the algorithm class to get the supported data types.
+    algorithm_name = cfg.algorithm._target_.rsplit(".", 1)[-1]
+    algorithm_cls = hydra.utils.get_object(cfg.algorithm._target_)
+    supported_input_data_types = algorithm_cls.get_supported_input_data_types()
+    supported_output_data_types = algorithm_cls.get_supported_output_data_types()
+    if (
+        supported_input_data_types is not None
+        and supported_output_data_types is not None
+    ):
+        return algorithm_name, supported_input_data_types, supported_output_data_types
+
+    raise ValueError(
+        f"Algorithm {algorithm_name} does not have supported input or output "
+        "data types, please check the algorithm class."
+    )
+
+
+def build_cross_embodiment_description_from_data_types(
+    data_types_cfg: list[str],
+    dataset: Dataset,
+) -> CrossEmbodimentDescription:
+    """Construct a cross-embodiment description from data types and dataset specs."""
+    data_types = [DataType(data_type) for data_type in data_types_cfg]
+    robot_ids = dataset.robot_ids
+    robot_names = (
+        dataset.get_robot_names()
+        if any(is_robot_id(robot_id) for robot_id in robot_ids)
+        else {}
+    )
+
+    cross_embodiment_description: CrossEmbodimentDescription = {}
+    for robot_id in robot_ids:
+        robot_full_spec = dataset.get_full_embodiment_description(robot_id)
+        robot_name = robot_names[robot_id] if is_robot_id(robot_id) else robot_id
+        cross_embodiment_description[robot_name] = {
+            data_type: dict(robot_full_spec.get(data_type, {}))
+            for data_type in data_types
+        }
+
+    return cross_embodiment_description
+
+
+def _normalize_cross_embodiment_description(
+    cross_embodiment_cfg: Any,
+) -> CrossEmbodimentDescription:
+    """Convert config data type keys to DataType enums."""
+    result: CrossEmbodimentDescription = {}
+    for embodiment, embodiment_values in cross_embodiment_cfg.items():
+        result[embodiment] = {}
+        for data_type, item_names in embodiment_values.items():
+            try:
+                data_type_enum = (
+                    data_type
+                    if isinstance(data_type, DataType)
+                    else DataType(data_type)
+                )
+            except ValueError:
+                raise ValueError(
+                    f"Invalid data type '{data_type}' for robot '{embodiment}'. "
+                    f"Expected one of {[item.value for item in DataType]}."
+                )
+            result[embodiment][data_type_enum] = dict(item_names)
+    return result
+
+
+def _resolve_cross_embodiment_description(
+    cross_embodiment_description_cfg: Any,
+    data_types_cfg: list[str],
+    dataset: Dataset,
+    field_name: str,
+) -> CrossEmbodimentDescription:
+    """Resolve an explicit cross-embodiment config or build one from data types."""
+    if _is_provided(cross_embodiment_description_cfg):
+        return _normalize_cross_embodiment_description(cross_embodiment_description_cfg)
+    if not _is_provided(data_types_cfg):
+        raise ValueError(f"Either '{field_name}' or data types must be provided.")
+    return build_cross_embodiment_description_from_data_types(
+        data_types_cfg=data_types_cfg,
+        dataset=dataset,
+    )
+
+
+def _primitive_attr(value: Any, attr: str, fallback: str | None) -> str | None:
+    """Return a primitive string attribute value, ignoring mock attributes."""
+    resolved = getattr(value, attr, None)
+    return resolved if isinstance(resolved, str) else fallback
+
+
+def resolve_to_complete_config(
+    cfg: DictConfig, dataset: Dataset | None = None
+) -> DictConfig:
+    """Resolve selectors and data-type shorthand to a complete training config."""
+    cfg = resolve_to_merged_config(cfg)
+    _resolve_local_output_dir(cfg)
+
+    # Populate dataset name/id from whichever selector the caller supplied.
+    if dataset is not None:
+        cfg.dataset_id = _primitive_attr(dataset, "id", cfg.get("dataset_id"))
+        cfg.dataset_name = _primitive_attr(dataset, "name", cfg.get("dataset_name"))
+    elif cfg.dataset_name is not None:
+        dataset = nc.get_dataset(name=cfg.dataset_name)
+        cfg.dataset_id = _primitive_attr(dataset, "id", cfg.get("dataset_id"))
+    else:
+        dataset = nc.get_dataset(id=cfg.dataset_id)
+        cfg.dataset_name = _primitive_attr(dataset, "name", cfg.get("dataset_name"))
+
+    # Populate algorithm name/id from whichever selector the caller supplied.
+    if cfg.algorithm_id is not None:
+        algorithm_name, supported_input_data_types, supported_output_data_types = (
+            _resolve_algorithm_name_and_supported_data_types(cfg, [])
+        )
+        cfg.algorithm_name = algorithm_name
+    elif cfg.get("algorithm") is not None:
+        algorithm_name, supported_input_data_types, supported_output_data_types = (
+            _resolve_algorithm_name_and_supported_data_types(cfg, [])
+        )
+    else:
+        algorithms_jsons = _get_algorithms()
+        algorithm_id = get_algorithm_id(cfg.algorithm_name, algorithms_jsons)
+        if algorithm_id is None:
+            raise ValueError(
+                f"Algorithm name {cfg.algorithm_name} not found in available "
+                "algorithms. Please check the training job requirements."
+            )
+        cfg.algorithm_id = algorithm_id
+        algorithm_name, supported_input_data_types, supported_output_data_types = (
+            _resolve_algorithm_name_and_supported_data_types(cfg, algorithms_jsons)
+        )
+
+    cfg.input_cross_embodiment_description = _resolve_cross_embodiment_description(
+        cross_embodiment_description_cfg=cfg.input_cross_embodiment_description,
+        data_types_cfg=cfg.input_data_types,
+        dataset=dataset,
+        field_name="input_cross_embodiment_description",
+    )
+    cfg.output_cross_embodiment_description = _resolve_cross_embodiment_description(
+        cross_embodiment_description_cfg=cfg.output_cross_embodiment_description,
+        data_types_cfg=cfg.output_data_types,
+        dataset=dataset,
+        field_name="output_cross_embodiment_description",
+    )
+
+    input_cross_embodiment_description = (
+        convert_cross_embodiment_description_names_to_ids(
+            cfg.input_cross_embodiment_description
+        )
+    )
+    output_cross_embodiment_description = (
+        convert_cross_embodiment_description_names_to_ids(
+            cfg.output_cross_embodiment_description
+        )
+    )
+    cfg.input_cross_embodiment_description = input_cross_embodiment_description
+    cfg.output_cross_embodiment_description = output_cross_embodiment_description
+
+    validate_training_params(
+        dataset,
+        dataset_name=cfg.dataset_name if cfg.dataset_name is not None else "",
+        algorithm_name=algorithm_name,
+        input_cross_embodiment_description=input_cross_embodiment_description,
+        output_cross_embodiment_description=output_cross_embodiment_description,
+        supported_input_data_types=supported_input_data_types,
+        supported_output_data_types=supported_output_data_types,
+    )
+
+    return cfg

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -298,6 +298,14 @@ def mock_data_requests(
         json=[recording["robot_id"] for recording in recordings_list],
         status_code=200,
     )
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/datasets/{dataset_model.id}/robots",
+        json=[
+            {"id": recording["robot_id"], "name": f"robot-{index + 1}"}
+            for index, recording in enumerate(recordings_list)
+        ],
+        status_code=200,
+    )
 
     # Mock dataset creation endpoint
     mock_auth_requests.post(

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -847,6 +847,21 @@ class TestDatasetIteration:
 class TestDatasetSynchronization:
     """Tests for dataset synchronization."""
 
+    def test_get_robot_names_returns_names_by_id(
+        self, mock_data_requests, dataset_dict
+    ):
+        nc.login("test_api_key")
+        dataset = Dataset(**dataset_dict)
+
+        assert dataset.get_robot_names() == {
+            "20a621b7-2f9b-4699-a08e-7d080488a5a3": "robot-1",
+            "30b731c8-3f9c-5799-b19e-8d190599b6b4": "robot-2",
+        }
+        assert dataset.robot_ids == [
+            "20a621b7-2f9b-4699-a08e-7d080488a5a3",
+            "30b731c8-3f9c-5799-b19e-8d190599b6b4",
+        ]
+
     def test_synchronize_with_no_data_types(
         self, mock_data_requests, dataset_dict, recordings_list, mocked_org_id
     ):

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -18,12 +18,12 @@ from omegaconf import OmegaConf
 from neuracore.core.data.synced_dataset import SynchronizedDataset
 from neuracore.core.data.synced_recording import SynchronizedRecording
 from neuracore.core.utils.robot_data_spec_utils import (
-    convert_omegaconf_to_cross_embodiment_description,
     merge_cross_embodiment_description,
 )
 from neuracore.ml import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
+    _cacheable_cross_embodiment_description,
 )
 from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
 from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
@@ -34,6 +34,16 @@ NUM_EPISODES = 5
 NUM_OBSERVATIONS_PER_EPISODE = 10
 ROBOT_ID = "11111111-1111-1111-1111-111111111111"
 MISSING_ROBOT_ID = "22222222-2222-2222-2222-222222222222"
+
+
+class ModelDumpCrossEmbodimentDescription:
+    def model_dump(self, mode):
+        assert mode == "json"
+        return {
+            ROBOT_ID: {
+                DataType.JOINT_POSITIONS: OmegaConf.create({0: "joint_positions_0"})
+            }
+        }
 
 
 def _indexed_names(data_type: DataType, count: int) -> dict[int, str]:
@@ -218,14 +228,6 @@ def mock_synchronized_dataset(
             return mock_synced_recording
 
     return MockSynchronizedDataset()
-
-
-def _cacheable_cross_embodiment_description(
-    cross_embodiment_description: CrossEmbodimentDescription,
-):
-    if hasattr(cross_embodiment_description, "model_dump"):
-        return cross_embodiment_description.model_dump(mode="json")
-    return cross_embodiment_description
 
 
 def _stats_cache_path(cache_root, sync_id, input_spec, output_spec):
@@ -417,6 +419,41 @@ def mock_synchronized_dataset_with_depth(
             return mock_synced_recording_with_depth
 
     return MockSynchronizedDataset()
+
+
+def test_cacheable_cross_embodiment_description_handles_nested_omegaconf():
+    """Test OmegaConf descriptions can be used in statistics cache keys."""
+    spec = OmegaConf.create({
+        ROBOT_ID: {
+            DataType.JOINT_POSITIONS: {
+                0: "joint_positions_0",
+                1: "joint_positions_1",
+            }
+        }
+    })
+
+    cacheable_spec = _cacheable_cross_embodiment_description(spec)
+
+    json.dumps(cacheable_spec, sort_keys=True, separators=(",", ":"))
+    assert cacheable_spec == {
+        ROBOT_ID: {
+            DataType.JOINT_POSITIONS: {
+                0: "joint_positions_0",
+                1: "joint_positions_1",
+            }
+        }
+    }
+
+
+def test_cacheable_cross_embodiment_description_recurses_after_model_dump():
+    cacheable_spec = _cacheable_cross_embodiment_description(
+        ModelDumpCrossEmbodimentDescription()
+    )
+
+    json.dumps(cacheable_spec, sort_keys=True, separators=(",", ":"))
+    assert cacheable_spec == {
+        ROBOT_ID: {DataType.JOINT_POSITIONS: {0: "joint_positions_0"}}
+    }
 
 
 def test_should_initialize_with_correct_args(
@@ -617,29 +654,26 @@ def test_merge_cross_embodiment_description_preserves_robot_order():
     ]
 
 
-def test_merge_cross_embodiment_description_handles_omegaconf_dict_values():
-    input_cfg = OmegaConf.create({
+def test_merge_cross_embodiment_description_handles_config_dict_values():
+    input_spec: CrossEmbodimentDescription = {
         ROBOT_ID: {
-            "JOINT_POSITIONS": {
+            DataType.JOINT_POSITIONS: {
                 0: "vx300s_right/wrist_angle",
                 1: "vx300s_left/waist",
             },
-            "RGB_IMAGES": {
+            DataType.RGB_IMAGES: {
                 0: "rgb_angle",
             },
         }
-    })
-    output_cfg = OmegaConf.create({
+    }
+    output_spec: CrossEmbodimentDescription = {
         ROBOT_ID: {
-            "JOINT_POSITIONS": {
+            DataType.JOINT_POSITIONS: {
                 0: "vx300s_right/wrist_angle",
                 1: "vx300s_left/waist",
             }
         }
-    })
-
-    input_spec = convert_omegaconf_to_cross_embodiment_description(input_cfg)
-    output_spec = convert_omegaconf_to_cross_embodiment_description(output_cfg)
+    }
 
     assert merge_cross_embodiment_description(input_spec, output_spec) == {
         ROBOT_ID: {

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -35,8 +35,6 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
 )
 from neuracore.ml.train import (
-    _resolve_algorithm_name_and_supported_data_types,
-    _resolve_cross_embodiment_description,
     _resolve_output_dir,
     _resolve_recording_cache_dir,
     assert_valid_batch_size,
@@ -48,6 +46,13 @@ from neuracore.ml.train import (
 )
 from neuracore.ml.trainers.batch_autotuner import find_optimal_batch_size
 from neuracore.ml.utils.preprocessing_utils import resolve_preprocessing_config
+from neuracore.ml.utils.training_config import (
+    _resolve_algorithm_name_and_supported_data_types,
+    _resolve_algorithm_name_config,
+    _resolve_cross_embodiment_description,
+    resolve_to_complete_config,
+    resolve_user_input_config,
+)
 
 SKIP_TEST = (
     os.environ.get("CI", "false").lower() == "true" or not torch.cuda.is_available()
@@ -165,6 +170,8 @@ class MainTestSetup:
         self.cuda_device_count = cuda_device_count
 
         self.mock_dataset = Mock()
+        self.mock_dataset.id = "test-dataset-id"
+        self.mock_dataset.name = "test-dataset-name"
         # Provide realistic robot metadata for code paths that resolve robot keys.
         # Many tests use cross-embodiment specs.
         self.mock_dataset.robot_ids = ["robot-id-1", "robot-id-2"]
@@ -201,6 +208,14 @@ class MainTestSetup:
         self.mock_get_algorithms = Mock(
             return_value=[{"id": "test-algorithm-id", "name": "test-algorithm"}]
         )
+        self.mock_get_algorithm = Mock(
+            return_value={
+                "id": "test-algorithm-id",
+                "name": "test-algorithm",
+                "supported_input_data_types": [DataType.JOINT_POSITIONS],
+                "supported_output_data_types": [DataType.JOINT_TARGET_POSITIONS],
+            }
+        )
         self.mock_get_algorithm_name = Mock(return_value="test-algorithm")
         self.mock_validate_training_params = Mock()
 
@@ -216,13 +231,19 @@ class MainTestSetup:
         self.monkeypatch.setattr("neuracore.login", self.mock_login)
         self.monkeypatch.setattr("neuracore.get_dataset", self.mock_get_dataset)
         self.monkeypatch.setattr(
-            "neuracore.ml.train._get_algorithms", self.mock_get_algorithms
+            "neuracore.ml.utils.training_config._get_algorithms",
+            self.mock_get_algorithms,
         )
         self.monkeypatch.setattr(
-            "neuracore.ml.train.get_algorithm_name", self.mock_get_algorithm_name
+            "neuracore.ml.utils.training_config.get_algorithm",
+            self.mock_get_algorithm,
         )
         self.monkeypatch.setattr(
-            "neuracore.ml.train.validate_training_params",
+            "neuracore.ml.utils.training_config.get_algorithm_name",
+            self.mock_get_algorithm_name,
+        )
+        self.monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.validate_training_params",
             self.mock_validate_training_params,
         )
         self.monkeypatch.setattr(
@@ -255,7 +276,7 @@ class MainTestSetup:
             self.mock_cloud_log_streamer_class,
         )
         self.monkeypatch.setattr(
-            "neuracore.ml.train.convert_cross_embodiment_description_names_to_ids",
+            "neuracore.ml.utils.training_config.convert_cross_embodiment_description_names_to_ids",
             Mock(side_effect=lambda x: x),
         )
 
@@ -615,62 +636,64 @@ class TestSetupLogging:
 class TestResolveOutputDir:
     """Tests for local output directory resolver behavior."""
 
-    def test_resolve_output_dir_fails_when_run_exists_and_auto_increment_false(
+    def test_resolve_output_dir_fails_when_training_exists_and_auto_increment_false(
         self, monkeypatch, tmp_path
     ):
-        """Strict default: fail if run name already exists."""
-        run_name = "duplicate-run"
+        """Strict default: fail if training name already exists."""
+        training_name = "duplicate-run"
         base_dir = tmp_path / ".neuracore" / "training" / "runs"
         base_dir.mkdir(parents=True, exist_ok=True)
-        (base_dir / run_name).mkdir()
+        (base_dir / training_name).mkdir()
 
         monkeypatch.setattr(
             "neuracore.ml.train.DEFAULT_CACHE_DIR", tmp_path / ".neuracore" / "training"
         )
 
-        with pytest.raises(FileExistsError, match=r"A run named .* already exists"):
-            _resolve_output_dir(run_name, run_name_auto_increment=False)
+        with pytest.raises(
+            FileExistsError, match=r"A training named .* already exists"
+        ):
+            _resolve_output_dir(training_name, training_name_auto_increment=False)
 
     def test_resolve_output_dir_uses_suffix_when_auto_increment_true(
         self, monkeypatch, tmp_path
     ):
-        """Opt-in auto-increment: use run_name_1 when run_name exists."""
-        run_name = "duplicate-run"
+        """Opt-in auto-increment: use training_name_1 when training_name exists."""
+        training_name = "duplicate-run"
         base_dir = tmp_path / ".neuracore" / "training" / "runs"
         base_dir.mkdir(parents=True, exist_ok=True)
-        (base_dir / run_name).mkdir()
+        (base_dir / training_name).mkdir()
 
         monkeypatch.setattr(
             "neuracore.ml.train.DEFAULT_CACHE_DIR", tmp_path / ".neuracore" / "training"
         )
 
-        path = _resolve_output_dir(run_name, run_name_auto_increment=True)
-        assert path == str(base_dir / f"{run_name}_1")
+        path = _resolve_output_dir(training_name, training_name_auto_increment=True)
+        assert path == str(base_dir / f"{training_name}_1")
         assert not Path(path).exists()
 
-    def test_resolve_output_dir_uses_next_suffix_when_named_run_prefix_exists(
+    def test_resolve_output_dir_uses_next_suffix_when_named_training_prefix_exists(
         self, monkeypatch, tmp_path
     ):
-        """Auto-increment finds next free suffix (run_name_2 when _1 exists)."""
-        run_name = "duplicate-run"
+        """Auto-increment finds next free suffix (training_name_2 when _1 exists)."""
+        training_name = "duplicate-run"
         base_dir = tmp_path / ".neuracore" / "training" / "runs"
         base_dir.mkdir(parents=True, exist_ok=True)
-        (base_dir / run_name).mkdir()
-        (base_dir / f"{run_name}_1").mkdir()
+        (base_dir / training_name).mkdir()
+        (base_dir / f"{training_name}_1").mkdir()
 
         monkeypatch.setattr(
             "neuracore.ml.train.DEFAULT_CACHE_DIR", tmp_path / ".neuracore" / "training"
         )
 
-        path = _resolve_output_dir(run_name, run_name_auto_increment=True)
-        assert path == str(base_dir / f"{run_name}_2")
+        path = _resolve_output_dir(training_name, training_name_auto_increment=True)
+        assert path == str(base_dir / f"{training_name}_2")
         assert not Path(path).exists()
 
-    def test_resolve_output_dir_no_suffix_when_run_does_not_exist(
+    def test_resolve_output_dir_no_suffix_when_training_does_not_exist(
         self, monkeypatch, tmp_path
     ):
-        """When run name does not exist, use it as-is (strict or auto-increment)."""
-        run_name = "unique-run"
+        """When training name does not exist, use it as-is."""
+        training_name = "unique-run"
         base_dir = tmp_path / ".neuracore" / "training" / "runs"
         base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -678,9 +701,197 @@ class TestResolveOutputDir:
             "neuracore.ml.train.DEFAULT_CACHE_DIR", tmp_path / ".neuracore" / "training"
         )
 
-        path_strict = _resolve_output_dir(run_name, run_name_auto_increment=False)
-        path_auto = _resolve_output_dir(run_name, run_name_auto_increment=True)
-        assert path_strict == path_auto == str(base_dir / run_name)
+        path_strict = _resolve_output_dir(
+            training_name, training_name_auto_increment=False
+        )
+        path_auto = _resolve_output_dir(
+            training_name, training_name_auto_increment=True
+        )
+        assert path_strict == path_auto == str(base_dir / training_name)
+
+
+class TestTrainingConfigMerge:
+    """Tests for native Hydra user config composition."""
+
+    def test_main_passes_cfg_through_to_hydra_composed_config(self, monkeypatch):
+        captured_configs: list[DictConfig] = []
+
+        def capture_main(cfg):
+            captured_configs.append(cfg)
+
+        monkeypatch.setattr("sys.argv", ["python", "-m", "neuracore.ml.train"])
+        monkeypatch.setattr("neuracore.ml.train._main", capture_main)
+
+        cfg = OmegaConf.create({
+            "epochs": 3,
+            "dataset_id": "dataset-id",
+            "input_data_types": ["JOINT_VELOCITIES"],
+            "algorithm_params": {"learning_rate": 0.001},
+        })
+        main(cfg)
+
+        assert len(captured_configs) == 1
+        assert captured_configs[0].epochs == 3
+        assert captured_configs[0].dataset_id == "dataset-id"
+        assert "seed" not in captured_configs[0]
+
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            {"algorithm_name": "CNNMLP", "epochs": 3},
+            {"algorithm": None, "algorithm_name": "CNNMLP", "epochs": 3},
+        ],
+    )
+    def test_resolves_algorithm_name_string_to_packaged_config(self, cfg):
+        cfg = OmegaConf.create(cfg)
+
+        resolved_cfg = _resolve_algorithm_name_config(cfg)
+
+        assert resolved_cfg.algorithm._target_.endswith(".CNNMLP")
+        assert resolved_cfg.epochs == 3
+        assert resolved_cfg.algorithm.hidden_dim == 512
+        assert resolved_cfg.algorithm_name == "CNNMLP"
+
+    def test_algorithm_string_is_rejected(self):
+        cfg = OmegaConf.create({"algorithm": "CNNMLP"})
+
+        with pytest.raises(ValueError, match="'algorithm' as a string"):
+            _resolve_algorithm_name_config(cfg)
+
+    def test_invalid_algorithm_name_string_has_clear_error(self):
+        cfg = OmegaConf.create({"algorithm_name": "MissingAlgorithm"})
+
+        with pytest.raises(ValueError, match="Unknown algorithm 'MissingAlgorithm'"):
+            _resolve_algorithm_name_config(cfg)
+
+    def test_algorithm_name_and_algorithm_id_are_rejected_together(self):
+        cfg = OmegaConf.create({
+            "algorithm_name": "CNNMLP",
+            "algorithm_id": "custom-algorithm-id",
+        })
+
+        with pytest.raises(
+            ValueError, match="Both 'algorithm_name' and 'algorithm_id'"
+        ):
+            _resolve_algorithm_name_config(cfg)
+
+    def test_complete_config_uses_training_name_for_output_dir(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            "neuracore.ml.train.DEFAULT_CACHE_DIR", tmp_path / ".neuracore" / "training"
+        )
+
+        cfg = resolve_user_input_config(
+            OmegaConf.create({
+                "training_name": "named-training",
+                "algorithm_id": "test-algorithm-id",
+                "dataset_id": "test-dataset-id",
+            })
+        )
+
+        assert cfg.local_output_dir == str(
+            tmp_path / ".neuracore" / "training" / "runs" / "named-training"
+        )
+
+    def test_complete_config_populates_dataset_id_from_dataset_name(self, monkeypatch):
+        dataset = Mock(id="resolved-dataset-id")
+        mock_get_dataset = Mock(return_value=dataset)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.nc.get_dataset", mock_get_dataset
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.get_algorithm",
+            Mock(
+                return_value={
+                    "id": "test-algorithm-id",
+                    "name": "TestAlgorithm",
+                    "supported_input_data_types": [DataType.JOINT_POSITIONS],
+                    "supported_output_data_types": [DataType.JOINT_TARGET_POSITIONS],
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.get_algorithm_name",
+            Mock(return_value="TestAlgorithm"),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.validate_training_params",
+            Mock(),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.convert_cross_embodiment_description_names_to_ids",
+            Mock(side_effect=lambda x: x),
+        )
+
+        cfg = resolve_to_complete_config(
+            OmegaConf.create({
+                "algorithm_id": "test-algorithm-id",
+                "dataset_name": "test-dataset",
+                "input_cross_embodiment_description": INPUT_CROSS_EMBODIMENT_SPEC,
+                "output_cross_embodiment_description": OUTPUT_CROSS_EMBODIMENT_SPEC,
+            })
+        )
+
+        assert cfg.dataset_id == "resolved-dataset-id"
+        mock_get_dataset.assert_called_once_with(name="test-dataset")
+
+    def test_complete_config_populates_cross_embodiment_from_data_types(
+        self, monkeypatch
+    ):
+        dataset = Mock(id="dataset-id")
+        dataset.name = "test-dataset"
+        dataset.robot_ids = ["robot-id-1"]
+        dataset.get_full_embodiment_description.return_value = {
+            DataType.JOINT_POSITIONS: {0: "joint_1", 1: "joint_2"},
+            DataType.RGB_IMAGES: {0: "front"},
+            DataType.JOINT_TARGET_POSITIONS: {0: "target_1"},
+        }
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.get_algorithm",
+            Mock(
+                return_value={
+                    "id": "test-algorithm-id",
+                    "name": "TestAlgorithm",
+                    "supported_input_data_types": [DataType.JOINT_POSITIONS],
+                    "supported_output_data_types": [DataType.JOINT_TARGET_POSITIONS],
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.get_algorithm_name",
+            Mock(return_value="TestAlgorithm"),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.validate_training_params",
+            Mock(),
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.training_config.convert_cross_embodiment_description_names_to_ids",
+            Mock(side_effect=lambda x: x),
+        )
+
+        cfg = resolve_to_complete_config(
+            OmegaConf.create({
+                "algorithm_id": "test-algorithm-id",
+                "dataset_id": "dataset-id",
+                "input_data_types": ["JOINT_POSITIONS", "RGB_IMAGES"],
+                "output_data_types": ["JOINT_TARGET_POSITIONS"],
+            }),
+            dataset=dataset,
+        )
+
+        assert OmegaConf.to_container(cfg.input_cross_embodiment_description) == {
+            "robot-id-1": {
+                "JOINT_POSITIONS": {0: "joint_1", 1: "joint_2"},
+                "RGB_IMAGES": {0: "front"},
+            }
+        }
+        assert OmegaConf.to_container(cfg.output_cross_embodiment_description) == {
+            "robot-id-1": {
+                "JOINT_TARGET_POSITIONS": {0: "target_1"},
+            }
+        }
 
 
 class TestResolveRecordingCacheDir:
@@ -1970,10 +2181,12 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             return_value=(expected_input_types, expected_output_types)
         )
         monkeypatch.setattr(
-            "neuracore.ml.train.get_algorithm_name", mock_get_algorithm_name
+            "neuracore.ml.utils.training_config.get_algorithm_name",
+            mock_get_algorithm_name,
         )
         monkeypatch.setattr(
-            "neuracore.ml.train._get_data_types_for_algorithms", mock_get_data_types
+            "neuracore.ml.utils.training_config._get_data_types_for_algorithms",
+            mock_get_data_types,
         )
 
         (
@@ -2005,7 +2218,7 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
 
         # Ensure hydra.utils.get_object returns our local validation class.
         monkeypatch.setattr(
-            "neuracore.ml.train.hydra.utils.get_object",
+            "neuracore.ml.utils.training_config.hydra.utils.get_object",
             lambda target: LocalValidationAlgorithm,
         )
 
@@ -2348,8 +2561,10 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
             assert call_args[1]["join"] is True
             args_tuple = call_args[1]["args"]
             assert args_tuple[0] == world_size
-            # Compare OmegaConf objects using to_container for proper comparison
-            assert OmegaConf.to_container(args_tuple[1]) == OmegaConf.to_container(cfg)
+            spawned_cfg = args_tuple[1]
+            assert spawned_cfg.dataset_id == "test-dataset-id"
+            assert spawned_cfg.dataset_name == "test-dataset-name"
+            assert spawned_cfg.algorithm_id == "test-algorithm-id"
             assert args_tuple[2] == 8  # batch_size
             setup.mock_run_training.assert_not_called()
         else:
@@ -2630,7 +2845,8 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
         setup.mock_determine_optimal_batch_size.assert_called_once()
         det_kwargs = setup.mock_determine_optimal_batch_size.call_args.kwargs
         assert det_kwargs["dataset"] is setup.mock_pytorch_dataset
-        assert det_kwargs["cfg"] is cfg
+        assert det_kwargs["cfg"].dataset_id == "test-dataset-id"
+        assert det_kwargs["cfg"].batch_size == "auto"
         # Verify run_training was called with the optimal batch size
         assert setup.mock_run_training.call_args[0][3] == 16
 

--- a/tests/unit/ml/utils/test_nc_archive.py
+++ b/tests/unit/ml/utils/test_nc_archive.py
@@ -1,0 +1,49 @@
+import json
+
+from neuracore_types import DataType
+from omegaconf import OmegaConf
+
+from neuracore.ml.utils.json_serialization import to_json_serializable
+
+
+class ModelDumpWithOmegaConf:
+    def model_dump(self, mode):
+        assert mode == "json"
+        return {"model_init": OmegaConf.create({"hidden_dim": 128})}
+
+
+def test_to_json_serializable_handles_nested_omegaconf_config():
+    payload = {
+        "algorithm_config": OmegaConf.create(
+            {"optimizer": {"name": "adam", "lr": 1e-4}}
+        ),
+        "input_cross_embodiment_description": {
+            "robot_id": {
+                DataType.JOINT_POSITIONS: OmegaConf.create(
+                    {0: "joint_positions_0", 1: "joint_positions_1"}
+                )
+            }
+        },
+    }
+
+    result = to_json_serializable(payload)
+
+    json.dumps(result)
+    assert result == {
+        "algorithm_config": {"optimizer": {"name": "adam", "lr": 1e-4}},
+        "input_cross_embodiment_description": {
+            "robot_id": {
+                DataType.JOINT_POSITIONS: {
+                    0: "joint_positions_0",
+                    1: "joint_positions_1",
+                }
+            }
+        },
+    }
+
+
+def test_to_json_serializable_recurses_after_model_dump():
+    result = to_json_serializable(ModelDumpWithOmegaConf())
+
+    json.dumps(result)
+    assert result == {"model_init": {"hidden_dim": 128}}


### PR DESCRIPTION
### Features
- Added support for composing user training YAML files via Hydra's optional `user` config group, so training arguments can live in reusable config files instead of long CLI commands.
- Introduced `algorithm_name` as packaged-algorithm shorthand, resolving it to the matching bundled algorithm config while preserving support for cloud `algorithm_id` workflows.
- Renamed local run naming config from `run_name` / `run_name_auto_increment` to `training_name` / `training_name_auto_increment`, including output directory resolution and documentation updates.
- Added training config normalization utilities in `neuracore/ml/utils/training_config.py` for default merging, algorithm resolution, dataset lookup, data type shorthand expansion, robot name/id conversion, and validation.
- Added `get_robot_name_from_id` to support converting resolved robot IDs back to user-facing robot names for saved training metadata.
- Moved all validation and completion checks outside of train.py