### PR TITLE
chore: improve logging across neuracore

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -388,3 +388,7 @@ urdfdom
 tinyxml
 assimp
 octomap
+absl
+ONEDNN
+qpsolvers
+renderable

--- a/neuracore/__init__.py
+++ b/neuracore/__init__.py
@@ -1,4 +1,9 @@
+# ruff: noqa: E402
 """Init."""
+
+import logging
+
+logging.getLogger("neuracore").addHandler(logging.NullHandler())
 
 from .api.core import *  # noqa: F403
 from .api.datasets import *  # noqa: F403

--- a/neuracore/core/cli/app.py
+++ b/neuracore/core/cli/app.py
@@ -1,4 +1,16 @@
+# ruff: noqa: E402
 """Neuracore CLI entry point."""
+
+import logging
+import os
+import warnings
+
+# Must run before any neuracore import — neuracore/__init__.py triggers datasets/TF
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+warnings.filterwarnings("ignore", category=UserWarning, module="qpsolvers")
+# TF skips adding its BASIC_FORMAT StreamHandler when root already has handlers
+logging.getLogger().addHandler(logging.NullHandler())
 
 import typer
 
@@ -8,6 +20,7 @@ from neuracore.core.cli.generate_api_key import run as login
 from neuracore.core.cli.launch_server import run as launch_server
 from neuracore.core.cli.select_current_org import run as select_org
 from neuracore.data_daemon.main import app as data_daemon_app
+from neuracore.utils import setup_logging
 
 app = typer.Typer(add_completion=True, help="Neuracore command line interface.")
 
@@ -44,9 +57,16 @@ def callback(
         is_eager=True,
         is_flag=True,
     ),
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
 ) -> None:
-    """Handle global CLI option for --version."""
-    return None
+    """Handle global CLI options."""
+    if log_level:
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(level=log_level, force=log_level is not None)
 
 
 app.command("login")(login)

--- a/neuracore/core/cli/cache_commands.py
+++ b/neuracore/core/cli/cache_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -10,6 +11,23 @@ import typer
 from neuracore.core.const import DEFAULT_CACHE_DIR, DEFAULT_RECORDING_CACHE_DIR
 
 cache_app = typer.Typer(help="Cache management utilities.")
+
+
+@cache_app.callback()
+def callback(
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
+) -> None:
+    """Configure cache command options."""
+    from neuracore.utils import setup_logging
+
+    if log_level:
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(level=log_level, force=log_level is not None)
+
 
 DEFAULT_DATASET_CACHE_DIR = DEFAULT_CACHE_DIR / "dataset_cache"
 

--- a/neuracore/core/cli/launch_server.py
+++ b/neuracore/core/cli/launch_server.py
@@ -15,8 +15,8 @@ from neuracore_types import DataType
 import neuracore as nc
 from neuracore.core.endpoint import policy_local_server
 from neuracore.ml.utils.endpoint_storage_handler import EndpointStorageHandler
