### PR TITLE
ci: pin workers to ubuntu 24.04 and macos 26

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   discover-algorithms:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       latest_release_tag: ${{ steps.release-tag.outputs.latest_release_tag }}
       matrix: ${{ steps.list.outputs.matrix }}
@@ -66,7 +66,7 @@ jobs:
 
   evaluate:
     needs: [discover-algorithms]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -153,6 +153,6 @@ jobs:
         DISPLAY: :0
       run: |
         sudo apt-get update
-        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
+        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
         pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate "$TEST_HARNESS_PATH"

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   discover-algorithms:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   evaluate:
     needs: [discover-algorithms]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +114,6 @@ jobs:
         DISPLAY: :0
       run: |
         sudo apt-get update
-        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
+        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
         pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate "$TEST_HARNESS_PATH"

--- a/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   discover-algorithms:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       latest_release_tag: ${{ steps.release-tag.outputs.latest_release_tag }}
       matrix: ${{ steps.list.outputs.matrix }}
@@ -66,7 +66,7 @@ jobs:
 
   start-training:
     needs: [discover-algorithms]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   discover-algorithms:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   start-training:
     needs: [discover-algorithms]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-ml-algorithm-validation-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository metadata

--- a/.github/workflows/integration-ml-algorithm-validation-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-staging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout test harness

--- a/.github/workflows/integration-ml-training-flow-prod.yaml
+++ b/.github/workflows/integration-ml-training-flow-prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -17,7 +17,7 @@ jobs:
 
   test:
     needs: pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # TODO: NDD has socket issue when running in parallel
     #   in CommunicationsManager when calling create_producer_socket()
 
@@ -99,7 +99,7 @@ jobs:
           DISPLAY: :0
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
+          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-training-flow-staging.yaml
+++ b/.github/workflows/integration-ml-training-flow-staging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -17,7 +17,7 @@ jobs:
 
   test:
     needs: pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # TODO: NDD has socket issue when running in parallel
     #   in CommunicationsManager when calling create_producer_socket()
 
@@ -73,7 +73,7 @@ jobs:
           DISPLAY: :0
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1-mesa-glx libosmesa6-dev
+          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-platform.yaml
+++ b/.github/workflows/integration-platform.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-changelog-reminder.yaml
+++ b/.github/workflows/pr-changelog-reminder.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   suggest-changelog-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Only run if PR has version:major or version:minor label
     if: |
       contains(github.event.pull_request.labels.*.name, 'version:major') ||

--- a/.github/workflows/pr-check-commit-messages.yaml
+++ b/.github/workflows/pr-check-commit-messages.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-check-label.yaml
+++ b/.github/workflows/pr-check-label.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   check-version-label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     
     steps:
     - name: Check for version label

--- a/.github/workflows/pr-coverage-check.yaml
+++ b/.github/workflows/pr-coverage-check.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   coverage-comment:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@v8

--- a/.github/workflows/pr-merge-test.yaml
+++ b/.github/workflows/pr-merge-test.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test-ml-slow:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       UV_VENV_SEED: "true"
     strategy:

--- a/.github/workflows/pr-pre-commit-and-test.yaml
+++ b/.github/workflows/pr-pre-commit-and-test.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       ml: ${{ steps.filter.outputs.ml }}
       non-ml: ${{ steps.filter.outputs.non-ml }}
@@ -43,7 +43,7 @@ jobs:
               - '.pre-commit-config.yaml'
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
@@ -60,13 +60,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-26]
         python-version: ["3.10", "3.11"]
         package-manager: [uv, pip]
     env:
       UV_VENV_SEED: "true"
       SHOULD_RUN: ${{ needs.detect-changes.outputs.non-ml == 'true' || needs.detect-changes.outputs.deps == 'true' || needs.detect-changes.outputs.ci == 'true' }}
-      SHOULD_RUN_COVERAGE: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.package-manager == 'uv' }}
+      SHOULD_RUN_COVERAGE: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && matrix.package-manager == 'uv' }}
     steps:
       - name: Checkout code
         if: env.SHOULD_RUN == 'true'
@@ -91,7 +91,7 @@ jobs:
       - name: Install Python dependencies
         if: env.SHOULD_RUN == 'true'
         run: |
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          if [ "${{ matrix.os }}" = "macos-26" ]; then
             EXTRAS=".[dev]"
           else
             EXTRAS=".[dev,import]"
@@ -114,7 +114,7 @@ jobs:
           fi
           # Importer tests require pinocchio, which only publishes manylinux wheels
           IGNORE="--ignore=tests/unit/ml"
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          if [ "${{ matrix.os }}" = "macos-26" ]; then
             IGNORE="${IGNORE} --ignore=tests/unit/importer"
           fi
           PYTEST_ARGS="-sv -o log_cli=true --log-cli-level=INFO"
@@ -149,10 +149,10 @@ jobs:
             pytest-coverage.txt
             pytest.xml
             diff-cover.json
-            
+
   test-non-ml-complete:
     needs: [test-non-ml]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: Check all matrix jobs passed
@@ -163,7 +163,7 @@ jobs:
 
   test-ml:
     needs: [detect-changes, pre-commit]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       UV_VENV_SEED: "true"
       SHOULD_RUN: ${{ needs.detect-changes.outputs.ml == 'true' || needs.detect-changes.outputs.deps == 'true' || needs.detect-changes.outputs.ci == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analyze-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_release: ${{ steps.analyze.outputs.should_release }}
       bump_type: ${{ steps.analyze.outputs.bump_type }}
@@ -136,7 +136,7 @@ jobs:
 
   generate-changelog:
     needs: analyze-changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       new_version: ${{ steps.calc_version.outputs.new_version }}
       changelog_content: ${{ steps.generate.outputs.changelog_content }}
@@ -300,7 +300,7 @@ jobs:
   release:
     needs: [analyze-changes, generate-changelog]
     if: needs.analyze-changes.outputs.should_release == 'true' && inputs.dry_run == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     outputs:
@@ -438,7 +438,7 @@ jobs:
   dry-run-summary:
     needs: [analyze-changes, generate-changelog]
     if: inputs.dry_run == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Generate dry run summary
@@ -484,7 +484,7 @@ jobs:
   no-release-needed:
     needs: [analyze-changes, generate-changelog]
     if: always() && needs.analyze-changes.outputs.should_release != 'true' && inputs.dry_run == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Fail - no release needed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@
 
 # 🛠️ Installation
 
+Neuracore has been tested on Ubuntu 24.04 and MacOS 26 (Arm64, Apple Silicon, M1 series Chips). If you're on Windows, please use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install)
+
 To install the basic package for data logging and visualization:
 
 ```bash


### PR DESCRIPTION
### Bugfixes
- Pin all CI `ubuntu-latest` runners to `ubuntu-24.04` to prevent silent breakage on future runner updates
- Pin all CI `macos-latest` runners to `macos-26`
- Replace `libgl1-mesa-glx` with `libgl1` in ML integration test workflows as package was removed in Ubuntu 24.04

Stats for Ubuntu version usage: https://fr.archive.ubuntu.com/stats/stats_of_day-24.html?version=last
Stats for MacOS version usage: https://telemetrydeck.com/survey/apple/macOS/versions/