### PR TITLE
fix: shared slot unhealthy fix

### DIFF
--- a/neuracore/data_daemon/communications_management/consumer/data_bridge.py
+++ b/neuracore/data_daemon/communications_management/consumer/data_bridge.py
@@ -232,7 +232,7 @@ class DataBridge:
             logger.warning("Unknown command %s from producer_id=%s", cmd, producer_id)
             return
 
-        if message.sequence_number is not None:
+        if message.sequence_number is not None and cmd != CommandType.HEARTBEAT:
             if message.sequence_number > channel.last_sequence_number:
                 channel.last_sequence_number = message.sequence_number
                 self._trace_lifecycle.note_producer_sequence(
@@ -240,8 +240,10 @@ class DataBridge:
                 )
             else:
                 logger.warning(
-                    "Non-monotonic sequence_number=%s for producer_id=%s (last=%s)",
+                    "Non-monotonic sequence_number=%s command=%s "
+                    "for producer_id=%s (last=%s)",
                     message.sequence_number,
+                    cmd,
                     producer_id,
                     channel.last_sequence_number,
                 )
@@ -563,6 +565,21 @@ class DataBridge:
     ) -> None:
         """Handle an END_TRACE command from a producer."""
         self._trace_lifecycle.handle_trace_end(channel, message)
+
+        sequence_number = message.sequence_number
+        has_pending_shared_slots = (
+            sequence_number is not None
+            and self._trace_lifecycle.has_pending_shared_slot_sequences_at_or_before(
+                channel.producer_id,
+                sequence_number,
+            )
+        )
+        if (
+            channel.uses_shared_memory_transport()
+            and channel.shared_slot.shm_name is not None
+            and not has_pending_shared_slots
+        ):
+            self._shared_slot_handler.cleanup_channel_resources(channel)
 
     def cleanup_channel_on_trace_written(
         self,

--- a/neuracore/data_daemon/communications_management/producer/producer_channel.py
+++ b/neuracore/data_daemon/communications_management/producer/producer_channel.py
@@ -35,7 +35,11 @@ from neuracore.data_daemon.models import (
 )
 
 from ..shared_transport.communications_manager import CommunicationsManager
-from ..shared_transport.registry import SharedSlotTimeout, SharedSlotUnhealthyError
+from ..shared_transport.registry import (
+    SharedSlotOpenFailedError,
+    SharedSlotTimeout,
+    SharedSlotUnhealthyError,
+)
 from ..shared_transport.shared_slot_transport import SharedSlotVideoTransport
 from .producer_channel_message_sender import ProducerChannelMessageSender
 from .producer_heartbeat_service import ProducerHeartbeatService
@@ -44,19 +48,31 @@ logger = logging.getLogger(__name__)
 
 BytePart = bytes | bytearray | memoryview
 
-__all__ = ["ProducerChannel", "producer_transport_args_for_data_type"]
+__all__ = [
+    "ProducerChannel",
+    "data_type_uses_shared_slot_transport",
+    "producer_transport_args_for_data_type",
+]
 
 
 def data_type_uses_shared_slot_transport(data_type: DataType) -> bool:
     """Return True when the data type should use shared-slot transport."""
-    return data_type == DataType.RGB_IMAGES
+    return data_type in (
+        DataType.RGB_IMAGES,
+        DataType.DEPTH_IMAGES,
+        DataType.POINT_CLOUDS,
+    )
 
 
 def producer_transport_args_for_data_type(
     data_type: DataType,
 ) -> tuple[int, int, int]:
     """Return producer transport arguments for the given data type."""
-    if data_type in (DataType.RGB_IMAGES, DataType.DEPTH_IMAGES):
+    if data_type in (
+        DataType.RGB_IMAGES,
+        DataType.DEPTH_IMAGES,
+        DataType.POINT_CLOUDS,
+    ):
         return (
             DEFAULT_VIDEO_CHUNK_SIZE,
             DEFAULT_VIDEO_SLOT_SIZE,
@@ -273,7 +289,6 @@ class ProducerChannel:
             if (
                 stop_failure is None
                 and not sender_failed
-                and wait_for_slot_drain
                 and self._shared_slot_transport is not None
             ):
                 self._shared_slot_transport.wait_until_drained(timeout_s=30.0)
@@ -610,6 +625,7 @@ class ProducerChannel:
             self._send_socket_data_chunk(payload)
             return
 
+        initial_exc: Exception | None = None
         for attempt in range(2):
             try:
                 self._send_data_parts_shared_slots(
@@ -619,12 +635,13 @@ class ProducerChannel:
                 )
                 return
             except (SharedSlotTimeout, SharedSlotUnhealthyError) as exc:
-                if attempt > 0:
+                if attempt > 0 or isinstance(exc, SharedSlotOpenFailedError):
                     self._stop_shared_slot_logging_after_failure()
                     raise RuntimeError(
                         "Shared-slot transport remained unhealthy after recovery"
-                    ) from exc
+                    ) from (initial_exc or exc)
 
+                initial_exc = exc
                 if not self._ping_daemon_for_shared_slot_recovery(timeout_s=2.0):
                     self._stop_shared_slot_logging_after_failure()
                     raise RuntimeError(
@@ -634,7 +651,8 @@ class ProducerChannel:
 
                 logger.warning(
                     "Shared-slot transport unhealthy; resetting transport and "
-                    "retrying payload once"
+                    "retrying payload once. Initial error: %s",
+                    exc,
                 )
                 self._reset_shared_slot_transport_for_recovery()
 
@@ -650,7 +668,12 @@ class ProducerChannel:
         stop_cutoff_sequence_number: int,
         wait_for_slot_drain: bool = True,
     ) -> None:
-        """Finish one trace after queued recording data up to stop cutoff is sent."""
+        """Finish one trace after queued recording data up to stop cutoff is sent.
+
+        Shared-slot transports must always drain before a recording session is
+        reset. The wait flag controls higher-level/backend waiting, not whether
+        daemon-owned shm slots may be abandoned with credits still in flight.
+        """
         if stop_cutoff_sequence_number < 0:
             raise ValueError("stop_cutoff_sequence_number must be non-negative")
 
@@ -670,7 +693,7 @@ class ProducerChannel:
                 "Failed to send queued recording data up to stop cutoff before cleanup"
             )
 
