### PR TITLE
fix: task cancellation race condition on macOs

### DIFF
--- a/neuracore/data_daemon/event_loop_manager.py
+++ b/neuracore/data_daemon/event_loop_manager.py
@@ -165,6 +165,7 @@ class EventLoopManager:
         finally:
             # Cancel remaining tasks
             try:
+                loop.run_until_complete(asyncio.sleep(0))
                 tasks = [
                     task
                     for task in asyncio.all_tasks(self.general_loop)


### PR DESCRIPTION
This unit test shutdown cancel task in event loop manager is failing on macOS. Have a look at the unit test runs on this pr: [622](https://github.com/NeuracoreAI/neuracore/pull/622)

When a task is scheduled and the loop is stopped immediately after on macOS the loop can stop before the task is fully created. So asyncio.all_tasks() finds nothing to cancel. This is less of an issue on Linux due to differences in how the OS schedules threads.

I have verified with this fix, the test sompletes successfully on macOS

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - flushed any pending callbacks first before cancelling them.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-976](https://neuracore.atlassian.net/browse/NCP-976)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - [622](https://github.com/NeuracoreAI/neuracore/pull/622)

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
