### PR TITLE
fix: recording time threaded

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -24,9 +24,6 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.streaming.data_stream import DataStream
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
 from neuracore.core.utils.http_session import Session
-from neuracore.data_daemon.communications_management.producer.producer_channel import (
-    ProducerChannel,
-)
 from neuracore.data_daemon.communications_management.shared_transport import (
     recording_context,
 )
@@ -371,17 +368,19 @@ class Robot:
 
         for stream_id, stream in self._data_streams.items():
             try:
-                producer_channel = stream.get_producer_channel()
-                stream.stop_recording(wait_for_producer_drain=wait_for_producer_drain)
 
-                if isinstance(producer_channel, ProducerChannel):
-                    cutoff_sequence_number = (
-                        producer_channel.get_last_enqueued_sequence_number()
-                    )
+                (producer_channel, stop_cutoff_sequence_number) = (
+                    stream.prepare_recording_stopped()
+                )
 
-                    producer_stop_sequence_numbers[producer_channel.channel_id] = (
-                        cutoff_sequence_number
-                    )
+                producer_stop_sequence_numbers[producer_channel.channel_id] = (
+                    stop_cutoff_sequence_number
+                )
+
+                stream.stop_recording(
+                    stop_cutoff_sequence_number=stop_cutoff_sequence_number,
+                    wait_for_producer_drain=wait_for_producer_drain,
+                )
 
             except Exception:
                 logger.exception("Failed to stop data stream %s", stream_id)

--- a/neuracore/core/streaming/data_stream.py
+++ b/neuracore/core/streaming/data_stream.py
@@ -16,9 +16,7 @@ from dataclasses import dataclass
 import numpy as np
 from neuracore_types import CameraData, DataType, NCData
 