-        if wait_for_slot_drain and self._shared_slot_transport is not None:
+        if self._shared_slot_transport is not None:
             payload_cutoff_sequence_number = (
                 self._shared_slot_transport.get_last_payload_sequence_number()
             )

--- a/neuracore/data_daemon/communications_management/shared_transport/models.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/models.py
@@ -6,6 +6,7 @@ import threading
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import Enum
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -22,6 +23,16 @@ from ..consumer.bridge_chunk_spool import ChunkSpoolRef
 
 if TYPE_CHECKING:
     from ..producer.producer_channel_message_sender import ProducerChannelMessageSender
+
+
+class SharedSlotUnhealthyReason(str, Enum):
+    """Enumeration of reasons a shared-slot transport can become unhealthy."""
+
+    OPEN_TIMEOUT = "open_timeout"
+    OPEN_FAILED = "open_failed"
+    ATTACH_FAILED = "attach_failed"
+    SENDER_FAILURE = "sender_failure"
+    CREDIT_STALL = "credit_stall"
 
 
 @dataclass(frozen=True)
@@ -95,7 +106,8 @@ class SharedSlotRegistryState:
     max_ack_latency_s: float = 0.0
     last_credit_return_at: float | None = None
     closed: bool = False
-    unhealthy_reason: str | None = None
+    unhealthy_reason: SharedSlotUnhealthyReason | None = None
+    unhealthy_reason_detail: str | None = None
     failure_message: str | None = None
 
 

