### PR TITLE
fix: resolve macOS file name too long errors in data daemon

### DIFF
--- a/neuracore/data_daemon/communications_management/shared_transport/shared_memory_budget.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/shared_memory_budget.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from neuracore.data_daemon.communications_management.shared_transport.models import (
     SharedSlotReservation,
 )
+from neuracore.data_daemon.lifecycle.runtime_recovery import _default_shm_path
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,11 @@ class SharedMemoryBudget:
 
     def __init__(
         self,
-        shm_path: str = "/dev/shm",
+        shm_path: str | None = None,
         budget_fraction: float = 0.75,
     ) -> None:
         """Initialize budget state for future shared-memory reservations."""
-        self._shm_path = shm_path
+        self._shm_path = shm_path or _default_shm_path()
         self._budget_fraction = budget_fraction
         self._lock = threading.Lock()
         self._reserved_bytes = 0

--- a/neuracore/data_daemon/communications_management/shared_transport/shared_slot_daemon_handler.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/shared_slot_daemon_handler.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-import time
 import uuid
 from multiprocessing.shared_memory import SharedMemory
 from typing import Protocol
 
 import zmq
 
+from neuracore.data_daemon.const import SHARED_SLOT_SHM_PREFIX
 from neuracore.data_daemon.models import (
     CommandType,
     MessageEnvelope,
@@ -89,7 +89,7 @@ class SharedSlotDaemonHandler:
         if channel.shared_slot.shm_name is not None:
             self._cleanup_previous_shared_slots(channel, request.control_endpoint)
 
-        shm_name = f"neuracore-slots-{uuid.uuid4().hex}-{int(time.time() * 1000)}"
+        shm_name = f"{SHARED_SLOT_SHM_PREFIX}{uuid.uuid4().hex[:16]}"
 
         reservation = None
         shm: SharedMemory | None = None

--- a/neuracore/data_daemon/const.py
+++ b/neuracore/data_daemon/const.py
@@ -20,6 +20,7 @@ CHUNK_HEADER_SIZE = struct.calcsize(CHUNK_HEADER_FORMAT)
 SHARED_MEMORY_RECORD_MAGIC = b"NCR1"
 SHARED_MEMORY_RECORD_HEADER_FORMAT = "!4sII"
 SHARED_MEMORY_RECORD_HEADER_SIZE = struct.calcsize(SHARED_MEMORY_RECORD_HEADER_FORMAT)
+SHARED_SLOT_SHM_PREFIX = "ncs-"
 
 # Shared transport sizing.
 # Keep these aligned with frontend/PFE expectations.

--- a/neuracore/data_daemon/lifecycle/runtime_recovery.py
+++ b/neuracore/data_daemon/lifecycle/runtime_recovery.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 import shutil
 import sqlite3
+import sys
 import time
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
+from neuracore.data_daemon.const import SHARED_SLOT_SHM_PREFIX
 from neuracore.data_daemon.lifecycle.daemon_os_control import (
     DaemonLifecycleError,
     remove_pid_file,
@@ -18,8 +20,13 @@ from neuracore.data_daemon.state_management.state_store import StateStore
 
 logger = logging.getLogger(__name__)
 
-_SHARED_MEMORY_DIR = Path("/dev/shm")
-_NEURACORE_SHARED_SLOT_PREFIX = "neuracore-slots-"
+
+def _default_shm_path() -> str:
+    """Pick the right disk path for shared-memory budget estimation."""
+    return "/dev/shm" if sys.platform.startswith("linux") else "/tmp"
+
+
+_SHARED_MEMORY_DIR = Path(_default_shm_path())
 
 
 class SharedMemoryCapacityError(RuntimeError):
@@ -99,7 +106,7 @@ def cleanup_stale_shared_slot_segments(
     cleaned = 0
 
     for shm_path in shm_dir.iterdir():
-        if not shm_path.name.startswith(_NEURACORE_SHARED_SLOT_PREFIX):
+        if not shm_path.name.startswith(SHARED_SLOT_SHM_PREFIX):
             continue
 
         try:

--- a/tests/unit/data_daemon/lifecycle/test_runtime_recovery.py
+++ b/tests/unit/data_daemon/lifecycle/test_runtime_recovery.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import pytest
 
-from neuracore.data_daemon.const import DEFAULT_SHARED_MEMORY_SIZE
+from neuracore.data_daemon.const import (
+    DEFAULT_SHARED_MEMORY_SIZE,
+    SHARED_SLOT_SHM_PREFIX,
+)
 from neuracore.data_daemon.lifecycle.daemon_os_control import (
     acquire_pid_file,
     pid_is_running,
@@ -95,8 +98,8 @@ def test_cleanup_stale_shared_memory_buffers_removes_stale_shared_slot_segments(
     shm_dir.mkdir()
 
     stale_names = (
-        "neuracore-slots-stale-1",
-        "neuracore-slots-stale-2",
+        f"{SHARED_SLOT_SHM_PREFIX}stale-1",
+        f"{SHARED_SLOT_SHM_PREFIX}stale-2",
     )
     for buffer_name in stale_names:
         (shm_dir / buffer_name).write_bytes(b"shm")

--- a/tests/unit/data_daemon/test_ipc_communications.py
+++ b/tests/unit/data_daemon/test_ipc_communications.py
@@ -1,7 +1,9 @@
 import logging
+import tempfile
 import time
 from collections.abc import Generator
 from enum import Enum
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -112,20 +114,21 @@ def test_daemon_singleton_socket_enforced(zmq_context: zmq.Context) -> None:
 
 
 def test_create_producer_socket_returns_continues_without_daemon(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    socket_path = tmp_path / "ndd" / "management.sock"
-    monkeypatch.setattr(const_module, "SOCKET_PATH", socket_path)
-    monkeypatch.setattr(comms_module, "SOCKET_PATH", socket_path)
+    with tempfile.TemporaryDirectory(prefix="nc-", dir="/tmp") as tmp_path:
+        socket_path = Path(tmp_path) / "ndd" / "management.sock"
+        monkeypatch.setattr(const_module, "SOCKET_PATH", socket_path)
+        monkeypatch.setattr(comms_module, "SOCKET_PATH", socket_path)
 
-    comm = CommunicationsManager()
-    assert not socket_path.exists()
-    comm.create_producer_socket()
-    assert isinstance(comm._producer_socket, zmq.Socket)
-    assert (
-        comm._producer_socket.getsockopt(zmq.IMMEDIATE) == 1
-    ), "Socket should be setup in IMMEDIATE mode"
-    comm.cleanup_producer()
+        comm = CommunicationsManager()
+        assert not socket_path.exists()
+        comm.create_producer_socket()
+        assert isinstance(comm._producer_socket, zmq.Socket)
+        assert (
+            comm._producer_socket.getsockopt(zmq.IMMEDIATE) == 1
+        ), "Socket should be setup in IMMEDIATE mode"
+        comm.cleanup_producer()
 
 
 def test_message_envelope_round_trip_bytes() -> None:

--- a/tests/unit/data_daemon/test_messaging.py
+++ b/tests/unit/data_daemon/test_messaging.py
@@ -4,6 +4,7 @@ import threading
 import time
 from datetime import datetime, timedelta, timezone
 from multiprocessing.shared_memory import SharedMemory
+from uuid import uuid4
 
 import pytest
 import zmq
@@ -41,6 +42,7 @@ from neuracore.data_daemon.const import (
     DEFAULT_VIDEO_SLOT_COUNT,
     HEARTBEAT_TIMEOUT_SECS,
     SHARED_MEMORY_RECORD_HEADER_FORMAT,
+    SHARED_SLOT_SHM_PREFIX,
 )
 from neuracore.data_daemon.models import (
     BatchedJointDataItemPayload,
@@ -756,7 +758,7 @@ def test_shared_slot_timeout_clock_starts_after_socket_send() -> None:
         ack_timeout_s=0.01,
         allocate_timeout_s=0.01,
     )
-    shm_name = f"test-credit-timeout-{time.time_ns()}"
+    shm_name = f"{SHARED_SLOT_SHM_PREFIX}{uuid4().hex[:16]}"
     shm = SharedMemory(name=shm_name, create=True, size=2048 * 2)
 
     try:
@@ -813,7 +815,7 @@ def test_shared_slot_ready_message_populates_free_slots() -> None:
         ack_timeout_s=DEFAULT_VIDEO_ACK_TIMEOUT_SECONDS,
         allocate_timeout_s=DEFAULT_VIDEO_SLOT_ALLOCATE_TIMEOUT_SECONDS,
     )
-    shm_name = f"test-ready-populates-free-slots-{time.time_ns()}"
+    shm_name = f"{SHARED_SLOT_SHM_PREFIX}{uuid4().hex[:16]}"
     shm = SharedMemory(name=shm_name, create=True, size=2048 * 3)
 
     try:
@@ -842,7 +844,7 @@ def test_shared_slot_ready_message_adopts_daemon_slot_dimensions() -> None:
         ack_timeout_s=DEFAULT_VIDEO_ACK_TIMEOUT_SECONDS,
         allocate_timeout_s=DEFAULT_VIDEO_SLOT_ALLOCATE_TIMEOUT_SECONDS,
     )
-    shm_name = f"test-ready-adopts-slot-dimensions-{time.time_ns()}"
+    shm_name = f"{SHARED_SLOT_SHM_PREFIX}{uuid4().hex[:16]}"
     shm = SharedMemory(name=shm_name, create=True, size=4096 * 4)
 
     try:


### PR DESCRIPTION
macOS enforces stricter limits than Linux: shared memory names max out at 31 chars and socket paths at 104 bytes. Both were exceeded by the daemon's naming scheme and the test socket paths.


### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- Renamed shm for what is safe for all platforms.
 - Fixed maing issues with tests for macOS (we will soon have unit tests running on diff envs)

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-962](https://neuracore.atlassian.net/browse/NCP-962)