-from neuracore.data_daemon.communications_management.producer.producer_channel import (
-    ProducerChannel,
-)
+from neuracore.data_daemon.communications_management.producer import ProducerChannel
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +82,11 @@ class DataStream(ABC):
             None
         """
         if self.is_recording():
-            self.stop_recording()
+            _, stop_cutoff_sequence_number = self.prepare_recording_stopped()
+            self.stop_recording(
+                wait_for_producer_drain=False,
+                stop_cutoff_sequence_number=stop_cutoff_sequence_number,
+            )
         self._recording = True
         self._context = context
         self._handle_ensure_producer_channel(context)
@@ -113,7 +115,22 @@ class DataStream(ABC):
             recording_id=context.recording_id
         )
 
-    def stop_recording(self, wait_for_producer_drain: bool = True) -> None:
+    def prepare_recording_stopped(self) -> tuple[ProducerChannel, int]:
+        """Mark the producer channel as stopping and return it."""
+        producer_channel = self.get_producer_channel()
+
+        if not isinstance(producer_channel, ProducerChannel):
+            raise RuntimeError(f"Stream {self._stream_name} has no ProducerChannel")
+
+        stop_cutoff_sequence_number = producer_channel.mark_recording_stop_requested()
+
+        return producer_channel, stop_cutoff_sequence_number
+
+    def stop_recording(
+        self,
+        stop_cutoff_sequence_number: int,
+        wait_for_producer_drain: bool = True,
+    ) -> None:
         """Stop recording data and tear down the active producer, if any."""
         self._recording = False
         self._context = None
@@ -121,16 +138,17 @@ class DataStream(ABC):
         self._producer_channel = None
 
         if not isinstance(producer_channel, ProducerChannel):
-            return
+            raise RuntimeError("Stream has no ProducerChannel")
 
         try:
             if producer_channel.trace_id:
                 producer_channel.cleanup_producer_channel(
-                    wait_for_slot_drain=wait_for_producer_drain
+                    stop_cutoff_sequence_number=stop_cutoff_sequence_number,
+                    wait_for_slot_drain=wait_for_producer_drain,
                 )
         finally:
             producer_channel.stop_producer_channel(
-                wait_for_slot_drain=wait_for_producer_drain
+                wait_for_slot_drain=wait_for_producer_drain,
             )
 
     def is_recording(self) -> bool:

--- a/neuracore/data_daemon/communications_management/producer/__init__.py
+++ b/neuracore/data_daemon/communications_management/producer/__init__.py
@@ -1,1 +1,11 @@
 """Producer-side communications management package."""
+
+from .producer_channel import ProducerChannel
+from .producer_channel_message_sender import ProducerChannelMessageSender
+from .producer_heartbeat_service import ProducerHeartbeatService
+
+__all__ = [
+    "ProducerChannel",
+    "ProducerChannelMessageSender",
+    "ProducerHeartbeatService",
+]

--- a/neuracore/data_daemon/communications_management/producer/producer_channel.py
+++ b/neuracore/data_daemon/communications_management/producer/producer_channel.py
@@ -11,6 +11,12 @@ from collections.abc import Iterator, Sequence
 
 import zmq
 
+from neuracore.data_daemon.communications_management.producer.models import (
+    QueuedEnvelope,
+)
+from neuracore.data_daemon.communications_management.sequence_allocator import (
+    ChannelSequenceAllocator,
+)
 from neuracore.data_daemon.const import (
     DEFAULT_CHUNK_SIZE,
     DEFAULT_SHARED_MEMORY_SIZE,
@@ -29,10 +35,7 @@ from neuracore.data_daemon.models import (
 
 from ..shared_transport.communications_manager import CommunicationsManager
 from ..shared_transport.shared_slot_transport import SharedSlotVideoTransport
-from .producer_channel_message_sender import (
-    ProducerChannelMessageSender,
-    QueuedEnvelope,
-)
+from .producer_channel_message_sender import ProducerChannelMessageSender
 from .producer_heartbeat_service import ProducerHeartbeatService
 
 logger = logging.getLogger(__name__)
@@ -107,13 +110,15 @@ class ProducerChannel:
         self._use_shared_slot_transport = data_type_uses_shared_slot_transport(
             data_type
         )
-        self._shared_slot_transport = (
+        self._sequence_allocator = ChannelSequenceAllocator()
+        self._shared_slot_transport: SharedSlotVideoTransport | None = (
             SharedSlotVideoTransport(
+                sequence_allocator=self._sequence_allocator,
                 slot_size=int(
                     default_shared_memory_size
                     if shared_memory_size is None
                     else shared_memory_size
-                )
+                ),
             )
             if self._use_shared_slot_transport
             else None
@@ -122,16 +127,18 @@ class ProducerChannel:
             producer_id=self.channel_id,
             comm=self._comm,
             send_queue_maxsize=self.send_queue_maxsize,
+            sequence_allocator=self._sequence_allocator,
         )
         self._heartbeat_service = ProducerHeartbeatService(
             interval_s=self._heartbeat_interval,
             send_heartbeat=self.heartbeat,
         )
 
+        self._recording_send_lock = threading.RLock()
+        self._stop_cutoff_sequence_number: int | None = None
+
     @property
-    def _send_queue(
-        self,
-    ) -> queue.Queue[QueuedEnvelope | None]:
+    def _send_queue(self) -> queue.Queue[QueuedEnvelope | None]:
         """Expose the sender queue for compatibility with existing tests."""
         return self._message_sender.queue
 
@@ -152,23 +159,53 @@ class ProducerChannel:
         """Set the recording ID for the producer."""
         self.recording_id = recording_id
 
+    def get_last_accepted_sequence_number(self) -> int:
+        """Return the latest sequence accepted by either sender or shared-slot queue."""
+        last_enqueued = self.get_last_enqueued_sequence_number()
+
+        if self._shared_slot_transport is None:
+            return last_enqueued
+
+        return max(
+            last_enqueued,
+            self._shared_slot_transport.get_last_reserved_sequence_number(),
+        )
+
+    def mark_recording_stop_requested(self) -> int:
+        """Freeze recording data sends and return the last accepted sequence number."""
+        with self._recording_send_lock:
+            if self._stop_cutoff_sequence_number is None:
+                self._stop_cutoff_sequence_number = (
+                    self.get_last_accepted_sequence_number()
+                )
+            return self._stop_cutoff_sequence_number
+
+    def _recording_data_stopped(self) -> bool:
+        return self._stop_cutoff_sequence_number is not None
+
     def start_recording_session(
         self,
         recording_id: str | None = None,
         shared_memory_size: int | None = None,
     ) -> None:
         """Start a fresh recording session for this producer channel."""
-        if recording_id is not None:
-            self.set_recording_id(recording_id)
-        if not self.recording_id:
-            raise ValueError("recording_id is required; set on ProducerChannel init.")
-        if self.trace_id is not None:
-            raise RuntimeError(
-                "Cannot start a new recording session while a trace is active."
-            )
+        with self._recording_send_lock:
+            self._stop_cutoff_sequence_number = None
 
-        self.start_producer_channel()
-        self.start_new_trace()
+            if recording_id is not None:
+                self.set_recording_id(recording_id)
+            if not self.recording_id:
+                raise ValueError(
+                    "recording_id is required; set on ProducerChannel init."
+                )
+            if self.trace_id is not None:
+                raise RuntimeError(
+                    "Cannot start a new recording session while a trace is active."
+                )
+
+            self.start_producer_channel()
+            self.start_new_trace()
+
         if self._use_shared_slot_transport:
             self.open_fixed_shared_slots(slot_size=shared_memory_size)
 
@@ -203,32 +240,27 @@ class ProducerChannel:
         self,
         wait_for_slot_drain: bool = True,
     ) -> None:
-        """Stop the producer channel and release local resources.
-
-        When ``wait_for_slot_drain`` is True, this also waits for all shared-slot
-        credits to return before closing the control endpoint and registry.
-        """
+        """Stop the producer channel and release local resources."""
         self._stop_heartbeat_service()
 
-        # Ensure all descriptors were actually sent
-        cutoff_sequence = self.get_last_enqueued_sequence_number()
+        final_flush_sequence = self.get_last_enqueued_sequence_number()
         stop_failure: RuntimeError | None = None
         sender_failed = False
-        if not self.wait_until_sequence_sent(cutoff_sequence):
+        if not self.wait_until_sequence_sent(final_flush_sequence):
             sender_error = self._get_message_sender_error()
             if sender_error is not None:
                 sender_failed = True
                 logger.warning(
                     "Producer channel stopping after sender failure without "
-                    "flushing stop cutoff sequence_number=%s error=%r",
-                    cutoff_sequence,
+                    "flushing final sequence_number=%s error=%r",
+                    final_flush_sequence,
                     sender_error,
                 )
             else:
                 logger.error(
-                    "Producer channel sender stopped before flushing stop cutoff "
+                    "Producer channel sender stopped before flushing final "
                     "sequence_number=%s",
-                    cutoff_sequence,
+                    final_flush_sequence,
                 )
                 stop_failure = RuntimeError(
                     "Failed to send all enqueued messages "
@@ -256,9 +288,7 @@ class ProducerChannel:
         shared_slot_transport = (
             self._shared_slot_transport if self._use_shared_slot_transport else None
         )
-        sequence_number = None
-        if shared_slot_transport is not None:
-            sequence_number = shared_slot_transport.next_sequence_number()
+        sequence_number = self._sequence_allocator.reserve()
         return self._message_sender.send(
             command,
             payload,
@@ -293,7 +323,7 @@ class ProducerChannel:
         ):
             self._shared_slot_transport.close()
             self._shared_slot_transport = SharedSlotVideoTransport(
-                slot_size=int(slot_size)
+                sequence_allocator=self._sequence_allocator, slot_size=int(slot_size)
             )
         if self._shared_slot_transport.is_announced():
             return
@@ -311,17 +341,25 @@ class ProducerChannel:
 
     def _send_socket_data_chunk(self, payload: DataChunkPayload) -> None:
         """Send one DATA_CHUNK payload directly over the producer socket."""
-        self._send(
-            CommandType.DATA_CHUNK,
-            {"data_chunk": payload.to_dict()},
-        )
+        with self._recording_send_lock:
+            if self._recording_data_stopped():
+                return
+
+            self._send(
+                CommandType.DATA_CHUNK,
+                {"data_chunk": payload.to_dict()},
+            )
 
     def send_batched_joint_data(self, payload: BatchedJointDataPayload) -> None:
         """Send one explicit batched joint payload over the producer socket."""
-        self._send(
-            CommandType.BATCHED_JOINT_DATA,
-            {CommandType.BATCHED_JOINT_DATA.value: payload.to_dict()},
-        )
+        with self._recording_send_lock:
+            if self._recording_data_stopped():
+                return
+
+            self._send(
+                CommandType.BATCHED_JOINT_DATA,
+                {CommandType.BATCHED_JOINT_DATA.value: payload.to_dict()},
+            )
 
     def send_data(
         self,
@@ -405,6 +443,9 @@ class ProducerChannel:
         dataset_name: str | None = None,
     ) -> None:
         """Send a logical payload assembled from multiple byte-like parts."""
+        if self._recording_data_stopped():
+            return
+
         normalised_parts = self._normalise_parts(parts)
         if total_bytes is None:
             total_bytes = sum(len(view) for view in normalised_parts)
@@ -445,23 +486,23 @@ class ProducerChannel:
                 if len(normalised_parts) == 1
                 else b"".join(bytes(part) for part in normalised_parts)
             )
-            self._send_socket_data_chunk(
-                DataChunkPayload(
-                    channel_id=self.channel_id,
-                    recording_id=recording_id,
-                    trace_id=trace_id,
-                    chunk_index=0,
-                    total_chunks=1,
-                    data_type_name=data_type_name,
-                    dataset_id=dataset_id,
-                    dataset_name=dataset_name,
-                    robot_name=robot_name,
-                    robot_id=robot_id,
-                    robot_instance=robot_instance,
-                    data=payload_bytes,
-                    data_type=data_type,
-                )
+            payload = DataChunkPayload(
+                channel_id=self.channel_id,
+                recording_id=recording_id,
+                trace_id=trace_id,
+                chunk_index=0,
+                total_chunks=1,
+                data_type_name=data_type_name,
+                dataset_id=dataset_id,
+                dataset_name=dataset_name,
+                robot_name=robot_name,
+                robot_id=robot_id,
+                robot_instance=robot_instance,
+                data=payload_bytes,
+                data_type=data_type,
             )
+
+            self._send_socket_data_chunk(payload)
             return
 
         self.open_fixed_shared_slots()
@@ -470,18 +511,29 @@ class ProducerChannel:
             raise RuntimeError("Shared-slot transport is not available")
 
         for idx, chunk in enumerate(self._iter_chunk_views(normalised_parts)):
+            metadata = SharedMemoryChunkMetadata(
+                trace_id=trace_id,
+                chunk_index=idx,
+                total_chunks=total_chunks,
+                trace_metadata=trace_metadata if idx == 0 else None,
+            ).to_dict()
+
+            with self._recording_send_lock:
+                if self._recording_data_stopped():
+                    return
+
+                sequence_number = shared_slot_transport.enqueue_packet(
+                    producer_id=self.channel_id,
+                    sender=self._message_sender,
+                    metadata=metadata,
+                    chunk=chunk,
+                    stop_cutoff_sequence_number=self._stop_cutoff_sequence_number,
+                )
+
+            if sequence_number is None:
+                return
+
             produced_chunks += 1
-            shared_slot_transport.enqueue_packet(
-                producer_id=self.channel_id,
-                sender=self._message_sender,
-                metadata=SharedMemoryChunkMetadata(
-                    trace_id=trace_id,
-                    chunk_index=idx,
-                    total_chunks=total_chunks,
-                    trace_metadata=trace_metadata if idx == 0 else None,
-                ).to_dict(),
-                chunk=chunk,
-            )
 
         if produced_chunks != total_chunks:
             raise RuntimeError(
@@ -497,26 +549,39 @@ class ProducerChannel:
 
     def cleanup_producer_channel(
         self,
+        stop_cutoff_sequence_number: int,
         wait_for_slot_drain: bool = True,
     ) -> None:
-        """Finish one trace after all queued payload descriptors are sent.
+        """Finish one trace after queued recording data up to stop cutoff is sent."""
+        if stop_cutoff_sequence_number < 0:
+            raise ValueError("stop_cutoff_sequence_number must be non-negative")
 