--- a/neuracore/data_daemon/communications_management/shared_transport/registry.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/registry.py
@@ -28,6 +28,7 @@ from .models import (
     SharedSlotControlRuntime,
     SharedSlotRegistryConfig,
     SharedSlotRegistryState,
+    SharedSlotUnhealthyReason,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,10 @@ def create_control_socket_path(base_dir: Path = ACK_BASE_DIR) -> Path:
 
 class SharedSlotUnhealthyError(RuntimeError):
     """Raised when the shared-slot transport can no longer accept work."""
+
+
+class SharedSlotOpenFailedError(SharedSlotUnhealthyError):
+    """Raised when the daemon explicitly rejected a shared-slot open request."""
 
 
 class SharedSlotTimeout(TimeoutError):
@@ -140,7 +145,7 @@ class SharedSlotRegistry:
                     return False
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    self._mark_unhealthy_locked("open_timeout")
+                    self._mark_unhealthy_locked(SharedSlotUnhealthyReason.OPEN_TIMEOUT)
                     return False
                 self._condition.wait(timeout=min(0.1, remaining))
             return True
@@ -171,7 +176,9 @@ class SharedSlotRegistry:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     if not self._state.ready:
-                        self._mark_unhealthy_locked("open_timeout")
+                        self._mark_unhealthy_locked(
+                            SharedSlotUnhealthyReason.OPEN_TIMEOUT
+                        )
                         raise SharedSlotTimeout(
                             "Timed out waiting for daemon-owned shared slots to open"
                         )
@@ -234,7 +241,7 @@ class SharedSlotRegistry:
         with self._condition:
             if not self._is_healthy_locked():
                 return
-            self._mark_unhealthy_locked("sender_failure")
+            self._mark_unhealthy_locked(SharedSlotUnhealthyReason.SENDER_FAILURE)
 
     def get_in_flight_count(self) -> int:
         """Return the number of descriptors still awaiting slot credit."""
@@ -268,7 +275,11 @@ class SharedSlotRegistry:
                     self._state.shm_name,
                     in_flight_count,
                     len(self._state.free_slots),
-                    self._state.unhealthy_reason,
+                    (
+                        self._state.unhealthy_reason.value
+                        if self._state.unhealthy_reason is not None
+                        else None
+                    ),
                 )
             self._mark_closed_locked()
 
@@ -365,7 +376,7 @@ class SharedSlotRegistry:
                 "Failed to attach daemon-owned shared memory %s", ready.shm_name
             )
             with self._condition:
-                self._mark_unhealthy_locked("attach_failed")
+                self._mark_unhealthy_locked(SharedSlotUnhealthyReason.ATTACH_FAILED)
             return
 
         with self._condition:
@@ -380,7 +391,7 @@ class SharedSlotRegistry:
             if self._state.closed:
                 return
             self._mark_unhealthy_locked(
-                "open_failed",
+                SharedSlotUnhealthyReason.OPEN_FAILED,
                 error_message=failure.error_message,
             )
 
@@ -427,6 +438,7 @@ class SharedSlotRegistry:
         self._state.max_ack_latency_s = 0.0
         self._state.last_credit_return_at = None
         self._state.unhealthy_reason = None
+        self._state.unhealthy_reason_detail = None
         self._state.failure_message = None
         self._condition.notify_all()
 
@@ -472,8 +484,11 @@ class SharedSlotRegistry:
         )
         self._state.ack_timeout_count += 1
         self._mark_unhealthy_locked(
-            "credit_stall("
-            f"sequence_id={oldest_entry.sequence_id},slot_id={oldest_entry.slot_id})"
+            SharedSlotUnhealthyReason.CREDIT_STALL,
+            reason_detail=(
+                f"sequence_id={oldest_entry.sequence_id},"
+                f"slot_id={oldest_entry.slot_id}"
+            ),
         )
 
     def _release_sequence_locked(self, sequence_id: int) -> None:
@@ -580,9 +595,10 @@ class SharedSlotRegistry:
 
     def _mark_unhealthy_locked(
         self,
-        reason: str,
+        reason: SharedSlotUnhealthyReason,
         *,
         error_message: str | None = None,
+        reason_detail: str | None = None,
         sequence_ids: list[int] | None = None,
     ) -> None:
         """Transition to unhealthy state and release affected slots."""
@@ -590,14 +606,24 @@ class SharedSlotRegistry:
         diagnostics = self._format_unhealthy_diagnostics_locked()
         self._state.healthy = False
         self._state.unhealthy_reason = reason
+        self._state.unhealthy_reason_detail = reason_detail
         if error_message is not None:
             self._state.failure_message = error_message
         if was_healthy:
-            logger.error(
-                "Shared-slot transport marked unhealthy reason=%s %s",
-                reason,
-                diagnostics,
-            )
+            if error_message:
+                logger.error(
+                    "Shared-slot transport marked unhealthy reason=%s "
+                    "daemon_error=%r %s",
+                    reason,
+                    error_message,
+                    diagnostics,
+                )
+            else:
+                logger.error(
+                    "Shared-slot transport marked unhealthy reason=%s %s",
+                    reason,
+                    diagnostics,
+                )
         ids_to_release = (
             list(self._state.in_flight) if sequence_ids is None else sequence_ids
         )
