### PR TITLE
fix: ensure db cleanup

### DIFF
--- a/tests/integration/platform/data_daemon/shared/storage_assertions.py
+++ b/tests/integration/platform/data_daemon/shared/storage_assertions.py
@@ -7,6 +7,7 @@ neuracore helpers, stdlib, and test constants.
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 from neuracore.data_daemon.helpers import (
     get_daemon_db_path,
@@ -23,8 +24,8 @@ def assert_db_absent() -> None:
     db_path = get_daemon_db_path()
     for candidate in (
         db_path,
-        db_path.with_suffix(db_path.suffix + ".wal"),
-        db_path.with_suffix(db_path.suffix + ".shm"),
+        Path(str(db_path) + "-wal"),
+        Path(str(db_path) + "-shm"),
     ):
         assert (
             not candidate.exists()

--- a/tests/integration/platform/data_daemon/shared/test_infrastructure.py
+++ b/tests/integration/platform/data_daemon/shared/test_infrastructure.py
@@ -187,9 +187,9 @@ def apply_storage_state_action(storage_state_action: str) -> None:
             shutil.rmtree(recordings_root, ignore_errors=True)
 
     if storage_state_action in {STORAGE_STATE_EMPTY, STORAGE_STATE_DELETE}:
-        for suffix in (".shm", ".wal"):
+        for suffix in ("-shm", "-wal"):
             try:
-                db_path.with_suffix(db_path.suffix + suffix).unlink(missing_ok=True)
+                Path(str(db_path) + suffix).unlink(missing_ok=True)
             except OSError:
                 pass
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - The test was clearing the .wal and .shm files with the wrong prefix