-        When ``wait_for_slot_drain`` is False, this returns after the producer has
-        pushed all currently queued shared-slot descriptors and the TRACE_END
-        control message onto the socket. Slot credits may still return
-        asynchronously while the channel remains alive for later cleanup.
-        """
         if self._shared_slot_transport is not None:
-            self._shared_slot_transport.wait_until_payload_handed_off(timeout_s=30.0)
+            payload_cutoff_sequence_number = (
+                self._shared_slot_transport.get_last_payload_sequence_number()
+            )
 
-        cutoff_sequence = self.get_last_enqueued_sequence_number()
-        if not self.wait_until_sequence_sent(cutoff_sequence):
+            if payload_cutoff_sequence_number > 0:
+                self._shared_slot_transport.wait_until_payload_handed_off(
+                    timeout_s=30.0,
+                    max_sequence_number=payload_cutoff_sequence_number,
+                )
+
+        if not self.wait_until_sequence_sent(stop_cutoff_sequence_number):
             raise RuntimeError(
-                "Failed to send all queued payload descriptors before cleanup"
+                "Failed to send queued recording data up to stop cutoff before cleanup"
             )
 
         if wait_for_slot_drain and self._shared_slot_transport is not None:
-            self._shared_slot_transport.wait_until_drained(timeout_s=30.0)
+            payload_cutoff_sequence_number = (
+                self._shared_slot_transport.get_last_payload_sequence_number()
+            )
+
+            if payload_cutoff_sequence_number > 0:
+                self._shared_slot_transport.wait_until_drained(
+                    timeout_s=30.0,
+                    max_sequence_number=payload_cutoff_sequence_number,
+                )
 
         self.end_trace()
 

--- a/neuracore/data_daemon/communications_management/producer/producer_channel_message_sender.py
+++ b/neuracore/data_daemon/communications_management/producer/producer_channel_message_sender.py
@@ -7,13 +7,15 @@ import queue
 import threading
 from collections.abc import Callable
 
-from neuracore.data_daemon.models import CommandType
-
-from ..shared_transport.communications_manager import (
-    CommunicationsManager,
-    MessageEnvelope,
+from neuracore.data_daemon.communications_management.producer.models import (
+    QueuedEnvelope,
 )
-from .models import QueuedEnvelope
+from neuracore.data_daemon.communications_management.sequence_allocator import (
+    ChannelSequenceAllocator,
+)
+from neuracore.data_daemon.models import CommandType, MessageEnvelope
+
+from ..shared_transport.communications_manager import CommunicationsManager
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +25,15 @@ class ProducerChannelMessageSender:
 
     def __init__(
         self,
-        *,
         producer_id: str,
         comm: CommunicationsManager,
         send_queue_maxsize: int,
+        sequence_allocator: ChannelSequenceAllocator,
     ) -> None:
         """Initialize ordered dispatch state for socket messages."""
         self._producer_id = producer_id
         self._comm = comm
+        self._sequence_allocator = sequence_allocator
         self._send_queue: queue.Queue[QueuedEnvelope | None] = queue.Queue(
             maxsize=send_queue_maxsize
         )
@@ -39,7 +42,6 @@ class ProducerChannelMessageSender:
             name="producer-channel-sender",
             daemon=True,
         )
-        self._next_sequence_number = 1
         self._last_enqueued_sequence_number = 0
         self._last_socket_sent_sequence_number = 0
         self._sender_error: Exception | None = None
@@ -66,11 +68,18 @@ class ProducerChannelMessageSender:
         with self._sequence_cv:
             self._sequence_cv.notify_all()
 
+    def reserve_sequence_number(self) -> int:
+        """Reserve and return the next sender sequence number without enqueueing.
+
+        Use this when another transport layer needs to attach a sender-compatible
+        sequence number before it can enqueue a prebuilt envelope later.
+        """
+        return self._sequence_allocator.reserve()
+
     def send(
         self,
         command: CommandType,
         payload: dict | None = None,
-        *,
         sequence_number: int | None = None,
         on_sent: Callable[[], None] | None = None,
         on_failed_send: Callable[[], None] | None = None,
@@ -96,8 +105,24 @@ class ProducerChannelMessageSender:
         on_sent: Callable[[], None] | None = None,
         on_failed_send: Callable[[], None] | None = None,
     ) -> None:
-        """Enqueue a prebuilt envelope for ordered socket delivery."""
+        """Enqueue a prebuilt envelope for ordered socket delivery.
+
+        Prebuilt envelopes are used by shared-slot transport. They must still
+        update sender sequence progress so stop cutoffs and flush waits observe
+        them correctly.
+        """
         with self._enqueue_lock:
+            if envelope.sequence_number is None:
+                sequence_number = self.reserve_sequence_number()
+                envelope = MessageEnvelope(
+                    producer_id=envelope.producer_id,
+                    command=envelope.command,
+                    payload=envelope.payload,
+                    sequence_number=sequence_number,
+                )
+            if envelope.sequence_number is not None:
+                self._note_enqueued_sequence_number(envelope.sequence_number)
+
             self._enqueue_envelope_locked(
                 envelope,
                 on_sent=on_sent,
@@ -141,22 +166,29 @@ class ProducerChannelMessageSender:
         sequence_number: int | None = None,
     ) -> MessageEnvelope:
         """Reserve a sequence number and build a transport envelope."""
-        with self._sequence_cv:
-            if sequence_number is None:
-                sequence_number = self._next_sequence_number
-                self._next_sequence_number += 1
-            else:
-                sequence_number = int(sequence_number)
-                if sequence_number >= self._next_sequence_number:
-                    self._next_sequence_number = sequence_number + 1
-            if sequence_number > self._last_enqueued_sequence_number:
-                self._last_enqueued_sequence_number = sequence_number
+        if sequence_number is None:
+            sequence_number = self.reserve_sequence_number()
+        else:
+            sequence_number = sequence_number
+
+        self._note_enqueued_sequence_number(sequence_number)
+
         return MessageEnvelope(
             producer_id=self._producer_id,
             command=command,
             payload=payload or {},
             sequence_number=sequence_number,
         )
+
+    def _note_enqueued_sequence_number(self, sequence_number: int) -> None:
+        """Record that a sequence number has entered the sender queue."""
+        with self._sequence_cv:
+            self._last_enqueued_sequence_number = max(
+                self._last_enqueued_sequence_number,
+                sequence_number,
+            )
+
+            self._sequence_cv.notify_all()
 
     def _enqueue_envelope_locked(
         self,
@@ -165,6 +197,10 @@ class ProducerChannelMessageSender:
         on_sent: Callable[[], None] | None = None,
         on_failed_send: Callable[[], None] | None = None,
     ) -> None:
+        """Enqueue an envelope.
+
+        Caller must hold self._enqueue_lock.
+        """
         with self._sequence_cv:
             if self._sender_error is not None:
                 raise RuntimeError("Sender thread is no longer healthy")
@@ -193,13 +229,9 @@ class ProducerChannelMessageSender:
                             logger.exception("Sender success callback crashed")
                     if item.envelope.sequence_number is not None:
                         with self._sequence_cv:
-                            if (
-                                item.envelope.sequence_number
-                                > self._last_socket_sent_sequence_number
-                            ):
-                                self._last_socket_sent_sequence_number = (
-                                    item.envelope.sequence_number
-                                )
+                            sequence_number = int(item.envelope.sequence_number)
+                            if sequence_number > self._last_socket_sent_sequence_number:
+                                self._last_socket_sent_sequence_number = sequence_number
                             self._sequence_cv.notify_all()
                 except Exception as exc:
                     if item.on_failed_send is not None:
@@ -212,6 +244,7 @@ class ProducerChannelMessageSender:
                         self._sequence_cv.notify_all()
                     logger.exception("Send failed")
                     break
+
             finally:
                 self._send_queue.task_done()
 

--- a/neuracore/data_daemon/communications_management/sequence_allocator.py
+++ b/neuracore/data_daemon/communications_management/sequence_allocator.py
@@ -1,0 +1,26 @@
+"""Thread-safe channel-scoped sequence number allocation."""
+
+from __future__ import annotations
+
+import threading
+
+
+class ChannelSequenceAllocator:
+    """Reserve monotonically increasing sequence numbers for one channel."""
+
+    def __init__(self, start: int = 1) -> None:
+        """Initialize the sequence allocator."""
+        self._next_sequence_number = int(start)
+        self._lock = threading.Lock()
+
+    def reserve(self) -> int:
+        """Reserve and return the next sequence number."""
+        with self._lock:
+            sequence_number = self._next_sequence_number
+            self._next_sequence_number += 1
+            return sequence_number
+
+    def get_last_reserved_sequence_number(self) -> int:
+        """Return the most recently reserved sequence number."""
+        with self._lock:
+            return self._next_sequence_number - 1

--- a/neuracore/data_daemon/communications_management/shared_transport/__init__.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/__init__.py
@@ -1,5 +1,22 @@
 """Internal shared-slot transport runtime components."""
 
+from __future__ import annotations
+
+from .communications_manager import CommunicationsManager
 from .registry import SharedSlotRegistry, SharedSlotTimeout
 
-__all__ = ["SharedSlotRegistry", "SharedSlotTimeout"]
+__all__ = [
+    "SharedSlotRegistry",
+    "SharedSlotTimeout",
+    "CommunicationsManager",
+    "SharedSlotVideoTransport",
+]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily expose heavier transport types to avoid package import cycles."""
+    if name == "SharedSlotVideoTransport":
+        from .shared_slot_transport import SharedSlotVideoTransport
+
+        return SharedSlotVideoTransport
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/neuracore/data_daemon/communications_management/shared_transport/models.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/models.py
@@ -32,15 +32,16 @@ class SharedSlotReservation:
     allocated_bytes: int
 
 