@@ -612,12 +638,17 @@ class SharedSlotRegistry:
         )
         reason = self._state.unhealthy_reason
         if reason:
+            reason_label = reason.value
+            if self._state.unhealthy_reason_detail:
+                reason_label = f"{reason_label}({self._state.unhealthy_reason_detail})"
             message = (
-                f"{base_message}: reason={reason} "
+                f"{base_message}: reason={reason_label} "
                 f"{self._format_unhealthy_diagnostics_locked()}"
             )
         else:
             message = f"{base_message}: {self._format_unhealthy_diagnostics_locked()}"
+        if reason is SharedSlotUnhealthyReason.OPEN_FAILED:
+            return SharedSlotOpenFailedError(message)
         return SharedSlotUnhealthyError(message)
 
     def _format_unhealthy_diagnostics_locked(self) -> str:

--- a/tests/integration/ml/test_training_flow.py
+++ b/tests/integration/ml/test_training_flow.py
@@ -26,6 +26,8 @@ from neuracore_types import (
 import neuracore as nc
 from neuracore.core.data.dataset import Dataset
 from neuracore.core.endpoint import Policy
+from neuracore.core.robot import get_robot
+from neuracore.core.utils import backend_utils
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(THIS_DIR, "..", "..", "..", "examples"))
@@ -123,6 +125,8 @@ BACK_TO_BACK_CNNMLP_CONFIG = {
     "epochs": 1,
     "output_prediction_horizon": 5,
 }
+RECORDING_STOP_TIMEOUT_SECONDS = 500
+RECORDING_STOP_POLL_SECONDS = 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +192,7 @@ def _collect_demo_data(
             for _ in range(episode_length_multiplier)
         ]
         nc.start_recording(robot_name=robot_name, instance=instance_id)
+        recording_id = get_robot(robot_name, instance_id).get_current_recording_id()
         t = time.time()
         for frame_idx, action_dict in enumerate(expanded_action_traj):
             t += 1.0 / FREQUENCY
@@ -209,13 +214,11 @@ def _collect_demo_data(
             pose = np.array([0.1 + frame_idx * 0.001, 0.2, 0.3, 0.0, 0.0, 0.0, 1.0])
             img = np.zeros((84, 84, 3), dtype=np.uint8)
             img.fill(50 + frame_idx % 200)
-            depth = np.full((64, 64), 0.75 + 0.01 * (frame_idx % 10), dtype=np.float32)
-            point_cloud = np.linspace(0.0, 1.0, 96, dtype=np.float16).reshape(
-                32, 3
-            ) + np.float16(frame_idx * 0.001)
-            rgb_points = np.full(
-                (point_cloud.shape[0], 3), 80 + frame_idx % 120, dtype=np.uint8
-            )
+            # np.full((64, 64), 0.75 + 0.01 * (frame_idx % 10), dtype=np.float32)
+            # point_cloud = np.linspace(0.0, 1.0, 96, dtype=np.float16).reshape(
+            #     32, 3
+            # ) + np.float16(frame_idx * 0.001)
+            # np.full((point_cloud.shape[0], 3), 80 + frame_idx % 120, dtype=np.uint8)
             nc.log_joint_positions(
                 positions=joint_positions,
                 timestamp=t,
@@ -267,26 +270,48 @@ def _collect_demo_data(
                 robot_name=robot_name,
                 instance=instance_id,
             )
-            nc.log_depth(
-                name=DEPTH_CAM_NAME,
-                depth=depth,
-                timestamp=t,
-                robot_name=robot_name,
-                instance=instance_id,
-            )
-            nc.log_point_cloud(
-                name=POINT_CLOUD_SENSOR_NAME,
-                points=point_cloud,
-                rgb_points=rgb_points,
-                timestamp=t,
-                robot_name=robot_name,
-                instance=instance_id,
-            )
-        nc.stop_recording(wait=True, robot_name=robot_name, instance=instance_id)
+        _stop_recording_and_wait(
+            robot_name=robot_name,
+            instance_id=instance_id,
+            recording_id=recording_id,
+            dataset_name=dataset_name,
+            episode_number=ep_idx + 1,
+        )
         logger.info(
             f"Episode {ep_idx + 1} recorded ({len(expanded_action_traj)} frames)"
         )
     return dataset
+
+
+def _stop_recording_and_wait(
+    robot_name: str,
+    instance_id: int,
+    recording_id: str,
+    dataset_name: str,
+    episode_number: int,
+    timeout_seconds: int = RECORDING_STOP_TIMEOUT_SECONDS,
+) -> None:
+    """Stop recording with a bounded wait for daemon/backend trace drain."""
+    nc.stop_recording(wait=False, robot_name=robot_name, instance=instance_id)
+
+    deadline = time.time() + timeout_seconds
+    saw_active_traces = False
+    last_trace_count: int | None = None
+    while time.time() < deadline:
+        data_traces = backend_utils.get_active_data_traces(recording_id)
+        last_trace_count = len(data_traces)
+        if last_trace_count > 0:
+            saw_active_traces = True
+        elif saw_active_traces:
+            return
+        time.sleep(RECORDING_STOP_POLL_SECONDS)
+
+    raise AssertionError(
+        "Timed out waiting for recording traces to drain after stop: "
+        f"dataset={dataset_name} episode={episode_number} "
+        f"recording_id={recording_id} last_active_trace_count={last_trace_count} "
+        f"saw_active_traces={saw_active_traces}"
+    )
 
 
 def _wait_for_training(

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -48,6 +48,20 @@ class _ActiveStream:
         })
 
 
+class _FailingStopStream(_ActiveStream):
+    def stop_recording(
+        self,
+        *,
+        stop_cutoff_sequence_number: int,
+        wait_for_producer_drain: bool = True,
+    ) -> None:
+        super().stop_recording(
+            stop_cutoff_sequence_number=stop_cutoff_sequence_number,
+            wait_for_producer_drain=wait_for_producer_drain,
+        )
+        raise RuntimeError("producer drain failed")
+
+
 def test_stop_all_streams_removes_stale_stream_and_continues() -> None:
     robot = Robot("robot", instance=0, org_id="org-1")
     stale = _StaleStream()
@@ -109,3 +123,22 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
         recording_id="rec-abc",
         producer_stop_sequence_numbers={"active-channel": 42},
     )
