### PR TITLE
fix: select org for cli training run inspections

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -336,11 +336,12 @@ def get_training_job_logs(
         raise ValueError(f"Error getting training job logs: {e}")
 
 
-def delete_training_job(job_id: str) -> None:
+def delete_training_job(job_id: str, org_id: str | None = None) -> None:
     """Delete a training job and free its resources.
 
     Args:
         job_id: The ID of the training job to delete
+        org_id: Optional organization ID. Defaults to the current organization.
 
     Raises:
         ValueError: If there is an error deleting the job
@@ -349,11 +350,11 @@ def delete_training_job(job_id: str) -> None:
         ConfigError: If there is an error trying to get the current org
     """
     auth = get_auth()
-    org_id = get_current_org()
+    resolved_org_id = org_id or get_current_org()
     try:
         session = thread_local_session()
         response = session.delete(
-            f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
+            f"{API_URL}/org/{resolved_org_id}/training/jobs/{job_id}",
             headers=auth.get_headers(),
         )
         response.raise_for_status()

--- a/neuracore/core/cli/training_commands.py
+++ b/neuracore/core/cli/training_commands.py
@@ -25,6 +25,7 @@ from neuracore.core.cli.training_display import (
     RunDisplayRow,
     print_run_table,
 )
+from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import DEFAULT_CACHE_DIR
 from neuracore.core.exceptions import AuthenticationError, ConfigError, TrainingRunError
 from neuracore.ml.cli import training_runs_cloud as training_runs
@@ -585,6 +586,7 @@ def delete_training(
 
     try:
         if use_cloud:
+            org_id = get_current_org()
             job_id, job = _resolve_cloud_training_job(training_name)
             if not yes:
                 confirm = typer.confirm(
@@ -593,7 +595,7 @@ def delete_training(
                 if not confirm:
                     typer.echo("Aborted.")
                     raise typer.Exit(code=0)
-            delete_training_job(job_id)
+            delete_training_job(job_id, org_id=org_id)
             typer.echo(f"Deleted cloud training run '{job.name}' ({job_id}).")
         else:
             run_path = _resolve_local_run_path(training_name, root)

--- a/tests/unit/ml/test_training_cli.py
+++ b/tests/unit/ml/test_training_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 
 import neuracore as nc
 from neuracore.core.cli.app import app
+from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.const import API_URL
 
 runner = CliRunner()
@@ -128,6 +129,61 @@ def test_training_cloud_list(
     assert "No" in result.output
     assert "cnnmlp" in result.output
     assert "dataset_123" in result.output
+
+
+def test_training_cloud_list_uses_env_org_override(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    sample_training_jobs_response,
+    monkeypatch,
+):
+    """Cloud list prefers the environment organization over select-org."""
+    nc.login("test_api_key")
+    other_org_id = "other-org-id"
+    monkeypatch.setenv("NEURACORE_ORG_ID", mocked_org_id)
+
+    mock_auth_requests.get(
+        f"{API_URL}/org-management/my-orgs",
+        json=[
+            {"org": {"id": mocked_org_id, "name": "test organization"}},
+            {"org": {"id": other_org_id, "name": "Other Org"}},
+        ],
+    )
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs",
+        json=sample_training_jobs_response,
+        status_code=200,
+    )
+
+    select_result = runner.invoke(
+        app,
+        ["select-org", "--org-name", "Other Org"],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+    assert select_result.exit_code == 0
+    get_config_manager()._config = None
+
+    result = runner.invoke(
+        app,
+        ["training", "list", "--cloud"],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "training_run_1" in result.output
+    assert any(
+        req.method == "GET"
+        and req.url == f"{API_URL}/org/{mocked_org_id}/training/jobs"
+        for req in mock_auth_requests.request_history
+    )
+    assert not any(
+        req.method == "GET" and req.url == f"{API_URL}/org/{other_org_id}/training/jobs"
+        for req in mock_auth_requests.request_history
+    )
 
 
 def test_training_local_inspect(tmp_path):
@@ -289,5 +345,65 @@ def test_training_cloud_delete(
     assert "Deleted cloud training run 'training_run_1' (job_123)." in result.output
     assert any(
         req.method == "DELETE" and req.url.endswith("/job_123")
+        for req in mock_auth_requests.request_history
+    )
+
+
+def test_training_cloud_delete_uses_env_org_override(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    sample_training_jobs_response,
+    monkeypatch,
+):
+    """Delete prefers the environment organization over select-org."""
+    nc.login("test_api_key")
+    other_org_id = "other-org-id"
+    monkeypatch.setenv("NEURACORE_ORG_ID", mocked_org_id)
+
+    mock_auth_requests.get(
+        f"{API_URL}/org-management/my-orgs",
+        json=[
+            {"org": {"id": mocked_org_id, "name": "test organization"}},
+            {"org": {"id": other_org_id, "name": "Other Org"}},
+        ],
+    )
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs",
+        json=sample_training_jobs_response,
+        status_code=200,
+    )
+    mock_auth_requests.delete(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123", status_code=204
+    )
+
+    select_result = runner.invoke(
+        app,
+        ["select-org", "--org-name", "Other Org"],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+    assert select_result.exit_code == 0
+    get_config_manager()._config = None
+
+    result = runner.invoke(
+        app,
+        [
+            "training",
+            "delete",
+            "--training-name",
+            "training_run_1",
+            "--yes",
+        ],
+        color=False,
+        env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "Deleted cloud training run 'training_run_1' (job_123)." in result.output
+    assert any(
+        req.method == "DELETE"
+        and req.url == f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123"
         for req in mock_auth_requests.request_history
     )


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Bug notices by Mark/Halid/Ke for when they selected an org with select org and then viewed their traning runs it used the primary org, added extra param to handle requests for different organisations. 