### PR TITLE
feat: policy inference fall back to active robot if no robot name/id given

### DIFF
--- a/examples/example_local_endpoint_bigym.py
+++ b/examples/example_local_endpoint_bigym.py
@@ -137,13 +137,32 @@ def main(
         mjcf_path="bigym/bigym/envs/xmls/h1/h1.xml",  # Update path as needed
         overwrite=True,
     )
-    # If you know the path to the local model.nc.zip file
-    # you can use it directly without connecting to a robot
+    # If you have a train run name, you can use it to connect to a local policy. E.g.:
     policy = nc.policy(
-        model_file="PATH/TO/MODEL.nc.zip",
-        input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
-        output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+        train_run_name=TRAINING_JOB_NAME,
     )
+
+    # If the robot you are using is not present in the training,
+    # you can specify the embodiment descriptions explicitly as:
+    # policy = nc.policy(
+    #     train_run_name=TRAINING_JOB_NAME,
+    #     input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+    #     output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+    # )
+
+    # If you know the path to the local model.nc.zip file, you can use it directly as:
+    # policy = nc.policy(
+    #     model_file="PATH/TO/MODEL.nc.zip",
+    #     input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+    #     output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+    # )
+
+    # Alternatively, you can connect to a local endpoint that has been started
+    # policy = nc.policy_local_server(
+    #     train_run_name=TRAINING_JOB_NAME,
+    #     input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+    #     output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+    # )
 
     # Optional. Set the checkpoint to the last epoch.
     # Note by default, model is loaded from the last epoch.

--- a/examples/example_local_endpoint_vx300s.py
+++ b/examples/example_local_endpoint_vx300s.py
@@ -54,12 +54,18 @@ def main():
         urdf_path=str(BIMANUAL_VIPERX_URDF_PATH),
         overwrite=False,
     )
-    # If you have a train run name, you can use it to connect to a local. E.g.:
+    # If you have a train run name, you can use it to connect to a local policy. E.g.:
     policy = nc.policy(
         train_run_name=TRAINING_JOB_NAME,
-        input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
-        output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
     )
+
+    # If the robot you are using is not present in the training,
+    # you can specify the embodiment descriptions explicitly as:
+    # policy = nc.policy(
+    #     train_run_name=TRAINING_JOB_NAME,
+    #     input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+    #     output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+    # )
 
     # If you know the path to the local model.nc.zip file, you can use it directly as:
     # policy = nc.policy(

--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -5,6 +5,8 @@ managing local model endpoints, and handling the lifecycle of model deployments
 including deployment, status monitoring, and deletion operations.
 """
 
+import logging
+
 from neuracore_types import (
     DeploymentConfig,
     DeploymentRequest,
@@ -32,15 +34,25 @@ from neuracore.core.utils.robot_data_spec_utils import (
     resolve_embodiment_descriptions_with_override,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def _resolve_robot_id(
     robot_id: str | None, robot_name: str | None, instance: int
 ) -> str | None:
-    """Resolve robot_id from explicit id or robot name."""
-    if robot_name is not None:
-        assert robot_id is None, "Specify only one of robot_id or robot_name."
-        return _get_robot(robot_name, instance).id
-    return robot_id
+    """Resolve robot_id from explicit id or robot name.
+
+    If both robot ID and robot name are provided, robot_id takes precedence.
+    If both are omitted, the active robot is used as a fallback.
+    """
+    if robot_id is not None:
+        if robot_name is not None:
+            logger.warning(
+                "Both robot_id and robot_name were provided; "
+                "using robot_id and ignoring robot_name."
+            )
+        return robot_id
+    return _get_robot(robot_name, instance).id
 
 
 def policy(
@@ -65,7 +77,8 @@ def policy(
         model_file: Path to the model file to load.
         device: Torch device to run the model on (CPU or GPU, or MPS).
         robot_id: Robot ID used to select embodiments from the model archive when
-            input/output embodiments are not provided.
+            input/output embodiments are not provided. If both robot_id and
+            robot_name are omitted, the active robot is used as a fallback.
         robot_name: Robot name to resolve to robot_id before model loading.
         instance: Robot instance number used with robot_name resolution.
 
@@ -76,7 +89,18 @@ def policy(
         EndpointError: If the model download or initialization fails.
         ConfigError: If there is an error trying to get the current org.
     """