-@dataclass(frozen=True)
+@dataclass
 class QueuedSharedSlotPacket:
-    """One shared-slot payload waiting to be written and announced."""
+    """Transport packet queued for background worker."""
 
     producer_id: str
     sender: ProducerChannelMessageSender
     metadata_bytes: bytes
-    chunk: bytes | bytearray | memoryview
+    chunk: bytes
     packet_length: int
+    sequence_number: int
 
 
 @dataclass(frozen=True)

--- a/neuracore/data_daemon/communications_management/shared_transport/registry.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/registry.py
@@ -53,19 +53,21 @@ class SharedSlotRegistry:
 
     def __init__(
         self,
-        *,
         slot_size: int,
         slot_count: int,
         ack_timeout_s: float,
         allocate_timeout_s: float,
     ) -> None:
-        """Initialize producer-side shared-slot state.
+        """Initialize a producer-side shared-slot registry.
 
         Args:
-            slot_size: Bytes available in each fixed shared-memory slot.
-            slot_count: Number of slots available in the shared segment.
-            ack_timeout_s: Timeout for returned slot credits after send.
-            allocate_timeout_s: Timeout while waiting for a free writable slot.
+            slot_size: Size of each shared-memory slot in bytes.
+            slot_count: Number of fixed slots available in the shared-memory
+                transport.
+            ack_timeout_s: Maximum time to wait for daemon acknowledgements and
+                credit-return progress before marking the transport unhealthy.
+            allocate_timeout_s: Maximum time to wait for shared-slot setup or
+                slot allocation before timing out.
         """
         self._config = SharedSlotRegistryConfig(
             slot_size=int(slot_size),
@@ -172,13 +174,18 @@ class SharedSlotRegistry:
                     raise SharedSlotTimeout("Timed out waiting for a free shared slot")
                 self._condition.wait(timeout=min(0.1, remaining))
 
-    def mark_in_flight(self, slot_id: int) -> int:
+    def mark_in_flight(self, slot_id: int, sequence_id: int) -> int:
         """Record that the slot now backs one sent descriptor."""
         with self._condition:
             self._check_for_timeouts_locked()
+
             if not self._is_healthy_locked():
                 raise self._build_unhealthy_error_locked()
-            return self._reserve_slot_for_descriptor_locked(slot_id)
+            self._reserve_slot_for_descriptor_locked(
+                slot_id=slot_id,
+                sequence_id=sequence_id,
+            )
+            return sequence_id
 
     def mark_sent(self, sequence_id: int) -> None:
         """Start the credit-return timeout clock after socket send."""
@@ -190,7 +197,18 @@ class SharedSlotRegistry:
         with self._condition:
             sequence_id = self._state.sequence_id
             self._state.sequence_id += 1
+            self._condition.notify_all()
             return sequence_id
+
+    def get_last_reserved_sequence_number(self) -> int:
+        """Return the most recently reserved shared-slot sequence number."""
+        with self._condition:
+            return self._state.sequence_id - 1
+
+    def has_in_flight_at_or_before(self, sequence_number: int) -> bool:
+        """Return True if any in-flight descriptor at or before sequence remains."""
+        with self._condition:
+            return any(seq <= sequence_number for seq in self._state.in_flight)
 
     def release_slot(self, shm_name: str, slot_id: int, sequence_id: int) -> bool:
         """Release one in-flight slot after a matching credit return arrives."""
@@ -328,8 +346,6 @@ class SharedSlotRegistry:
     def _apply_ready_message(self, ready: SharedSlotReadyModel) -> None:
         try:
             shm = SharedMemory(name=ready.shm_name, create=False)
-            # The daemon owns unlink() for this segment. This process only closes
-            # its local attachment, so opt out of resource_tracker cleanup here.
             try:
                 resource_tracker.unregister(
                     getattr(shm, "_name", shm.name), "shared_memory"
@@ -375,7 +391,7 @@ class SharedSlotRegistry:
         shm: SharedMemory,
         ready: SharedSlotReadyModel,
     ) -> None:
-        """Swap in a newly attached shared-memory region and mark the registry ready."""
+        """Swap in a newly attached shared-memory region and mark registry ready."""
         if self._state.shm is not None:
             self._state.shm.close()
         self._config = SharedSlotRegistryConfig(
@@ -455,13 +471,22 @@ class SharedSlotRegistry:
         self._state.free_slots.append(entry.slot_id)
         self._condition.notify_all()
 
-    def _reserve_slot_for_descriptor_locked(self, slot_id: int) -> int:
-        """Create in-flight tracking for a reserved slot."""
+    def _reserve_slot_for_descriptor_locked(
+        self,
+        slot_id: int,
+        sequence_id: int,
+    ) -> None:
+        """Create in-flight tracking for a reserved slot and sequence."""
         shm_name = self._state.shm_name
         if shm_name is None:
             raise RuntimeError("Shared-slot transport is not ready")
-        sequence_id = self._state.sequence_id
-        self._state.sequence_id += 1
+
+        if sequence_id < 0:
+            raise ValueError("sequence_id must be non-negative")
+
+        if sequence_id in self._state.in_flight:
+            raise RuntimeError(f"Shared-slot sequence already in flight: {sequence_id}")
+
         self._state.in_flight[sequence_id] = InFlightSlot(
             shm_name=shm_name,
             slot_id=int(slot_id),
@@ -472,13 +497,14 @@ class SharedSlotRegistry:
             self._state.max_in_flight_count,
             len(self._state.in_flight),
         )
-        return sequence_id
+        self._condition.notify_all()
 
     def _mark_descriptor_sent_locked(self, sequence_id: int) -> None:
         """Start the credit timeout clock for one in-flight descriptor."""
         entry = self._state.in_flight.get(sequence_id)
         if entry is None or entry.socket_sent_at is not None:
             return
+
         self._state.in_flight[sequence_id] = InFlightSlot(
             shm_name=entry.shm_name,
             slot_id=entry.slot_id,
@@ -486,10 +512,10 @@ class SharedSlotRegistry:
             reserved_at=entry.reserved_at,
             socket_sent_at=time.monotonic(),
         )
+        self._condition.notify_all()
 
     def _apply_slot_credit_locked(
         self,
-        *,
         shm_name: str,
         slot_id: int,
         sequence_id: int,
@@ -514,10 +540,12 @@ class SharedSlotRegistry:
                 self._state.max_ack_latency_s,
                 ack_latency_s,
             )
+
         self._state.last_acked_sequence_id = sequence_id
         self._state.acked_sequence_count += 1
         self._release_sequence_locked(sequence_id)
         self._state.last_credit_return_at = now
+        self._condition.notify_all()
         return True
 
     def _process_slot_credit_return(self, credit: SharedSlotCreditReturn) -> None:

--- a/neuracore/data_daemon/communications_management/shared_transport/shared_slot_transport.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/shared_slot_transport.py
@@ -9,6 +9,9 @@ import struct
 import threading
 import time
 
+from neuracore.data_daemon.communications_management.sequence_allocator import (
+    ChannelSequenceAllocator,
+)
 from neuracore.data_daemon.const import (
     DEFAULT_VIDEO_ACK_TIMEOUT_SECONDS,
     DEFAULT_VIDEO_SLOT_ALLOCATE_TIMEOUT_SECONDS,
@@ -115,6 +118,8 @@ class SharedSlotVideoWorker:
         self._active_items_lock = threading.Lock()
         self._error: Exception | None = None
         self._error_lock = threading.Lock()
+        self._last_handed_off_sequence_number = 0
+        self._handoff_cv = threading.Condition()
         self._thread = threading.Thread(
             target=self._worker_loop,
             name="shared-slot-video-worker",
@@ -187,6 +192,39 @@ class SharedSlotVideoWorker:
         with self._active_items_lock:
             return self._queue.qsize() == 0 and self._active_items == 0
 
+    def last_handed_off_sequence_number(self) -> int:
+        """Return the latest descriptor sequence handed off to the sender."""
+        with self._handoff_cv:
+            return self._last_handed_off_sequence_number
+
+    def wait_until_handed_off_through(
+        self,
+        sequence_number: int,
+        timeout_s: float,
+    ) -> None:
+        """Wait until all packets through sequence_number are descriptor-enqueued."""
+        if sequence_number <= 0:
+            return
+
+        deadline = time.monotonic() + timeout_s
+
+        with self._handoff_cv:
+            while self._last_handed_off_sequence_number < sequence_number:
+                worker_error = self.get_error()
+                if worker_error is not None:
+                    raise RuntimeError(
+                        "Shared-slot video worker failed before payload handoff "
+                        f"completed: {worker_error}"
+                    ) from worker_error
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(
+                        "Timed out waiting for shared-slot payload handoff before stop"
+                    )
+
+                self._handoff_cv.wait(timeout=min(0.05, remaining))
+
     def get_error(self) -> Exception | None:
         """Return the worker error, if the background thread failed."""
         with self._error_lock:
@@ -215,6 +253,8 @@ class SharedSlotVideoWorker:
                 except Exception as exc:
                     with self._error_lock:
                         self._error = exc
+                    with self._handoff_cv:
+                        self._handoff_cv.notify_all()
                     logger.exception("Shared-slot video worker failed")
                     break
                 finally:
@@ -223,7 +263,11 @@ class SharedSlotVideoWorker:
             finally:
                 self._queue.task_done()
 
+        with self._handoff_cv:
+            self._handoff_cv.notify_all()
+
     def _process_item(self, item: QueuedSharedSlotPacket) -> None:
+        """Copy a queued packet into a shm and hand off descriptor."""
         slot_id, offset = self._registry.allocate_slot()
         try:
             shm_view = self._registry.shared_memory_view(offset, item.packet_length)
@@ -242,7 +286,13 @@ class SharedSlotVideoWorker:
             finally:
                 shm_view.release()
 
-            sequence_id = self._registry.mark_in_flight(slot_id)
+            sequence_id = item.sequence_number
+
+            self._registry.mark_in_flight(
+                slot_id=slot_id,
+                sequence_id=sequence_id,
+            )
+
             if self._registry.shm_name is None:
                 raise RuntimeError("Shared-slot transport is not ready")
             descriptor = SharedSlotDescriptor(
@@ -270,6 +320,14 @@ class SharedSlotVideoWorker:
             except Exception:
                 self._registry.rollback_enqueued_slot(sequence_id)
                 raise
+
+            with self._handoff_cv:
+                self._last_handed_off_sequence_number = max(
+                    self._last_handed_off_sequence_number,
+                    sequence_id,
+                )
+                self._handoff_cv.notify_all()
+
         finally:
             del item
 
@@ -279,19 +337,23 @@ class SharedSlotVideoTransport:
 
     def __init__(
         self,
-        *,
+        sequence_allocator: ChannelSequenceAllocator | None = None,
         slot_size: int = DEFAULT_VIDEO_SLOT_SIZE,
         slot_count: int = DEFAULT_VIDEO_SLOT_COUNT,
         ack_timeout_s: float = DEFAULT_VIDEO_ACK_TIMEOUT_SECONDS,
         allocate_timeout_s: float = DEFAULT_VIDEO_SLOT_ALLOCATE_TIMEOUT_SECONDS,
     ) -> None:
-        """Initialize a producer-facing shared-slot transport.
+        """Initialize a producer-side shared-slot transport.
 
         Args:
-            slot_size: Bytes available in each daemon-owned shared-memory slot.
-            slot_count: Number of shared-memory slots to provision.
-            ack_timeout_s: Timeout for receiving slot credits after send.
-            allocate_timeout_s: Timeout while waiting for a writable slot.
+            sequence_allocator: Channel sequence allocator to use.
+            slot_size: Size of each shared-memory slot in bytes.
+            slot_count: Number of fixed slots available in the shared-memory
+                transport.
+            ack_timeout_s: Maximum time to wait for daemon acknowledgements and
+                credit-return progress before marking the transport unhealthy.
+            allocate_timeout_s: Maximum time to wait for shared-slot setup or
+                slot allocation before timing out.
         """
         self._registry = SharedSlotRegistry(
             slot_size=slot_size,
@@ -305,8 +367,15 @@ class SharedSlotVideoTransport:
                 allocate_timeout_s,
             ),
         )
