### PR TITLE
feat: Preflight daemon auth before socket readiness polling

### DIFF
--- a/neuracore/data_daemon/config_manager/args_handler.py
+++ b/neuracore/data_daemon/config_manager/args_handler.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import typer
 
+from neuracore.core.exceptions import AuthenticationError
 from neuracore.data_daemon.config_manager.cli_options import (
     ApiKeyOption,
     BackgroundOption,
@@ -32,6 +33,7 @@ from neuracore.data_daemon.config_manager.profiles import (
 )
 from neuracore.data_daemon.const import DEFAULT_PROFILE_NAME, SOCKET_PATH
 from neuracore.data_daemon.helpers import get_daemon_db_path, get_daemon_pid_path
+from neuracore.data_daemon.lifecycle.auth_preflight import ensure_daemon_auth_ready
 from neuracore.data_daemon.lifecycle.daemon_os_control import (
     DaemonLifecycleError,
     cleanup_stale_client_state,
@@ -209,6 +211,8 @@ def run_launch(
         env_overrides["NDD_DEBUG"] = "true"
 
     try:
+        ensure_daemon_auth_ready(env_overrides)
+
         daemon_process = launch_new_daemon_subprocess(
             pid_path=pid_path,
             db_path=db_path,
@@ -219,6 +223,9 @@ def run_launch(
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
     except RuntimeError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    except AuthenticationError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
 

--- a/neuracore/data_daemon/lifecycle/auth_preflight.py
+++ b/neuracore/data_daemon/lifecycle/auth_preflight.py
@@ -1,0 +1,28 @@
+"""Authentication preflight for daemon startup."""
+
+import os
+
+from neuracore.core.auth import login
+from neuracore.data_daemon.config_manager.config import ConfigManager
+from neuracore.data_daemon.config_manager.profiles import ProfileManager
+from neuracore.data_daemon.const import DEFAULT_PROFILE_NAME
+
+
+def ensure_daemon_auth_ready(
+    env_overrides: dict[str, str] | None = None,
+) -> None:
+    """Ensure authentication completes before daemon socket readiness polling starts."""
+    profile_name = (
+        (env_overrides or {}).get("NEURACORE_DAEMON_PROFILE")
+        or os.environ.get("NEURACORE_DAEMON_PROFILE")
+        or DEFAULT_PROFILE_NAME
+    )
+
+    profile_manager = ProfileManager()
+    config_manager = ConfigManager(profile_manager, profile=profile_name)
+    config = config_manager.resolve_effective_config()
+
+    if config.offline:
+        return
+
+    login()

--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -19,6 +19,7 @@ from neuracore.data_daemon.const import (
     SOCKET_PATH,
 )
 from neuracore.data_daemon.helpers import get_daemon_db_path, get_daemon_pid_path
+from neuracore.data_daemon.lifecycle.auth_preflight import ensure_daemon_auth_ready
 
 # cspell:ignore WNOHANG waitpid
 
@@ -230,6 +231,8 @@ def launch_new_daemon_subprocess(
     """Launch a new daemon subprocess, rejecting an already-running daemon."""
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_file_lock = str(pid_path) + ".lock"
+
+    ensure_daemon_auth_ready(env_overrides)
 
     with filelock.FileLock(pid_file_lock):
         existing_pid = read_pid_from_file(pid_path)

--- a/tests/unit/data_daemon/cli/test_launch_cli.py
+++ b/tests/unit/data_daemon/cli/test_launch_cli.py
@@ -31,6 +31,7 @@ def test_launch_background_exits_if_pid_is_running(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
 
     def fake_launch(**_: object) -> FakePopen:
         raise ah.DaemonLifecycleError("Daemon already running (pid=12345).")
@@ -55,6 +56,7 @@ def test_launch_background_propagates_runtime_error(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
 
     def fake_launch(**_: object) -> FakePopen:
         raise RuntimeError("Daemon failed to start.")
@@ -78,6 +80,7 @@ def test_launch_background_passes_expected_args(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
 
     captured_kwargs: dict[str, object] = {}
 
@@ -106,6 +109,7 @@ def test_launch_foreground_passes_background_false(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
 
     captured_kwargs: dict[str, object] = {}
 
@@ -131,6 +135,7 @@ def test_launch_foreground_waits_and_sends_sigint_on_keyboard_interrupt(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
 
     popen_obj = FakePopen(pid=66666)
 
@@ -164,6 +169,7 @@ def test_launch_with_profile_sets_env_and_validates_profile_exists(
 
     monkeypatch.setattr(ah, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(ah, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(ah, "ensure_daemon_auth_ready", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(ah.profile_manager, "get_profile", lambda name: object())
 
     captured_kwargs: dict[str, object] = {}


### PR DESCRIPTION
### Features
- Added authentication preflight before daemon subprocess startup, so interactive login completes before daemon socket readiness polling begins.

### Items
 - [NC-974](https://neuracore.atlassian.net/browse/NCP-974)
