### PR TITLE
fix: pytorch train sample retry removal

### DIFF
--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -158,8 +158,6 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             self.synchronized_dataset_statistics.dataset_statistics
         )
 
-        self._max_error_count = 100
-        self._error_count = 0
         self._memory_monitor = MemoryMonitor(
             max_ram_utilization=0.8, max_gpu_utilization=1.0, gpu_id=None
         )
@@ -500,19 +498,13 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         return self._num_samples_excluding_last
 
     def __getitem__(self, idx: int) -> TrainingSample:
-        """Get a training sample by index with error handling.
-
-        Implements the PyTorch Dataset interface with robust error handling
-        to manage data loading failures gracefully during training.
+        """Get a training sample by index.
 
         Args:
             idx: Index of the sample to retrieve.
 
         Returns:
             A TrainingSample containing the requested data.
-
-        Raises:
-            Exception: If sample loading fails after exhausting retry attempts.
         """
         if idx < 0:
             # Handle negative indices by wrapping around
@@ -521,19 +513,10 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             raise IndexError(
                 f"Index {idx} out of bounds for dataset of size {len(self)}"
             )
-        while self._error_count < self._max_error_count:
-            try:
-                episode_idx = self.episode_indices[idx]
-                timestep = idx - self.episode_indices.index(episode_idx)
-                return self.load_sample(episode_idx, timestep)
-            except Exception:
-                self._error_count += 1
-                logger.error(f"Error loading item {idx}.", exc_info=True)
-                if self._error_count >= self._max_error_count:
-                    raise
-        raise Exception(
-            f"Maximum error count ({self._max_error_count}) already reached"
-        )
+
+        episode_idx = self.episode_indices[idx]
+        timestep = idx - self.episode_indices.index(episode_idx)
+        return self.load_sample(episode_idx, timestep)
 
     @property
     def dataset_statistics(self) -> dict[str, dict[DataType, list[NCDataStats]]]:

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -1032,8 +1032,10 @@ class TestDatasetIntegration:
         assert len(dataset) == 45
 
     @patch("neuracore.login")
-    def test_error_handling_in_getitem(self, mock_login, mock_synchronized_dataset):
-        """Test error handling in __getitem__ method."""
+    def test_getitem_propagates_load_sample_error(
+        self, mock_login, mock_synchronized_dataset
+    ):
+        """Test __getitem__ propagates load_sample failures."""
         input_spec: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
@@ -1059,9 +1061,10 @@ class TestDatasetIntegration:
         with patch.object(dataset, "load_sample") as mock_load_sample:
             mock_load_sample.side_effect = Exception("Load error")
 
-            # Should propagate the error after max retries
             with pytest.raises(Exception):
                 _ = dataset[0]
+
+            mock_load_sample.assert_called_once_with(0, 0)
 
 
 class TestPerformanceAndOptimization:
@@ -1125,38 +1128,6 @@ class TestPerformanceAndOptimization:
         # Check structure: first 9 should be episode 0, next 9 episode 1, etc.
         assert all(idx == 0 for idx in dataset.episode_indices[:9])
         assert all(idx == 1 for idx in dataset.episode_indices[9:18])
-
-
-class TestErrorRecovery:
-    """Test error recovery and robustness."""
-
-    def test_error_count_tracking(self, mock_synchronized_dataset):
-        """Test error count tracking in parent class."""
-        input_spec: CrossEmbodimentDescription = {
-            ROBOT_ID: {
-                DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
-            }
-        }
-        output_spec: CrossEmbodimentDescription = {
-            ROBOT_ID: {
-                DataType.JOINT_TARGET_POSITIONS: _indexed_names(
-                    DataType.JOINT_TARGET_POSITIONS, 3
-                )
-            }
-        }
-
-        dataset = PytorchSynchronizedDataset(
-            synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
-            output_prediction_horizon=3,
-            input_preprocessing_config=_default_preprocessing_config(),
-            output_preprocessing_config=_default_preprocessing_config(),
-        )
-
-        # Initial error count should be 0
-        assert dataset._error_count == 0
-        assert dataset._max_error_count == 100
 
 
 class TestIntegrationWithPyTorchDataLoader:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 -  Removed the catch and retry for loading samples as this did not catch any expected errors, and retrying would not help any known possible failure cases. 