-    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+    if not (input_embodiment_description and output_embodiment_description):
+        try:
+            robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+        except Exception:
+            raise ValueError(
+                "Missing input_embodiment_description or "
+                "output_embodiment_description for policy inference. "
+                "Tried to load from training metadata or the model archive "
+                "using robot_id/robot_name/active robot, but failed. "
+                "Please provide a robot_id/robot_name or connect to "
+                "a robot first."
+            )
 
     return _policy(
         input_embodiment_description=input_embodiment_description,
@@ -113,7 +137,8 @@ def policy_local_server(
         port: TCP port number where the local server will run.
         host: Host address to bind the server to. Defaults to localhost.
         robot_id: Robot ID used to select embodiments from the model archive when
-            input/output embodiments are not provided.
+            input/output embodiments are not provided. If both robot_id and
+            robot_name are omitted, the active robot is used as a fallback.
         robot_name: Robot name to resolve to robot_id before model loading.
         instance: Robot instance number used with robot_name resolution.
 
@@ -124,7 +149,18 @@ def policy_local_server(
         EndpointError: If the server startup or model initialization fails.
         ConfigError: If there is an error trying to get the current org.
     """
-    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+    if not (input_embodiment_description and output_embodiment_description):
+        try:
+            robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+        except Exception:
+            raise ValueError(
+                "Missing input_embodiment_description or "
+                "output_embodiment_description for policy inference. "
+                "Tried to load from training metadata or the model archive "
+                "using robot_id/robot_name/active robot, but failed. "
+                "Please provide a robot_id/robot_name or connect to "
+                "a robot first."
+            )
 
     return _policy_local_server(
         input_embodiment_description=input_embodiment_description,
@@ -188,7 +224,8 @@ def deploy_model(
             the endpoint will be automatically deleted after this duration.
         gpu_type: Type of GPU to use for deployment.
         robot_id: Robot ID used to select embodiments from the model archive when
-            input/output embodiments are not provided.
+            input/output embodiments are not provided. If both robot_id and
+            robot_name are omitted, the active robot is used as a fallback.
         robot_name: Robot name to resolve to robot_id before model loading.
         instance: Robot instance number used with robot_name resolution.
 
@@ -206,7 +243,19 @@ def deploy_model(
     """
     auth = get_auth()
     org_id = get_current_org()
-    robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+
+    if not (input_embodiment_description and output_embodiment_description):
+        try:
+            robot_id = _resolve_robot_id(robot_id, robot_name, instance)
+        except Exception:
+            raise ValueError(
+                "Missing input_embodiment_description or "
+                "output_embodiment_description for policy inference. "
+                "Tried to load from training metadata or the model archive "
+                "using robot_id/robot_name/active robot, but failed. "
+                "Please provide a robot_id/robot_name or connect to "
+                "a robot first."
+            )
 
     (
         resolved_input_embodiment_description,

--- a/neuracore/core/utils/robot_data_spec_utils.py
+++ b/neuracore/core/utils/robot_data_spec_utils.py
@@ -257,10 +257,9 @@ def resolve_embodiment_descriptions_with_override(
             or output_cross_embodiment_description is None
         ):
             raise ValueError(
-                "Must provide both input_cross_embodiment_description and "
-                "output_cross_embodiment_description, or provide robot_id "
-                "with job_id or model_file to load them from training "
-                "metadata or the model archive."
+                "Failed to load input_cross_embodiment_description and "
+                "output_cross_embodiment_description from training metadata "
+                "or the model archive."
             )
 
         (
@@ -282,6 +281,7 @@ def resolve_embodiment_descriptions_with_override(
         or resolved_output_embodiment_description is None
     ):
         raise ValueError(
+            "Failed to resolve embodiment descriptions. "
             "Must provide both input_embodiment_description and "
             "output_embodiment_description, or provide robot_id with job_id/model_file "
             "to load them from training metadata or the model archive."

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import requests_mock
 
 import neuracore as nc
+from neuracore.api.globals import GlobalSingleton
 from neuracore.core.config import config_manager
 from neuracore.core.const import API_URL
 from neuracore.core.streaming.p2p.provider.global_live_data_enabled import (
@@ -162,16 +163,26 @@ def mock_model_mar(tmp_path):
 def reset_neuracore():
     """Reset Neuracore global state between tests."""
     original_auth = nc.core.auth._auth
+    global_state = GlobalSingleton()
+    original_active_robot = global_state._active_robot
+    original_active_dataset_id = global_state._active_dataset_id
+    original_has_validated_version = global_state._has_validated_version
 
     nc.api._active_robot = None
     nc.api._active_dataset_id = None
     nc.api._active_recording_id = None
+    global_state._active_robot = None
+    global_state._active_dataset_id = None
+    global_state._has_validated_version = False
 
     nc.core.auth._auth = nc.core.auth.Auth()
 
     yield
 
     nc.core.auth._auth = original_auth
+    global_state._active_robot = original_active_robot
+    global_state._active_dataset_id = original_active_dataset_id
+    global_state._has_validated_version = original_has_validated_version
 
 
 @pytest.fixture

--- a/tests/unit/ml/test_direct_policy_endpoint.py
+++ b/tests/unit/ml/test_direct_policy_endpoint.py
@@ -3,6 +3,7 @@
 This module tests the DirectPolicy and other core endpoint classes.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -18,10 +19,16 @@ from neuracore_types import (
 )
 
 import neuracore as nc
+import neuracore.api.endpoints as endpoints
 from neuracore.core.const import API_URL
 from neuracore.core.endpoint import DirectPolicy
+from neuracore.core.exceptions import RobotError
 
 TEST_API_KEY = "test_api_key"
+TEST_ROBOT_ID = "test_robot"
+TEST_ROBOT_PAYLOAD = {"robot_id": "mock_robot_id", "has_urdf": True}
+TRAIN_RUN_NAME = "test_run"
+TRAIN_JOB_ID = "job_123"
 
 
 def _ordered_names(names_or_mapping):
@@ -50,6 +57,231 @@ def _mock_policy_output(output_embodiment_description):
             for name in _ordered_names(names_or_mapping)
         }
     return output
+
+
+def test_resolve_robot_id_returns_explicit_robot_id(monkeypatch):
+    """When only robot_id is provided, it should be returned without lookup."""
+
+    assert (
+        endpoints._resolve_robot_id(robot_id="robot-123", robot_name=None, instance=0)
+        == "robot-123"
+    )
+
+
+def test_resolve_robot_id_resolves_robot_name_via_get_robot(monkeypatch):
+    """When only robot_name is provided, it should resolve via get_robot."""
+    robot_name = "my-robot"
+    instance = 2
+    stub_robot = SimpleNamespace(id="resolved-robot-id")
+    mock_get_robot = MagicMock(return_value=stub_robot)
+    monkeypatch.setattr("neuracore.api.core.get_robot", mock_get_robot)
+
+    resolved = endpoints._resolve_robot_id(
+        robot_id=None, robot_name=robot_name, instance=instance
+    )
+    assert resolved == "resolved-robot-id"
+    mock_get_robot.assert_called_once_with(robot_name, instance)
+
+
+def test_resolve_robot_id_prioritizes_robot_id_when_both_are_provided(caplog):
+    """When both selectors are provided, robot_id should take precedence."""
+    resolved = endpoints._resolve_robot_id(
+        robot_id="robot-123", robot_name="my-robot", instance=0
+    )
+    assert resolved == "robot-123"
+
+
+def test_resolve_robot_id_falls_back_to_active_robot(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    monkeypatch,
+    mock_urdf,
+):
+    """When neither selector is provided, use the active robot."""
+    nc.login("test_api_key")
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json={"robot_id": "mock_robot_id", "has_urdf": True},
+        status_code=200,
+    )
+    nc.connect_robot("test_robot", urdf_path=mock_urdf)
+
+    resolved = endpoints._resolve_robot_id(robot_id=None, robot_name=None, instance=0)
+    assert resolved == "mock_robot_id"
+
+
+def test_resolve_robot_id_raises_when_no_active_robot(reset_neuracore):
+    """When neither selector is provided and there is no active robot, raise."""
+    with pytest.raises(RobotError, match="No active robot"):
+        endpoints._resolve_robot_id(robot_id=None, robot_name=None, instance=0)
+
+
+def _login_and_connect_robot(
+    mock_auth_requests, mocked_org_id: str, *, mock_urdf: str | None = None
+) -> None:
+    nc.login(TEST_API_KEY)
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json=TEST_ROBOT_PAYLOAD,
+        status_code=200,
+    )
+    if mock_urdf is not None:
+        nc.connect_robot(TEST_ROBOT_ID, urdf_path=mock_urdf)
+    else:
+        nc.connect_robot(TEST_ROBOT_ID)
+
+
+def _mock_training_job_metadata(mock_auth_requests, mocked_org_id: str) -> None:
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/{TRAIN_JOB_ID}",
+        json={
+            "input_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_POSITIONS": {"0": "joint1"}}
+            },
+            "output_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
+            },
+        },
+        status_code=200,
+    )
+
+
+def _setup_direct_policy_train_run_mocks(
+    mock_auth_requests,
+    mocked_org_id: str,
+    port: int,
+    *,
+    job_id: str = TRAIN_JOB_ID,
+    train_run_name: str = TRAIN_RUN_NAME,
+) -> None:
+    localhost = f"http://127.0.0.1:{port}"
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs",
+        json=[{
+            "id": job_id,
+            "name": train_run_name,
+            "status": "completed",
+        }],
+        status_code=200,
+    )
+    _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/{job_id}/model_url",
+        json={"url": f"{localhost}/model.nc.zip"},
+        status_code=200,
+    )
+    mock_auth_requests.get(
+        f"{localhost}/model.nc.zip",
+        content=b"dummy model content",
+        status_code=200,
+    )
+
+
+def _patch_policy_inference_model_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_model = SimpleNamespace(
+        eval=lambda: None,
+        model_init_description=SimpleNamespace(
+            input_dataset_statistics={},
+            output_prediction_horizon=1,
+        ),
+    )
+    monkeypatch.setattr(
+        "neuracore.ml.utils.policy_inference.load_model_from_nc_archive",
+        lambda model_file, device=None: (
+            fake_model,
+            {},
+            {},
+            {"JOINT_POSITIONS": []},
+            {},
+        ),
+    )
+
+
+def _assert_policy_embodiments_from_job_metadata(direct_policy: DirectPolicy) -> None:
+    assert direct_policy._policy.input_embodiment_description[
+        DataType.JOINT_POSITIONS
+    ] == {"0": "joint1"}
+    assert direct_policy._policy.output_embodiment_description[
+        DataType.JOINT_TARGET_POSITIONS
+    ] == {"0": "joint1"}
+
+
+def test_policy_loads_embodiments_from_job_metadata_for_robot_id(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    monkeypatch,
+):
+    """Direct policy should load embodiments from job metadata when robot_id is set."""
+    nc.login(TEST_API_KEY)
+    port = np.random.randint(8000, 9000)
+    _setup_direct_policy_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    _patch_policy_inference_model_load(monkeypatch)
+
+    direct_policy = nc.policy(
+        train_run_name=TRAIN_RUN_NAME,
+        robot_id=TEST_ROBOT_PAYLOAD["robot_id"],
+    )
+
+    _assert_policy_embodiments_from_job_metadata(direct_policy)
+
+
+def test_policy_loads_embodiments_from_job_metadata_for_robot_name(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    monkeypatch,
+    mock_urdf,
+):
+    """Direct policy should resolve robot_name and load job metadata embodiments."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id, mock_urdf=mock_urdf)
+    port = np.random.randint(8000, 9000)
+    _setup_direct_policy_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    _patch_policy_inference_model_load(monkeypatch)
+
+    direct_policy = nc.policy(
+        train_run_name=TRAIN_RUN_NAME,
+        robot_name=TEST_ROBOT_ID,
+    )
+
+    _assert_policy_embodiments_from_job_metadata(direct_policy)
+
+
+def test_policy_loads_embodiments_from_job_metadata_for_active_robot(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    monkeypatch,
+    mock_urdf,
+):
+    """Direct policy should use the active robot when no robot selector is provided."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id, mock_urdf=mock_urdf)
+    port = np.random.randint(8000, 9000)
+    _setup_direct_policy_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    _patch_policy_inference_model_load(monkeypatch)
+
+    direct_policy = nc.policy(train_run_name=TRAIN_RUN_NAME)
+
+    _assert_policy_embodiments_from_job_metadata(direct_policy)
+
+
+def test_policy_raises_when_missing_embodiments_and_robot_selector(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mock_model_mar,
+    monkeypatch,
+):
+    """Direct policy requires embodiments or a robot_id/robot_name/active robot."""
+    nc.login(TEST_API_KEY)
+    _patch_policy_inference_model_load(monkeypatch)
+    with pytest.raises(ValueError, match="Missing input_embodiment_description"):
+        nc.policy(model_file=mock_model_mar)
 
 
 @pytest.fixture