+        self._sequence_allocator = (
+            sequence_allocator
+            if sequence_allocator is not None
+            else ChannelSequenceAllocator()
+        )
         self._worker = SharedSlotVideoWorker(self._registry)
         self._announced = False
+        self._payload_sequence_lock = threading.Lock()
+        self._last_payload_sequence_number = 0
 
     @property
     def slot_size(self) -> int:
@@ -332,20 +401,27 @@ class SharedSlotVideoTransport:
 
     def enqueue_packet(
         self,
-        *,
         producer_id: str,
         sender: ProducerChannelMessageSender,
         metadata: dict[str, str | int | None],
         chunk: bytes | bytearray | memoryview,
-    ) -> None:
+        stop_cutoff_sequence_number: int | None = None,
+    ) -> int | None:
         """Serialize one transport packet and hand it to the background worker.
 
-        Copy the payload bytes before queueing them to the worker thread so the
-        caller can safely reuse or mutate its source buffer immediately after
-        this method returns.
+        Returns the reserved sequence number, or None if rejected by stop cutoff.
         """
+        sequence_number = self._sequence_allocator.reserve()
+
+        if (
+            stop_cutoff_sequence_number is not None
+            and sequence_number > stop_cutoff_sequence_number
+        ):
+            return None
+
         metadata_bytes, packet_length = build_shared_frame_packet_metadata(
-            metadata, chunk
+            metadata,
+            chunk,
         )
         chunk_bytes = chunk if isinstance(chunk, bytes) else bytes(chunk)
         self._worker.enqueue_packet(
@@ -355,12 +431,30 @@ class SharedSlotVideoTransport:
                 metadata_bytes=metadata_bytes,
                 chunk=chunk_bytes,
                 packet_length=packet_length,
+                sequence_number=sequence_number,
             )
         )
 
