### PR TITLE
fix: notify daemon when recording is stopped remotely

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -176,6 +176,7 @@ def connect_robot(
         raise RobotError("Robot not initialized. Call init() first.")
     StreamManagerOrchestrator().get_provider_manager(robot.id, robot.instance)
     get_recording_state_manager()
+    robot._register_remote_stop_handler()
     return robot
 
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -6,6 +6,7 @@ URDF/MJCF model uploads, data stream management, and coordinates recording
 state across multiple robot instances.
 """
 
+import functools
 import io
 import logging
 import os
@@ -336,13 +337,8 @@ class Robot:
         get_recording_state_manager().recording_stopped(
             robot_id=self.id, instance=self.instance, recording_id=recording_id
         )
-        producer_stop_sequence_numbers = self._stop_all_streams(
-            wait_for_producer_drain=wait_for_producer_drain
-        )
-
-        self._get_daemon_recording_context().stop_recording(
-            recording_id=recording_id,
-            producer_stop_sequence_numbers=producer_stop_sequence_numbers,
+        self._drain_streams_and_notify_daemon(
+            recording_id, wait_for_producer_drain=wait_for_producer_drain
         )
 
         try:
@@ -367,6 +363,35 @@ class Robot:
             )
         except requests.exceptions.RequestException as e:
             raise RobotError(f"Failed to stop recording: {str(e)}")
+
+    def _drain_streams_and_notify_daemon(
+        self, recording_id: str, *, wait_for_producer_drain: bool
+    ) -> None:
+        """Stop all streams and send the recording-stopped IPC message to the daemon."""
+        try:
+            producer_stop_sequence_numbers = self._stop_all_streams(
+                wait_for_producer_drain=wait_for_producer_drain
+            )
+            self._get_daemon_recording_context().stop_recording(
+                recording_id=recording_id,
+                producer_stop_sequence_numbers=producer_stop_sequence_numbers,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to stop streams and notify daemon for recording_id=%s",
+                recording_id,
+            )
+
+    def _register_remote_stop_handler(self) -> None:
+        """Register a callback to drain streams when a remote stop arrives."""
+        assert self.id is not None
+        get_recording_state_manager().register_remote_stop_handler(
+            robot_id=self.id,
+            instance=self.instance,
+            callback=functools.partial(
+                self._drain_streams_and_notify_daemon, wait_for_producer_drain=False
+            ),
+        )
 
     def _stop_all_streams(
         self,
@@ -731,6 +756,10 @@ class Robot:
     def close(self) -> None:
         """Release local resources owned by this Robot instance."""
         self._cleanup_daemon_recording_context()
+        if self.id is not None:
+            get_recording_state_manager().deregister_remote_stop_handler(
+                self.id, self.instance
+            )
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -8,6 +8,8 @@ state and remote recording triggers.
 
 import asyncio
 import logging
+import threading
+from collections.abc import Callable
 from concurrent.futures import Future
 
 from aiohttp import ClientSession
@@ -18,7 +20,6 @@ from neuracore_types import (
     RecordingStartPayload,
     RobotInstanceIdentifier,
 )
-from pyee.asyncio import AsyncIOEventEmitter
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
@@ -35,17 +36,12 @@ from neuracore.data_daemon.lifecycle.daemon_os_control import ensure_daemon_runn
 logger = logging.getLogger(__name__)
 
 
-class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
+class RecordingStateManager(BaseSSEConsumer):
     """Manages recording state across robot instances with real-time notifications.
 
     Provides centralized tracking of recording sessions for multiple robot instances,
-    with automatic synchronization via Server-Sent Events and event emission for
-    state changes.
+    with automatic synchronization via Server-Sent Events.
     """
-
-    RECORDING_STARTED = "RECORDING_STARTED"
-    RECORDING_STOPPED = "RECORDING_STOPPED"
-    RECORDING_SAVED = "RECORDING_SAVED"
 
     RECORDING_EXPIRY_WARNING = 60 * 4.5  # 4.5 minutes
     MAX_RECORDING_DURATION_S = 60 * 5  # 5 minutes
@@ -89,6 +85,7 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
+        self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
 
     def get_current_recording_id(self, robot_id: str, instance: int) -> str | None:
         """Get the current recording ID for a robot instance.
@@ -136,8 +133,8 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
     ) -> None:
         """Handle recording start for a robot instance.
 
-        Updates internal state and emits RECORDING_STARTED event. If the robot
-        was already recording with a different ID, stops the previous recording first.
+        Updates internal state. If the robot was already recording with a different
+        ID, stops the previous recording first.
 
         Args:
             robot_id: Robot ID
@@ -162,13 +159,6 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
 
         self.recording_robot_instances[instance_key] = recording_id
         self._schedule_recording_timers(
-            robot_id=robot_id,
-            instance=instance,
-            recording_id=recording_id,
-        )
-
-        self.emit(
-            self.RECORDING_STARTED,
             robot_id=robot_id,
             instance=instance,
             recording_id=recording_id,
@@ -233,8 +223,8 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
     ) -> None:
         """Handle recording stop for a robot instance.
 
