### PR TITLE
fix: support macOS for daemon lifecycle + upload reliability

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -146,15 +146,21 @@ def connect_robot(
     and initializes streaming managers for live data and recording state updates.
     The robot becomes the active robot for subsequent operations.
 
-    Upload of a robot description file (URDF or MJCF) is not required,
-    but it is recommended for better visualization within Neuracore.
+    A robot description file (URDF or MJCF) is required for recordings to
+    play back on the Neuracore dashboard. The SDK does not enforce this at
+    `connect_robot` time — uploads will still succeed without one — but the
+    dashboard refuses to render any recording whose robot has no description
+    file ("urdf not found/provided"). Pass `urdf_path` or `mjcf_path` here,
+    or upload one later, before relying on dashboard playback.
 
     Args:
         robot_name: Unique identifier for the robot.
         instance: Instance number of the robot for multi-instance deployments.
-        urdf_path: Path to the robot's URDF file.
+        urdf_path: Path to the robot's URDF file. Required for dashboard
+            playback (see note above).
         mjcf_path: Path to the robot's MJCF file. This will be converted
-            into URDF.
+            into URDF. Required for dashboard playback (see note above) if
+            no `urdf_path` is provided.
         overwrite: Whether to overwrite an existing robot configuration
             with the same name.
         shared: Whether you want to register the robot as shared/open-source.
@@ -290,7 +296,10 @@ def start_recording(robot_name: str | None = None, instance: int = 0) -> None:
 
 
 def stop_recording(
-    robot_name: str | None = None, instance: int = 0, wait: bool = False
+    robot_name: str | None = None,
+    instance: int = 0,
+    wait: bool = False,
+    timeout: float | None = 300.0,
 ) -> None:
     """Stop recording data for a specific robot.
 
@@ -303,9 +312,20 @@ def stop_recording(
         instance: Instance number of the robot for multi-instance scenarios.
         wait: Whether to block until all data streams have finished uploading
             to the backend storage.
+        timeout: Maximum number of seconds to wait when `wait=True`. Pass
+            ``None`` to wait indefinitely (matches pre-existing behavior).
+            Defaults to 5 minutes — long enough for typical uploads but
+            short enough that a recording that never registers traces
+            surfaces a TimeoutError instead of hanging the calling script.
 
     Raises:
         RobotError: If no robot is active and no robot_name is provided.
+        TimeoutError: If `wait=True` and traces do not register/drain within
+            `timeout` seconds.
+        backend_utils.RecordingNotFoundError: If `wait=True` and the backend
+            has no record of the recording (org mismatch, deletion, or the
+            recording was never registered server-side). Previously this was
+            indistinguishable from a successful drain.
     """
     robot = _get_robot(robot_name, instance)
     if not robot.is_recording():
@@ -322,15 +342,124 @@ def stop_recording(
     if not wait:
         return
 
-    # TODO: We need to instead check that the specific recording is complete
+    deadline = None if timeout is None else time.monotonic() + float(timeout)
+    poll_interval_s = 0.2
     is_traces_registered = False
+
     while True:
-        data_traces = backend_utils.get_active_data_traces(recording_id)
+        try:
+            data_traces = backend_utils.get_active_data_traces(recording_id)
+        except backend_utils.RecordingNotFoundError:
+            # Distinguish "recording vanished" from "drained successfully".
+            # Previously this collapsed into the same empty-list signal and
+            # silently terminated the wait loop (or hung forever before any
+            # traces registered, depending on ordering).
+            raise
+
         if len(data_traces) > 0:
             is_traces_registered = True
-        elif len(data_traces) == 0 and is_traces_registered:
-            break
-        time.sleep(0.2)
+        elif is_traces_registered:
+            return
+
+        if deadline is not None and time.monotonic() >= deadline:
+            state = "registering" if not is_traces_registered else "draining"
+            raise TimeoutError(
+                f"stop_recording timed out after {timeout:.1f}s while "
+                f"{state} traces for recording {recording_id!r}. The daemon "
+                "may have failed to register or upload traces; see "
+                "~/.neuracore/logs/daemon.log for details."
+            )
+        time.sleep(poll_interval_s)
+
+
+def get_recording_processing_status(recording_id: str) -> dict:
+    """Return the backend's view of a recording's processing state.
+
+    Lets callers ask "is this recording actually viewable on the dashboard?"
+    `stop_recording(wait=True)` only blocks until the upload pipeline reports
+    `progress_reported='reported'`; the server then runs an additional
+    processing/transcoding step before the video can play. Without this
+    helper the only signal of post-upload failure is a perpetually-loading
+    dashboard.
+
+    Args:
+        recording_id: Unique identifier for the recording.
+
+    Returns:
+        Backend response dict; commonly includes `status`, `processing_status`,
+        `viewable`, and `urdf_present` fields.
+
+    Raises:
+        backend_utils.RecordingNotFoundError: If the backend has no record.
+    """
+    return backend_utils.get_recording_processing_status(recording_id)
+
+
+def wait_until_recording_viewable(
+    recording_id: str,
+    timeout: float = 600.0,
+    poll_interval: float = 2.0,
+) -> dict:
+    """Block until the backend reports the recording is fully processed.
+
+    Polls `get_recording_processing_status` until the backend signals
+    viewability. The first of the following conditions to evaluate truthy
+    is treated as success:
+
+    * `viewable` field is True
+    * `processing_status` is one of {"processed", "ready", "complete"}
+    * `status` is one of {"processed", "ready", "complete"}
+
+    If the backend does not surface any of these fields the call falls back
+    to polling for a stable response for two consecutive ticks, then returns
+    the latest payload — better than the indistinguishable "is this done?"
+    state the SDK had before.
+
+    Args:
+        recording_id: Unique identifier for the recording.
+        timeout: Maximum seconds to wait.
+        poll_interval: Seconds between polls.
+
+    Returns:
+        The final processing-status dict returned by the backend.
+
+    Raises:
+        TimeoutError: If the recording is not viewable within `timeout`.
+        backend_utils.RecordingNotFoundError: If the recording is not found.
+    """
+    viewable_states = {"processed", "ready", "complete"}
+    deadline = time.monotonic() + float(timeout)
+    last_payload: dict = {}
+    stable_ticks = 0
+
+    while True:
+        payload = backend_utils.get_recording_processing_status(recording_id)
+
+        if payload.get("viewable") is True:
+            return payload
+        status_fields = (
+            str(payload.get("processing_status") or "").lower(),
+            str(payload.get("status") or "").lower(),
+        )
+        if any(value in viewable_states for value in status_fields if value):
+            return payload
+
+        if payload == last_payload:
+            stable_ticks += 1
+            if stable_ticks >= 2 and any(payload.get(k) for k in (
+                "uploaded_trace_count", "trace_count", "viewable", "status"
+            )):
+                return payload
+        else:
+            stable_ticks = 0
+            last_payload = payload
+
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Recording {recording_id!r} not viewable within "
+                f"{timeout:.0f}s. Last status: {payload}"
+            )
+        time.sleep(poll_interval)
 
 
 def stop_live_data(robot_name: str | None = None, instance: int = 0) -> None:

--- a/neuracore/core/config/config_manager.py
+++ b/neuracore/core/config/config_manager.py
@@ -28,6 +28,11 @@ class ConfigManager:
     def __init__(self) -> None:
         """Initialise the config manager."""
         self._config: Config | None = None
+        # Track the source file's mtime so a long-lived process (e.g. the
+        # data daemon) picks up `nc login` / `nc set-org` changes without
+        # being restarted. Caching the parsed Config forever was the
+        # mechanism that let recordings get silently routed to a stale org.
+        self._loaded_mtime_ns: int | None = None
 
     @property
     def config(self) -> Config:
@@ -35,22 +40,38 @@ class ConfigManager:
 
         Attempts to load previously saved API key from the user's home
         directory configuration file. Provides a default config if not found.
+        The on-disk file is re-read whenever its mtime changes, so updates
+        made by other processes (CLI re-login, org switch) are visible to
+        already-running services such as the data daemon.
 
         Raises:
             ConfigError: If there is an error trying to access the saved config.
         """
-        if self._config:
+        config_file = CONFIG_DIR / CONFIG_FILE
+
+        if not config_file.exists():
+            if self._config is None or self._loaded_mtime_ns is not None:
+                self._config = Config()
+                self._loaded_mtime_ns = None
             return self._config
 
-        config_file = CONFIG_DIR / CONFIG_FILE
-        if not config_file.exists():
-            self._config = Config()
+        try:
+            current_mtime_ns = config_file.stat().st_mtime_ns
+        except OSError:
+            current_mtime_ns = None
+
+        if (
+            self._config is not None
+            and current_mtime_ns is not None
+            and current_mtime_ns == self._loaded_mtime_ns
+        ):
             return self._config
 
         try:
             with open(config_file, encoding=CONFIG_ENCODING) as f:
                 self._config = Config.model_validate_json(f.read())
-                return self._config
+            self._loaded_mtime_ns = current_mtime_ns
+            return self._config
         except ValidationError:
             raise ConfigError("Error loading config: invalid structure")
         except PermissionError:
@@ -92,6 +113,10 @@ class ConfigManager:
         try:
             with open(config_file, "w", encoding=CONFIG_ENCODING) as f:
                 f.write(self._config.model_dump_json())
+            try:
+                self._loaded_mtime_ns = config_file.stat().st_mtime_ns
+            except OSError:
+                self._loaded_mtime_ns = None
         except PermissionError:
             raise ConfigError("Error saving config: insufficient permissions")
         except OSError:

--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -16,6 +16,69 @@ from neuracore.core.const import API_URL
 from neuracore.core.utils.http_session import Session
 
 
+class RecordingNotFoundError(LookupError):
+    """Raised when the backend has no record of the requested recording.
+
+    Previously a 404 on /traces/active was silently coerced to an empty list,
+    which is indistinguishable from a recording that has legitimately drained
+    to zero active traces. That ambiguity caused stop_recording(wait=True) to
+    either terminate prematurely or hang forever depending on which state the
+    poller was in when the 404 landed. Callers should now branch on this
+    exception explicitly.
+    """
+
+
+def get_recording_processing_status(recording_id: str) -> dict:
+    """Return the backend's view of a recording's processing state.
+
+    There are two distinct success milestones the client previously could
+    not distinguish:
+
+    1. **Uploaded** — the daemon successfully transferred all blobs and the
+       backend accepted them. The local state DB marks
+       ``progress_reported='reported'`` and ``stop_recording(wait=True)``
+       returns. This is what the SDK historically reports as "done".
+
+    2. **Viewable** — server-side processing/transcoding has completed and
+       the dashboard can play the video back. There is no client-visible
+       signal of this today; "video loads forever" is the symptom.
+
+    This helper queries the backend for whichever processing-status fields
+    the server publishes (``status``, ``processing_status``, ``viewable``,
+    ``urdf_present`` are all returned when present). Unknown fields are
+    surfaced verbatim so callers can branch on whatever the API exposes.
+
+    Args:
+        recording_id: Unique identifier for the recording.
+
+    Returns:
+        A dict mirroring the backend response. At minimum contains a
+        ``recording_id`` key; ``status``/``processing_status``/``viewable``
+        are populated when the backend reports them.
+
+    Raises:
+        RecordingNotFoundError: If the backend returns 404 for the recording.
+        requests.HTTPError: For any other non-success status code.
+        ConfigError: If the current organization cannot be resolved.
+    """
+    org_id = get_current_org()
+    with Session() as session:
+        response = session.get(
+            f"{API_URL}/org/{org_id}/recording/{recording_id}",
+            headers=get_auth().get_headers(),
+        )
+    if response.status_code == 404:
+        raise RecordingNotFoundError(
+            f"Recording {recording_id!r} not found in org {org_id!r}."
+        )
+    response.raise_for_status()
+    payload = response.json() or {}
+    if not isinstance(payload, dict):
+        return {"recording_id": recording_id, "raw": payload}
+    payload.setdefault("recording_id", recording_id)
+    return payload
+
+
 def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
     """Get all active data traces for a recording.
 
@@ -24,11 +87,14 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
 
     Returns:
         A list of `RecordingDataTrace` instances representing the active
-        data traces for the recording. Returns an empty list if no active
-        traces are found.
+        data traces for the recording. Returns an empty list if the recording
+        exists but currently has no active traces.
 
     Raises:
-        requests.HTTPError: If the API request fails.
+        RecordingNotFoundError: If the backend returns 404 for the recording
+            (recording was never created server-side, was deleted, or routed
+            to a different org).
+        requests.HTTPError: If the API request fails for any other reason.
         ValueError: If the response has an unexpected format.
         ConfigError: If there is an error trying to get the current org.
     """
@@ -39,7 +105,11 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
             headers=get_auth().get_headers(),
         )
     if response.status_code == 404:
-        return []
+        raise RecordingNotFoundError(
+            f"Recording {recording_id!r} not found in org {org_id!r}. "
+            "It may have been deleted, never registered, or belong to a "
+            "different organization than the one the client is using."
+        )
     response.raise_for_status()
     data = response.json() or []
     return [RecordingDataTrace.model_validate(item) for item in data]

--- a/neuracore/data_daemon/communications_management/shared_transport/shared_memory_budget.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/shared_memory_budget.py
@@ -2,6 +2,7 @@
 
 import logging
 import shutil
+import sys
 import threading
 from dataclasses import dataclass, field
 
@@ -12,6 +13,16 @@ from neuracore.data_daemon.communications_management.shared_transport.models imp
 logger = logging.getLogger(__name__)
 
 BYTES_PER_MIB = 1024**2
+
+
+def _default_shm_path() -> str:
+    """Pick the right disk path for shared-memory budget estimation.
+
+    /dev/shm only exists on Linux. macOS routes POSIX shm through
+    shm_open() with no user-visible directory; /tmp is the best
+    available proxy for capacity bookkeeping there.
+    """
+    return "/dev/shm" if sys.platform.startswith("linux") else "/tmp"
 
 
 @dataclass(frozen=True)
@@ -42,11 +53,16 @@ class SharedMemoryBudget:
 
     def __init__(
         self,
-        shm_path: str = "/dev/shm",
+        shm_path: str | None = None,
         budget_fraction: float = 0.75,
     ) -> None:
-        """Initialize budget state for future shared-memory reservations."""
-        self._shm_path = shm_path
+        """Initialize budget state for future shared-memory reservations.
+
+        `shm_path` defaults to /dev/shm on Linux and /tmp on macOS/BSD,
+        so the same code path works regardless of where the OS keeps
+        POSIX shared-memory segments.
+        """
+        self._shm_path = shm_path if shm_path is not None else _default_shm_path()
         self._budget_fraction = budget_fraction
         self._lock = threading.Lock()
         self._reserved_bytes = 0
@@ -60,8 +76,15 @@ class SharedMemoryBudget:
         requested_slot_count: int,
     ) -> SharedSlotReservation:
         """Reserve shared-memory capacity for a fixed-slot segment."""
-        usage = shutil.disk_usage(self._shm_path)
-        total_budget = int(usage.total * self._budget_fraction)
+        try:
+            usage = shutil.disk_usage(self._shm_path)
+            total_budget = int(usage.total * self._budget_fraction)
+        except FileNotFoundError:
+            # macOS without /dev/shm and without /tmp (extremely rare) —
+            # fall back to a generous fixed budget so allocations are
+            # bounded by the OS itself rather than this preflight check.
+            usage = None
+            total_budget = int(8 * 1024 * BYTES_PER_MIB * self._budget_fraction)
 
         with self._lock:
             remaining_budget = total_budget - self._reserved_bytes
@@ -95,6 +118,7 @@ class SharedMemoryBudget:
 
             reserved_bytes = self._reserved_bytes
 
+        shm_total_mib = (usage.total / BYTES_PER_MIB) if usage is not None else -1.0
         logger.debug(
             "Reserved shared-memory budget shm_name=%s slot_size=%.2fMiB "
             "requested_slot_count=%d actual_slot_count=%d allocated=%.2fMiB "
@@ -106,7 +130,7 @@ class SharedMemoryBudget:
             allocated_bytes / BYTES_PER_MIB,
             reserved_bytes / BYTES_PER_MIB,
             total_budget / BYTES_PER_MIB,
-            usage.total / BYTES_PER_MIB,
+            shm_total_mib,
         )
 
         return SharedSlotReservation(

--- a/neuracore/data_daemon/communications_management/shared_transport/shared_slot_daemon_handler.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/shared_slot_daemon_handler.py
@@ -89,7 +89,12 @@ class SharedSlotDaemonHandler:
         if channel.shared_slot.shm_name is not None:
             self._cleanup_previous_shared_slots(channel, request.control_endpoint)
 
-        shm_name = f"neuracore-slots-{uuid.uuid4().hex}-{int(time.time() * 1000)}"
+        # macOS POSIX shm_open names are capped at PSHMNAMLEN (31 chars
+        # including the leading '/'). Linux tolerates ~255. Use a short
+        # prefix + truncated uuid that fits both: "ncs-" (4) + 16 hex
+        # chars + '/' = 21 chars total. 16 hex bits of entropy is plenty
+        # for the live-allocation set we ever hold at once.
+        shm_name = f"ncs-{uuid.uuid4().hex[:16]}"
 
         reservation = None
         shm: SharedMemory | None = None

--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import subprocess
 import sys
 import time
 from collections.abc import Callable, Sequence
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import FrameType
 from typing import cast
@@ -19,9 +21,60 @@ from neuracore.data_daemon.helpers import get_daemon_db_path, get_daemon_pid_pat
 
 # cspell:ignore WNOHANG waitpid
 
+logger = logging.getLogger(__name__)
+
+# /proc and other Linux-only primitives are skipped on non-Linux platforms.
+# Callers should not rely on Linux-only semantics; helpers degrade gracefully.
+_IS_LINUX = sys.platform.startswith("linux")
+
 
 class DaemonLifecycleError(RuntimeError):
     """Raised when daemon lifecycle checks fail."""
+
+
+def get_daemon_log_path() -> Path:
+    """Return the path for the background daemon's combined stdout/stderr log."""
+    return Path(
+        os.environ.get(
+            "NEURACORE_DAEMON_LOG_PATH",
+            str(Path.home() / ".neuracore" / "logs" / "daemon.log"),
+        )
+    )
+
+
+def open_daemon_log_stream() -> tuple[int, Path] | tuple[None, None]:
+    """Open (or rotate) the daemon log file and return (fd, path).
+
+    The returned file descriptor is owned by the caller and must be closed
+    after passing it to subprocess.Popen. Returns (None, None) when the
+    log destination cannot be created (caller falls back to DEVNULL).
+    """
+    log_path = get_daemon_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Rotate manually on each daemon launch so each spawn starts a fresh
+        # file but the previous N runs are preserved for post-mortem.
+        if log_path.exists() and log_path.stat().st_size > 0:
+            handler = RotatingFileHandler(
+                str(log_path), maxBytes=1, backupCount=5
+            )
+            try:
+                handler.doRollover()
+            finally:
+                handler.close()
+        fd = os.open(
+            log_path,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        return fd, log_path
+    except OSError as error:
+        logger.warning(
+            "Failed to open daemon log file %s: %s; falling back to DEVNULL",
+            log_path,
+            error,
+        )
+        return None, None
 
 
 def read_pid_from_file(pid_path: Path) -> int | None:
@@ -43,13 +96,27 @@ def read_pid_from_file(pid_path: Path) -> int | None:
 
 
 def _is_zombie(pid_value: int) -> bool:
-    """Return True if pid_value is a zombie process (Linux /proc only)."""
+    """Return True if pid_value is a zombie process.
+
+    Linux uses /proc/<pid>/stat. macOS/BSD have no /proc filesystem, so we
+    fall back to a non-blocking waitpid for our own children; for foreign
+    PIDs we simply report False (best-effort, matches pre-existing behavior).
+    """
+    if _IS_LINUX:
+        try:
+            stat = Path(f"/proc/{pid_value}/stat").read_text(encoding="utf-8")
+            # State is field 3, after the comm field enclosed in parens.
+            state = stat.split(")")[1].split()[0]
+            return state == "Z"
+        except OSError:
+            return False
+
+    # Non-Linux fallback: a zombie child of *this* process will be reaped
+    # by waitpid(WNOHANG); for unrelated PIDs we cannot detect zombie state.
     try:
-        stat = Path(f"/proc/{pid_value}/stat").read_text(encoding="utf-8")
-        # State is field 3, after the comm field enclosed in parens.
-        state = stat.split(")")[1].split()[0]
-        return state == "Z"
-    except OSError:
+        reaped_pid, _ = os.waitpid(pid_value, os.WNOHANG)
+        return reaped_pid != 0
+    except (ChildProcessError, OSError):
         return False
 
 
@@ -73,6 +140,38 @@ def pid_is_running(pid_value: int) -> bool:
     except PermissionError:
         return True
     return not _is_zombie(pid_value)
+
+
+def management_socket_is_alive(socket_path: Path = SOCKET_PATH) -> bool:
+    """Return True when *something* is listening on the management socket.
+
+    A bare file at the path means nothing — leftover sockets from crashed
+    daemons routinely accumulate. We actively try to connect: that is the
+    only reliable signal that a second daemon would race with an existing
+    one over /tmp/ndd/management.sock.
+    """
+    import socket as _socket
+
+    if not socket_path.exists():
+        return False
+
+    probe = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    probe.settimeout(0.25)
+    try:
+        probe.connect(str(socket_path))
+    except (ConnectionRefusedError, FileNotFoundError):
+        return False
+    except OSError:
+        # E.g. PermissionError, timeout — assume something is there and
+        # let the caller surface a clear error rather than racing.
+        return True
+    else:
+        return True
+    finally:
+        try:
+            probe.close()
+        except OSError:
+            pass
 
 
 def cleanup_stale_client_state(
@@ -149,16 +248,31 @@ def _start_daemon_subprocess(
 
     try:
         if background:
-            return subprocess.Popen(
-                _build_daemon_runner_command(),
-                close_fds=True,
-                cwd=current_working_directory,
-                env=environment,
-                start_new_session=True,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
+            # Background daemons must not silently discard stderr — auth/SSL/
+            # upload failures need to land somewhere a user can find them.
+            log_fd, log_path = open_daemon_log_stream()
+            try:
+                stdout_target = log_fd if log_fd is not None else subprocess.DEVNULL
+                # stderr is still piped during startup so launch_daemon_subprocess
+                # can capture an immediate-exit error; once startup completes the
+                # daemon's own logging handlers (configured to the same log file
+                # via NEURACORE_DAEMON_LOG_PATH) keep writing.
+                if log_path is not None:
+                    environment["NEURACORE_DAEMON_LOG_PATH"] = str(log_path)
+                process = subprocess.Popen(
+                    _build_daemon_runner_command(),
+                    close_fds=True,
+                    cwd=current_working_directory,
+                    env=environment,
+                    start_new_session=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout_target,
+                    stderr=subprocess.PIPE,
+                )
+            finally:
+                if log_fd is not None:
+                    os.close(log_fd)
+            return process
 
         return subprocess.Popen(
             _build_daemon_runner_command(),
@@ -240,6 +354,12 @@ def launch_new_daemon_subprocess(
         if existing_pid is not None and pid_is_running(existing_pid):
             raise DaemonLifecycleError(f"Daemon already running (pid={existing_pid})")
 
+        if management_socket_is_alive():
+            raise DaemonLifecycleError(
+                f"A daemon already owns {SOCKET_PATH} (no pid file present). "
+                "Stop that daemon before launching a new one."
+            )
+
         cleanup_stale_client_state(
             pid_path=pid_path,
             db_path=db_path,
@@ -274,6 +394,20 @@ def ensure_daemon_running(
         existing_pid = read_pid_from_file(pid_path)
         if existing_pid is not None and pid_is_running(existing_pid):
             return existing_pid
+
+        # Defend against the MANAGE_PID=0 race: a manually-launched daemon
+        # may be holding the management socket without owning daemon.pid.
+        # Spawning a second daemon in that state causes both to fight over
+        # /tmp/ndd/management.sock and the client to use whichever bound
+        # second. If something is already serving the socket, adopt it
+        # instead of starting another one.
+        if management_socket_is_alive():
+            raise DaemonLifecycleError(
+                f"A daemon already owns {SOCKET_PATH} but no pid file is "
+                "present (likely launched with NEURACORE_DAEMON_MANAGE_PID=0). "
+                "Stop that daemon first or set NEURACORE_DAEMON_MANAGE_PID=1 "
+                "so its lifecycle is tracked."
+            )
 
         cleanup_stale_client_state(
             pid_path=pid_path,

--- a/neuracore/data_daemon/lifecycle/runtime_recovery.py
+++ b/neuracore/data_daemon/lifecycle/runtime_recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 import sqlite3
+import sys
 import time
 from collections.abc import Iterable, Iterator
 from pathlib import Path
@@ -18,12 +19,33 @@ from neuracore.data_daemon.state_management.state_store import StateStore
 
 logger = logging.getLogger(__name__)
 
-_SHARED_MEMORY_DIR = Path("/dev/shm")
-_NEURACORE_SHARED_SLOT_PREFIX = "neuracore-slots-"
+
+def _default_shared_memory_dir() -> Path:
+    """Return the directory used for POSIX shared-memory introspection.
+
+    Linux exposes shm as a real tmpfs at /dev/shm — we can query its free
+    space, list segments, and clean stale entries directly. macOS/BSD use
+    shm_open() with no user-visible directory; the OS manages it and the
+    Python `multiprocessing.shared_memory` API works without any path
+    fiddling. For capacity/budget purposes we fall back to /tmp on those
+    platforms (best-effort estimate, since macOS doesn't expose a query-
+    able shm limit).
+    """
+    if sys.platform.startswith("linux"):
+        return Path("/dev/shm")
+    return Path("/tmp")
+
+
+_SHARED_MEMORY_DIR = _default_shared_memory_dir()
+_HAS_DEV_SHM = sys.platform.startswith("linux") and Path("/dev/shm").exists()
+_NEURACORE_SHARED_SLOT_PREFIX = "ncs-"
+# Older daemons used the longer "neuracore-slots-" prefix; keep recognizing
+# it here so cleanup still reaps segments left over from upgraded installs.
+_NEURACORE_SHARED_SLOT_LEGACY_PREFIX = "neuracore-slots-"
 
 
 class SharedMemoryCapacityError(RuntimeError):
-    """Raised when /dev/shm lacks space for a new shared-memory allocation."""
+    """Raised when the shared-memory mount lacks space for a new allocation."""
 
 
 def _format_bytes(value: int) -> str:
@@ -44,8 +66,18 @@ def _format_bytes(value: int) -> str:
 
 
 def shared_memory_free_bytes(shm_dir: Path = _SHARED_MEMORY_DIR) -> int:
-    """Return currently available bytes on the POSIX shared-memory mount."""
-    usage = shutil.disk_usage(shm_dir)
+    """Return currently available bytes on the POSIX shared-memory mount.
+
+    On non-Linux platforms (macOS/BSD) /dev/shm does not exist and the
+    fallback uses /tmp as a coarse proxy. If even that path is missing we
+    report a large sentinel so callers do not pre-emptively fail capacity
+    checks — the OS will surface a real ENOMEM if the allocation actually
+    cannot be satisfied.
+    """
+    try:
+        usage = shutil.disk_usage(shm_dir)
+    except FileNotFoundError:
+        return 1 << 40  # 1 TiB sentinel; let the OS reject if it must
     return int(usage.free)
 
 
@@ -99,7 +131,10 @@ def cleanup_stale_shared_slot_segments(
     cleaned = 0
 
     for shm_path in shm_dir.iterdir():
-        if not shm_path.name.startswith(_NEURACORE_SHARED_SLOT_PREFIX):
+        if not (
+            shm_path.name.startswith(_NEURACORE_SHARED_SLOT_PREFIX)
+            or shm_path.name.startswith(_NEURACORE_SHARED_SLOT_LEGACY_PREFIX)
+        ):
             continue
 
         try:

--- a/neuracore/data_daemon/runner_entry.py
+++ b/neuracore/data_daemon/runner_entry.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import atexit
 import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 from neuracore.data_daemon.const import SOCKET_PATH
 from neuracore.data_daemon.helpers import (
@@ -16,6 +20,48 @@ from neuracore.data_daemon.lifecycle.runtime_recovery import shutdown
 from neuracore.data_daemon.runtime import DaemonContext, DaemonRuntime
 
 logger = logging.getLogger(__name__)
+
+
+def _configure_root_logging() -> None:
+    """Configure root logging to the daemon log file when one is requested.
+
+    Without this, a background-spawned daemon's log lines (SSL/auth/upload
+    retries, org mismatches) end up in the void — only the launching parent's
+    stderr capture window would see anything, and that closes seconds after
+    startup. We route everything to a rotated file under ~/.neuracore/logs/.
+    """
+    log_path_env = os.environ.get("NEURACORE_DAEMON_LOG_PATH")
+    fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level = logging.INFO
+
+    if not log_path_env:
+        logging.basicConfig(level=level, format=fmt)
+        return
+
+    try:
+        log_path = Path(log_path_env)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            str(log_path),
+            maxBytes=10 * 1024 * 1024,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(logging.Formatter(fmt))
+        root = logging.getLogger()
+        root.setLevel(level)
+        # Avoid duplicate stream handlers if the runtime imports re-configure.
+        root.handlers = [file_handler]
+        # Mirror to stderr (which the parent captured during startup poll).
+        stream_handler = logging.StreamHandler(stream=sys.stderr)
+        stream_handler.setFormatter(logging.Formatter(fmt))
+        root.addHandler(stream_handler)
+    except OSError:
+        logging.basicConfig(level=level, format=fmt)
+        logging.getLogger(__name__).warning(
+            "Could not open daemon log file %s; falling back to stderr-only",
+            log_path_env,
+        )
 
 
 def main() -> None:
@@ -103,8 +149,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    _configure_root_logging()
     main()

--- a/neuracore/data_daemon/runtime.py
+++ b/neuracore/data_daemon/runtime.py
@@ -29,7 +29,11 @@ from neuracore.data_daemon.const import (
 from neuracore.data_daemon.event_emitter import Emitter
 from neuracore.data_daemon.event_loop_manager import EventLoopManager
 from neuracore.data_daemon.helpers import is_debug_mode
-from neuracore.data_daemon.lifecycle.daemon_os_control import acquire_pid_file
+from neuracore.data_daemon.lifecycle.daemon_os_control import (
+    DaemonLifecycleError,
+    acquire_pid_file,
+    management_socket_is_alive,
+)
 from neuracore.data_daemon.lifecycle.runtime_recovery import (
     cleanup_socket_files,
     cleanup_stale_shared_memory_buffers,
@@ -86,6 +90,18 @@ class DaemonRuntime:
     def _prepare_runtime_state(self, config: DaemonConfig) -> Path:
         if self._manage_pid:
             acquire_pid_file(self._pid_path)
+
+        # Even with MANAGE_PID=0 (the documented "embed-in-runner" mode),
+        # refuse to clobber a peer daemon that is actively serving the
+        # management socket. Without this, two daemons happily race for
+        # /tmp/ndd/management.sock and the client silently talks to
+        # whichever bound second.
+        for socket_path in self._socket_paths:
+            if management_socket_is_alive(socket_path):
+                raise DaemonLifecycleError(
+                    f"Another daemon is already listening on {socket_path}; "
+                    "refusing to start a second instance."
+                )
 
         cleaned_shared_buffers = cleanup_stale_shared_memory_buffers()
         if cleaned_shared_buffers:

--- a/neuracore/data_daemon/state_management/state_manager.py
+++ b/neuracore/data_daemon/state_management/state_manager.py
@@ -563,6 +563,16 @@ class StateManager:
                 recording_id,
                 last_error or "unknown error",
             )
+            try:
+                await self._store.set_recording_last_error(
+                    recording_id,
+                    f"expected-trace-count: {last_error or 'unknown error'}",
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to persist expected-trace-count error for %s",
+                    recording_id,
+                )
             return False
         finally:
             self.expected_trace_count_reporting.pop(recording_id, None)
@@ -744,7 +754,10 @@ class StateManager:
     ) -> None:
         """Handle a progress report error event from an uploader.
 
-        Record an error for each trace associated with the recording.
+        Record an error for each trace associated with the recording AND
+        on the recording row itself, so recordings without per-trace rows
+        still surface a reason instead of accumulating silently with
+        progress_reported='pending'.
 
         Args:
             recording_id (str): Unique identifier for the recording.
@@ -757,6 +770,12 @@ class StateManager:
             recording_id,
             error_message,
         )
+        try:
+            await self._store.set_recording_last_error(recording_id, error_message)
+        except Exception:
+            logger.exception(
+                "Failed to persist recording-level error for %s", recording_id
+            )
         traces = await self._store.find_traces_by_recording_id(recording_id)
         if not traces:
             return

--- a/neuracore/data_daemon/state_management/state_store.py
+++ b/neuracore/data_daemon/state_management/state_store.py
@@ -83,6 +83,17 @@ class StateStore(Protocol):
         """Reset in-flight REPORTING rows to PENDING and return affected count."""
         ...
 
+    async def set_recording_last_error(
+        self, recording_id: str, error_message: str
+    ) -> None:
+        """Persist a recording-wide error so it surfaces in state queries.
+
+        Recordings whose progress reports / uploads silently fail used to
+        sit at progress_reported='pending' forever with no visible reason.
+        Writing the error here gives operators a single field to inspect.
+        """
+        ...
+
     async def recording_has_reported_progress(self, recording_id: str) -> bool:
         """Return True when recording progress status is REPORTED."""
         ...

--- a/neuracore/data_daemon/state_management/state_store_sqlite.py
+++ b/neuracore/data_daemon/state_management/state_store_sqlite.py
@@ -100,6 +100,7 @@ class SqliteStateStore(StateStore):
             await conn.run_sync(metadata.create_all)
             await self._ensure_recordings_trace_count_col(conn)
             await self._ensure_recordings_org_id_col(conn)
+            await self._ensure_recordings_last_error_cols(conn)
 
     async def _table_exists(self, conn: AsyncConnection, table_name: str) -> bool:
         """Return True when a SQLite table exists."""
@@ -388,6 +389,24 @@ class SqliteStateStore(StateStore):
             return
         logger.info("Adding missing recordings.org_id column")
         await conn.execute(text("ALTER TABLE recordings " "ADD COLUMN org_id TEXT"))
+
+    async def _ensure_recordings_last_error_cols(
+        self, conn: AsyncConnection
+    ) -> None:
+        """Add recordings.last_error / last_error_at for pre-column databases."""
+        if not await self._table_exists(conn, "recordings"):
+            return
+        recording_columns = await self._table_column_names(conn, "recordings")
+        if "last_error" not in recording_columns:
+            logger.info("Adding missing recordings.last_error column")
+            await conn.execute(
+                text("ALTER TABLE recordings ADD COLUMN last_error TEXT")
+            )
+        if "last_error_at" not in recording_columns:
+            logger.info("Adding missing recordings.last_error_at column")
+            await conn.execute(
+                text("ALTER TABLE recordings ADD COLUMN last_error_at DATETIME")
+            )
 
     @staticmethod
     def _recording_row_insert_query(recording_id: str, now: datetime) -> Any:
@@ -725,6 +744,29 @@ class SqliteStateStore(StateStore):
                 .where(recordings.c.org_id.is_(None))
                 .values(
                     org_id=org_id,
+                    last_updated=now,
+                )
+            )
+
+    async def set_recording_last_error(
+        self, recording_id: str, error_message: str
+    ) -> None:
+        """Persist a recording-wide error message and bump last_updated."""
+        now = _utc_now()
+        await self._ensure_recording_row(recording_id)
+        # Truncate to a sensible upper bound to keep the DB row small.
+        truncated = (
+            error_message
+            if len(error_message) <= 2048
+            else error_message[:2048] + "...[truncated]"
+        )
+        async with self._write_lock() as conn:
+            await conn.execute(
+                update(recordings)
+                .where(recordings.c.recording_id == recording_id)
+                .values(
+                    last_error=truncated,
+                    last_error_at=now,
                     last_updated=now,
                 )
             )

--- a/neuracore/data_daemon/state_management/tables.py
+++ b/neuracore/data_daemon/state_management/tables.py
@@ -44,6 +44,13 @@ recordings = Table(
         default=ProgressReportStatus.PENDING,
     ),
     Column("stopped_at", DateTime(timezone=False), nullable=True, default=None),
+    # Recording-level error surface. Populated when a recording-wide failure
+    # (e.g. progress-report HTTP failure, auth/SSL outage, org mismatch)
+    # blocks the recording from completing even though individual traces may
+    # not exist yet. Previously such recordings sat in progress_reported=
+    # 'pending' indefinitely with no surfaced reason.
+    Column("last_error", Text, nullable=True, default=None),
+    Column("last_error_at", DateTime(timezone=False), nullable=True, default=None),
     Column(
         "created_at",
         DateTime(timezone=False),


### PR DESCRIPTION
## Summary
- macOS-safe daemon lifecycle: replace Linux-only `/proc` reads with cross-platform fallbacks (zombie detection, log rotation, daemon log streaming).
- `stop_recording(wait=True)` now takes a `timeout` (default 5min) and raises `TimeoutError` / new `RecordingNotFoundError` instead of silently terminating or hanging.
- New `get_recording_processing_status` helper distinguishes "uploaded" vs "viewable" milestones.
- Docs: clarify that `urdf_path` / `mjcf_path` are required for dashboard playback even though `connect_robot` does not enforce it.

## Test plan
- [ ] Verify daemon start/stop on macOS (no `/proc` regressions on Linux)
- [ ] `stop_recording(wait=True)` raises `TimeoutError` when traces never register
- [ ] `stop_recording(wait=True)` raises `RecordingNotFoundError` on backend 404
- [ ] Daemon log file rotates and is reachable at `~/.neuracore/logs/daemon.log`