+        with self._payload_sequence_lock:
+            self._last_payload_sequence_number = max(
+                self._last_payload_sequence_number,
+                sequence_number,
+            )
+
+        return sequence_number
+
     def next_sequence_number(self) -> int:
         """Reserve a channel-scoped sequence number for control messages."""
-        return self._registry.next_sequence_number()
+        return self._sequence_allocator.reserve()
+
+    def get_last_reserved_sequence_number(self) -> int:
+        """Return the most recently reserved shared-slot sequence number."""
+        return self._sequence_allocator.get_last_reserved_sequence_number()
+
+    def get_last_payload_sequence_number(self) -> int:
+        """Return the latest sequence number reserved for a payload packet."""
+        with self._payload_sequence_lock:
+            return self._last_payload_sequence_number
 
     def is_healthy(self) -> bool:
         """Return True while the transport can accept new video writes."""
@@ -375,8 +469,15 @@ class SharedSlotVideoTransport:
         self._registry.reset_session()
         self._announced = False
 
-    def wait_until_drained(self, timeout_s: float = 30.0) -> None:
-        """Wait until all queued packets and in-flight credits are settled."""
+        with self._payload_sequence_lock:
+            self._last_payload_sequence_number = 0
+
+    def wait_until_drained(
+        self,
+        timeout_s: float = 30.0,
+        max_sequence_number: int | None = None,
+    ) -> None:
+        """Wait until queued packets and in-flight credits are settled."""
         deadline = time.monotonic() + timeout_s
 
         while time.monotonic() < deadline:
