### PR TITLE
fix: skip duplicate drain on local recording stop

### DIFF
--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -293,7 +293,7 @@ class RecordingStateManager(BaseSSEConsumer):
                 robot_id=robot_id, robot_instance=instance
             )
             callback = self._drain_callbacks.get(instance_key)
-            if callback:
+            if callback and was_recording:
                 threading.Thread(
                     target=callback,
                     args=(recording_id,),


### PR DESCRIPTION
When stopping a recording localy the client drains before hitting the stop api.The api would then send a stop sse back which was triggering a second drain. This bug was introduced in this [PR-641](https://github.com/NeuracoreAI/neuracore/pull/641) which fixed the start and stop recording flow for web frontend by adding a drain callback for sse but as a result the drain is happening twice for local stop.

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - guarded the drain callback, if we already stopped locally, was recording is False by the time the SSE arrives.


Also @StevenJacobs61, you suggested removing the entire else block. we can't remove it entirely since web frontend stops rely on it. The SSE is the only stop signal in that case, so was_recording is still True and the drain needs to fire from here.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1010](https://neuracore.atlassian.net/browse/NCP-1010)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - [NCP-641](https://github.com/NeuracoreAI/neuracore/pull/641)