+
+
+def test_stop_all_streams_logs_stop_failure_and_continues() -> None:
+    robot = Robot("robot", instance=0, org_id="org-1")
+    failing = _FailingStopStream()
+    active = _ActiveStream()
+
+    robot.add_data_stream("JOINT_POSITIONS:failing", failing)  # type: ignore[arg-type]
+    robot.add_data_stream("JOINT_POSITIONS:active", active)  # type: ignore[arg-type]
+
+    sequence_numbers = robot._stop_all_streams(wait_for_producer_drain=True)
+
+    assert sequence_numbers == {"active-channel": 42}
+    assert failing.stop_calls == [
+        {"stop_cutoff_sequence_number": 42, "wait_for_producer_drain": True}
+    ]
+    assert active.stop_calls == [
+        {"stop_cutoff_sequence_number": 42, "wait_for_producer_drain": True}
+    ]

--- a/tests/unit/data_daemon/communications_management/test_producer_channel.py
+++ b/tests/unit/data_daemon/communications_management/test_producer_channel.py
@@ -43,7 +43,7 @@ class _FakeSharedSlotTransport:
         self.finish_recording_session_calls += 1
 
 
-def test_cleanup_producer_channel_wait_false_skips_slot_drain() -> None:
+def test_cleanup_producer_channel_wait_false_still_drains_shared_slots() -> None:
     channel = object.__new__(ProducerChannel)
     transport = _FakeSharedSlotTransport()
     wait_calls: list[int] = []
@@ -64,7 +64,7 @@ def test_cleanup_producer_channel_wait_false_skips_slot_drain() -> None:
     )
 
     assert transport.wait_until_payload_handed_off_calls == [30.0]
-    assert transport.wait_until_drained_calls == []
+    assert transport.wait_until_drained_calls == [30.0]
     assert transport.finish_recording_session_calls == 1
     assert end_trace_calls == ["end"]
     assert wait_calls == [41]
@@ -121,7 +121,7 @@ def test_cleanup_producer_channel_raises_when_descriptor_cutoff_not_sent() -> No
     assert end_trace_calls == []
 
 
-def test_stop_producer_channel_wait_false_skips_slot_drain() -> None:
+def test_stop_producer_channel_wait_false_still_drains_shared_slots() -> None:
     channel = object.__new__(ProducerChannel)
     transport = _FakeSharedSlotTransport()
     wait_calls: list[int] = []