@@ -387,7 +488,20 @@ class SharedSlotVideoTransport:
                     f"{worker_error}"
                 ) from worker_error
 
-            if self._is_drained():
+            if max_sequence_number is None:
+                drained = self._is_drained()
+            elif max_sequence_number <= 0:
+                drained = True
+            else:
+                drained = (
+                    self._worker.last_handed_off_sequence_number()
+                    >= max_sequence_number
+                    and not self._registry.has_in_flight_at_or_before(
+                        max_sequence_number
+                    )
+                )
+
+            if drained:
                 return
 
             time.sleep(0.05)
@@ -396,8 +510,19 @@ class SharedSlotVideoTransport:
             "Timed out waiting for shared-slot transport to drain before close"
         )
 
-    def wait_until_payload_handed_off(self, timeout_s: float = 30.0) -> None:
+    def wait_until_payload_handed_off(
+        self,
+        timeout_s: float = 30.0,
+        max_sequence_number: int | None = None,
+    ) -> None:
         """Wait until queued payloads have been copied and descriptor-enqueued."""
+        if max_sequence_number is not None:
+            self._worker.wait_until_handed_off_through(
+                sequence_number=max_sequence_number,
+                timeout_s=timeout_s,
+            )
+            return
+
         deadline = time.monotonic() + timeout_s
 
         while time.monotonic() < deadline:

--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -194,7 +194,6 @@ def launch_daemon_subprocess(
         stdout=stdout,
         stderr=stderr,
     )
-
     socket_poll_interval_s = 0.05
     daemon_startup_timeout_s = time.monotonic() + timeout_s
 

--- a/neuracore/data_daemon/runtime.py
+++ b/neuracore/data_daemon/runtime.py
@@ -12,7 +12,7 @@ from neuracore.data_daemon.communications_management.consumer.data_bridge import
     DataBridge,
 )
 from neuracore.data_daemon.communications_management.shared_transport import (
-    communications_manager,
+    CommunicationsManager,
 )
 from neuracore.data_daemon.config_manager.config import ConfigManager
 from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
