### PR TITLE
fix: configure siglip to speedup pi unit tests

### DIFF
--- a/neuracore/ml/algorithms/pi0/gemma_pytorch.py
+++ b/neuracore/ml/algorithms/pi0/gemma_pytorch.py
@@ -263,6 +263,10 @@ class PaliGemmaWithExpertModel(nn.Module):
         # Keep pretrained-compatible projection size for real models, but make
         # tiny variant align vision/text dims to avoid concat shape mismatch.
         if vlm_config.variant == "gemma_tiny":
+            paligemma_config.vision_config.hidden_size = vlm_config.width
+            paligemma_config.vision_config.num_hidden_layers = vlm_config.depth
+            paligemma_config.vision_config.intermediate_size = vlm_config.mlp_dim
+            paligemma_config.vision_config.num_attention_heads = vlm_config.num_heads
             paligemma_config.vision_config.projection_dim = vlm_config.width
         else:
             paligemma_config.vision_config.projection_dim = 2048

--- a/neuracore/ml/algorithms/pi05/gemma_pytorch.py
+++ b/neuracore/ml/algorithms/pi05/gemma_pytorch.py
@@ -263,6 +263,10 @@ class PaliGemmaWithExpertModel(nn.Module):
         # Keep pretrained-compatible projection size for real models, but make
         # tiny variant align vision/text dims to avoid concat shape mismatch.
         if vlm_config.variant == "gemma_tiny":
+            paligemma_config.vision_config.hidden_size = vlm_config.width
+            paligemma_config.vision_config.num_hidden_layers = vlm_config.depth
+            paligemma_config.vision_config.intermediate_size = vlm_config.mlp_dim
+            paligemma_config.vision_config.num_attention_heads = vlm_config.num_heads
             paligemma_config.vision_config.projection_dim = vlm_config.width
         else:
             paligemma_config.vision_config.projection_dim = 2048


### PR DESCRIPTION
### Bugfixes
 - Configure SigLIP vision tower (hidden layers, hidden size, intermediate size, attention heads) to match `gemma_tiny` dimensions when the tiny variant is used, dramatically reducing Pi0 and Pi05 unit test runtime by eliminating the 27-layer, 1152-hidden-dim SigLIP bottleneck

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)