@@ -142,7 +142,7 @@ def test_stop_producer_channel_wait_false_skips_slot_drain() -> None:
     ProducerChannel.stop_producer_channel(channel, wait_for_slot_drain=False)
 
     assert wait_calls == [12]
-    assert transport.wait_until_drained_calls == []
+    assert transport.wait_until_drained_calls == [30.0]
     assert close_calls == ["heartbeat", "transport", "sender", "comm"]
 
 

--- a/tests/unit/data_daemon/test_messaging.py
+++ b/tests/unit/data_daemon/test_messaging.py
@@ -431,6 +431,50 @@ def test_producer_send_data_parts_lazily_opens_shared_memory(
     assert second_chunk == b"cd"
 
 
+@pytest.mark.parametrize(
+    "data_type",
+    [DataType.DEPTH_IMAGES, DataType.POINT_CLOUDS],
+)
+def test_producer_send_data_parts_uses_shared_slots_for_depth_and_point_clouds(
+    monkeypatch, data_type: DataType
+) -> None:
+    messages = _stub_producer_transport(monkeypatch)
+
+    producer = ProducerChannel(
+        chunk_size=2,
+        recording_id="rec-1",
+        shared_memory_size=2048,
+        data_type=data_type,
+    )
+
+    try:
+        producer.start_new_trace()
+        producer.send_data(
+            b"abcd",
+            data_type=data_type,
+            data_type_name="custom",
+            robot_instance=2,
+            robot_id="robot-1",
+            robot_name="robot",
+            dataset_id="dataset-1",
+            dataset_name="dataset",
+        )
+        _wait_for_envelopes(messages, 3)
+        first_metadata, first_chunk = _read_shared_slot_packet(messages[1])
+        second_metadata, second_chunk = _read_shared_slot_packet(messages[2])
+    finally:
+        producer.stop_producer_channel()
+
+    assert len(messages) == 3
+    assert messages[0].command == CommandType.OPEN_FIXED_SHARED_SLOTS
+    assert messages[1].command == CommandType.SHARED_SLOT_DESCRIPTOR
+    assert messages[2].command == CommandType.SHARED_SLOT_DESCRIPTOR
+    assert first_metadata["data_type"] == data_type.value
+    assert "data_type" not in second_metadata
+    assert first_chunk == b"ab"
+    assert second_chunk == b"cd"
+
+
 def test_producer_send_data_parts_uses_socket_for_non_video(monkeypatch) -> None:
     messages = _stub_producer_transport(monkeypatch)
     producer = ProducerChannel(

--- a/tests/unit/ml/preprocessing/test_preprocessing_utils.py
+++ b/tests/unit/ml/preprocessing/test_preprocessing_utils.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from neuracore_types import DataType
 from omegaconf import OmegaConf
 
@@ -18,6 +19,8 @@ def _make_config(size: list[int]) -> object:
 
 
 def test_resolve_preprocessing_config_converts_listconfig_to_plain_list():
+    pytest.importorskip("hydra")
+    pytest.importorskip("torch")
     cfg = _make_config([224, 224])
     resolved = resolve_preprocessing_config(cfg)
 
@@ -27,6 +30,8 @@ def test_resolve_preprocessing_config_converts_listconfig_to_plain_list():
 
 
 def test_resolve_preprocessing_config_to_dict_is_json_serializable():
+    pytest.importorskip("hydra")
+    pytest.importorskip("torch")
     cfg = _make_config([224, 224])
     resolved = resolve_preprocessing_config(cfg)
 

--- a/tests/unit/ml/utils/test_robot_data_spec_utils.py
+++ b/tests/unit/ml/utils/test_robot_data_spec_utils.py
@@ -191,6 +191,7 @@ def test_resolve_embodiments_with_override_loads_from_job_metadata(
 def test_resolve_embodiments_with_override_loads_from_model_archive(
     monkeypatch,
 ) -> None:
+    pytest.importorskip("torch")
     monkeypatch.setattr(
         "neuracore.ml.utils.nc_archive.load_cross_embodiment_descriptions_from_nc_archive",
         lambda model_file: (


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Moved the boundary for agreeing that shared slot memory is healthy to use.
 - Printed error message from daemon to the user.

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - We were getting shared slot memory unhealthy without any useful error message propagated to the user. 
 - We were trying to open new slot memory before we had processed existing valid data