### PR TITLE
fix: importer overwrite should wait for dataset to complete deletion

### DIFF
--- a/neuracore/importer/importer.py
+++ b/neuracore/importer/importer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -18,6 +19,7 @@ from rich.logging import RichHandler
 
 import neuracore as nc
 from neuracore.core.data.dataset import Dataset
+from neuracore.core.exceptions import DatasetError
 from neuracore.importer.core.dataset_detector import (
     DatasetDetector,
     iter_first_two_levels,
@@ -42,6 +44,8 @@ from neuracore.importer.rlds_tfds_importer import (
 )
 
 logger = logging.getLogger(__name__)
+DATASET_DELETE_TIMEOUT_S = 300.0
+DATASET_DELETE_POLL_INTERVAL_S = 30.0
 
 # Setup rich handler for colorful logging output in the importer module
 importer_logger = logging.getLogger("neuracore.importer")
@@ -201,19 +205,24 @@ def _run_import(
                 raise DatasetOperationError(
                     f"Failed to delete dataset '{dataset_name}': {exc}"
                 ) from exc
-            logger.info("Deleted existing dataset '%s'.", dataset_name)
+            logger.info("Deleting existing dataset '%s'.", dataset_name)
+            deleted_dataset_id = dataset.id
             dataset = None
         else:
             logger.warning(
                 "Dataset '%s' already exists; new data will be appended.",
                 dataset_name,
             )
+            deleted_dataset_id = None
+    else:
+        deleted_dataset_id = None
     if dataset is None:
-        dataset = nc.create_dataset(
-            name=dataset_name,
+        dataset = _create_dataset_with_overwrite_guard(
+            dataset_name=dataset_name,
             description=dataconfig.output_dataset.description,
             tags=dataconfig.output_dataset.tags,
             shared=args.shared,
+            deleted_dataset_id=deleted_dataset_id,
         )
     logger.info(
         "Output dataset ready: %s (id=%s), shared=%s",
@@ -374,6 +383,59 @@ def _run_import(
         raise DatasetOperationError(f"Unsupported dataset type: {dataset_type}")
 
     logger.info("Finished importing dataset.")
+
+
+def _create_dataset_with_overwrite_guard(
+    dataset_name: str,
+    description: str | None,
+    tags: list[str] | None,
+    shared: bool,
+    deleted_dataset_id: str | None,
+    timeout_s: float = DATASET_DELETE_TIMEOUT_S,
+    poll_interval_s: float = DATASET_DELETE_POLL_INTERVAL_S,
+) -> Dataset:
+    """Create dataset, ensuring overwrite does not reuse the deleted dataset id."""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            dataset = nc.create_dataset(
+                name=dataset_name,
+                description=description,
+                tags=tags,
+                shared=shared,
+            )
+        except DatasetError as exc:
+            retryable_soft_delete_error = (
+                deleted_dataset_id is not None and "already exists" in str(exc).lower()
+            )
+            if not retryable_soft_delete_error:
+                raise DatasetOperationError(
+                    f"Failed to create dataset '{dataset_name}': {exc}"
+                ) from exc
+            if time.monotonic() >= deadline:
+                raise DatasetOperationError(
+                    f"Timed out waiting to create replacement dataset '{dataset_name}'."
+                ) from exc
+            logger.info(
+                "Dataset '%s' creation still blocked by pending delete; "
+                "retrying in %.1fs.",
+                dataset_name,
+                poll_interval_s,
+            )
+            time.sleep(poll_interval_s)
+            continue
+        if deleted_dataset_id is None or dataset.id != deleted_dataset_id:
+            return dataset
+        if time.monotonic() >= deadline:
+            raise DatasetOperationError(
+                f"Timed out waiting to create replacement dataset '{dataset_name}'."
+            )
+        logger.info(
+            "Dataset '%s' still resolves to previous id; retrying in %.1fs.",
+            dataset_name,
+            poll_interval_s,
+        )
+        time.sleep(poll_interval_s)
 
 
 def main() -> None:

--- a/tests/unit/importer/test_importer.py
+++ b/tests/unit/importer/test_importer.py
@@ -1,0 +1,110 @@
+import pytest
+
+from neuracore.core.exceptions import DatasetError
+from neuracore.importer.core.exceptions import DatasetOperationError
+from neuracore.importer.importer import _create_dataset_with_overwrite_guard
+
+
+def test_create_dataset_with_overwrite_guard_retries_if_old_id_returned(monkeypatch):
+    class _Dataset:
+        def __init__(self, dataset_id: str):
+            self.id = dataset_id
+
+    responses = [_Dataset("old-id"), _Dataset("old-id"), _Dataset("new-id")]
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "neuracore.importer.importer.nc.create_dataset",
+        lambda **_kwargs: responses.pop(0),
+    )
+    monkeypatch.setattr(
+        "neuracore.importer.importer.time.sleep",
+        lambda interval: sleep_calls.append(interval),
+    )
+
+    result = _create_dataset_with_overwrite_guard(
+        dataset_name="my-dataset",
+        description="desc",
+        tags=["tag"],
+        shared=False,
+        deleted_dataset_id="old-id",
+        timeout_s=10.0,
+        poll_interval_s=0.5,
+    )
+
+    assert result.id == "new-id"
+    assert sleep_calls == [0.5, 0.5]
+
+
+def test_create_dataset_with_overwrite_guard_raises_on_timeout(monkeypatch):
+    class _Dataset:
+        def __init__(self, dataset_id: str):
+            self.id = dataset_id
+
+    monkeypatch.setattr(
+        "neuracore.importer.importer.nc.create_dataset",
+        lambda **_kwargs: _Dataset("old-id"),
+    )
+    monkeypatch.setattr("neuracore.importer.importer.time.sleep", lambda *_args: None)
+
+    monotonic_values = iter([0.0, 0.5, 1.1])
+    monkeypatch.setattr(
+        "neuracore.importer.importer.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    with pytest.raises(
+        DatasetOperationError,
+        match="Timed out waiting to create replacement dataset 'my-dataset'.",
+    ):
+        _create_dataset_with_overwrite_guard(
+            dataset_name="my-dataset",
+            description=None,
+            tags=None,
+            shared=False,
+            deleted_dataset_id="old-id",
+            timeout_s=1.0,
+            poll_interval_s=0.1,
+        )
+
+
+def test_create_dataset_with_overwrite_guard_retries_on_transient_create_error(
+    monkeypatch,
+):
+    class _Dataset:
+        def __init__(self, dataset_id: str):
+            self.id = dataset_id
+
+    responses = iter([
+        DatasetError("Failed to create dataset: Dataset already exists"),
+        _Dataset("new-id"),
+    ])
+
+    def fake_create_dataset(**_kwargs):
+        value = next(responses)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "neuracore.importer.importer.nc.create_dataset",
+        fake_create_dataset,
+    )
+    monkeypatch.setattr(
+        "neuracore.importer.importer.time.sleep",
+        lambda interval: sleep_calls.append(interval),
+    )
+
+    result = _create_dataset_with_overwrite_guard(
+        dataset_name="my-dataset",
+        description=None,
+        tags=None,
+        shared=False,
+        deleted_dataset_id="old-id",
+        timeout_s=10.0,
+        poll_interval_s=0.5,
+    )
+
+    assert result.id == "new-id"
+    assert sleep_calls == [0.5]


### PR DESCRIPTION
### Bugfixes
- Importer has overwrite option to delete existing dataset with the same name and create a new one
- Dataset deletion request is sent but does not wait for deletion to complete before creating new one causing error on dataset creation
- This fix tries to create the new dataset at a fixed time interval until it is successfully created