-        Updates internal state and emits RECORDING_STOPPED event. Only processes
-        the stop if the recording ID matches the current recording.
+        Updates internal state. Only processes the stop if the recording ID
+        matches the current recording.
 
         Args:
             robot_id: Robot ID
@@ -249,12 +239,6 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
             return
         self.recording_robot_instances.pop(instance_key, None)
         self._cancel_recording_timers(recording_id)
-        self.emit(
-            self.RECORDING_STOPPED,
-            robot_id=robot_id,
-            instance=instance,
-            recording_id=recording_id,
-        )
 
     def updated_recording_state(
         self, is_recording: bool, details: BaseRecodingUpdatePayload
@@ -308,12 +292,32 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
             instance_key = RobotInstanceIdentifier(
                 robot_id=robot_id, robot_instance=instance
             )
+            callback = self._drain_callbacks.get(instance_key)
+            if callback:
+                threading.Thread(
+                    target=callback,
+                    args=(recording_id,),
+                    daemon=True,
+                    name=f"remote-stop-{recording_id[:8]}",
+                ).start()
             self.active_dataset_ids.pop(instance_key, None)
             self.recording_stopped(
                 robot_id=robot_id,
                 instance=instance,
                 recording_id=recording_id,
             )
+
+    def register_remote_stop_handler(
+        self, robot_id: str, instance: int, callback: Callable[[str], None]
+    ) -> None:
+        """Register a callback to drain streams when a web-initiated stop arrives."""
+        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
+        self._drain_callbacks[key] = callback
+
+    def deregister_remote_stop_handler(self, robot_id: str, instance: int) -> None:
+        """Remove the drain callback for a robot instance."""
+        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
+        self._drain_callbacks.pop(key, None)
 
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.
@@ -337,9 +341,7 @@ class RecordingStateManager(BaseSSEConsumer, AsyncIOEventEmitter):
         """
         message = RecordingNotification.model_validate_json(message_data)
         # Python 3.9 compatibility: replace match/case with if/elif
-        if message.type == RecordingNotificationType.SAVED:
-            self.emit(self.RECORDING_SAVED, **message.payload.model_dump())
-        elif message.type == RecordingNotificationType.START:
+        if message.type == RecordingNotificationType.START:
             self.updated_recording_state(is_recording=True, details=message.payload)
 
         elif message.type in (

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from neuracore_types import DataType
 
 from neuracore.core.robot import Robot
@@ -65,3 +67,45 @@ def test_stop_all_streams_removes_stale_stream_and_continues() -> None:
     assert "JOINT_POSITIONS:joint" in robot.list_all_streams()
     assert robot._data_stream_counts[DataType.CUSTOM_1D] == 0
     assert robot._data_stream_counts[DataType.JOINT_POSITIONS] == 1
+
+
+def test_web_stop_drains_streams_and_notifies_daemon() -> None:
+    """Callback registered at connect time must drain streams and notify the daemon."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    captured: dict[str, object] = {}
+
+    class _FakeManager:
+        def register_remote_stop_handler(
+            self, robot_id: str, instance: int, callback: object
+        ) -> None:
+            captured["callback"] = callback
+
+        def deregister_remote_stop_handler(self, robot_id: str, instance: int) -> None:
+            pass
+
+    with patch(
+        "neuracore.core.robot.get_recording_state_manager", return_value=_FakeManager()
+    ):
+        robot._register_remote_stop_handler()
+        robot.id = None  # prevent __del__ from hitting the real manager
+
+    callback = captured["callback"]
+    assert callable(callback)
+    callback("rec-abc")
+
+    assert active.stop_calls == [{
+        "stop_cutoff_sequence_number": 42,
+        "wait_for_producer_drain": False,
+    }]
+    fake_daemon.stop_recording.assert_called_once_with(
+        recording_id="rec-abc",
+        producer_stop_sequence_numbers={"active-channel": 42},
+    )


### PR DESCRIPTION
When a recording is stopped from the web frontend, we were never draining data streams or notifying the data daemon, so recordings were never finalized or uploaded. The bug was introduced when the data daemon was updated to use a shared ring buffer transport that requires an explicit stop IPC with sequence number cutoffs in this pr: [NCP-695](https://github.com/NeuracoreAI/neuracore/pull/595)

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Fixed by registering a remote stop handler on connect that drains streams and notifies the daemon the same way the local stop path does, but is only triggered by the SSE stop event.
 - Added a test for this remote path which checks if drain happend after the sse

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-970](https://neuracore.atlassian.net/browse/NCP-970)

