### PR TITLE
fix: update robot list request

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -37,6 +37,8 @@ from .utils.http_errors import extract_error_detail
 logger = logging.getLogger(__name__)
 DaemonRecordingContext = recording_context.RecordingContext
 
+_ROBOTS_LIST_PAGE_SIZE = 30
+
 
 @dataclass
 class JointLimits:
@@ -913,14 +915,31 @@ def list_organization_robots(
         raise RobotError(
             "Invalid robot list mode. Please use 'current', 'archived', or 'mixed'."
         )
+    robots: list[dict] = []
+    start_after: dict | None = None
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/robots?is_shared={is_shared}&mode={mode}",
-                headers=get_auth().get_headers(),
-            )
-            response.raise_for_status()
-            return response.json()
+        while True:
+            with Session() as session:
+                response = session.post(
+                    f"{API_URL}/org/{org_id}/robots/list",
+                    headers=get_auth().get_headers(),
+                    params={
+                        "is_shared": str(is_shared).lower(),
+                        "mode": mode,
+                        "limit": str(_ROBOTS_LIST_PAGE_SIZE),
+                    },
+                    json=start_after,
+                )
+                response.raise_for_status()
+                page = response.json()
+
+            batch = page.get("data", [])
+            robots.extend(batch)
+            total = page.get("total", len(robots))
+            if not batch or len(robots) >= total:
+                break
+            start_after = batch[-1]
+        return robots
     except requests.exceptions.ConnectionError:
         raise RobotError(
             "Failed to connect to neuracore server, "
@@ -949,23 +968,10 @@ def get_robot_id_from_name(robot_name: str, org_id: str | None = None) -> str:
     if org_id is None:
         org_id = get_current_org()
 
-    with Session() as session:
-        response_private = session.get(
-            f"{API_URL}/org/{org_id}/robots",
-            headers=get_auth().get_headers(),
-            params={"is_shared": False},
-        )
+    private_robots = list_organization_robots(org_id, is_shared=False)
+    shared_robots = list_organization_robots(org_id, is_shared=True)
+    robots = private_robots + shared_robots
 
-        response_shared = session.get(
-            f"{API_URL}/org/{org_id}/robots",
-            headers=get_auth().get_headers(),
-            params={"is_shared": True},
-        )
-
-    response_private.raise_for_status()
-    response_shared.raise_for_status()
-
-    robots = response_private.json() + response_shared.json()
     # There is a change the same name can exist in both private and shared,
     # we will return the private first in this case
     for robot in robots:

--- a/tests/unit/ml/utils/test_robot_data_spec_utils.py
+++ b/tests/unit/ml/utils/test_robot_data_spec_utils.py
@@ -17,20 +17,95 @@ def _indexed_names(*names: str) -> dict[int, str]:
     return dict(enumerate(names))
 
 
+def _robots_list_requests(mock_auth_requests, mocked_org_id: str):
+    list_url = f"{API_URL}/org/{mocked_org_id}/robots/list"
+    return [r for r in mock_auth_requests.request_history if r.url.startswith(list_url)]
+
+
+def _robots_list_page(
+    robots: list[dict],
+    *,
+    total: int | None = None,
+) -> dict:
+    return {
+        "data": robots,
+        "metadata": None,
+        "total": total if total is not None else len(robots),
+        "limit": 30,
+        "start_after": None,
+    }
+
+
 @pytest.fixture
-def mock_auth_requests_robots(mock_auth_requests):
+def mock_current_org(monkeypatch, mocked_org_id):
+    monkeypatch.setattr(
+        "neuracore.core.robot.get_current_org",
+        lambda: mocked_org_id,
+    )
+
+
+@pytest.fixture
+def mock_auth_requests_robots(
+    mock_auth_requests,
+    temp_config_dir,
+    reset_neuracore,
+    mocked_org_id,
+    mock_current_org,
+):
     nc.login("test_api_key")
-    mocked_org_id = "test-org-id"
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/robots?is_shared=false",
-        json=[{"id": TEST_ROBOT_ID, "name": "robot_name"}],
+    robot = {"id": TEST_ROBOT_ID, "name": "robot_name"}
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots/list",
+        json=_robots_list_page([robot]),
         status_code=200,
     )
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/robots?is_shared=true",
-        json=[{"id": TEST_ROBOT_ID, "name": "robot_name"}],
-        status_code=200,
+
+
+@pytest.fixture
+def mock_auth_requests_robots_paginated(
+    mock_auth_requests,
+    temp_config_dir,
+    reset_neuracore,
+    mocked_org_id,
+    mock_current_org,
+):
+    nc.login("test_api_key")
+    other_robot = {
+        "id": "11111111-1111-4111-8111-111111111111",
+        "name": "other_robot",
+    }
+    target_robot = {"id": TEST_ROBOT_ID, "name": "robot_name"}
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots/list",
+        [
+            {
+                "json": _robots_list_page([other_robot], total=2),
+                "status_code": 200,
+            },
+            {
+                "json": _robots_list_page([target_robot], total=2),
+                "status_code": 200,
+            },
+            {
+                "json": _robots_list_page([]),
+                "status_code": 200,
+            },
+        ],
     )
+
+
+def test_convert_robot_data_spec_names_to_ids_resolves_name_across_pages(
+    mock_auth_requests,
+    mock_auth_requests_robots_paginated,
+    mocked_org_id,
+) -> None:
+    spec = {"robot_name": {DataType.RGB_IMAGES: _indexed_names("cam")}}
+    result = convert_cross_embodiment_description_names_to_ids(spec)
+
+    assert result == {TEST_ROBOT_ID: {DataType.RGB_IMAGES: _indexed_names("cam")}}
+
+    list_requests = _robots_list_requests(mock_auth_requests, mocked_org_id)
+    assert len(list_requests) == 3
 
 
 def test_convert_robot_data_spec_names_to_ids_raises_error_on_duplicates(


### PR DESCRIPTION
### Bugfixes
- Get robot id from name should use the new list method since the old one is now deprecated in (https://github.com/NeuracoreAI/neuracore_backend/pull/379)

### Items
 - [NCRL-593](https://neuracore.atlassian.net/browse/NCRL-593)

### Related PRs
- https://github.com/NeuracoreAI/neuracore_backend/pull/379