@@ -575,26 +807,12 @@ def test_connect_direct_policy_with_train_run(
     """Test connecting to a direct in-process policy using a training run name."""
     nc.login(TEST_API_KEY)
     port = np.random.randint(8000, 9000)
-    localhost = f"http://127.0.0.1:{port}"
-
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/training/jobs",
-        json=[{
-            "id": "job_direct_123",
-            "name": "test_run_direct",
-            "status": "completed",
-        }],
-        status_code=200,
-    )
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_direct_123/model_url",
-        json={"url": f"{localhost}/model.nc.zip"},
-        status_code=200,
-    )
-    mock_auth_requests.get(
-        f"{localhost}/model.nc.zip",
-        content=b"dummy model content",
-        status_code=200,
+    _setup_direct_policy_train_run_mocks(
+        mock_auth_requests,
+        mocked_org_id,
+        port,
+        job_id="job_direct_123",
+        train_run_name="test_run_direct",
     )
 
     input_embodiment_description = {

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -49,6 +49,107 @@ def _login_and_connect_robot(mock_auth_requests, mocked_org_id: str) -> None:
     nc.connect_robot(TEST_ROBOT_ID)
 
 
+def _mock_deploy_endpoint(mock_auth_requests, mocked_org_id: str) -> None:
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/models/deploy",
+        json={"id": "endpoint_123", "name": "test_endpoint", "status": "deploying"},
+        status_code=200,
+    )
+
+
+def _mock_training_job_metadata(mock_auth_requests, mocked_org_id: str) -> None:
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123",
+        json={
+            "input_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_POSITIONS": {"0": "joint1"}}
+            },
+            "output_cross_embodiment_description": {
+                "mock_robot_id": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
+            },
+        },
+        status_code=200,
+    )
+
+
+def _assert_deployed_embodiments_from_job_metadata(request_body: dict) -> None:
+    assert request_body["input_embodiment_description"]["JOINT_POSITIONS"] == {
+        "0": "joint1"
+    }
+    assert request_body["output_embodiment_description"]["JOINT_TARGET_POSITIONS"] == {
+        "0": "joint1"
+    }
+
+
+def _local_server_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}"
+
+
+def _mock_local_server_http(
+    mock_auth_requests, port: int, *, predict: bool = False
+) -> str:
+    localhost = _local_server_url(port)
+    mock_auth_requests.get(f"{localhost}/ping", status_code=200)
+    if predict:
+        mock_auth_requests.post(
+            f"{localhost}/predict",
+            json=FAKE_PREDICTED_DATA_JSON,
+            status_code=200,
+        )
+    return localhost
+
+
+def _setup_policy_local_server_train_run_mocks(
+    mock_auth_requests, mocked_org_id: str, port: int, *, predict: bool = False
+) -> str:
+    localhost = _mock_local_server_http(mock_auth_requests, port, predict=predict)
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs",
+        json=[{
+            "id": "job_123",
+            "name": "test_run",
+            "status": "completed",
+        }],
+        status_code=200,
+    )
+    _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
+    mock_auth_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123/model_url",
+        json={"url": f"{localhost}/model.nc.zip"},
+        status_code=200,
+    )
+    mock_auth_requests.get(
+        f"{localhost}/model.nc.zip",
+        content=b"dummy model content",
+        status_code=200,
+    )
+    return localhost
+
+
+def _patch_subprocess_for_local_server(
+    monkeypatch, *, capture: bool = False
+) -> list[list[str]]:
+    captured_commands: list[list[str]] = []
+
+    def popen(cmd, **kwargs):
+        if capture:
+            captured_commands.append(cmd)
+        return mock_subprocess_popen(cmd, **kwargs)
+
+    monkeypatch.setattr("subprocess.Popen", popen)
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+    return captured_commands
+
+
+def _assert_local_policy_passes_robot_id(
+    local_endpoint, captured_commands: list[list[str]], expected_robot_id: str
+) -> None:
+    assert local_endpoint.robot_id == expected_robot_id
+    cmd = captured_commands[0]
+    robot_id_flag_index = cmd.index("--robot-id")
+    assert cmd[robot_id_flag_index + 1] == expected_robot_id
+
+
 def _log_default_inputs() -> None:
     nc.log_joint_positions(positions={"joint1": 0.5, "joint2": 0.5, "joint3": 0.5})
     nc.log_rgb("top_camera", np.zeros((100, 100, 3), dtype=np.uint8))