@@ -46,7 +46,6 @@ from neuracore.data_daemon.services import DaemonServices
 from neuracore.data_daemon.tools.event_logger import EventLogger
 
 logger = logging.getLogger(__name__)
-CommunicationsManager = communications_manager.CommunicationsManager
 
 
 @dataclass

--- a/tests/unit/core/test_data_stream.py
+++ b/tests/unit/core/test_data_stream.py
@@ -105,8 +105,10 @@ class _FakeProducerChannel:
     def cleanup_producer_channel(
         self,
         *,
+        stop_cutoff_sequence_number: int | None = None,
         wait_for_slot_drain: bool = True,
     ) -> None:
+        del stop_cutoff_sequence_number
         self.cleanup_wait_for_slot_drain_calls.append(wait_for_slot_drain)
         return
 
@@ -210,7 +212,10 @@ def test_stream_stop_recording_wait_false_skips_slot_drain(monkeypatch) -> None:
     stream.start_recording(_context())
 
     producer = _FakeProducerChannel.instances[0]
-    stream.stop_recording(wait_for_producer_drain=False)
+    stream.stop_recording(
+        stop_cutoff_sequence_number=0,
+        wait_for_producer_drain=False,
+    )
 
     assert producer.cleanup_wait_for_slot_drain_calls == [False]
     assert producer.stop_wait_for_slot_drain_calls == [False]

--- a/tests/unit/data_daemon/communications_management/test_producer_channel.py
+++ b/tests/unit/data_daemon/communications_management/test_producer_channel.py
@@ -10,12 +10,30 @@ class _FakeSharedSlotTransport:
         self.wait_until_payload_handed_off_calls: list[float] = []
         self.wait_until_drained_calls: list[float] = []
         self.finish_recording_session_calls = 0
+        self.last_payload_sequence_number = 0
 
-    def wait_until_payload_handed_off(self, timeout_s: float = 30.0) -> None:
+    def get_last_payload_sequence_number(self) -> int:
+        return self.last_payload_sequence_number
+
+    def wait_until_payload_handed_off(
+        self,
+        timeout_s: float = 30.0,
+        max_sequence_number: int | None = None,
+    ) -> None:
         self.wait_until_payload_handed_off_calls.append(timeout_s)
+        self.last_payload_sequence_number = (
+            0 if max_sequence_number is None else max_sequence_number
+        )
 
-    def wait_until_drained(self, timeout_s: float = 30.0) -> None:
+    def wait_until_drained(
+        self,
+        timeout_s: float = 30.0,
+        max_sequence_number: int | None = None,
+    ) -> None:
         self.wait_until_drained_calls.append(timeout_s)
+        self.last_payload_sequence_number = (
+            0 if max_sequence_number is None else max_sequence_number
+        )
 
     def finish_recording_session(self) -> None:
         self.finish_recording_session_calls += 1
@@ -33,8 +51,13 @@ def test_cleanup_producer_channel_wait_false_skips_slot_drain() -> None:
         lambda sequence_number: wait_calls.append(sequence_number) or True
     )
     channel.end_trace = lambda: end_trace_calls.append("end")
+    transport.last_payload_sequence_number = 41
 
-    ProducerChannel.cleanup_producer_channel(channel, wait_for_slot_drain=False)
+    ProducerChannel.cleanup_producer_channel(
+        channel,
+        stop_cutoff_sequence_number=41,
+        wait_for_slot_drain=False,
+    )
 
     assert transport.wait_until_payload_handed_off_calls == [30.0]
     assert transport.wait_until_drained_calls == []
@@ -53,8 +76,13 @@ def test_cleanup_producer_channel_wait_true_drains_shared_slots() -> None:
         lambda sequence_number: wait_calls.append(sequence_number) or True
     )
     channel.end_trace = lambda: None
+    transport.last_payload_sequence_number = 99
 
-    ProducerChannel.cleanup_producer_channel(channel, wait_for_slot_drain=True)
+    ProducerChannel.cleanup_producer_channel(
+        channel,
+        stop_cutoff_sequence_number=99,
+        wait_for_slot_drain=True,
+    )
 
     assert transport.wait_until_payload_handed_off_calls == [30.0]
     assert transport.wait_until_drained_calls == [30.0]
@@ -71,12 +99,17 @@ def test_cleanup_producer_channel_raises_when_descriptor_cutoff_not_sent() -> No
     channel.get_last_enqueued_sequence_number = lambda: 44
     channel.wait_until_sequence_sent = lambda sequence_number: False
     channel.end_trace = lambda: end_trace_calls.append("end")
+    transport.last_payload_sequence_number = 44
 
     with pytest.raises(
         RuntimeError,
-        match="Failed to send all queued payload descriptors before cleanup",
+        match="Failed to send queued recording data up to stop cutoff before cleanup",
     ):
-        ProducerChannel.cleanup_producer_channel(channel, wait_for_slot_drain=True)
+        ProducerChannel.cleanup_producer_channel(
+            channel,
+            stop_cutoff_sequence_number=44,
+            wait_for_slot_drain=True,
+        )
 
     assert transport.wait_until_payload_handed_off_calls == [30.0]
     assert transport.wait_until_drained_calls == []

--- a/tests/unit/data_daemon/test_messaging.py
+++ b/tests/unit/data_daemon/test_messaging.py
@@ -707,6 +707,7 @@ def test_shared_slot_video_worker_surfaces_background_failure() -> None:
         metadata_bytes=b"{}",
         chunk=b"x",
         packet_length=1,
+        sequence_number=1,
     )
 
     try:
@@ -767,7 +768,7 @@ def test_shared_slot_timeout_clock_starts_after_socket_send() -> None:
             )
         )
         slot_id, _offset = registry.allocate_slot()
-        sequence_id = registry.mark_in_flight(slot_id)
+        sequence_id = registry.mark_in_flight(slot_id=slot_id, sequence_id=1)
 
         time.sleep(0.03)
         with registry._condition:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- Fixes recording shutdown so each stream captures a precise stop cutoff sequence before teardown, avoiding data being recorded past the intended stop boundary.
- Updates the threaded producer/shared-slot transport flow to honor that cutoff during async handoff and drain, improving stop-recording reliability for shared-memory video/data streams.
- Cleans up producer/shared transport exports and sequence tracking so socket-sent, handed-off, and in-flight payload state stay consistent during recording stop/cleanup.