+from neuracore.utils import setup_logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -41,6 +41,11 @@ def _try_report_error_to_cloud(
 
 
 def run(
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
     input_embodiment_description: str = typer.Option(
         ...,
         "--input_embodiment_description",
@@ -66,6 +71,11 @@ def run(
     port: int = typer.Option(8080, "--port", help="Port to bind the server"),
 ) -> None:
     """Launch a local policy server."""
+    if log_level:
+        import os
+
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(level=log_level, force=log_level is not None)
     try:
         input_order_raw = json.loads(input_embodiment_description)
         output_order_raw = json.loads(output_embodiment_description)
@@ -113,6 +123,7 @@ def run(
 
 def main() -> None:
     """CLI entrypoint for launching the local policy server."""
+    setup_logging()
     typer.run(run)
 
 

--- a/neuracore/core/cli/training_commands.py
+++ b/neuracore/core/cli/training_commands.py
@@ -31,6 +31,25 @@ from neuracore.ml.cli import training_runs_cloud as training_runs
 training_app = typer.Typer(help="Training utilities.")
 console = Console()
 
+
+@training_app.callback()
+def callback(
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
+) -> None:
+    """Configure training command options."""
+    import os
+
+    from neuracore.utils import setup_logging
+
+    if log_level:
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(level=log_level, force=log_level is not None)
+
+
 LOCAL_RUNS_ROOT = DEFAULT_CACHE_DIR / "runs"
 SUCCESS_MARKER = "Training completed successfully"
 

--- a/neuracore/core/utils/server.py
+++ b/neuracore/core/utils/server.py
@@ -28,11 +28,11 @@ from neuracore.core.const import (
     SET_CHECKPOINT_ENDPOINT,
 )
 from neuracore.core.exceptions import InsufficientSynchronizedPointError
-from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 from neuracore.ml.utils.preprocessing_utils import (
     PreprocessingConfiguration,
     resolve_preprocessing_config,
 )
+from neuracore.utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -49,23 +49,6 @@ class CheckpointRequest(BaseModel):
     """Request model for setting checkpoints."""
 
     epoch: int
-
-
-def setup_server_logging(log_level: str, log_file_path: str | None = None) -> None:
-    """Configure structured logging for the server process."""
-    handlers: list[logging.Handler] = [logging.StreamHandler()]
-    if log_file_path is not None:
-        path = Path(log_file_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        file_handler = logging.FileHandler(path)
-        handlers.append(file_handler)
-
-    formatter = JsonLineLogFormatter()
-    for handler in handlers:
-        handler.setFormatter(formatter)
-
-    level = getattr(logging, log_level.upper(), logging.INFO)
-    logging.basicConfig(level=level, handlers=handlers, force=True)
 
 
 def write_startup_status(
@@ -244,7 +227,12 @@ def start_server(
     Returns:
         ModelServer instance
     """
-    setup_server_logging(log_level=log_level, log_file_path=log_file_path)
+    setup_logging(
+        level=log_level,
+        json_format=True,
+        log_file=Path(log_file_path) if log_file_path is not None else None,
+        force=True,
+    )
     logger.info("Starting model server on %s:%s.", host, port)
     server = ModelServer(
         input_embodiment_description=input_embodiment_description,

--- a/neuracore/data_daemon/main.py
+++ b/neuracore/data_daemon/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import typer
 
 from neuracore.data_daemon.config_manager.args_handler import (
@@ -17,6 +19,23 @@ app = typer.Typer(
     add_completion=False,
     help="Neuracore Data Daemon CLI.",
 )
+
+
+@app.callback()
+def callback(
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
+) -> None:
+    """Configure data-daemon command options."""
+    from neuracore.utils import setup_logging
+
+    if log_level:
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(level=log_level, force=log_level is not None)
+
 
 app.command("launch")(run_launch)
 app.command("stop")(run_stop)

--- a/neuracore/data_daemon/runner_entry.py
+++ b/neuracore/data_daemon/runner_entry.py
@@ -103,8 +103,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
+    from neuracore.utils import setup_logging
+
+    setup_logging(level="DEBUG")
     main()

--- a/neuracore/importer/cli/app.py
+++ b/neuracore/importer/cli/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import typer
@@ -16,10 +17,31 @@ from neuracore.importer.core.exceptions import (
 )
 from neuracore.importer.core.utils import parse_storage_size
 from neuracore.importer.importer import _run_import
+from neuracore.utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     add_completion=False, help="Neuracore dataset import command line interface."
 )
+
+
+@app.callback()
+def callback(
+    log_level: str | None = typer.Option(
+        None,
+        "--log-level",
+        help="Set log level (e.g. DEBUG, INFO, WARNING, ERROR).",
+    ),
+) -> None:
+    """Configure importer command options."""
+    from neuracore.importer.core.base import get_shared_console
+
+    if log_level:
+        os.environ["NEURACORE_LOG_LEVEL"] = log_level
+    setup_logging(
+        console=get_shared_console(), level=log_level, force=log_level is not None
+    )
 
 
 @app.command("import")
@@ -58,8 +80,7 @@ def import_dataset(
         False,
         "--shared",
         help=(
-            "Create the output dataset as shared "
-            "(only available for administrators)."
+            "Create the output dataset as shared (only available for administrators)."
         ),
     ),
     dry_run: bool = typer.Option(
@@ -139,13 +160,13 @@ def import_dataset(
         DatasetOperationError,
         DatasetDetectionError,
     ) as exc:
-        logging.getLogger(__name__).error("%s", exc)
+        logger.error(f"{exc}")
         raise typer.Exit(code=1) from exc
     except ImporterError as exc:
-        logging.getLogger(__name__).error("%s", exc)
+        logger.error(f"{exc}")
         raise typer.Exit(code=1) from exc
     except Exception:
-        logging.getLogger(__name__).exception("Unexpected error during dataset import.")
+        logger.exception("Unexpected error during dataset import.")
         raise typer.Exit(code=1) from None
 
 

--- a/neuracore/importer/core/base.py
+++ b/neuracore/importer/core/base.py
@@ -14,6 +14,7 @@ import traceback
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from logging.handlers import QueueHandler
 from pathlib import Path
 from queue import Empty
 from typing import Any
@@ -29,16 +30,20 @@ from neuracore_types.importer.data_config import DataFormat
 from neuracore_types.nc_data import DatasetImportConfig, DataType, NCDataImportConfig
 from neuracore_types.nc_data.nc_data import MappingItem
 from rich.console import Console
+from rich.console import Group as RichGroup
+from rich.logging import RichHandler
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
     Progress,
     SpinnerColumn,
+    Task,
     TaskID,
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
+from rich.text import Text
 from scipy.spatial.transform import Rotation as R
 
 import neuracore as nc
@@ -63,6 +68,8 @@ from .exceptions import (
     ImporterError,
     ImportError,
 )
+
+logger = logging.getLogger(__name__)
 
 JOINT_TARGET_CHECK_TOLERANCE = 1e-6
 
@@ -185,9 +192,6 @@ class NeuracoreDatasetImporter(ABC):
         self.debug_target_ee_frame = (debug_target_ee_frame or "").strip() or None
         self.worker_errors: list[WorkerError] = []
         self._logged_error_keys: set[tuple[int | None, int | None, str]] = set()
-        self.logger = logging.getLogger(
-            f"{self.__class__.__module__}.{self.__class__.__name__}"
-        )
         self._progress_queue: mp.Queue[ProgressUpdate] | None = None
         self._worker_id: int = -1
         self._error_queue: mp.Queue[WorkerError] | None = None
@@ -566,10 +570,11 @@ class NeuracoreDatasetImporter(ABC):
                 self._validate_input_data(data_type, source_data, format)
         except DataValidationWarning as w:
             if not self.suppress_warnings:
-                self.logger.warning("[WARNING] %s (%s): %s", data_type, item.name, w)
+                logger.warning(f"[WARNING] {data_type} ({item.name}): {w}")
         except DataValidationError as e:
-            self.logger.error(
-                "[ERROR] %s (%s): %s -- skipping episode", data_type, item.name, e
+            logger.error(
+                f"[ERROR] {data_type} ({item.name}): {e} -- skipping episode",
+                exc_info=True,
             )
             raise
 
@@ -667,15 +672,17 @@ class NeuracoreDatasetImporter(ABC):
                     self._validate_joint_data(data_type, transformed_data, item.name)
         except DataValidationWarning as w:
             if not self.suppress_warnings:
-                self.logger.warning("[WARNING] %s (%s): %s", data_type, item.name, w)
+                logger.warning(f"[WARNING] {data_type} ({item.name}): {w}")
         except DataValidationError as e:
-            self.logger.error(
-                "[ERROR] %s (%s): %s -- skipping episode", data_type, item.name, e
+            logger.error(
+                f"[ERROR] {data_type} ({item.name}): {e} -- skipping episode",
+                exc_info=True,
             )
             raise
         except Exception as e:
-            self.logger.error(
-                "[ERROR] %s (%s): %s -- skipping episode", data_type, item.name, e
+            logger.error(
+                f"[ERROR] {data_type} ({item.name}): {e} -- skipping episode",
+                exc_info=True,
             )
             raise
 
@@ -731,8 +738,9 @@ class NeuracoreDatasetImporter(ABC):
                     intrinsics=intrinsics,
                 )
         except Exception as e:
-            self.logger.error(
-                "[ERROR] %s (%s): %s -- skipping episode", data_type, item.name, e
+            logger.error(
+                f"[ERROR] {data_type} ({item.name}): {e} -- skipping episode",
+                exc_info=True,
             )
             raise
 
@@ -920,7 +928,7 @@ class NeuracoreDatasetImporter(ABC):
         """
         items = list(self.build_work_items())
         if not items:
-            self.logger.info("No import items found; nothing to do.")
+            logger.info("No import items found; nothing to do.")
             return
 
         original_count = len(items)
@@ -931,25 +939,22 @@ class NeuracoreDatasetImporter(ABC):
             ]
             skipped_count = original_count - len(items)
             if skipped_count > 0:
-                self.logger.info(
-                    "Skipping %s previously completed episode(s) from %s.",
-                    skipped_count,
-                    self.completed_items_file,
+                logger.info(
+                    f"Skipping {skipped_count} previously completed episode(s) "
+                    f"from {self.completed_items_file}."
                 )
             if not items:
-                self.logger.info(
-                    "All episodes are already completed according to %s.",
-                    self.completed_items_file,
+                logger.info(
+                    f"All episodes are already completed according to "
+                    f"{self.completed_items_file}."
                 )
                 return
 
         if self.random_sample is not None:
             n = min(self.random_sample, len(items))
             items = random.sample(items, n)
-            self.logger.info(
-                "Sampling %s random episode(s) from %s episodes.",
-                n,
-                original_count,
+            logger.info(
+                f"Sampling {n} random episode(s) from {original_count} episodes."
             )
 
         # Pre-check: dry run to check for errors
@@ -959,13 +964,15 @@ class NeuracoreDatasetImporter(ABC):
         self.pre_check = True
         skip_joint_target_positions = False
         try:
-            self.logger.info(
-                "Pre-check: importing %s episode(s) with 1 worker.",
-                len(precheck_items),
+            logger.info(
+                f"Pre-check: importing {len(precheck_items)} episode(s) with 1 worker."
             )
             precheck_errors, precheck_processes, precheck_result_queue = (
                 self._run_import_workers(
-                    precheck_items, 1, use_precheck_result_queue=True
+                    precheck_items,
+                    1,
+                    use_precheck_result_queue=True,
+                    show_progress=False,
                 )
             )
             self._report_process_status(precheck_processes)
@@ -991,23 +998,14 @@ class NeuracoreDatasetImporter(ABC):
                     for c in self.ordered_import_configs
                     if c[0] != DataType.JOINT_TARGET_POSITIONS
                 ]
-                self.logger.warning(
+                logger.warning(
                     "Joint target positions provided are equivalent to joint positions "
                     "in next step. Skip importing joint target positions."
                 )
 
         worker_count = self._resolve_worker_count(len(items))
-        live_status = "Live" if not self.dry_run else "Dry-run"
-        self.logger.info(
-            "%s: importing %s episodes with %s workers",
-            live_status,
-            len(items),
-            worker_count,
-        )
-
-        self.worker_errors, processes, _ = self._run_import_workers(items, worker_count)
+        _, processes, _ = self._run_import_workers(items, worker_count)
         self._report_process_status(processes)
-        self._report_errors(self.worker_errors)
 
         if self.worker_errors and self.skip_on_error == "all":
             raise ImporterError("Import aborted due to worker errors.")
@@ -1017,6 +1015,7 @@ class NeuracoreDatasetImporter(ABC):
         items: Sequence[ImportItem],
         worker_count: int,
         use_precheck_result_queue: bool = False,
+        show_progress: bool = True,
     ) -> tuple[
         list[WorkerError],
         list[mp.context.SpawnProcess],
@@ -1025,8 +1024,9 @@ class NeuracoreDatasetImporter(ABC):
         """Run import with the given items and worker count."""
         ctx = mp.get_context("spawn")
         error_queue: mp.Queue[WorkerError] = ctx.Queue()
-        progress_queue: mp.Queue[ProgressUpdate] = ctx.Queue()
+        progress_queue: mp.Queue[ProgressUpdate] = ctx.Queue(maxsize=2048)
         completed_queue: mp.Queue[str] = ctx.Queue()
+        log_queue: mp.Queue[logging.LogRecord] = ctx.Queue(-1)
         pause_event = ctx.Event()  # when set, workers pause at next item boundary
         precheck_result_queue: mp.Queue[bool] | None = (
             ctx.Queue() if use_precheck_result_queue else None
@@ -1048,13 +1048,21 @@ class NeuracoreDatasetImporter(ABC):
                     ready_barrier,
                     pause_event,
                     precheck_result_queue,
+                    log_queue,
                 ),
             )
             process.start()
             processes.append(process)
 
         self._monitor_progress(
-            processes, progress_queue, len(items), pause_event, completed_queue
+            processes,
+            progress_queue,
+            len(items),
+            pause_event,
+            completed_queue,
+            log_queue,
+            error_queue,
+            show_progress=show_progress,
         )
 
         for process in processes:
@@ -1063,6 +1071,8 @@ class NeuracoreDatasetImporter(ABC):
         progress_queue.join_thread()
         completed_queue.close()
         completed_queue.join_thread()
+        log_queue.close()
+        log_queue.join_thread()
 
         return (
             self._collect_errors(error_queue),
@@ -1109,6 +1119,7 @@ class NeuracoreDatasetImporter(ABC):
         ready_barrier: mp.synchronize.Barrier | None = None,
         pause_event: mp.synchronize.Event | None = None,
         precheck_result_queue: mp.Queue[bool] | None = None,
+        log_queue: mp.Queue | None = None,
     ) -> None:
         """Worker body that wraps import with error capture.
 
@@ -1122,6 +1133,11 @@ class NeuracoreDatasetImporter(ABC):
         """
         self._worker_id = worker_id
         self._progress_queue = progress_queue
+
+        if log_queue is not None:
+            from neuracore.utils import setup_logging
+
+            setup_logging(handler=QueueHandler(log_queue), force=True)
 
         try:
             sig = inspect.signature(self.prepare_worker)
@@ -1173,7 +1189,6 @@ class NeuracoreDatasetImporter(ABC):
                             traceback=tb,
                         )
                     )
-                self._log_worker_error(worker_id, item.index, str(exc))
                 raise
 
         if self.pre_check and precheck_result_queue is not None:
@@ -1257,10 +1272,9 @@ class NeuracoreDatasetImporter(ABC):
             with self.completed_items_file.open("r", encoding="utf-8") as file:
                 return {line.strip() for line in file if line.strip()}
         except Exception as exc:  # noqa: BLE001 - best effort
-            self.logger.warning(
-                "Failed to read completed imports file '%s': %s",
-                self.completed_items_file,
-                exc,
+            logger.warning(
+                f"Failed to read completed imports file "
+                f"'{self.completed_items_file}': {exc}"
             )
             return set()
 
@@ -1285,16 +1299,14 @@ class NeuracoreDatasetImporter(ABC):
         """Log any non-zero exit codes from worker processes."""
         for process in processes:
             if process.exitcode not in (0, None):
-                self.logger.error(
-                    "Worker pid=%s exited with status %s",
-                    process.pid,
-                    process.exitcode,
+                logger.error(
+                    f"Worker pid={process.pid} exited with status {process.exitcode}"
                 )
 
     def _report_errors(self, errors: list[WorkerError]) -> None:
         """Summarize captured worker errors."""
         if not errors:
-            self.logger.info("All workers completed without reported errors.")
+            logger.info("All workers completed without reported errors.")
             return
 
         deduped: dict[tuple[int | None, int | None, str], int] = {}
@@ -1302,10 +1314,9 @@ class NeuracoreDatasetImporter(ABC):
             key = (err.worker_id, err.item_index, err.message)
             deduped[key] = deduped.get(key, 0) + 1
 
-        self.logger.error(
-            "Completed with %s worker error event(s) (%s unique).",
-            len(errors),
-            len(deduped),
+        logger.error(
+            f"Completed with {len(errors)} worker error event(s) "
+            f"({len(deduped)} unique)."
         )
 
         for (worker_id, item_index, message), count in deduped.items():
@@ -1314,12 +1325,9 @@ class NeuracoreDatasetImporter(ABC):
                 prefix += f" item {item_index}"
             prefix += "]"
             suffix = f" (x{count})" if count > 1 else ""
-            self.logger.error("%s %s%s", prefix, message, suffix)
+            logger.error(f"{prefix} {message}{suffix}")
 
-        self.logger.error(
-            "Import finished with errors. Re-run with DEBUG logging for tracebacks "
-            "or fix the reported issues above."
-        )
+        logger.error("Import finished with errors. Fix the reported issues above.")
 
     def _log_worker_error(
         self, worker_id: int, item_index: int | None, message: str
@@ -1334,7 +1342,7 @@ class NeuracoreDatasetImporter(ABC):
         if item_index is not None:
             prefix += f" item {item_index}"
         prefix += "]"
-        self.logger.error("%s %s", prefix, message)
+        logger.error(f"{prefix} {message}")
 
     def _emit_progress(
         self,
@@ -1357,7 +1365,7 @@ class NeuracoreDatasetImporter(ABC):
                 )
             )
         except Exception:  # noqa: BLE001 - best-effort progress updates
-            self.logger.debug("Failed to emit progress update.", exc_info=True)
+            logger.debug("Failed to emit progress update.", exc_info=True)
 
     @staticmethod
     def _format_bytes(num_bytes: int | float) -> str:
@@ -1392,6 +1400,68 @@ class NeuracoreDatasetImporter(ABC):
                     pass  # Skip files that disappear or can't be accessed
         return total_size
 
+    def _monitor_no_progress(
+        self,
+        processes: Sequence[mp.context.SpawnProcess],
+        progress_queue: mp.Queue[ProgressUpdate],
+        completed_queue: mp.Queue[str] | None,
+        log_queue: mp.Queue | None,
+        error_queue: mp.Queue | None,
+    ) -> None:
+        """Wait for workers without showing a progress bar (used for pre-check)."""
+        nc_handlers = [
+            h
+            for h in logging.getLogger("neuracore").handlers
+            if not isinstance(h, logging.NullHandler)
+        ]
+        log_handlers = nc_handlers or logging.root.handlers
+        rich_handler = next(
+            (h for h in log_handlers if isinstance(h, RichHandler)), None
+        )
+        non_rich_handlers = [h for h in log_handlers if not isinstance(h, RichHandler)]
+
+        def drain_log_queue() -> None:
+            if log_queue is None:
+                return
+            records: list[logging.LogRecord] = []
+            try:
+                while True:
+                    records.append(log_queue.get_nowait())
+            except Empty:
+                pass
+            if rich_handler is not None:
+                formatted = [
+                    rich_handler.render(
+                        record=r,
+                        traceback=None,
+                        message_renderable=rich_handler.render_message(
+                            r, rich_handler.format(r)
+                        ),
+                    )
+                    for r in records
+                    if r.levelno >= rich_handler.level
+                ]
+                if formatted:
+                    get_shared_console().print(RichGroup(*formatted))
+            for record in records:
+                for handler in non_rich_handlers:
+                    if record.levelno >= handler.level:
+                        handler.emit(record)
+
+        while True:
+            try:
+                progress_queue.get_nowait()
+            except Empty:
+                pass
+            drain_log_queue()
+            any_alive = any(proc.is_alive() for proc in processes)
+            if not any_alive:
+                drain_log_queue()
+                if error_queue is not None:
+                    self.worker_errors = self._collect_errors(error_queue)
+                break
+            time.sleep(0.1)
+
     def _monitor_progress(
         self,
         processes: Sequence[mp.context.SpawnProcess],
@@ -1399,6 +1469,9 @@ class NeuracoreDatasetImporter(ABC):
         total_items: int,
         pause_event: mp.synchronize.Event | None = None,
         completed_queue: mp.Queue[str] | None = None,
+        log_queue: mp.Queue | None = None,
+        error_queue: mp.Queue | None = None,
+        show_progress: bool = True,
     ) -> None:
         """Render a progress bar by aggregating all worker updates.
 
@@ -1408,11 +1481,39 @@ class NeuracoreDatasetImporter(ABC):
         """
         if not processes:
             return
+        if not show_progress:
+            self._monitor_no_progress(
+                processes, progress_queue, completed_queue, log_queue, error_queue
+            )
+            return
 
         completed_items: set[int] = set()
         worker_states: dict[int, ProgressUpdate] = {}
+        worker_tasks: dict[int, TaskID] = {}
+        worker_labels: dict[int, str] = {}
         last_disk_check = 0.0
         workers_paused = False
+
+        class OverallOnlyTimeElapsed(TimeElapsedColumn):
+            def render(self_, task: Task) -> Text:  # noqa: N805
+                return (
+                    Text("") if task.fields.get("is_worker") else super().render(task)
+                )
+
+        progress = Progress(
+            SpinnerColumn(style="cyan"),
+            TextColumn("{task.description}"),
+            BarColumn(bar_width=None, complete_style="green", pulse_style="cyan"),
+            MofNCompleteColumn(),
+            OverallOnlyTimeElapsed(),
+            TimeRemainingColumn(),
+            console=get_shared_console(),
+            auto_refresh=False,
+            transient=True,
+        )
+        overall_task = progress.add_task(
+            "[bold blue]Importing episodes", total=total_items
+        )
 
         def flush_completed_queue() -> None:
             if completed_queue is None:
@@ -1426,19 +1527,51 @@ class NeuracoreDatasetImporter(ABC):
             if batch:
                 self._append_completed_item_keys(batch)
 
-        with Progress(
-            SpinnerColumn(style="cyan"),
-            TextColumn("[bold blue]{task.description}"),
-            BarColumn(bar_width=None, complete_style="green", pulse_style="cyan"),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            TimeRemainingColumn(),
-            refresh_per_second=10,
-            transient=False,
-            console=get_shared_console(),
-        ) as progress:
-            overall_task = progress.add_task("Importing episodes", total=total_items)
+        nc_handlers = [
+            h
+            for h in logging.getLogger("neuracore").handlers
+            if not isinstance(h, logging.NullHandler)
+        ]
+        log_handlers = nc_handlers or logging.root.handlers
+        rich_handler = next(
+            (h for h in log_handlers if isinstance(h, RichHandler)), None
+        )
+        non_rich_handlers = [h for h in log_handlers if not isinstance(h, RichHandler)]
 
+        def drain_log_queue() -> None:
+            if log_queue is None:
+                return
+            records: list[logging.LogRecord] = []
+            try:
+                while True:
+                    records.append(log_queue.get_nowait())
+            except Empty:
+                pass
+            if rich_handler is not None:
+                formatted = [
+                    rich_handler.render(
+                        record=r,
+                        traceback=None,
+                        message_renderable=rich_handler.render_message(
+                            r, rich_handler.format(r)
+                        ),
+                    )
+                    for r in records
+                    if r.levelno >= rich_handler.level
+                ]
+                if formatted:
+                    progress.console.print(RichGroup(*formatted))
+            for record in records:
+                for handler in non_rich_handlers:
+                    if record.levelno >= handler.level:
+                        handler.emit(record)
+
+        with progress:
+            live_status = "Dry-run" if self.dry_run else "Live"
+            logger.info(
+                f"{live_status}: importing {total_items} episodes "
+                f"with {len(processes)} workers"
+            )
             while True:
                 flush_completed_queue()
 
@@ -1455,7 +1588,7 @@ class NeuracoreDatasetImporter(ABC):
                             if pause_event is not None and not workers_paused:
                                 workers_paused = True
                                 pause_event.set()
-                                self.logger.warning(
+                                logger.warning(
                                     "Local cache limit exceeded "
                                     f"({used_str} of {limit_str}). "
                                     "Pausing workers until usage drops below limit."
@@ -1463,19 +1596,22 @@ class NeuracoreDatasetImporter(ABC):
                             progress.update(
                                 overall_task,
                                 description=(
-                                    f"Paused ({pct_used:.0f}% of local cache used: "
+                                    f"[bold blue]Paused "
+                                    f"({pct_used:.0f}% of local cache used: "
                                     f"{used_str} / {limit_str}). "
                                     "Waiting for recordings to upload to cloud "
                                     "and free up local cache."
                                 ),
                             )
+                            drain_log_queue()
+                            progress.refresh()
                             time.sleep(self.DISK_CHECK_INTERVAL_SECS)
                             continue
                         else:
                             if workers_paused and pause_event is not None:
                                 workers_paused = False
                                 pause_event.clear()
-                                self.logger.info(
+                                logger.info(
                                     "Local cache usage below limit "
                                     f"({used_str} of {limit_str}). "
                                     "Resuming import."
@@ -1483,7 +1619,7 @@ class NeuracoreDatasetImporter(ABC):
                             progress.update(
                                 overall_task,
                                 description=(
-                                    f"Importing episodes "
+                                    f"[bold blue]Importing episodes "
                                     f"({pct_used:.0f}% of local cache used: "
                                     f"{used_str} / {limit_str})."
                                 ),
@@ -1492,9 +1628,8 @@ class NeuracoreDatasetImporter(ABC):
                         pass
 
                 any_alive = any(proc.is_alive() for proc in processes)
-                timeout = 0.1 if any_alive else 0
                 try:
-                    update = progress_queue.get(timeout=timeout)
+                    update = progress_queue.get(timeout=0.1 if any_alive else 0)
                 except Empty:
                     update = None
 
@@ -1504,25 +1639,35 @@ class NeuracoreDatasetImporter(ABC):
                         overall_task,
                         completed_items,
                         worker_states,
+                        worker_tasks,
+                        worker_labels,
                         update,
                     )
 
+                drain_log_queue()
+                progress.refresh()
+
                 if not any_alive:
-                    while True:
-                        try:
-                            update = progress_queue.get_nowait()
-                        except Empty:
-                            break
-                        self._apply_progress_update(
-                            progress,
-                            overall_task,
-                            completed_items,
-                            worker_states,
-                            update,
-                        )
+                    try:
+                        while True:
+                            self._apply_progress_update(
+                                progress,
+                                overall_task,
+                                completed_items,
+                                worker_states,
+                                worker_tasks,
+                                worker_labels,
+                                progress_queue.get_nowait(),
+                            )
+                    except Empty:
+                        pass
+                    drain_log_queue()
                     flush_completed_queue()
                     progress.update(overall_task, completed=total_items)
-                    return
+                    if error_queue is not None:
+                        self.worker_errors = self._collect_errors(error_queue)
+                        self._report_errors(self.worker_errors)
+                    break
 
     def _apply_progress_update(
         self,
@@ -1530,19 +1675,40 @@ class NeuracoreDatasetImporter(ABC):
         overall_task: TaskID,
         completed_items: set[int],
         worker_states: dict[int, ProgressUpdate],
+        worker_tasks: dict[int, TaskID],
+        worker_labels: dict[int, str],
         update: ProgressUpdate,
     ) -> None:
-        """Process a single progress update and refresh the unified bar."""
+        """Process a single progress update and refresh the progress bars."""
         prev = worker_states.get(update.worker_id)
         if prev is not None and prev.item_index != update.item_index:
             completed_items.add(prev.item_index)
-
         if update.total_steps is not None and update.step >= update.total_steps:
             completed_items.add(update.item_index)
-
         worker_states[update.worker_id] = update
-
-        progress.update(
-            overall_task,
-            completed=len(completed_items),
-        )
+        progress.update(overall_task, completed=len(completed_items))
+        if update.total_steps is None:
+            return
+        label = update.episode_label or f"episode {update.item_index}"
+        description = f"  [dim]↳[/dim] [blue]worker {update.worker_id}  {label}"
+        worker_id = update.worker_id
+        if worker_id not in worker_tasks:
+            worker_tasks[worker_id] = progress.add_task(
+                description, total=update.total_steps, is_worker=True
+            )
+            worker_labels[worker_id] = description
+        elif worker_labels[worker_id] != description:
+            worker_labels[worker_id] = description
+            progress.reset(
+                worker_tasks[worker_id],
+                start=True,
+                total=update.total_steps,
+                completed=update.step,
+                description=description,
+            )
+        else:
+            progress.update(
+                worker_tasks[worker_id],
+                completed=update.step,
+                total=update.total_steps,
+            )

--- a/neuracore/importer/importer.py
+++ b/neuracore/importer/importer.py
@@ -15,7 +15,6 @@ from neuracore_types.importer.config import (
     JointPositionInputTypeConfig,
 )
 from neuracore_types.nc_data import DatasetImportConfig
-from rich.logging import RichHandler
 
 import neuracore as nc
 from neuracore.core.data.dataset import Dataset
@@ -46,15 +45,6 @@ from neuracore.importer.rlds_tfds_importer import (
 logger = logging.getLogger(__name__)
 DATASET_DELETE_TIMEOUT_S = 300.0
 DATASET_DELETE_POLL_INTERVAL_S = 30.0
-
-# Setup rich handler for colorful logging output in the importer module
-importer_logger = logging.getLogger("neuracore.importer")
-if not any(isinstance(handler, RichHandler) for handler in importer_logger.handlers):
-    rich_handler = RichHandler(rich_tracebacks=True, markup=False)
-    rich_handler.setFormatter(logging.Formatter("%(message)s"))
-    importer_logger.addHandler(rich_handler)
-importer_logger.setLevel(logging.INFO)
-importer_logger.propagate = True
 
 
 def load_dataset_config(path: Path) -> DatasetImportConfig:

--- a/neuracore/importer/lerobot_importer.py
+++ b/neuracore/importer/lerobot_importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 import traceback
 from collections.abc import Iterable, Iterator, Sequence
@@ -30,6 +31,8 @@ from neuracore.importer.core.base import (
     WorkerError,
 )
 from neuracore.importer.core.exceptions import ImportError
+
+logger = logging.getLogger(__name__)
 
 
 class LeRobotDatasetImporter(NeuracoreDatasetImporter):
@@ -144,12 +147,9 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
         worker_label = (
             f"worker {self._worker_id}" if self._worker_id is not None else "worker 0"
         )
-        self.logger.info(
-            "[%s] Importing episode %s (%s/%s)",
-            worker_label,
-            episode_id,
-            item.index + 1,
-            self.num_episodes,
+        logger.info(
+            f"[{worker_label}] Importing episode {episode_id} "
+            f"({item.index + 1}/{self.num_episodes})"
         )
         if not self.dry_run:
             nc.start_recording(robot_name=self.robot_name, instance=self._worker_id)
@@ -188,19 +188,15 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
             nc.stop_recording(
                 robot_name=self.robot_name, instance=self._worker_id, wait=True
             )
-        self.logger.info("[%s] Completed episode %s", worker_label, episode_id)
+        logger.info(f"[{worker_label}] Completed episode {episode_id}")
 
     def _load_metadata(self) -> LeRobotDatasetMetadata:
         """Fetch metadata without pulling down the entire dataset."""
         ds_meta = LeRobotDatasetMetadata(self.dataset_name, root=self.dataset_root)
-        self.logger.info(
-            "Dataset metadata loaded: name=%s root=%s episodes=%s "
-            "camera_keys=%s fps=%s",
-            self.dataset_name,
-            self.dataset_root,
-            ds_meta.total_episodes,
-            ds_meta.camera_keys,
-            ds_meta.fps,
+        logger.info(
+            f"Dataset metadata loaded: name={self.dataset_name} "
+            f"root={self.dataset_root} episodes={ds_meta.total_episodes} "
+            f"camera_keys={ds_meta.camera_keys} fps={ds_meta.fps}"
         )
         return ds_meta
 
@@ -208,10 +204,9 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
         """Pick the frequency from config or dataset metadata."""
         if self.data_config.frequency is not None:
             if meta_frequency and meta_frequency != self.data_config.frequency:
-                self.logger.warning(
-                    "Dataset FPS %s does not match configured FPS %s",
-                    meta_frequency,
-                    self.data_config.frequency,
+                logger.warning(
+                    f"Dataset FPS {meta_frequency} does not match "
+                    f"configured FPS {self.data_config.frequency}"
                 )
             return self.data_config.frequency
         if meta_frequency is None:
@@ -222,8 +217,8 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
 
     def _load_dataset(self) -> LeRobotDataset:
         """Load the actual dataset."""
-        self.logger.info(
-            "Loading LeRobot dataset '%s' from %s", self.dataset_name, self.dataset_root
+        logger.info(
+            f"Loading LeRobot dataset '{self.dataset_name}' from {self.dataset_root}"
         )
         try:
             return LeRobotDataset(self.dataset_name, root=self.dataset_root)

--- a/neuracore/importer/mcap/mcap_importer.py
+++ b/neuracore/importer/mcap/mcap_importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,8 @@ from neuracore.importer.mcap.utils import (
     validate_channel_decoder_support,
     validate_requested_topics,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class MCAPDatasetImporter(NeuracoreDatasetImporter):
@@ -73,7 +76,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
             debug_target_ee_frame=debug_target_ee_frame,
         )
         if max_workers is not None and max_workers > 1:
-            self.logger.warning(
+            logger.warning(
                 f"MCAP import is configured with {max_workers} workers. Each MCAP "
                 "file is streamed as one episode, so memory use remains bounded per "
                 "worker.",
@@ -86,7 +89,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
         self._decoder_factories: list[DecoderFactory] | None = None
         self._init_runtime_components()
 
-        self.logger.info(
+        logger.info(
             f"Initialized MCAP importer for '{self.dataset_name}' "
             f"(files={len(self.mcap_files)}, "
             f"topics={len(get_mcap_topics(topic_map=self.topic_map))}, "
@@ -129,7 +132,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
 
         label = item.description or file_path.name
         instance = max(0, self._worker_id)
-        self.logger.info(
+        logger.info(
             f"Importing MCAP file {label} ({item.index + 1}/{len(self.mcap_files)})"
         )
 
@@ -147,7 +150,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
                     robot_name=self.robot_name, instance=instance, wait=True
                 )
 
-        self.logger.info(f"Completed MCAP file {label} | messages={message_count}")
+        logger.info(f"Completed MCAP file {label} | messages={message_count}")
 
     def _record_step(self, step: dict, timestamp: float) -> None:
         """Log decoded data from each MCAP source topic in this step."""
@@ -156,7 +159,6 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
                 topic=topic,
                 decoded_data=decoded_data,
                 topic_map=self.topic_map,
-                logger=self.logger,
                 timestamp=timestamp,
             ):
                 self._log_data(
@@ -179,15 +181,14 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
         with episode_file_path.open("rb") as stream:
             reader = make_reader(stream=stream, decoder_factories=factories)
             header = read_mcap_header(reader=reader)
-            log_mcap_header(header=header, logger=self.logger)
+            log_mcap_header(header=header)
             summary = read_mcap_summary(reader=reader)
-            log_mcap_summary_details(summary=summary, logger=self.logger)
+            log_mcap_summary_details(summary=summary)
             validate_requested_topics(summary=summary, topics=topics)
             validate_channel_decoder_support(
                 summary=summary,
                 topics=topics,
                 decoder_factories=factories,
-                logger=self.logger,
             )
             total = estimate_total_messages(summary=summary, topics=topics)
 
@@ -234,7 +235,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
     ) -> None:
         """Clip depth arrays before delegating to the base logging path."""
         if data_type == DataType.DEPTH_IMAGES:
-            transformed_data = clip_depth(data=transformed_data, logger=self.logger)
+            transformed_data = clip_depth(data=transformed_data)
         super()._log_transformed_data(
             data_type=data_type,
             transformed_data=transformed_data,
@@ -245,7 +246,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
         )
 
     def _init_runtime_components(self) -> None:
-        self._decoder_factories = list_decoder_factories(logger=self.logger)
+        self._decoder_factories = list_decoder_factories()
 
     def _ensure_runtime_components(self) -> None:
         if self._decoder_factories is None:

--- a/neuracore/importer/mcap/utils.py
+++ b/neuracore/importer/mcap/utils.py
@@ -33,6 +33,8 @@ from neuracore_types.nc_data.nc_data import MappingItem
 from neuracore.core.utils.depth_utils import MAX_DEPTH
 from neuracore.importer.core.exceptions import ImportError
 
+logger = logging.getLogger(__name__)
+
 
 def split_topic_path(source: str) -> tuple[str, list[str]]:
     """Split a source path into topic and nested field components."""
@@ -220,7 +222,7 @@ def read_mcap_summary(reader: McapReader) -> Any | None:
         return None
 
 
-def log_mcap_header(header: Any | None, logger: logging.Logger) -> None:
+def log_mcap_header(header: Any | None) -> None:
     """Log basic MCAP header details for diagnostics."""
     if header is None:
         return
@@ -231,7 +233,7 @@ def log_mcap_header(header: Any | None, logger: logging.Logger) -> None:
     )
 
 
-def log_mcap_summary_details(summary: Any | None, logger: logging.Logger) -> None:
+def log_mcap_summary_details(summary: Any | None) -> None:
     """Log non-message record counts that this importer does not process."""
     if summary is None:
         return
@@ -479,9 +481,7 @@ def _load_decoder_factory_class(module_name: str) -> type[DecoderFactory] | None
     return decoder_factory_cls
 
 
-def _discover_decoder_factory_classes(
-    logger: logging.Logger | None = None,
-) -> list[type[DecoderFactory]]:
+def _discover_decoder_factory_classes() -> list[type[DecoderFactory]]:
     global _DISCOVERED_DECODER_FACTORY_CLASSES
 
     if _DISCOVERED_DECODER_FACTORY_CLASSES is not None:
@@ -495,28 +495,22 @@ def _discover_decoder_factory_classes(
         classes.append(factory_cls)
 
     _DISCOVERED_DECODER_FACTORY_CLASSES = classes
-
-    if logger is not None:
-        logger.info(f"Discovered {len(classes)} MCAP decoder plugin class(es).")
-
+    logger.info(f"Discovered {len(classes)} MCAP decoder plugin class(es).")
     return list(_DISCOVERED_DECODER_FACTORY_CLASSES)
 
 
-def discover_decoder_factories(
-    logger: logging.Logger | None = None,
-) -> list[DecoderFactory]:
+def discover_decoder_factories() -> list[DecoderFactory]:
     """Discover and instantiate optional MCAP decoder factories."""
     factories: list[DecoderFactory] = []
-    for factory_cls in _discover_decoder_factory_classes(logger=logger):
+    for factory_cls in _discover_decoder_factory_classes():
         try:
             factories.append(factory_cls())
         except Exception as exc:  # noqa: BLE001
-            if logger is not None:
-                logger.debug(
-                    "Failed to instantiate discovered MCAP decoder factory "
-                    f"'{factory_cls}': {exc}",
-                    exc_info=True,
-                )
+            logger.debug(
+                "Failed to instantiate discovered MCAP decoder factory "
+                f"'{factory_cls}': {exc}",
+                exc_info=True,
+            )
     return factories
 
 
@@ -524,7 +518,6 @@ def list_decoder_factories(
     *,
     enable_discovery: bool = False,
     include_raw_fallback: bool = True,
-    logger: logging.Logger | None = None,
 ) -> list[DecoderFactory]:
     """Build decoder factories used by ``make_reader(..., decoder_factories=...)``."""
     factories: list[DecoderFactory] = [
@@ -542,7 +535,7 @@ def list_decoder_factories(
 
     if enable_discovery:
         seen = {factory.__class__ for factory in factories}
-        for factory in discover_decoder_factories(logger=logger):
+        for factory in discover_decoder_factories():
             if factory.__class__ in seen:
                 continue
             factories.append(factory)
@@ -551,15 +544,11 @@ def list_decoder_factories(
     if include_raw_fallback:
         factories.append(RawPassthroughDecoderFactory())
 
-    if logger is not None:
-        factory_names = [
-            f"{factory.__class__.__module__}.{factory.__class__.__qualname__}"
-            for factory in factories
-        ]
-        logger.debug(
-            f"Configured MCAP decoder factories: {factory_names}",
-        )
-
+    factory_names = [
+        f"{factory.__class__.__module__}.{factory.__class__.__qualname__}"
+        for factory in factories
+    ]
+    logger.debug(f"Configured MCAP decoder factories: {factory_names}")
     return factories
 
 
@@ -583,7 +572,6 @@ def validate_channel_decoder_support(
     summary: Any | None,
     topics: list[str],
     decoder_factories: list[DecoderFactory],
-    logger: logging.Logger,
 ) -> None:
     """Warn when configured topics lack non-raw decoder support."""
     if summary is None or not getattr(summary, "channels", None):
@@ -643,8 +631,6 @@ def _decode_raw_image(
     data_type: DataType,
     data: Any,
     message: Any,
-    *,
-    logger: logging.Logger,
 ) -> np.ndarray:
     """Decode ``sensor_msgs/Image``-style payloads."""
     height = _read_field(message, "height")
@@ -704,50 +690,46 @@ def _decode_raw_image(
     if is_bigendian and np.dtype(dtype).itemsize > 1:
         array = array.byteswap()
 
-    return _drop_alpha_channel(data_type, array, logger=logger)
+    return _drop_alpha_channel(data_type, array)
 
 
 def _decode_compressed_image(
     data_type: DataType,
     message: Any,
-    *,
-    logger: logging.Logger,
 ) -> np.ndarray:
     """Decode ``sensor_msgs/CompressedImage`` payloads."""
     raw = _read_field(message, "data")
     if raw is None:
         raise ImportError("Compressed image decoding requires data field.")
-    return __decode_compressed_image_bytes(data_type, raw, logger=logger)
+    return __decode_compressed_image_bytes(data_type, raw)
 
 
 def read_image_data(
     data_type: DataType,
     data: Any,
     message: Any,
-    *,
-    logger: logging.Logger,
 ) -> Any:
     """Read image payloads as arrays; keep non-image values untouched."""
     if data_type not in {DataType.RGB_IMAGES, DataType.DEPTH_IMAGES}:
         return data
 
     if isinstance(data, np.ndarray):
-        return _drop_alpha_channel(data_type, data, logger=logger)
+        return _drop_alpha_channel(data_type, data)
 
     if _is_raw_image_message(message):
-        return _decode_raw_image(data_type, data, message, logger=logger)
+        return _decode_raw_image(data_type, data, message)
 
     if _is_compressed_image_message(message):
-        return _decode_compressed_image(data_type, message, logger=logger)
+        return _decode_compressed_image(data_type, message)
 
     if isinstance(data, (list, tuple)) and data and not _is_byte_list(data):
         array = np.array(data)
         if array.ndim >= 2:
-            return _drop_alpha_channel(data_type, array, logger=logger)
+            return _drop_alpha_channel(data_type, array)
 
     if isinstance(data, (bytes, bytearray, memoryview, str)) or _is_byte_list(data):
         try:
-            return __decode_compressed_image_bytes(data_type, data, logger=logger)
+            return __decode_compressed_image_bytes(data_type, data)
         except ImportError:
             pass
 
@@ -761,7 +743,6 @@ def __decode_compressed_image_bytes(
     data_type: DataType,
     data: Any,
     *,
-    logger: logging.Logger,
     has_pil: bool = HAS_PIL,
     image_module: Any = Image,
 ) -> np.ndarray:
@@ -781,7 +762,7 @@ def __decode_compressed_image_bytes(
     except Exception as exc:  # noqa: BLE001
         raise ImportError(f"Failed decoding compressed image: {exc}") from exc
 
-    return _drop_alpha_channel(data_type, array, logger=logger)
+    return _drop_alpha_channel(data_type, array)
 
 
 def _read_bytes(data: Any) -> bytes:
@@ -798,8 +779,6 @@ def _read_bytes(data: Any) -> bytes:
 def _drop_alpha_channel(
     data_type: DataType,
     array: np.ndarray,
-    *,
-    logger: logging.Logger,
 ) -> np.ndarray:
     """Normalize image arrays into Neuracore-friendly shape and dtype."""
     if data_type == DataType.RGB_IMAGES and array.ndim == 3 and array.shape[2] == 4:
@@ -846,7 +825,6 @@ def iter_mcap_source_events(
     decoded_data: Any,
     *,
     topic_map: TopicMap,
-    logger: logging.Logger,
     timestamp: float,
 ) -> Iterator[MCAPSourceEvent]:
     """Yield source events for each mapping config, ready for _log_data."""
@@ -864,7 +842,6 @@ def iter_mcap_source_events(
                 config.data_type,
                 base,
                 decoded_data,
-                logger=logger,
             )
             if not _is_language_text(config.data_type, config.import_config):
                 source_data = to_numpy(source_data)
@@ -894,7 +871,6 @@ def iter_mcap_source_events(
                 config.data_type,
                 source_data,
                 decoded_data,
-                logger=logger,
             )
             if not _is_language_text(config.data_type, config.import_config):
                 source_data = to_numpy(source_data)
@@ -984,10 +960,7 @@ def to_numpy(data: Any) -> Any:
     return data
 
 
-def clip_depth(
-    data: Any,
-    logger: logging.Logger | None = None,
-) -> Any:
+def clip_depth(data: Any) -> Any:
     """Clip depth arrays to the backend-accepted meter range."""
     if not isinstance(data, np.ndarray):
         return data
@@ -998,7 +971,7 @@ def clip_depth(
         or float32.size > 0
         and (float(float32.min()) < 0.0 or float(float32.max()) > MAX_DEPTH)
     )
-    if needs_clip and logger is not None:
+    if needs_clip:
         logger.warning(
             f"Depth values outside valid range [0, {MAX_DEPTH:.1f} m] — clipping."
         )

--- a/neuracore/importer/rlds_tfds_importer.py
+++ b/neuracore/importer/rlds_tfds_importer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 import traceback
 from collections.abc import Sequence
@@ -35,18 +34,15 @@ from neuracore.importer.core.base import (
 from neuracore.importer.core.exceptions import ImportError
 
 logger = logging.getLogger(__name__)
+
 gpus = tf.config.list_physical_devices("GPU")
 if gpus:
     try:
         for gpu in gpus:
             tf.config.experimental.set_memory_growth(gpu, True)
-        logger.info("Memory growth enabled")
+        logger.debug("Memory growth enabled")
     except RuntimeError as e:
-        logger.error("Error enabling memory growth: %s", e)
-
-# Suppress TensorFlow informational messages (e.g., "End of sequence")
-# 0 = all logs, 1 = no INFO, 2 = no WARNING, 3 = no ERROR
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
+        logger.error(f"Error enabling memory growth: {e}")
 
 
 class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
@@ -124,14 +120,10 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         self._builder: tfds.core.DatasetBuilder | None = None
         self._episode_iter = None
 
-        self.logger.info(
-            "Initialized %s importer for '%s' (split=%s, episodes=%s, freq=%s, dir=%s)",
-            self.dataset_label,
-            self.dataset_name,
-            self.split,
-            self.num_episodes,
-            self.frequency,
-            self.builder_dir,
+        logger.info(
+            f"Initialized {self.dataset_label} importer for '{self.dataset_name}' "
+            f"(split={self.split}, episodes={self.num_episodes}, "
+            f"freq={self.frequency}, dir={self.builder_dir})"
         )
 
     def __getstate__(self) -> dict:
@@ -155,11 +147,8 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         self._builder = self._load_builder()
 
         sliced_split = self._build_sliced_split(chunk, self._builder)
-        self.logger.info(
-            "[worker %s] Loading split=%s from %s",
-            worker_id,
-            sliced_split,
-            self.builder_dir,
+        logger.info(
+            f"[worker {worker_id}] Loading split={sliced_split} from {self.builder_dir}"
         )
 
         dataset = self._load_dataset(self._builder, sliced_split)
@@ -230,13 +219,10 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         worker_label = (
             f"worker {self._worker_id}" if self._worker_id is not None else "worker 0"
         )
-        self.logger.info(
-            "[%s] Importing %s (%s/%s, steps=%s)",
-            worker_label,
-            episode_label,
-            item.index + 1,
-            self.num_episodes,
-            total_steps if total_steps is not None else "unknown",
+        logger.info(
+            f"[{worker_label}] Importing {episode_label} "
+            f"({item.index + 1}/{self.num_episodes}, "
+            f"steps={total_steps if total_steps is not None else 'unknown'})"
         )
         self._emit_progress(
             item.index, step=0, total_steps=total_steps, episode_label=episode_label
@@ -260,7 +246,7 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
             nc.stop_recording(
                 robot_name=self.robot_name, instance=self._worker_id, wait=True
             )
-        self.logger.info("[%s] Completed %s", worker_label, episode_label)
+        logger.info(f"[{worker_label}] Completed {episode_label}")
 
     def _handle_step_error(
         self, exc: Exception, item: ImportItem, step_index: int
@@ -334,9 +320,7 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
 
     def _load_builder(self) -> tfds.core.DatasetBuilder:
         """Load a TFDS builder directly from the local dataset directory."""
-        self.logger.info(
-            "Loading %s builder from %s", self.dataset_label, self.builder_dir
-        )
+        logger.info(f"Loading {self.dataset_label} builder from {self.builder_dir}")
         try:
             builder = tfds.builder_from_directory(str(self.builder_dir))
             self._on_builder_loaded(builder)
@@ -390,7 +374,7 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         self, builder: tfds.core.DatasetBuilder, split: tfds.typing.SplitArg
     ) -> tfds.core.dataset_builder.DatasetBuilder:
         """Load the TFDS dataset from the local builder."""
-        self.logger.info("Opening dataset split '%s' for import.", split)
+        logger.info(f"Opening dataset split '{split}' for import.")
         try:
             return builder.as_dataset(
                 split=split,
@@ -400,11 +384,10 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         except Exception as exc:
             retry_config = self._build_retry_read_config()
             if self._is_missing_file_error(exc) and retry_config is not None:
-                self.logger.warning(
+                logger.warning(
                     "Some dataset shard files appear to be missing. "
                     "This may indicate an incomplete dataset. "
-                    "Attempting to continue with available shards. Error: %s",
-                    exc,
+                    f"Attempting to continue with available shards. Error: {exc}"
                 )
                 try:
                     return builder.as_dataset(
@@ -642,11 +625,9 @@ class TFDSDatasetImporter(RLDSAndTFDSDatasetImporterBase):
             super()._handle_episode_load_error(exc, item)
             return
         if self._is_missing_file_error(exc):
-            self.logger.warning(
-                "[worker %s item %s] Skipping episode due to missing shard file: %s",
-                self._worker_id if self._worker_id is not None else 0,
-                item.index,
-                exc,
+            logger.warning(
+                f"[worker {self._worker_id if self._worker_id is not None else 0} "
+                f"item {item.index}] Skipping episode due to missing shard file: {exc}"
             )
             raise ImportError(
                 f"Episode {item.index} cannot be loaded due to missing shard "
@@ -663,14 +644,12 @@ class TFDSDatasetImporter(RLDSAndTFDSDatasetImporterBase):
                     if subdir.is_dir():
                         tfrecord_files.extend(subdir.glob("*.tfrecord*"))
             if tfrecord_files:
-                self.logger.info(
-                    "Found %d TFRecord shard files in dataset directory",
-                    len(tfrecord_files),
-                )
+                n = len(tfrecord_files)
+                logger.info(f"Found {n} TFRecord shard files in dataset directory")
             else:
-                self.logger.warning(
+                logger.warning(
                     "No TFRecord files found in dataset directory. "
                     "Dataset may be incomplete or use a different format."
                 )
         except Exception as exc:  # noqa: BLE001 - informational check only
-            self.logger.debug("Could not check for missing shards: %s", exc)
+            logger.debug(f"Could not check for missing shards: {exc}")

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -38,7 +38,6 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 )
 from neuracore.ml.logging.cloud_log_streamer import CloudLogStreamer
 from neuracore.ml.logging.cloud_training_logger import CloudTrainingLogger
-from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 from neuracore.ml.logging.tensorboard_training_logger import TensorboardTrainingLogger
 from neuracore.ml.trainers.batch_autotuner import (
     find_optimal_batch_size,
@@ -62,9 +61,11 @@ from neuracore.ml.utils.training_config import (
     validate_complete_config,
 )
 from neuracore.ml.utils.training_storage_handler import TrainingStorageHandler
+from neuracore.utils import setup_logging
 
 # Environment setup
 os.environ["PJRT_DEVICE"] = "GPU"
+os.environ.setdefault("HYDRA_FULL_ERROR", "1")
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -285,26 +286,6 @@ def _save_local_training_metadata(
     metadata_path.write_text(json.dumps(metadata, indent=2))
 
 
-def setup_logging(output_dir: str, rank: int = 0) -> None:
-    """Setup logging configuration."""
-    output_path = Path(output_dir)
-    output_path.mkdir(parents=True, exist_ok=True)
-    stream_handler = logging.StreamHandler()
-
-    if rank == 0:
-        file_handler = logging.FileHandler(output_path / "train.log")
-    else:
-        file_handler = logging.FileHandler(output_path / f"train-rank{rank}.log")
-    file_handler.setFormatter(JsonLineLogFormatter())
-
-    handlers: list[logging.Handler] = [file_handler, stream_handler]
-    logging.basicConfig(
-        level=logging.INFO,
-        handlers=handlers,
-        force=True,
-    )
-
-
 def get_model_and_algorithm_config(
     cfg: DictConfig,
     model_init_description: ModelInitDescription,
@@ -340,8 +321,7 @@ def get_model_and_algorithm_config(
         )
     else:
         raise ValueError(
-            "Either 'algorithm' or 'algorithm_id' "
-            "must be provided in the configuration"
+            "Either 'algorithm' or 'algorithm_id' must be provided in the configuration"
         )
     return model, algorithm_config
 
@@ -500,7 +480,10 @@ def run_training(
         setup_distributed(rank, world_size)
 
     # Setup logging (different file per process)
-    setup_logging(cfg.local_output_dir, rank)
+    log_file = Path(cfg.local_output_dir) / (
+        "train.log" if rank == 0 else f"train-rank{rank}.log"
+    )
+    setup_logging(json_format=True, log_file=log_file, force=True)
     logger = logging.getLogger(__name__)
 
     # Set random seed (different for each process to ensure different data sampling)
@@ -724,7 +707,11 @@ def _main(cfg: DictConfig) -> None:
     # Merge Config with the base config from the algorithm
     cfg = resolve_user_input_config(cfg)
 
-    setup_logging(cfg.local_output_dir)
+    setup_logging(
+        json_format=True,
+        log_file=Path(cfg.local_output_dir) / "train.log",
+        force=True,
+    )
     log_streamer: CloudLogStreamer | None = None
 
     try:

--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -18,6 +18,7 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 )
 from neuracore.ml.utils.device_utils import cpu_count
 from neuracore.ml.utils.memory_monitor import MemoryMonitor, OutOfMemoryError
+from neuracore.utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,7 @@ def _run_batch_size_test_worker(
     device_str: str,
 ) -> None:
     """Subprocess entrypoint that probes a single batch size."""
-    logging.basicConfig(level=logging.INFO)
+    setup_logging(force=True)
     worker_logger = logging.getLogger(__name__)
 
     try:

--- a/neuracore/ml/utils/validate.py
+++ b/neuracore/ml/utils/validate.py
@@ -26,15 +26,17 @@ from pydantic import BaseModel
 from torch.utils.data import DataLoader
 
 import neuracore as nc
-from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
+from neuracore.utils import setup_logging
 
 from ..core.ml_types import BatchedTrainingOutputs, BatchedTrainingSamples
 from ..datasets.pytorch_dummy_dataset import MAX_LEN_PER_DATA_TYPE, PytorchDummyDataset
 from .algorithm_loader import AlgorithmLoader
 from .nc_archive import create_nc_archive
+
+logger = logging.getLogger(__name__)
 
 
 class AlgorithmCheck(BaseModel):
@@ -59,23 +61,6 @@ def _indexed_names(data_type: DataType) -> dict[int, str]:
     return {
         index: f"{data_type.value}_{index}" for index in range(MAX_LEN_PER_DATA_TYPE)
     }
-
-
-def setup_logging(output_dir: Path) -> None:
-    """Configure logging for validation process with file output only.
-
-    Sets up logging to capture validation progress and errors in a log file.
-
-    Args:
-        output_dir: Directory where the validation log file will be created.
-    """
-    file_handler = logging.FileHandler(output_dir / "validate.log")
-    file_handler.setFormatter(JsonLineLogFormatter())
-    logging.basicConfig(
-        level=logging.INFO,
-        handlers=[file_handler],
-        force=True,
-    )
 
 
 def run_validation(
@@ -127,8 +112,11 @@ def run_validation(
     # Setup output directory
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    setup_logging(output_dir)
-    logger = logging.getLogger(__name__)
+    setup_logging(
+        json_format=True,
+        log_file=output_dir / "validate.log",
+        force=True,
+    )
 
     algo_check = AlgorithmCheck()
     error_msg = ""

--- a/neuracore/utils.py
+++ b/neuracore/utils.py
@@ -1,11 +1,26 @@
 """Utility functions."""
 
 import functools
+import logging
+import os
 import warnings
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+_NOISY_THIRD_PARTY = [
+    "datasets",
+    "huggingface_hub",
+    "transformers",
+    "urllib3",
+    "filelock",
+    "asyncio",
+    "tensorflow",
+    "tensorflow_datasets",
+    "absl",
+]
 
 
 def deprecated(reason: str = "") -> Callable[[F], F]:
@@ -24,3 +39,130 @@ def deprecated(reason: str = "") -> Callable[[F], F]:
         return wrapper
 
     return decorator
+
+
+def setup_logging(
+    level: int | str | None = None,
+    suppress_third_party: bool = True,
+    json_format: bool | None = None,
+    log_file: Path | str | None = None,
+    force: bool = False,
+    console: object = None,
+    handler: logging.Handler | None = None,
+) -> None:
+    """Configure the root logger for the current process.
+
+    Call once at each process entry point (CLI callback, worker main).
+    Not for library code. Explicit arguments take precedence over env vars.
+
+    Args:
+        level: Log level (e.g. logging.DEBUG or "DEBUG"). Defaults to
+            NEURACORE_LOG_LEVEL env var, or INFO.
+        suppress_third_party: Silence known noisy third-party loggers.
+        json_format: Emit JSON lines. Defaults to NEURACORE_LOG_JSON env var,
+            or False.
+        log_file: Path to write logs to in addition to stderr. Defaults to
+            NEURACORE_LOG_FILE env var, or None.
+        force: Re-apply configuration even if already called once.
+        console: Optional Rich Console instance passed to RichHandler.
+        handler: Custom handler to install (e.g. QueueHandler for workers).
+            When provided, json_format/log_file/console are ignored.
+
+    Environment variables (all optional, override defaults):
+        NEURACORE_LOG_LEVEL — log level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+        NEURACORE_LOG_FILE  — path to write logs to in addition to stderr
+        NEURACORE_LOG_JSON  — set to "1" to emit JSON lines (for training/server)
+    """
+    root = logging.getLogger()
+    already_configured = any(
+        getattr(existing, "_neuracore_managed", False) for existing in root.handlers
+    )
+
+    if already_configured and not force:
+        return
+
+    if isinstance(level, int):
+        resolved_level = level
+    else:
+        level_name = level or os.environ.get("NEURACORE_LOG_LEVEL", "INFO")
+        numeric = logging.getLevelName(level_name.upper())
+        if not isinstance(numeric, int):
+            warnings.warn(
+                f"Unknown log level {level!r}, defaulting to INFO.", stacklevel=2
+            )
+            numeric = logging.INFO
+        resolved_level = numeric
+
+    if not already_configured:
+        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+        os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+        warnings.filterwarnings("ignore", category=UserWarning, module="qpsolvers")
+
+    for existing_handler in list(root.handlers):
+        if getattr(existing_handler, "_neuracore_managed", False):
+            root.removeHandler(existing_handler)
+
+    handlers = (
+        [handler]
+        if handler is not None
+        else _create_handlers(json_format, log_file, console)
+    )
+    root.setLevel(resolved_level)
+    for new_handler in handlers:
+        new_handler._neuracore_managed = True  # type: ignore[attr-defined]
+        root.addHandler(new_handler)
+
+    if suppress_third_party and handler is None:
+        suppress_level = max(resolved_level, logging.WARNING)
+        for logger_name in _NOISY_THIRD_PARTY:
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(suppress_level)
+            logger.handlers.clear()  # remove own StreamHandlers to avoid double-logging
+            logger.propagate = True  # let WARNING+ reach root's RichHandler
+
+    logging.captureWarnings(True)
+
+
+def _create_handlers(
+    json_format: bool | None, log_file: Path | str | None, console: object
+) -> list[logging.Handler]:
+    """Build console and optional file handlers."""
+    json_format = (
+        json_format
+        if json_format is not None
+        else os.environ.get("NEURACORE_LOG_JSON", "0") == "1"
+    )
+    log_file = log_file or os.environ.get("NEURACORE_LOG_FILE")
+    log_file = Path(log_file) if log_file else None
+
+    formatter: logging.Formatter | None = None
+    if json_format:
+        from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
+
+        formatter = JsonLineLogFormatter()
+        console_handler: logging.Handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+    else:
+        from rich.highlighter import NullHighlighter
+        from rich.logging import RichHandler
+        from rich.text import Text
+
+        console_handler = RichHandler(
+            console=console,  # type: ignore[arg-type]
+            rich_tracebacks=False,
+            show_path=True,
+            highlighter=NullHighlighter(),
+            omit_repeated_times=False,
+            log_time_format=lambda dt: Text(
+                dt.strftime("[%d %b %y %H:%M:%S.") + f"{dt.microsecond // 1000:03d}]"
+            ),
+        )
+
+    handlers: list[logging.Handler] = [console_handler]
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file)
+        if formatter:
+            file_handler.setFormatter(formatter)
+        handlers.append(file_handler)
+    return handlers

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,9 @@
+# ruff: noqa: E402
+import os
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+
 import pathlib
 import re
 import tempfile

--- a/tests/unit/importer/test_base_validation.py
+++ b/tests/unit/importer/test_base_validation.py
@@ -420,7 +420,7 @@ class TestLogData:
         timestamp = 1234567890.0
 
         with pytest.raises(DataValidationError):
-            with patch.object(importer.logger, "error") as mock_error:
+            with patch("neuracore.importer.core.base.logger") as mock_logger:
                 importer._log_data(
                     DataType.RGB_IMAGES,
                     source_data,
@@ -428,7 +428,7 @@ class TestLogData:
                     format,
                     timestamp,
                 )
-                assert mock_error.called
+                assert mock_logger.error.called
 
     @patch("neuracore.importer.core.base.nc")
     def test_log_data_joint_validation_warning(
@@ -441,7 +441,7 @@ class TestLogData:
         mock_mapping_item.transforms.return_value = 2.0  # Above limit 1.0
         mock_mapping_item.name = "joint1"  # Valid joint name
 
-        with patch.object(importer.logger, "warning") as mock_warning:
+        with patch("neuracore.importer.core.base.logger") as mock_logger:
             importer._log_data(
                 DataType.JOINT_POSITIONS,
                 source_data,
@@ -449,7 +449,7 @@ class TestLogData:
                 format,
                 timestamp,
             )
-            assert mock_warning.called
+            assert mock_logger.warning.called
             mock_nc.log_joint_position.assert_called_once()
 
     @patch("neuracore.importer.core.base.nc")
@@ -461,7 +461,7 @@ class TestLogData:
         mock_mapping_item.transforms.side_effect = ValueError("Transform error")
 
         with pytest.raises(ValueError):
-            with patch.object(importer.logger, "error") as mock_error:
+            with patch("neuracore.importer.core.base.logger") as mock_logger:
                 importer._log_data(
                     DataType.JOINT_POSITIONS,
                     source_data,
@@ -469,7 +469,7 @@ class TestLogData:
                     format,
                     timestamp,
                 )
-                assert mock_error.called
+                assert mock_logger.error.called
 
     @patch("neuracore.importer.core.base.nc")
     def test_log_data_logging_exception(self, mock_nc, importer, mock_mapping_item):
@@ -480,7 +480,7 @@ class TestLogData:
         mock_nc.log_depth.side_effect = RuntimeError("Logging error")
 
         with pytest.raises(RuntimeError):
-            with patch.object(importer.logger, "error") as mock_error:
+            with patch("neuracore.importer.core.base.logger") as mock_logger:
                 importer._log_data(
                     DataType.DEPTH_IMAGES,
                     source_data,
@@ -488,7 +488,7 @@ class TestLogData:
                     format,
                     timestamp,
                 )
-                assert mock_error.called
+                assert mock_logger.error.called
 
     @patch("neuracore.importer.core.base.nc")
     def test_log_data_joint_data_validates_transformed(

--- a/tests/unit/importer/test_importer_cli_arguments.py
+++ b/tests/unit/importer/test_importer_cli_arguments.py
@@ -31,6 +31,7 @@ def test_import_command_invokes_run_import_with_defaults(monkeypatch, tmp_path):
     result = runner.invoke(
         app,
         [
+            "import",
             "--dataset-config",
             str(config_path),
             "--dataset-dir",
@@ -73,6 +74,7 @@ def test_import_command_propagates_flags(monkeypatch, tmp_path):
     result = runner.invoke(
         app,
         [
+            "import",
             "--dataset-config",
             str(config_path),
             "--dataset-dir",
@@ -117,11 +119,11 @@ def test_import_command_handles_cli_error(monkeypatch, tmp_path, caplog):
         "_run_import",
         lambda **_: (_ for _ in ()).throw(CLIError("bad input")),
     )
-
     with caplog.at_level(logging.ERROR):
         result = runner.invoke(
             app,
             [
+                "import",
                 "--dataset-config",
                 str(config_path),
                 "--dataset-dir",
@@ -146,6 +148,7 @@ def test_import_command_validates_paths_with_click(tmp_path):
     result = runner.invoke(
         app,
         [
+            "import",
             "--dataset-config",
             str(missing_config),
             "--dataset-dir",

--- a/tests/unit/importer/test_lerobot_importer_behavior.py
+++ b/tests/unit/importer/test_lerobot_importer_behavior.py
@@ -483,26 +483,24 @@ def test_lerobot_resolve_frequency_prefers_config_and_warns_on_mismatch():
     """Configured frequency should be used even if metadata differs."""
     importer = object.__new__(LeRobotDatasetImporter)
     importer.data_config = SimpleNamespace(frequency=30.0)
-    importer.logger = MagicMock()
 
-    frequency = importer._resolve_frequency(meta_frequency=15.0)
+    with patch("neuracore.importer.lerobot_importer.logger") as mock_logger:
+        frequency = importer._resolve_frequency(meta_frequency=15.0)
 
     assert frequency == 30.0
-    importer.logger.warning.assert_called_once_with(
-        "Dataset FPS %s does not match configured FPS %s", 15.0, 30.0
-    )
+    mock_logger.warning.assert_called_once()
 
 
 def test_lerobot_resolve_frequency_falls_back_to_metadata():
     """Metadata FPS should be used when config frequency is missing."""
     importer = object.__new__(LeRobotDatasetImporter)
     importer.data_config = SimpleNamespace(frequency=None)
-    importer.logger = MagicMock()
 
-    frequency = importer._resolve_frequency(meta_frequency=25.0)
+    with patch("neuracore.importer.lerobot_importer.logger") as mock_logger:
+        frequency = importer._resolve_frequency(meta_frequency=25.0)
 
     assert frequency == 25.0
-    importer.logger.warning.assert_not_called()
+    mock_logger.warning.assert_not_called()
 
 
 def test_lerobot_resolve_frequency_raises_when_missing_everywhere():

--- a/tests/unit/importer/test_mcap_importer.py
+++ b/tests/unit/importer/test_mcap_importer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -176,7 +175,6 @@ def test_image_decoder_handles_base64_compressed_payload():
         DataType.DEPTH_IMAGES,
         message["data"],
         message,
-        logger=logging.getLogger(__name__),
     )
     assert isinstance(image_data, np.ndarray)
     assert image_data.shape == (1, 2)
@@ -457,12 +455,7 @@ def test_clip_depth_non_array_passthrough(value):
 
 def test_read_image_data_non_image_type_passthrough():
     data = {"position": 1.0}
-    assert (
-        read_image_data(
-            DataType.JOINT_POSITIONS, data, data, logger=logging.getLogger(__name__)
-        )
-        is data
-    )
+    assert read_image_data(DataType.JOINT_POSITIONS, data, data) is data
 
 
 def test_read_image_data_decodes_raw_rgb8():
@@ -477,9 +470,7 @@ def test_read_image_data_decodes_raw_rgb8():
         is_bigendian=False,
         data=raw.tobytes(),
     )
-    result = read_image_data(
-        DataType.RGB_IMAGES, message.data, message, logger=logging.getLogger(__name__)
-    )
+    result = read_image_data(DataType.RGB_IMAGES, message.data, message)
     assert isinstance(result, np.ndarray)
     assert result.shape == (h, w, 3)
 
@@ -499,7 +490,6 @@ def test_read_image_data_decodes_bigendian_mono16():
         DataType.DEPTH_IMAGES,
         message.data,
         message,
-        logger=logging.getLogger(__name__),
     )
 
     assert result.dtype == np.float32
@@ -520,7 +510,6 @@ def test_read_image_data_raises_on_unsupported_encoding():
             DataType.RGB_IMAGES,
             message.data,
             message,
-            logger=logging.getLogger(__name__),
         )
 
 
@@ -606,7 +595,6 @@ def test_iter_mcap_source_events_yields_source_event():
             "/joint",
             decoded_data,
             topic_map=topic_map,
-            logger=logging.getLogger(__name__),
             timestamp=1.0,
         )
     )
@@ -633,7 +621,6 @@ def test_iter_mcap_source_events_unknown_topic_yields_nothing():
             "/unknown",
             {},
             topic_map=topic_map,
-            logger=logging.getLogger(__name__),
             timestamp=0.0,
         )
     )

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -42,7 +42,6 @@ from neuracore.ml.train import (
     get_model_and_algorithm_config,
     main,
     run_training,
-    setup_logging,
 )
 from neuracore.ml.trainers.batch_autotuner import find_optimal_batch_size
 from neuracore.ml.utils.preprocessing_utils import resolve_preprocessing_config
@@ -53,6 +52,7 @@ from neuracore.ml.utils.training_config import (
     resolve_to_complete_config,
     resolve_user_input_config,
 )
+from neuracore.utils import setup_logging
 
 SKIP_TEST = (
     os.environ.get("CI", "false").lower() == "true" or not torch.cuda.is_available()
@@ -613,24 +613,31 @@ class TestSetupLogging:
     """Tests for setup_logging function."""
 
     @pytest.mark.parametrize("rank,should_create_log_file", [(0, True), (1, False)])
-    def test_setup_logging(self, temp_output_dir, rank, should_create_log_file):
-        setup_logging(str(temp_output_dir), rank=rank)
+    def test_setup_logging_creates_log_file(
+        self, temp_output_dir, rank, should_create_log_file
+    ):
+        log_file = temp_output_dir / "train.log" if rank == 0 else None
+        setup_logging(json_format=True, log_file=log_file, force=True)
+        assert (temp_output_dir / "train.log").exists() == should_create_log_file
 
-        log_file = temp_output_dir / "train.log"
-        if should_create_log_file:
-            assert log_file.exists()
-        else:
-            assert not log_file.exists()
-
-        logger = logging.getLogger(__name__)
-        assert logger.level <= logging.INFO
+    @pytest.mark.parametrize("rank", [1, 2, 4])
+    def test_setup_logging_rank_log_file_name(self, temp_output_dir, rank):
+        log_file = temp_output_dir / f"train-rank{rank}.log"
+        setup_logging(json_format=True, log_file=log_file, force=True)
+        assert log_file.exists()
 
     def test_setup_logging_creates_directory(self, temp_output_dir):
         new_dir = temp_output_dir / "new_dir"
-        setup_logging(str(new_dir), rank=0)
-
+        log_file = new_dir / "train.log"
+        setup_logging(json_format=True, log_file=log_file, force=True)
         assert new_dir.exists()
-        assert (new_dir / "train.log").exists()
+        assert log_file.exists()
+
+    def test_setup_logging_sets_level(self, temp_output_dir):
+        import logging
+
+        setup_logging(level=logging.DEBUG, force=True)
+        assert logging.getLogger().level == logging.DEBUG
 
 
 class TestResolveOutputDir:
@@ -2599,12 +2606,12 @@ class TestResolveAlgorithmNameAndSupportedDataTypes:
         setup = MainTestSetup(monkeypatch)
         setup.setup_mocks()
 
-        mock_setup_logging = Mock()
-        monkeypatch.setattr("neuracore.ml.train.setup_logging", mock_setup_logging)
+        mock_logging = Mock()
+        monkeypatch.setattr("neuracore.ml.train.setup_logging", mock_logging)
 
         main(cfg)
 
-        mock_setup_logging.assert_called_once_with(cfg.local_output_dir)
+        mock_logging.assert_called_once()
 
     def test_main_sets_up_logging_before_login(self, monkeypatch, temp_output_dir):
         cfg = OmegaConf.create({


### PR DESCRIPTION
### Features
- Consolidated logging config into `setup_logging()` (`neuracore/utils.py`) — single RichHandler on root logger, all loggers flow through it; env vars: `NEURACORE_LOG_LEVEL`, `NEURACORE_LOG_JSON`, `NEURACORE_LOG_FILE`
- `--log-level` flag added to all CLI entry points (`neuracore`, `importer`, `data-daemon`, `training`, `cache`, `launch-server`)
- Importer worker processes inherit log level via env var instead of always logging at DEBUG
- `warnings.warn()` routed through logging via `logging.captureWarnings(True)`
- Importer progress bar interleaves cleanly with log output — no more fused/duplicate lines

### Bugfixes
- Suppressed noisy third-party loggers (`tensorflow`, `datasets`, `huggingface_hub`, etc.) — prevents double-logging, routes WARNING+ through RichHandler
- Module-level `logger = logging.getLogger(__name__)` added throughout importer and CLI code

### Items
- None

### Related PRs
- None