### PR TITLE
ci: use cpu torch tf in non ml tests

### DIFF
--- a/.github/workflows/pr-pre-commit-and-test.yaml
+++ b/.github/workflows/pr-pre-commit-and-test.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Python dependencies
         if: env.SHOULD_RUN == 'true'
         run: |
-          uv pip install ".[dev,import]"
+          uv pip install ".[dev,import]" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
           if [ "${SHOULD_RUN_COVERAGE}" = "true" ]; then
             uv pip install pytest-cov diff-cover
           fi

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
             "torch==2.7.1",
             "huggingface-hub==0.36.0",
             "tensorflow-datasets>=4.9.9",
-            "tensorflow>=2.20.0",
+            "tensorflow-cpu>=2.20.0",
             "pin-pink>=4",
             "mcap>=1.3.1,<2",
             "mcap-protobuf-support>=0.5.4,<0.6",


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - We don't use any GPU operations in the importer, so removing tensorflow gpu dependency.
 - Also added torch CPU index url to download CPU torch in importer as CI doesn't have a GPU.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)