@@ -438,21 +539,8 @@ def test_connect_local_endpoint(
     """Test connecting to a local endpoint."""
 
     port = np.random.randint(8000, 9000)
-    localhost = f"http://127.0.0.1:{port}"
-
-    mock_auth_requests.get(
-        f"{localhost}/ping",
-        status_code=200,
-    )
-
-    mock_auth_requests.post(
-        f"{localhost}/predict",
-        json=FAKE_PREDICTED_DATA_JSON,
-        status_code=200,
-    )
-
-    monkeypatch.setattr("subprocess.Popen", mock_subprocess_popen)
-    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+    _mock_local_server_http(mock_auth_requests, port, predict=True)
+    _patch_subprocess_for_local_server(monkeypatch)
 
     _login_and_connect_robot(mock_auth_requests, mocked_org_id)
 
@@ -480,17 +568,8 @@ def test_local_endpoint_filters_sync_point_from_input_description(
 ):
     """Local endpoints should only receive configured input data types."""
     port = np.random.randint(8000, 9000)
-    localhost = f"http://127.0.0.1:{port}"
-
-    mock_auth_requests.get(f"{localhost}/ping", status_code=200)
-    mock_auth_requests.post(
-        f"{localhost}/predict",
-        json=FAKE_PREDICTED_DATA_JSON,
-        status_code=200,
-    )
-
-    monkeypatch.setattr("subprocess.Popen", mock_subprocess_popen)
-    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+    _mock_local_server_http(mock_auth_requests, port, predict=True)
+    _patch_subprocess_for_local_server(monkeypatch)
 
     _login_and_connect_robot(mock_auth_requests, mocked_org_id)
 
@@ -694,42 +773,63 @@ def test_deploy_model_failure(
         )
 
 
+def test_deploy_model_loads_embodiments_from_job_metadata_for_robot_id(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Deploy model should load embodiments from job metadata when robot_id is set."""
+    nc.login(TEST_API_KEY)
+    _mock_deploy_endpoint(mock_auth_requests, mocked_org_id)
+    _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
+
+    result = nc.deploy_model(
+        job_id="job_123",
+        name="test_endpoint",
+        robot_id=TEST_ROBOT_PAYLOAD["robot_id"],
+    )
+
+    assert result["id"] == "endpoint_123"
+    _assert_deployed_embodiments_from_job_metadata(
+        mock_auth_requests.request_history[-1].json()
+    )
+
+
 def test_deploy_model_loads_embodiments_from_job_metadata_for_robot_name(
-    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id, monkeypatch
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
 ):
     """Deploy model should resolve robot_name and load job metadata embodiments."""
     _login_and_connect_robot(mock_auth_requests, mocked_org_id)
-    mock_auth_requests.post(
-        f"{API_URL}/org/{mocked_org_id}/models/deploy",
-        json={"id": "endpoint_123", "name": "test_endpoint", "status": "deploying"},
-        status_code=200,
-    )
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123",
-        json={
-            "input_cross_embodiment_description": {
-                "mock_robot_id": {"JOINT_POSITIONS": {"0": "joint1"}}
-            },
-            "output_cross_embodiment_description": {
-                "mock_robot_id": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
-            },
-        },
-        status_code=200,
-    )
+    _mock_deploy_endpoint(mock_auth_requests, mocked_org_id)
+    _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
 
-    nc.deploy_model(
+    result = nc.deploy_model(
         job_id="job_123",
         name="test_endpoint",
         robot_name=TEST_ROBOT_ID,
     )
 
-    request_body = mock_auth_requests.request_history[-1].json()
-    assert request_body["input_embodiment_description"]["JOINT_POSITIONS"] == {
-        "0": "joint1"
-    }
-    assert request_body["output_embodiment_description"]["JOINT_TARGET_POSITIONS"] == {
-        "0": "joint1"
-    }
+    assert result["id"] == "endpoint_123"
+    _assert_deployed_embodiments_from_job_metadata(
+        mock_auth_requests.request_history[-1].json()
+    )
+
+
+def test_deploy_model_loads_embodiments_from_job_metadata_for_active_robot(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Deploy model should use the active robot when no robot selector is provided."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    _mock_deploy_endpoint(mock_auth_requests, mocked_org_id)
+    _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
+
+    result = nc.deploy_model(
+        job_id="job_123",
+        name="test_endpoint",
+    )
+
+    assert result["id"] == "endpoint_123"
+    _assert_deployed_embodiments_from_job_metadata(
+        mock_auth_requests.request_history[-1].json()
+    )
 
 
 def test_deploy_model_raises_when_missing_embodiments_and_robot_selector(
@@ -737,13 +837,91 @@ def test_deploy_model_raises_when_missing_embodiments_and_robot_selector(
 ):
     """Deploy model requires embodiments or a robot_id/robot_name."""
     nc.login(TEST_API_KEY)
-    with pytest.raises(
-        ValueError, match="Must provide both input_embodiment_description"
-    ):
+    with pytest.raises(ValueError, match="Missing input_embodiment_description"):
         nc.deploy_model(
             job_id="job_123",
             name="test_endpoint",
         )
+
+
+def test_policy_local_server_loads_embodiments_from_job_metadata_for_robot_id(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id, monkeypatch
+):
+    """Local server should pass robot_id to the server when embodiments are omitted."""
+    nc.login(TEST_API_KEY)
+    port = np.random.randint(8000, 9000)
+    _setup_policy_local_server_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    captured_commands = _patch_subprocess_for_local_server(monkeypatch, capture=True)
+
+    local_endpoint = nc.policy_local_server(
+        train_run_name="test_run",
+        port=port,
+        robot_id=TEST_ROBOT_PAYLOAD["robot_id"],
+    )
+    try:
+        _assert_local_policy_passes_robot_id(
+            local_endpoint,
+            captured_commands,
+            TEST_ROBOT_PAYLOAD["robot_id"],
+        )
+    finally:
+        local_endpoint.disconnect()
+
+
+def test_policy_local_server_loads_embodiments_from_job_metadata_for_robot_name(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id, monkeypatch
+):
+    """Local server should resolve robot_name and pass robot_id to the server."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    port = np.random.randint(8000, 9000)
+    _setup_policy_local_server_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    captured_commands = _patch_subprocess_for_local_server(monkeypatch, capture=True)
+
+    local_endpoint = nc.policy_local_server(
+        train_run_name="test_run",
+        port=port,
+        robot_name=TEST_ROBOT_ID,
+    )
+    try:
+        _assert_local_policy_passes_robot_id(
+            local_endpoint,
+            captured_commands,
+            TEST_ROBOT_PAYLOAD["robot_id"],
+        )
+    finally:
+        local_endpoint.disconnect()
+
+
+def test_policy_local_server_loads_embodiments_from_job_metadata_for_active_robot(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id, monkeypatch
+):
+    """Local server should use the active robot when no robot selector is provided."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    port = np.random.randint(8000, 9000)
+    _setup_policy_local_server_train_run_mocks(mock_auth_requests, mocked_org_id, port)
+    captured_commands = _patch_subprocess_for_local_server(monkeypatch, capture=True)
+
+    local_endpoint = nc.policy_local_server(
+        train_run_name="test_run",
+        port=port,
+    )
+    try:
+        _assert_local_policy_passes_robot_id(
+            local_endpoint,
+            captured_commands,
+            TEST_ROBOT_PAYLOAD["robot_id"],
+        )
+    finally:
+        local_endpoint.disconnect()
+
+
+def test_policy_local_server_raises_when_missing_embodiments_and_robot_selector(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Local server requires embodiments or a robot_id/robot_name/active robot."""
+    nc.login(TEST_API_KEY)
+    with pytest.raises(ValueError, match="Missing input_embodiment_description"):
+        nc.policy_local_server(train_run_name="test_run")
 
 
 def test_connect_local_endpoint_with_train_run(
@@ -752,45 +930,10 @@ def test_connect_local_endpoint_with_train_run(
     """Test connecting to a local endpoint using a training run name."""
     _login_and_connect_robot(mock_auth_requests, mocked_org_id)
     port = np.random.randint(8000, 9000)
-
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/training/jobs",
-        json=[{
-            "id": "job_123",
-            "name": "test_run",
-            "status": "completed",
-        }],
-        status_code=200,
+    _setup_policy_local_server_train_run_mocks(
+        mock_auth_requests, mocked_org_id, port, predict=True
     )
-
-    localhost = f"http://127.0.0.1:{port}"
-
-    mock_auth_requests.get(
-        f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123/model_url",
-        json={
-            "url": f"{localhost}/model.nc.zip",
-        },
-        status_code=200,
-    )
-    mock_auth_requests.get(
-        f"{localhost}/model.nc.zip",
-        content=b"dummy model content",
-        status_code=200,
-    )
-
-    mock_auth_requests.get(
-        f"{localhost}/ping",
-        status_code=200,
-    )
-
-    mock_auth_requests.post(
-        f"{localhost}/predict",
-        json=FAKE_PREDICTED_DATA_JSON,
-        status_code=200,
-    )
-
-    monkeypatch.setattr("subprocess.Popen", mock_subprocess_popen)
-    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+    _patch_subprocess_for_local_server(monkeypatch)
 
     # Connect using train run name
     local_endpoint = nc.policy_local_server(

--- a/tests/unit/ml/utils/test_robot_data_spec_utils.py
+++ b/tests/unit/ml/utils/test_robot_data_spec_utils.py
@@ -150,7 +150,7 @@ def test_resolve_embodiments_with_override_returns_explicit_descriptions() -> No
 
 
 def test_resolve_embodiments_with_override_loads_from_job_metadata(
-    requests_mock, monkeypatch
+    requests_mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class _Auth:
         def get_headers(self):
@@ -193,7 +193,8 @@ def test_resolve_embodiments_with_override_loads_from_model_archive(
 ) -> None:
     pytest.importorskip("torch")
     monkeypatch.setattr(
-        "neuracore.ml.utils.nc_archive.load_cross_embodiment_descriptions_from_nc_archive",
+        "neuracore.ml.utils.nc_archive."
+        "load_cross_embodiment_descriptions_from_nc_archive",
         lambda model_file: (
             {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
             {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
@@ -211,10 +212,114 @@ def test_resolve_embodiments_with_override_loads_from_model_archive(
     assert resolved_output == {DataType.JOINT_TARGET_POSITIONS: {"0": "joint1"}}
 
 
-def test_resolve_embodiments_with_override_raises_when_incomplete() -> None:
+def test_resolve_embodiments_with_override_raises_when_training_job_not_found(
+    requests_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Job metadata fetch returns 404, so cross-embodiment specs are never loaded."""
+
+    class _Auth:
+        def get_headers(self):
+            return {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_current_org",
+        lambda: "test-org-id",
+    )
+    requests_mock.get(
+        f"{API_URL}/org/test-org-id/training/jobs/job-123",
+        status_code=404,
+    )
+
     with pytest.raises(
-        ValueError, match="Must provide both input_embodiment_description"
+        ValueError,
+        match=(
+            "Failed to load input_cross_embodiment_description and "
+            "output_cross_embodiment_description"
+        ),
     ):
+        resolve_embodiment_descriptions_with_override(
+            robot_id="robot-1",
+            job_id="job-123",
+        )
+
+
+def test_resolve_embodiments_override_raises_when_job_lacks_cross_embodiment(
+    requests_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Auth:
+        def get_headers(self):
+            return {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.utils.robot_data_spec_utils.get_current_org",
+        lambda: "test-org-id",
+    )
+    requests_mock.get(
+        f"{API_URL}/org/test-org-id/training/jobs/job-123",
+        json={"id": "job-123", "name": "run"},
+        status_code=200,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Failed to load input_cross_embodiment_description and "
+            "output_cross_embodiment_description"
+        ),
+    ):
+        resolve_embodiment_descriptions_with_override(
+            robot_id="robot-1",
+            job_id="job-123",
+        )
+
+
+def test_resolve_embodiments_override_raises_when_archive_lacks_cross_embodiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("torch")
+    monkeypatch.setattr(
+        "neuracore.ml.utils.nc_archive."
+        "load_cross_embodiment_descriptions_from_nc_archive",
+        lambda model_file: (None, None),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Failed to load input_cross_embodiment_description and "
+            "output_cross_embodiment_description"
+        ),
+    ):
+        resolve_embodiment_descriptions_with_override(
+            robot_id="robot-1",
+            model_file=Path("dummy.nc.zip"),
+        )
+
+
+def test_resolve_embodiments_with_override_raises_when_nothing_provided() -> None:
+    with pytest.raises(ValueError, match="Failed to resolve embodiment descriptions"):
+        resolve_embodiment_descriptions_with_override()
+
+
+def test_resolve_embodiments_with_override_raises_when_only_output_provided() -> None:
+    with pytest.raises(ValueError, match="Failed to resolve embodiment descriptions"):
+        resolve_embodiment_descriptions_with_override(
+            output_embodiment_description={
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names("joint1")
+            },
+        )
+
+
+def test_resolve_embodiments_with_override_raises_when_incomplete() -> None:
+    with pytest.raises(ValueError, match="Failed to resolve embodiment descriptions"):
         resolve_embodiment_descriptions_with_override(
             input_embodiment_description={
                 DataType.JOINT_POSITIONS: _indexed_names("j1")


### PR DESCRIPTION
### Features
- When doing policy inference, fall back to using active robot if no robot name/id given
- Update policy inference example to allow selection of embodiment using active robot
- Improve error message when failed to resolve embodiment description

### Bugfixes
- Correctly clear global singleton in unit test setup so active robot does not persist across tests

### Items
 - [NCRL-507](https://neuracore.atlassian.net/browse/NCRL-507)