### PR TITLE
fix: share an http session per thread instead of constructing per call

### DIFF
--- a/neuracore/api/datasets.py
+++ b/neuracore/api/datasets.py
@@ -12,7 +12,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.data.dataset import Dataset
 from neuracore.core.exceptions import DatasetError
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 
 def get_dataset(name: str | None = None, id: str | None = None) -> Dataset:
@@ -66,12 +66,12 @@ def merge_datasets(name: str, dataset_names: list[str]) -> Dataset:
             raise DatasetError(f"Dataset '{dataset_name}' not found.")
         source_ids.append(ds.id)
 
-    with Session() as session:
-        response = session.post(
-            f"{API_URL}/org/{org_id}/datasets/merge",
-            headers=auth.get_headers(),
-            json={"name": name, "sourceDatasetIds": source_ids},
-        )
+    session = thread_local_session()
+    response = session.post(
+        f"{API_URL}/org/{org_id}/datasets/merge",
+        headers=auth.get_headers(),
+        json={"name": name, "sourceDatasetIds": source_ids},
+    )
     if not response.ok:
         raise DatasetError(
             f"Failed to merge datasets: {response.status_code} {response.text}"

--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -27,7 +27,7 @@ from neuracore.core.get_latest_sync_point import (
 from neuracore.core.get_latest_sync_point import (
     get_latest_sync_point as _get_latest_sync_point,
 )
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.robot_data_spec_utils import (
     resolve_embodiment_descriptions_with_override,
 )
@@ -227,12 +227,12 @@ def deploy_model(
         config=DeploymentConfig(gpu_type=gpu_type),
     ).model_dump(mode="json")
     try:
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{org_id}/models/deploy",
-                headers=auth.get_headers(),
-                json=payload,
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{org_id}/models/deploy",
+            headers=auth.get_headers(),
+            json=payload,
+        )
         response.raise_for_status()
         return response.json()
     except Exception as e:
@@ -263,11 +263,11 @@ def get_endpoint_status(endpoint_id: str) -> str:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         return response.json()["status"]
     except Exception as e:
@@ -297,11 +297,11 @@ def delete_endpoint(endpoint_id: str) -> None:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        with Session() as session:
-            response = session.delete(
-                f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.delete(
+            f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
     except Exception as e:
         raise ValueError(f"Error deleting endpoint: {e}")

--- a/neuracore/api/orgs_fetch.py
+++ b/neuracore/api/orgs_fetch.py
@@ -1,18 +1,18 @@
 """Helpers for fetching the current user's organization IDs from the API."""
 
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 
 def fetch_org_ids(access_token: str) -> set[str] | None:
     """Return the set of org IDs for the authenticated user."""
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org-management/my-orgs",
-                headers={"Authorization": f"Bearer {access_token}"},
-                timeout=10,
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org-management/my-orgs",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
         if response.status_code != 200:
             return None
 

--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -16,7 +16,7 @@ from neuracore_types import (
 )
 
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.robot_data_spec_utils import (
     merge_cross_embodiment_description,
 )
@@ -64,21 +64,20 @@ def _get_algorithms() -> list[dict]:
     auth = get_auth()
     org_id = get_current_org()
 
-    with Session() as session:
+    def fetch_algorithms(shared: bool) -> list[dict]:
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/algorithms",
+            headers=auth.get_headers(),
+            params={"shared": shared},
+        )
+        response.raise_for_status()
+        return response.json()
 
-        def fetch_algorithms(shared: bool) -> list[dict]:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/algorithms",
-                headers=auth.get_headers(),
-                params={"shared": shared},
-            )
-            response.raise_for_status()
-            return response.json()
-
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            org_algorithms, shared_algorithms = executor.map(
-                fetch_algorithms, (False, True)
-            )
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        org_algorithms, shared_algorithms = executor.map(
+            fetch_algorithms, (False, True)
+        )
     return org_algorithms + shared_algorithms
 
 
@@ -86,11 +85,11 @@ def get_algorithm(algorithm_id: str) -> dict:
     """Retrieve a single algorithm by ID from the API."""
     auth = get_auth()
     org_id = get_current_org()
-    with Session() as session:
-        response = session.get(
-            f"{API_URL}/org/{org_id}/algorithms/{algorithm_id}",
-            headers=auth.get_headers(),
-        )
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/algorithms/{algorithm_id}",
+        headers=auth.get_headers(),
+    )
     response.raise_for_status()
     return response.json()
 
@@ -188,12 +187,12 @@ def start_training_run(
 
     auth = get_auth()
     org_id = get_current_org()
-    with Session() as session:
-        response = session.post(
-            f"{API_URL}/org/{org_id}/training/jobs",
-            headers=auth.get_headers(),
-            json=data.model_dump(mode="json"),
-        )
+    session = thread_local_session()
+    response = session.post(
+        f"{API_URL}/org/{org_id}/training/jobs",
+        headers=auth.get_headers(),
+        json=data.model_dump(mode="json"),
+    )
 
     response.raise_for_status()
 
@@ -219,11 +218,11 @@ def resume_training_run(job_id: str, additional_epochs: int) -> dict:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{org_id}/training/jobs/{job_id}/resume/{additional_epochs}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{org_id}/training/jobs/{job_id}/resume/{additional_epochs}",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         return response.json()
     except Exception as e:
@@ -242,11 +241,11 @@ def get_training_jobs() -> list[dict]:
     """
     auth = get_auth()
     org_id = get_current_org()
-    with Session() as session:
-        response = session.get(
-            f"{API_URL}/org/{org_id}/training/jobs",
-            headers=auth.get_headers(),
-        )
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/training/jobs",
+        headers=auth.get_headers(),
+    )
     response.raise_for_status()
     return response.json()
 
@@ -325,12 +324,12 @@ def get_training_job_logs(
         params["severity_filter"] = severity_filter
 
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/training/jobs/{job_id}/logs",
-                headers=auth.get_headers(),
-                params=params,
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/training/jobs/{job_id}/logs",
+            headers=auth.get_headers(),
+            params=params,
+        )
         response.raise_for_status()
         return response.json()
     except Exception as e:
@@ -352,11 +351,11 @@ def delete_training_job(job_id: str) -> None:
     auth = get_auth()
     org_id = get_current_org()
     try:
-        with Session() as session:
-            response = session.delete(
-                f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.delete(
+            f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
     except Exception as e:
         raise ValueError(f"Error deleting training job: {e}")

--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -13,7 +13,7 @@ import requests
 from neuracore.api.orgs_fetch import fetch_org_ids
 from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.config.get_api_key import get_api_key
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
 
 from .const import API_URL
@@ -57,11 +57,11 @@ class Auth(metaclass=SingletonMetaclass):
 
         # Verify API key with server and get access token
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/auth/verify-api-key",
-                    json={"api_key": api_key},
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/auth/verify-api-key",
+                json={"api_key": api_key},
+            )
             if response.status_code != 200:
                 raise AuthenticationError(
                     "Could not verify API key. Please check your key and try again."
@@ -135,11 +135,11 @@ class Auth(metaclass=SingletonMetaclass):
         # Placeholder for version validation logic
         from neuracore_types import __version__ as nc_types_version
 
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/auth/verify-version",
-                params={"version": nc_types_version},
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/auth/verify-version",
+            params={"version": nc_types_version},
+        )
         if response.status_code != 200:
             raise AuthenticationError(
                 f"Version validation failed: {response.json().get('detail')}"

--- a/neuracore/core/cli/generate_api_key.py
+++ b/neuracore/core/cli/generate_api_key.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, ValidationError
 from neuracore.core.cli.get_user_confirmation import get_user_confirmation
 from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.exceptions import AuthenticationError, InputError
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 from ..const import API_URL, MAX_INPUT_ATTEMPTS
 
@@ -63,12 +63,12 @@ def generate_api_key(email: str | None = None, password: str | None = None) -> s
             if not password:
                 password = getpass("Enter your password: ")
 
-            with Session() as session:
-                auth_response = session.post(
-                    f"{API_URL}/auth/token",
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                    data={"username": email, "password": password},
-                )
+            session = thread_local_session()
+            auth_response = session.post(
+                f"{API_URL}/auth/token",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={"username": email, "password": password},
+            )
 
             # Handle 401 *before* raise_for_status so it doesn't become HTTPError
             if auth_response.status_code == 401:
@@ -105,11 +105,11 @@ def generate_api_key(email: str | None = None, password: str | None = None) -> s
     # Use the access token to request an API key
     try:
         headers = {"Authorization": f"Bearer {access_token}"}
-        with Session() as session:
-            api_key_response = session.get(
-                f"{API_URL}/auth/api-key",
-                headers=headers,
-            )
+        session = thread_local_session()
+        api_key_response = session.get(
+            f"{API_URL}/auth/api-key",
+            headers=headers,
+        )
         api_key_response.raise_for_status()
         api_key = APIKey.model_validate(api_key_response.json()).key
         print(f"Your API key is: {api_key}")

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -27,7 +27,7 @@ from ..auth import Auth, get_auth
 from ..const import API_URL, DEFAULT_RECORDING_CACHE_DIR
 from ..exceptions import AuthenticationError, DatasetError
 from ..utils.http_errors import extract_error_detail
-from ..utils.http_session import Session
+from ..utils.http_session import thread_local_session
 
 PAGE_SIZE = 30
 SYNC_PROGRESS_POLL_INTERVAL_S = 5.0
@@ -118,14 +118,14 @@ class Dataset:
     def _initialize_num_recordings(self) -> None:
         """Fetch total number of recordings without loading them."""
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
-                    headers=get_auth().get_headers(),
-                    params={"limit": 1, "is_shared": self.is_shared},
-                    json=None,
-                    timeout=10,
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
+                headers=get_auth().get_headers(),
+                params={"limit": 1, "is_shared": self.is_shared},
+                json=None,
+                timeout=10,
+            )
             response.raise_for_status()
             data = response.json()
             self._num_recordings = data.get("total", 0)
@@ -144,13 +144,13 @@ class Dataset:
         params = {"limit": PAGE_SIZE, "is_shared": self.is_shared}
         payload = self._start_after or None
 
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
-                headers=get_auth().get_headers(),
-                params=params,
-                json=payload,
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
+            headers=get_auth().get_headers(),
+            params=params,
+            json=payload,
+        )
         response.raise_for_status()
         data = response.json()
 
@@ -235,11 +235,11 @@ class Dataset:
         """
         auth: Auth = get_auth()
         org_id = get_current_org()
-        with Session() as session:
-            req = session.get(
-                f"{API_URL}/org/{org_id}/datasets/{id}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        req = session.get(
+            f"{API_URL}/org/{org_id}/datasets/{id}",
+            headers=auth.get_headers(),
+        )
         if req.status_code != 200:
             if non_exist_ok:
                 return None
@@ -277,12 +277,12 @@ class Dataset:
         auth: Auth = get_auth()
         org_id = get_current_org()
         try:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{org_id}/datasets/search/by-name",
-                    params={"name": name},
-                    headers=auth.get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{org_id}/datasets/search/by-name",
+                params={"name": name},
+                headers=auth.get_headers(),
+            )
             if response.status_code != 200:
                 if non_exist_ok:
                     return None
@@ -360,17 +360,17 @@ class Dataset:
         """
         auth: Auth = get_auth()
         org_id = get_current_org()
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{org_id}/datasets",
-                headers=auth.get_headers(),
-                json={
-                    "name": name,
-                    "description": description,
-                    "tags": tags,
-                    "is_shared": shared,
-                },
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{org_id}/datasets",
+            headers=auth.get_headers(),
+            json={
+                "name": name,
+                "description": description,
+                "tags": tags,
+                "is_shared": shared,
+            },
+        )
         if not response.ok:
             detail = extract_error_detail(response)
             error_message = detail or f"{response.status_code} {response.reason}"
@@ -390,11 +390,11 @@ class Dataset:
 
     def delete(self) -> None:
         """Delete this dataset from Neuracore."""
-        with Session() as session:
-            response = session.delete(
-                f"{API_URL}/org/{self.org_id}/datasets/{self.id}",
-                headers=get_auth().get_headers(),
-            )
+        session = thread_local_session()
+        response = session.delete(
+            f"{API_URL}/org/{self.org_id}/datasets/{self.id}",
+            headers=get_auth().get_headers(),
+        )
         response.raise_for_status()
 
     def _format_failure_summary(self, failed_recording_ids: list[str]) -> str:
@@ -403,11 +403,11 @@ class Dataset:
         for recording_id in failed_recording_ids:
             if recording_id not in id_to_name:
                 try:
-                    with Session() as session:
-                        response = session.get(
-                            f"{API_URL}/org/{self.org_id}/recording/{recording_id}",
-                            headers=auth_headers,
-                        )
+                    session = thread_local_session()
+                    response = session.get(
+                        f"{API_URL}/org/{self.org_id}/recording/{recording_id}",
+                        headers=auth_headers,
+                    )
                     response.raise_for_status()
                     recording_model = RecordingModel.model_validate(response.json())
                     id_to_name[recording_id] = recording_model.metadata.name
@@ -464,21 +464,21 @@ class Dataset:
             requests.HTTPError: If the API request fails.
             DatasetError: If frequency is not greater than 0.
         """
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{self.org_id}/synchronize/synchronize-dataset",
-                headers=get_auth().get_headers(),
-                json=SynchronizeDatasetRequest(
-                    dataset_id=self.id,
-                    synchronization_details=SynchronizationDetails(
-                        frequency=frequency,
-                        max_delay_s=max_delay_s,
-                        allow_duplicates=allow_duplicates,
-                        trim_start_end=trim_start_end,
-                        cross_embodiment_union=cross_embodiment_union,
-                    ),
-                ).model_dump(mode="json"),
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{self.org_id}/synchronize/synchronize-dataset",
+            headers=get_auth().get_headers(),
+            json=SynchronizeDatasetRequest(
+                dataset_id=self.id,
+                synchronization_details=SynchronizationDetails(
+                    frequency=frequency,
+                    max_delay_s=max_delay_s,
+                    allow_duplicates=allow_duplicates,
+                    trim_start_end=trim_start_end,
+                    cross_embodiment_union=cross_embodiment_union,
+                ),
+            ).model_dump(mode="json"),
+        )
         response.raise_for_status()
         return SynchronizedDatasetModel.model_validate(response.json())
 
@@ -490,11 +490,11 @@ class Dataset:
         Returns:
             Synchronization progress for the dataset.
         """
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.org_id}/synchronize/synchronization-progress/{synchronized_dataset_id}",
-                headers=get_auth().get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/synchronize/synchronization-progress/{synchronized_dataset_id}",
+            headers=get_auth().get_headers(),
+        )
         if response.status_code == 409:
             detail = extract_error_detail(response) or "Synchronization failed."
             prefix = "Synchronization failed for recording(s): "
@@ -597,11 +597,11 @@ class Dataset:
         """
         # Best-effort resolution without additional network calls.
         # If we can resolve a robot_name to an ID, do so; otherwise delegate to server.
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.org_id}/datasets/{self.id}/full-embodiment-description/{robot_id}",
-                headers=get_auth().get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/datasets/{self.id}/full-embodiment-description/{robot_id}",
+            headers=get_auth().get_headers(),
+        )
         response.raise_for_status()
         raw_description = response.json()
         return {
@@ -619,11 +619,11 @@ class Dataset:
             List of robot IDs in the synchronized dataset.
         """
         if self._robot_ids is None:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robot_ids",
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robot_ids",
+                headers=get_auth().get_headers(),
+            )
             response.raise_for_status()
             self._robot_ids = response.json()
         return self._robot_ids
@@ -631,11 +631,11 @@ class Dataset:
     def get_robot_names(self) -> dict[str, str]:
         """Get robot names keyed by robot ID for this dataset."""
         if self._robot_names is None:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robots",
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{self.org_id}/datasets/{self.id}/robots",
+                headers=get_auth().get_headers(),
+            )
             response.raise_for_status()
             robots = response.json()
             self._robot_names = {robot["id"]: robot["name"] for robot in robots}
@@ -714,11 +714,11 @@ class Dataset:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            with Session() as session:
-                req = session.get(
-                    f"{API_URL}/org/{org_id}/datasets/{self.id}",
-                    headers=auth.get_headers(),
-                )
+            session = thread_local_session()
+            req = session.get(
+                f"{API_URL}/org/{org_id}/datasets/{self.id}",
+                headers=auth.get_headers(),
+            )
             req.raise_for_status()
             dataset_model = DatasetModel.model_validate(req.json())
             assert dataset_model.id == self.id
@@ -749,12 +749,12 @@ class Dataset:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            with Session() as session:
-                response = session.put(
-                    f"{API_URL}/org/{org_id}/datasets/{self.id}",
-                    headers=auth.get_headers(),
-                    json=dataset_metadata.model_dump(mode="json"),
-                )
+            session = thread_local_session()
+            response = session.put(
+                f"{API_URL}/org/{org_id}/datasets/{self.id}",
+                headers=auth.get_headers(),
+                json=dataset_metadata.model_dump(mode="json"),
+            )
             response.raise_for_status()
             if dataset_metadata.name is not None:
                 self.name = dataset_metadata.name

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -11,7 +11,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.data.synced_recording import SynchronizedRecording
 from neuracore.core.exceptions import AuthenticationError, SynchronizationError
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.robot_data_spec_utils import extract_data_types
 
 if TYPE_CHECKING:
@@ -138,11 +138,11 @@ class Recording:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{org_id}/recording/{self.id}",
-                    headers=auth.get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{org_id}/recording/{self.id}",
+                headers=auth.get_headers(),
+            )
             response.raise_for_status()
             updated_recording = RecordingModel.model_validate(response.json())
             self.metadata = updated_recording.metadata
@@ -165,12 +165,12 @@ class Recording:
         auth = get_auth()
         org_id = get_current_org()
         try:
-            with Session() as session:
-                response = session.put(
-                    f"{API_URL}/org/{org_id}/recording/{self.id}/metadata",
-                    headers=auth.get_headers(),
-                    json=recording_metadata.model_dump(mode="json"),
-                )
+            session = thread_local_session()
+            response = session.put(
+                f"{API_URL}/org/{org_id}/recording/{self.id}/metadata",
+                headers=auth.get_headers(),
+                json=recording_metadata.model_dump(mode="json"),
+            )
             response.raise_for_status()
             updated_recording = RecordingModel.model_validate(response.json())
             self.metadata = updated_recording.metadata

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -15,7 +15,7 @@ from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.data.recording import Recording
 from neuracore.core.data.synced_recording import SynchronizedRecording
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 if TYPE_CHECKING:
     from neuracore.core.data.dataset import Dataset
@@ -208,15 +208,15 @@ class SynchronizedDataset:
         Returns:
             SynchronizedDatasetStatistics containing the calculated statistics.
         """
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset/calculate-dataset-statistics",
-                json=SynchronizedDatasetStatistics(
-                    synchronized_dataset_id=self.id,
-                    input_cross_embodiment_description=input_cross_embodiment_description,
-                    output_cross_embodiment_description=output_cross_embodiment_description,
-                ).model_dump(mode="json"),
-                headers=get_auth().get_headers(),
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset/calculate-dataset-statistics",
+            json=SynchronizedDatasetStatistics(
+                synchronized_dataset_id=self.id,
+                input_cross_embodiment_description=input_cross_embodiment_description,
+                output_cross_embodiment_description=output_cross_embodiment_description,
+            ).model_dump(mode="json"),
+            headers=get_auth().get_headers(),
+        )
         response.raise_for_status()
         return SynchronizedDatasetStatistics.model_validate(response.json())

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 from neuracore.core.data.cache_manager import CacheManager
 from neuracore.core.utils.depth_utils import rgb_to_depth_storage
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 from ..auth import get_auth
 from ..const import API_URL
@@ -104,20 +104,20 @@ class SynchronizedRecording:
             requests.HTTPError: If the API request fails.
         """
         auth = get_auth()
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording",
-                json=SynchronizeRecordingRequest(
-                    recording_id=self.id,
-                    synchronization_details=SynchronizationDetails(
-                        frequency=self.frequency,
-                        cross_embodiment_union=self.cross_embodiment_union,
-                        max_delay_s=sys.float_info.max,
-                        allow_duplicates=True,
-                    ),
-                ).model_dump(mode="json"),
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording",
+            json=SynchronizeRecordingRequest(
+                recording_id=self.id,
+                synchronization_details=SynchronizationDetails(
+                    frequency=self.frequency,
+                    cross_embodiment_union=self.cross_embodiment_union,
+                    max_delay_s=sys.float_info.max,
+                    allow_duplicates=True,
+                ),
+            ).model_dump(mode="json"),
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         return SynchronizedEpisodeModel.model_validate(response.json())
 
@@ -135,12 +135,12 @@ class SynchronizedRecording:
             requests.HTTPError: If the API request fails.
         """
         auth = get_auth()
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.dataset.org_id}/recording/{self.id}/download_url",
-                params={"filepath": f"{camera_type.value}/{camera_id}/lossless.mp4"},
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.dataset.org_id}/recording/{self.id}/download_url",
+            params={"filepath": f"{camera_type.value}/{camera_id}/lossless.mp4"},
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         return response.json()["url"]
 

--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import requests
 from neuracore_types import DataType, EmbodimentDescription, SynchronizedPoint
 
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 if TYPE_CHECKING:
     from neuracore_types import BatchedNCData
@@ -259,13 +259,13 @@ class ServerPolicy(Policy):
         if epoch < -1:
             raise ValueError("Epoch must be -1 (last) or a non-negative integer.")
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{self._base_url}{SET_CHECKPOINT_ENDPOINT}",
-                    headers=self._headers,
-                    json={"epoch": epoch},
-                    timeout=30,
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{self._base_url}{SET_CHECKPOINT_ENDPOINT}",
+                headers=self._headers,
+                json={"epoch": epoch},
+                timeout=30,
+            )
             if response.status_code != 200:
                 raise EndpointError(
                     "Failed to set checkpoint: "
@@ -316,13 +316,13 @@ class ServerPolicy(Policy):
             sync_point.data = filtered_data
         response = None
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{self._base_url}{PREDICT_ENDPOINT}",
-                    headers=self._headers,
-                    json=sync_point.model_dump(mode="json"),
-                    timeout=int(os.getenv("NEURACORE_ENDPOINT_TIMEOUT", 10)),
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{self._base_url}{PREDICT_ENDPOINT}",
+                headers=self._headers,
+                json=sync_point.model_dump(mode="json"),
+                timeout=int(os.getenv("NEURACORE_ENDPOINT_TIMEOUT", 10)),
+            )
             response.raise_for_status()
             result = response.json()
             sync_point_preds = {
@@ -536,10 +536,10 @@ class LocalServerPolicy(ServerPolicy):
             if self.server_process and self.server_process.poll() is not None:
                 raise EndpointError("Local server process terminated unexpectedly.")
             try:
-                with Session() as session:
-                    response = session.get(
-                        f"http://{self.host}:{self.port}{PING_ENDPOINT}", timeout=1
-                    )
+                session = thread_local_session()
+                response = session.get(
+                    f"http://{self.host}:{self.port}{PING_ENDPOINT}", timeout=1
+                )
                 if response.status_code == 200:
                     logger.info(
                         f"Local server started successfully on {self.host}:{self.port}"
@@ -759,10 +759,10 @@ def policy_remote_server(
 
     try:
         # Find endpoint by name
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/models/endpoints", headers=auth.get_headers()
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/models/endpoints", headers=auth.get_headers()
+        )
         response.raise_for_status()
 
         endpoints = response.json()
@@ -809,12 +809,12 @@ def _download_model(job_id: str, org_id: str) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     print("Downloading model from training run...")
-    with Session() as session:
-        response = session.get(
-            f"{API_URL}/org/{org_id}/training/jobs/{job_id}/model_url",
-            headers=auth.get_headers(),
-            timeout=30,
-        )
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/training/jobs/{job_id}/model_url",
+        headers=auth.get_headers(),
+        timeout=30,
+    )
     response.raise_for_status()
 
     model_url_response = response.json()
@@ -830,10 +830,10 @@ def _download_model(job_id: str, org_id: str) -> Path:
 def _get_job_id(train_run_name: str, org_id: str) -> str:
     """Get job ID from training run name."""
     auth = get_auth()
-    with Session() as session:
-        response = session.get(
-            f"{API_URL}/org/{org_id}/training/jobs", headers=auth.get_headers()
-        )
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/training/jobs", headers=auth.get_headers()
+    )
     response.raise_for_status()
     jobs = response.json()
 

--- a/neuracore/core/organizations.py
+++ b/neuracore/core/organizations.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ValidationError
 
 from neuracore.core.auth import get_auth
 from neuracore.core.exceptions import AuthenticationError, OrganizationError
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 from .const import API_URL
 
@@ -35,10 +35,10 @@ def list_my_orgs() -> list[Organization]:
     """
     auth = get_auth()
     try:
-        with Session() as session:
-            org_response = session.get(
-                f"{API_URL}/org-management/my-orgs", headers=auth.get_headers()
-            )
+        session = thread_local_session()
+        org_response = session.get(
+            f"{API_URL}/org-management/my-orgs", headers=auth.get_headers()
+        )
         org_response.raise_for_status()
         orgs_raw = org_response.json()
         assert isinstance(

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -24,7 +24,7 @@ from neuracore_types import DataType, RobotInstanceIdentifier
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.streaming.data_stream import DataStream, MissingProducerChannelError
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.data_daemon.communications_management.shared_transport import (
     recording_context,
 )
@@ -178,20 +178,20 @@ class Robot:
             )
 
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/robots?is_shared={self.shared}",
-                    json={
-                        "name": self.name,
-                        "instance": self.instance,
-                    },  # TODO: Add camera support
-                    headers=self._auth.get_headers(),
-                )
-                response.raise_for_status()
-                response_body = response.json()
-                self.id = response_body["robot_id"]
-                self.archived = response_body.get("archived")
-                has_urdf = response_body["has_urdf"]
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/robots?is_shared={self.shared}",
+                json={
+                    "name": self.name,
+                    "instance": self.instance,
+                },  # TODO: Add camera support
+                headers=self._auth.get_headers(),
+            )
+            response.raise_for_status()
+            response_body = response.json()
+            self.id = response_body["robot_id"]
+            self.archived = response_body.get("archived")
+            has_urdf = response_body["has_urdf"]
             # Upload URDF and meshes if provided
             if self.urdf_path and (not has_urdf or self.overwrite):
                 self._upload_urdf_and_meshes()
@@ -280,24 +280,24 @@ class Robot:
             raise RobotError("Robot not initialized. Call init() first.")
 
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/recording/start",
-                    headers=self._auth.get_headers(),
-                    json={
-                        "robot_id": self.id,
-                        "instance": self.instance,
-                        "dataset_id": dataset_id,
-                    },
-                )
-                response.raise_for_status()
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/recording/start",
+                headers=self._auth.get_headers(),
+                json={
+                    "robot_id": self.id,
+                    "instance": self.instance,
+                    "dataset_id": dataset_id,
+                },
+            )
+            response.raise_for_status()
 
-                recording_details = response.json()
-                recording_id = recording_details["id"]
-                assert isinstance(recording_id, str)
+            recording_details = response.json()
+            recording_id = recording_details["id"]
+            assert isinstance(recording_id, str)
 
-                if "start_time" in recording_details:
-                    warn("This recording had already been started!")
+            if "start_time" in recording_details:
+                warn("This recording had already been started!")
 
             get_recording_state_manager().recording_started(
                 robot_id=self.id, instance=self.instance, recording_id=recording_id
@@ -344,13 +344,13 @@ class Robot:
         )
 
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/recording/stop?recording_id={recording_id}",
-                    headers=self._auth.get_headers(),
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/recording/stop?recording_id={recording_id}",
+                headers=self._auth.get_headers(),
+            )
 
-                response.raise_for_status()
+            response.raise_for_status()
 
             if response.json() == "WrongUser":
                 raise RobotError("Cannot stop recording initiated by another user")
@@ -579,12 +579,12 @@ class Robot:
             )
 
         try:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
-                    headers=self._auth.get_headers(),
-                )
-                response.raise_for_status()
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
+                headers=self._auth.get_headers(),
+            )
+            response.raise_for_status()
         except requests.exceptions.ConnectionError:
             raise RobotError(
                 "Failed to connect to neuracore server, "
@@ -627,12 +627,12 @@ class Robot:
             files = self._package_urdf()
 
             # Upload the package
-            with Session() as session:
-                response = session.put(
-                    f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
-                    headers=self._auth.get_headers(),
-                    files=files,
-                )
+            session = thread_local_session()
+            response = session.put(
+                f"{API_URL}/org/{self.org_id}/robots/{self.id}/package?is_shared={self.shared}",
+                headers=self._auth.get_headers(),
+                files=files,
+            )
 
             # Log response for debugging
             logger.info(f"Upload response status: {response.status_code}")
@@ -717,12 +717,12 @@ class Robot:
         self._get_daemon_recording_context().stop_recording(recording_id=recording_id)
 
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/recording/cancel?recording_id={recording_id}",
-                    headers=self._auth.get_headers(),
-                )
-                response.raise_for_status()
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/recording/cancel?recording_id={recording_id}",
+                headers=self._auth.get_headers(),
+            )
+            response.raise_for_status()
 
             if response.json() == "WrongUser":
                 raise RobotError("Cannot cancel recording initiated by another user")
@@ -879,13 +879,13 @@ def update_robot_name(
         raise RobotError("No organization selected. Please call nc.select_org() first.")
     robot_id = _robot_name_id_mapping.get(robot_key, robot_key)
     try:
-        with Session() as session:
-            response = session.post(
-                f"{API_URL}/org/{resolved_org_id}/robots?is_shared={shared}&robot_id={robot_id}",
-                json={"name": new_robot_name, "instance": instance},
-                headers=get_auth().get_headers(),
-            )
-            response.raise_for_status()
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{resolved_org_id}/robots?is_shared={shared}&robot_id={robot_id}",
+            json={"name": new_robot_name, "instance": instance},
+            headers=get_auth().get_headers(),
+        )
+        response.raise_for_status()
     except requests.exceptions.ConnectionError:
         raise RobotError(
             "Failed to connect to neuracore server, "
@@ -919,19 +919,19 @@ def list_organization_robots(
     start_after: dict | None = None
     try:
         while True:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{org_id}/robots/list",
-                    headers=get_auth().get_headers(),
-                    params={
-                        "is_shared": str(is_shared).lower(),
-                        "mode": mode,
-                        "limit": str(_ROBOTS_LIST_PAGE_SIZE),
-                    },
-                    json=start_after,
-                )
-                response.raise_for_status()
-                page = response.json()
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{org_id}/robots/list",
+                headers=get_auth().get_headers(),
+                params={
+                    "is_shared": str(is_shared).lower(),
+                    "mode": mode,
+                    "limit": str(_ROBOTS_LIST_PAGE_SIZE),
+                },
+                json=start_after,
+            )
+            response.raise_for_status()
+            page = response.json()
 
             batch = page.get("data", [])
             robots.extend(batch)

--- a/neuracore/core/streaming/bucket_uploaders/bucket_uploader.py
+++ b/neuracore/core/streaming/bucket_uploaders/bucket_uploader.py
@@ -15,7 +15,7 @@ from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 TRACE_FILE = "trace.json"
 
@@ -55,12 +55,12 @@ class BucketUploader(ABC):
 
         org_id = get_current_org()
         try:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces",
-                    json={"data_type": data_type.value},
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces",
+                json={"data_type": data_type.value},
+                headers=get_auth().get_headers(),
+            )
             response.raise_for_status()
             body = response.json()
             return body.get("id")
@@ -96,12 +96,12 @@ class BucketUploader(ABC):
 
         org_id = get_current_org()
         try:
-            with Session() as session:
-                session.put(
-                    f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces/{trace_id}",
-                    json=data_trace_payload,
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            session.put(
+                f"{API_URL}/org/{org_id}/recording/{self.recording_id}/traces/{trace_id}",
+                json=data_trace_payload,
+                headers=get_auth().get_headers(),
+            )
         except requests.exceptions.RequestException:
             pass
 

--- a/neuracore/core/streaming/bucket_uploaders/resumable_upload.py
+++ b/neuracore/core/streaming/bucket_uploaders/resumable_upload.py
@@ -12,7 +12,7 @@ import time
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 logger = logging.getLogger(__name__)
 
@@ -59,12 +59,12 @@ class ResumableUpload:
             "content_type": self.content_type,
         }
         org_id = get_current_org()
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/recording/{self.recording_id}/resumable_upload_url",
-                params=params,
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/recording/{self.recording_id}/resumable_upload_url",
+            params=params,
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         return response.json()["url"]
 
@@ -112,8 +112,8 @@ class ResumableUpload:
 
         for attempt in range(self.max_retries):
             try:
-                with Session() as session:
-                    response = session.put(self.session_uri, headers=headers, data=data)
+                session = thread_local_session()
+                response = session.put(self.session_uri, headers=headers, data=data)
                 status_code = response.status_code
 
                 if status_code == 200 or status_code == 201:
@@ -150,8 +150,8 @@ class ResumableUpload:
         """
         headers = {"Content-Length": "0", "Content-Range": "bytes */*"}
 
-        with Session() as session:
-            response = session.put(self.session_uri, headers=headers)
+        session = thread_local_session()
+        response = session.put(self.session_uri, headers=headers)
         if response.status_code == 200 or response.status_code == 201:
             logger.debug("Upload complete")
             return self.total_bytes_uploaded

--- a/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
+++ b/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
@@ -25,7 +25,7 @@ from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import EncodingError
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 from .bucket_uploader import TRACE_FILE, BucketUploader
 from .resumable_upload import ResumableUpload
@@ -394,12 +394,12 @@ class StreamingVideoUploader(BucketUploader):
         }
         org_id = get_current_org()
         try:
-            with Session() as session:
-                upload_url_response = session.get(
-                    f"{API_URL}/org/{org_id}/recording/{self.uploader.recording_id}/resumable_upload_url",
-                    params=params,
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            upload_url_response = session.get(
+                f"{API_URL}/org/{org_id}/recording/{self.uploader.recording_id}/resumable_upload_url",
+                params=params,
+                headers=get_auth().get_headers(),
+            )
         except requests.exceptions.RequestException as e:
             logger.debug(e)
             pass
@@ -408,9 +408,9 @@ class StreamingVideoUploader(BucketUploader):
         for i in range(0, len(self.frame_metadatas)):
             self.frame_metadatas[i].frame_idx = i
         data = json.dumps([fm.model_dump(mode="json") for fm in self.frame_metadatas])
-        with Session() as session:
-            response = session.put(
-                upload_url, headers={"Content-Length": str(len(data))}, data=data
-            )
+        session = thread_local_session()
+        response = session.put(
+            upload_url, headers={"Content-Length": str(len(data))}, data=data
+        )
         response.raise_for_status()
         self.frame_metadatas = []

--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -13,7 +13,7 @@ from neuracore_types import DataType, RecordingDataTrace
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 
 def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
@@ -33,11 +33,11 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
         ConfigError: If there is an error trying to get the current org.
     """
     org_id = get_current_org()
-    with Session() as session:
-        response = session.get(
-            f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/active",
-            headers=get_auth().get_headers(),
-        )
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/active",
+        headers=get_auth().get_headers(),
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()

--- a/neuracore/core/utils/download.py
+++ b/neuracore/core/utils/download.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 
 def download_with_progress(
@@ -22,43 +22,43 @@ def download_with_progress(
     Returns:
         Path to the downloaded file.
     """
-    with Session() as session:
-        response = session.get(
-            url,
-            timeout=120,
-            stream=True,
-        )
-        response.raise_for_status()
+    session = thread_local_session()
+    response = session.get(
+        url,
+        timeout=120,
+        stream=True,
+    )
+    response.raise_for_status()
 
-        # Get total file size
-        total_size = int(response.headers.get("Content-Length", 0))
+    # Get total file size
+    total_size = int(response.headers.get("Content-Length", 0))
 
-        # Create a temporary directory and file path
-        if destination is None:
-            destination = Path(tempfile.mkdtemp()) / "model.nc.zip"
-        else:
-            destination = Path(destination)
+    # Create a temporary directory and file path
+    if destination is None:
+        destination = Path(tempfile.mkdtemp()) / "model.nc.zip"
+    else:
+        destination = Path(destination)
 
-        # Create progress bar based on file size
-        progress_bar = tqdm(
-            total=total_size,
-            unit="B",
-            unit_scale=True,
-            unit_divisor=1024,
-            desc=description,
-            bar_format=(
-                "{desc}: {percentage:3.0f}%|{bar:30}| {n_fmt}/{total_fmt} "
-                "[{elapsed}<{remaining}, {rate_fmt}]"
-            ),
-        )
+    # Create progress bar based on file size
+    progress_bar = tqdm(
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        desc=description,
+        bar_format=(
+            "{desc}: {percentage:3.0f}%|{bar:30}| {n_fmt}/{total_fmt} "
+            "[{elapsed}<{remaining}, {rate_fmt}]"
+        ),
+    )
 
-        # Write the file with progress updates
-        with open(destination, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-                    progress_bar.update(len(chunk))
+    # Write the file with progress updates
+    with open(destination, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+                progress_bar.update(len(chunk))
 
-        # Close the progress bar
-        progress_bar.close()
+    # Close the progress bar
+    progress_bar.close()
     return destination

--- a/neuracore/core/utils/http_session.py
+++ b/neuracore/core/utils/http_session.py
@@ -1,13 +1,15 @@
-"""HTTP session with keep-alive disabled.
+"""Thread- and process-local HTTP session with shared retry policy.
 
-All Neuracore API calls should use ``Session()`` as a context manager rather than
-the bare ``requests.*`` module-level functions to ensure keep-alive is disabled and
-avoid stale connection issues in multi-threaded contexts.
-
-Example:
-    with Session() as session:
-        response = session.get(url)
+All Neuracore API calls should obtain a session via ``thread_local_session()``
+rather than constructing fresh ``requests.Session`` instances or using the
+module-level ``requests.*`` helpers. The returned session is cached per OS
+thread and per process: forks get a fresh session (since urllib3 connection
+pools are not safe to share across forks), and threads do not share a session
+with one another.
 """
+
+import os
+import threading
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -22,14 +24,24 @@ _RETRY = Retry(
     allowed_methods=False,  # type: ignore[arg-type]  # False = retry all methods
 )
 
+_thread_local = threading.local()
 
-class Session(requests.Session):
-    """A requests Session with keep-alive disabled."""
 
-    def __init__(self, *, keep_alive: bool = False) -> None:
-        """Initialize the session and configure retry-enabled HTTP adapters."""
-        super().__init__()
+def thread_local_session() -> requests.Session:
+    """Return a retry-enabled Session cached per thread and process."""
+    pid = os.getpid()
+
+    session = getattr(_thread_local, "session", None)
+    session_pid = getattr(_thread_local, "pid", None)
+
+    if session is None or session_pid != pid:
+        session = requests.Session()
+
         adapter = HTTPAdapter(max_retries=_RETRY)
-        self.mount("https://", adapter)
-        self.mount("http://", adapter)
-        self.keep_alive = keep_alive
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+
+        _thread_local.session = session
+        _thread_local.pid = pid
+
+    return session

--- a/neuracore/ml/cli/training_runs_cloud.py
+++ b/neuracore/ml/cli/training_runs_cloud.py
@@ -19,7 +19,7 @@ from neuracore.core.cli.training_display import RunDisplayRow, print_run_table
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError, ConfigError, TrainingRunError
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 
 TRAINING_JOB_LIST_ADAPTER = TypeAdapter(list[TrainingJob])
 console = Console()
@@ -128,11 +128,11 @@ def _fetch_training_jobs(auth: Any, org_id: str) -> list[TrainingJob]:
         TrainingRunError: If the API request fails.
     """
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/training/jobs",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/training/jobs",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         jobs = response.json()
         return TRAINING_JOB_LIST_ADAPTER.validate_python(jobs)
@@ -166,11 +166,11 @@ def _fetch_training_job(auth: Any, org_id: str, job_id: str) -> TrainingJob:
         TrainingRunError: If the job is not found or API request fails.
     """
     try:
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
-                headers=auth.get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
+            headers=auth.get_headers(),
+        )
         response.raise_for_status()
         job = response.json()
         return TrainingJob.model_validate(job)

--- a/neuracore/ml/logging/cloud_training_logger.py
+++ b/neuracore/ml/logging/cloud_training_logger.py
@@ -11,7 +11,7 @@ import torch
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.ml.logging.training_logger import TrainingLogger
 
 logger = logging.getLogger(__name__)
@@ -177,12 +177,12 @@ class CloudTrainingLogger(TrainingLogger):
                 for name, step_map in self._store.items()
             }
         }
-        with Session() as session:
-            response = session.put(
-                f"{API_URL}/org/{org_id}/training/jobs/{self.training_id}/metrics",
-                headers=get_auth().get_headers(),
-                json=metricsData,
-            )
+        session = thread_local_session()
+        response = session.put(
+            f"{API_URL}/org/{org_id}/training/jobs/{self.training_id}/metrics",
+            headers=get_auth().get_headers(),
+            json=metricsData,
+        )
         response.raise_for_status()
         self._store.clear()  # Clear local store after successful sync
 

--- a/neuracore/ml/utils/algorithm_storage_handler.py
+++ b/neuracore/ml/utils/algorithm_storage_handler.py
@@ -11,7 +11,7 @@ import wget
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 from neuracore.ml.utils.validate import AlgorithmCheck
 
@@ -32,11 +32,11 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         self.log_to_cloud = self.algorithm_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}",
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}",
+                headers=get_auth().get_headers(),
+            )
             if response.status_code != 200:
                 raise ValueError(
                     f"Algorithm {self.algorithm_id} not found or access denied."
@@ -49,12 +49,12 @@ class AlgorithmStorageHandler(UploadStorageMixin):
             error_message: Error message to save.
         """
         if self.log_to_cloud:
-            with Session() as session:
-                response = session.post(
-                    f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/validation-error",
-                    headers=get_auth().get_headers(),
-                    json={"error_message": error_message},
-                )
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/validation-error",
+                headers=get_auth().get_headers(),
+                json={"error_message": error_message},
+            )
             if response.status_code != 200:
                 logger.error(
                     f"Failed to save algorithm validation error: {response.text}"
@@ -66,11 +66,11 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         Args:
             extract_dir: Directory to extract algorithm code to.
         """
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.org_id}/algorithms/download_url/{self.algorithm_id}",
-                headers=get_auth().get_headers(),
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/algorithms/download_url/{self.algorithm_id}",
+            headers=get_auth().get_headers(),
+        )
         if response.status_code != 200:
             raise ValueError(
                 f"Failed to get download URL for algorithm {self.algorithm_id}: "
@@ -109,12 +109,12 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         else:
             dict_to_save["validation_status"] = "validation_failed"
             dict_to_save["validation_message"] = error_message
-        with Session() as session:
-            response = session.put(
-                f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/update-algorithm-validation",
-                headers=get_auth().get_headers(),
-                json=dict_to_save,
-            )
+        session = thread_local_session()
+        response = session.put(
+            f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/update-algorithm-validation",
+            headers=get_auth().get_headers(),
+            json=dict_to_save,
+        )
         if response.status_code != 200:
             logger.error(f"Failed to save algorithm validation check: {response.text}")
         else:
@@ -123,15 +123,15 @@ class AlgorithmStorageHandler(UploadStorageMixin):
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for algorithm artifacts/logs."""
         assert self.algorithm_id is not None, "Algorithm ID not provided"
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/upload-url",
-                headers=get_auth().get_headers(),
-                params={
-                    "filepath": filepath,
-                    "content_type": content_type,
-                },
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/algorithms/{self.algorithm_id}/upload-url",
+            headers=get_auth().get_headers(),
+            params={
+                "filepath": filepath,
+                "content_type": content_type,
+            },
+        )
         if response.status_code != 200:
             raise ValueError(
                 f"Failed to get upload URL for {filepath}: {response.text}"
@@ -144,9 +144,9 @@ class AlgorithmStorageHandler(UploadStorageMixin):
         data: bytes | IO[bytes],
         content_type: str,
     ) -> requests.Response:
-        with Session() as session:
-            return session.put(
-                upload_url,
-                data=data,
-                headers={"Content-Type": content_type},
-            )
+        session = thread_local_session()
+        return session.put(
+            upload_url,
+            data=data,
+            headers={"Content-Type": content_type},
+        )

--- a/neuracore/ml/utils/endpoint_storage_handler.py
+++ b/neuracore/ml/utils/endpoint_storage_handler.py
@@ -8,7 +8,7 @@ import requests
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
 
 logger = logging.getLogger(__name__)
@@ -27,11 +27,11 @@ class EndpointStorageHandler(UploadStorageMixin):
         self.log_to_cloud = self.endpoint_id is not None
         self.org_id = get_current_org()
         if self.log_to_cloud:
-            with Session() as session:
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}",
-                    headers=get_auth().get_headers(),
-                )
+            session = thread_local_session()
+            response = session.get(
+                f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}",
+                headers=get_auth().get_headers(),
+            )
             if response.status_code != 200:
                 raise ValueError(
                     f"Endpoint {self.endpoint_id} not found or access denied."
@@ -40,12 +40,12 @@ class EndpointStorageHandler(UploadStorageMixin):
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for endpoint logs."""
         assert self.endpoint_id is not None, "Endpoint ID not provided"
-        with Session() as session:
-            response = session.get(
-                f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/upload-url",
-                headers=get_auth().get_headers(),
-                params={"filepath": filepath, "content_type": content_type},
-            )
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/upload-url",
+            headers=get_auth().get_headers(),
+            params={"filepath": filepath, "content_type": content_type},
+        )
         if response.status_code != 200:
             raise ValueError(
                 f"Failed to get upload URL for {filepath}: {response.text}"
@@ -58,12 +58,12 @@ class EndpointStorageHandler(UploadStorageMixin):
         data: bytes | IO[bytes],
         content_type: str,
     ) -> requests.Response:
-        with Session() as session:
-            return session.put(
-                upload_url,
-                data=data,
-                headers={"Content-Type": content_type},
-            )
+        session = thread_local_session()
+        return session.put(
+            upload_url,
+            data=data,
+            headers={"Content-Type": content_type},
+        )
 
     def report_endpoint_error(self, error: str) -> None:
         """Report endpoint startup/runtime failures to cloud metadata."""
@@ -71,11 +71,11 @@ class EndpointStorageHandler(UploadStorageMixin):
             return
 
         assert self.endpoint_id is not None, "Endpoint ID not provided"
-        with Session() as session:
-            response = session.put(
-                f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/update",
-                headers=get_auth().get_headers(),
-                json={"error": error},
-            )
+        session = thread_local_session()
+        response = session.put(
+            f"{API_URL}/org/{self.org_id}/models/endpoints/{self.endpoint_id}/update",
+            headers=get_auth().get_headers(),
+            json={"error": error},
+        )
         if response.status_code != 200:
             logger.error("Failed to report endpoint error to cloud: %s", response.text)

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -18,7 +18,7 @@ from neuracore_types import (
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.utils.download import download_with_progress
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.robot_data_spec_utils import (
     resolve_embodiment_descriptions_with_override,
 )
@@ -200,12 +200,12 @@ class PolicyInference:
             )
             if not checkpoint_path.exists():
                 checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-                with Session() as session:
-                    response = session.get(
-                        f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}/checkpoint_url/{checkpoint_name}",
-                        headers=get_auth().get_headers(),
-                        timeout=30,
-                    )
+                session = thread_local_session()
+                response = session.get(
+                    f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}/checkpoint_url/{checkpoint_name}",
+                    headers=get_auth().get_headers(),
+                    timeout=30,
+                )
                 if response.status_code == 404:
                     raise ValueError(f"Checkpoint {checkpoint_name} does not exist.")
                 checkpoint_path = download_with_progress(

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -12,7 +12,7 @@ import neuracore as nc
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils.http_session import thread_local_session
 from neuracore.ml.utils.nc_archive import create_nc_archive
 from neuracore.ml.utils.preprocessing_utils import PreprocessingConfiguration
 from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
@@ -199,8 +199,8 @@ class TrainingStorageHandler(UploadStorageMixin):
         load_path = self.local_dir / checkpoint_name
         if self.log_to_cloud:
             download_url = self._get_checkpoint_download_url(checkpoint_name)
-            with Session() as session:
-                response = session.get(download_url)
+            session = thread_local_session()
+            response = session.get(download_url)
             if response.status_code != 200:
                 raise ValueError(
                     f"Failed to download checkpoint {checkpoint_name}: {response.text}"
@@ -330,12 +330,12 @@ class TrainingStorageHandler(UploadStorageMixin):
             headers: Optional headers to include in the request.
         """
         headers = headers or get_auth().get_headers()
-        with Session() as session:
+        session = thread_local_session()
+        response = session.put(url, headers=headers, json=json, data=data)
+        if response.status_code == 401:
+            logger.warning("Unauthorized request. Token may have expired.")
+            nc.login()
             response = session.put(url, headers=headers, json=json, data=data)
-            if response.status_code == 401:
-                logger.warning("Unauthorized request. Token may have expired.")
-                nc.login()
-                response = session.put(url, headers=headers, json=json, data=data)
         return response
 
     def _get_request(self, url: str, params: dict | None = None) -> requests.Response:
@@ -345,14 +345,12 @@ class TrainingStorageHandler(UploadStorageMixin):
             url: The URL to send the request to.
             params: Optional parameters to include in the request.
         """
-        with Session() as session:
+        session = thread_local_session()
+        response = session.get(url, headers=get_auth().get_headers(), params=params)
+        if response.status_code == 401:
+            logger.warning("Unauthorized request. Token may have expired.")
+            nc.login()
             response = session.get(url, headers=get_auth().get_headers(), params=params)
-            if response.status_code == 401:
-                logger.warning("Unauthorized request. Token may have expired.")
-                nc.login()
-                response = session.get(
-                    url, headers=get_auth().get_headers(), params=params
-                )
         return response
 
     def _delete_request(self, url: str) -> requests.Response:
@@ -361,10 +359,10 @@ class TrainingStorageHandler(UploadStorageMixin):
         Args:
             url: The URL to send the request to.
         """
-        with Session() as session:
+        session = thread_local_session()
+        response = session.delete(url, headers=get_auth().get_headers())
+        if response.status_code == 401:
+            logger.warning("Unauthorized request. Token may have expired.")
+            nc.login()
             response = session.delete(url, headers=get_auth().get_headers())
-            if response.status_code == 401:
-                logger.warning("Unauthorized request. Token may have expired.")
-                nc.login()
-                response = session.delete(url, headers=get_auth().get_headers())
         return response

--- a/tests/unit/core/cli/test_training_runs.py
+++ b/tests/unit/core/cli/test_training_runs.py
@@ -328,7 +328,7 @@ class TestLibraryFunctions:
 
         mock_session.get.side_effect = requests.exceptions.ConnectionError()
         with patch(
-            "neuracore.ml.cli.training_runs_cloud.Session",
+            "neuracore.ml.cli.training_runs_cloud.thread_local_session",
             return_value=mock_session,
         ):
             with pytest.raises(TrainingRunError, match="connect"):

--- a/tests/unit/core/utils/test_http_session.py
+++ b/tests/unit/core/utils/test_http_session.py
@@ -1,57 +1,74 @@
-from collections import Counter
-from unittest.mock import Mock
+import threading
+from unittest.mock import patch
 
-import pytest
 import requests
 import requests_mock
 from requests.adapters import HTTPAdapter
 
-from neuracore.core.utils.http_session import Session
+from neuracore.core.utils import http_session
+from neuracore.core.utils.http_session import thread_local_session
 
 # cspell:ignore poolmanager
 
 _URL = "https://api.neuracore.com"
 
 
-def test_session_is_requests_session():
-    with Session() as s:
-        assert isinstance(s, requests.Session)
+def _reset_thread_local() -> None:
+    """Drop any session cached on the current thread."""
+    if hasattr(http_session._thread_local, "session"):
+        del http_session._thread_local.session
+    if hasattr(http_session._thread_local, "pid"):
+        del http_session._thread_local.pid
 
 
-def test_session_disables_keep_alive():
-    with Session() as s:
-        assert s.keep_alive is False
+def test_returns_requests_session():
+    _reset_thread_local()
+    session = thread_local_session()
+    assert isinstance(session, requests.Session)
 
 
-def test_session_accepts_keep_alive_kwarg():
-    with Session(keep_alive=True) as s:
-        assert s.keep_alive is True
+def test_same_thread_returns_cached_session():
+    _reset_thread_local()
+    first = thread_local_session()
+    second = thread_local_session()
+    assert first is second
 
 
-def test_session_closes_on_exit():
-    with Session() as s:
-        adapter_call_counts = Counter(map(id, s.adapters.values()))
-        adapters = {id(adapter): adapter for adapter in s.adapters.values()}
+def test_different_threads_get_independent_sessions():
+    _reset_thread_local()
+    main_session = thread_local_session()
+    captured: dict = {}
 
-        for adapter in adapters.values():
-            adapter.close = Mock()
+    def worker() -> None:
+        captured["session"] = thread_local_session()
 
-        for adapter in adapters.values():
-            adapter.close.assert_not_called()
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
 
-    for adapter_id, adapter in adapters.items():
-        assert adapter.close.call_count == adapter_call_counts[adapter_id]
+    assert captured["session"] is not main_session
+
+
+def test_pid_change_invalidates_cached_session():
+    _reset_thread_local()
+    with patch.object(http_session.os, "getpid", return_value=1):
+        original = thread_local_session()
+    with patch.object(http_session.os, "getpid", return_value=2):
+        post_fork = thread_local_session()
+    assert post_fork is not original
 
 
 def test_session_mounts_http_and_https():
-    with Session() as s:
-        assert isinstance(s.get_adapter("https://"), HTTPAdapter)
-        assert isinstance(s.get_adapter("http://"), HTTPAdapter)
+    _reset_thread_local()
+    session = thread_local_session()
+    assert isinstance(session.get_adapter("https://"), HTTPAdapter)
+    assert isinstance(session.get_adapter("http://"), HTTPAdapter)
 
 
 def test_retry_config():
-    with Session() as s:
-        retry = s.get_adapter(_URL).max_retries
+    _reset_thread_local()
+    session = thread_local_session()
+    retry = session.get_adapter(_URL).max_retries
     assert retry.connect == 3
     assert retry.read == 0
     assert retry.status == 0
@@ -59,30 +76,25 @@ def test_retry_config():
 
 
 def test_retry_allows_all_methods():
-    with Session() as s:
-        retry = s.get_adapter(_URL).max_retries
+    _reset_thread_local()
+    session = thread_local_session()
+    retry = session.get_adapter(_URL).max_retries
     assert retry.allowed_methods is False
 
 
 def test_no_retry_on_5xx():
+    _reset_thread_local()
     with requests_mock.Mocker() as m:
         m.get(f"{_URL}/health", status_code=500)
-        with Session() as s:
-            r = s.get(f"{_URL}/health")
-    assert r.status_code == 500
+        session = thread_local_session()
+        response = session.get(f"{_URL}/health")
+    assert response.status_code == 500
     assert m.call_count == 1
 
 
-def test_each_session_is_independent():
-    with Session() as s1:
-        pass
-    with Session() as s2:
-        pass
-    assert s1 is not s2
-
-
-@pytest.mark.parametrize("scheme", ["http://", "https://"])
-def test_adapters_share_retry_config(scheme):
-    with Session() as s:
-        adapter = s.get_adapter(scheme)
-    assert adapter.max_retries.connect == 3
+def test_adapters_share_retry_config():
+    _reset_thread_local()
+    session = thread_local_session()
+    for scheme in ("http://", "https://"):
+        adapter = session.get_adapter(scheme)
+        assert adapter.max_retries.connect == 3

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -316,7 +316,7 @@ def test_set_checkpoint_raises_endpoint_error_for_connection_error(
     endpoint = _connect_test_remote_endpoint(mock_auth_requests, mocked_org_id)
     mock_session.post.side_effect = requests.exceptions.ConnectionError()
     with patch(
-        "neuracore.core.endpoint.Session", return_value=mock_session
+        "neuracore.core.endpoint.thread_local_session", return_value=mock_session
     ), pytest.raises(
         EndpointError,
         match=(
@@ -339,7 +339,7 @@ def test_set_checkpoint_raises_endpoint_error_for_request_exception(
     endpoint = _connect_test_remote_endpoint(mock_auth_requests, mocked_org_id)
     mock_session.post.side_effect = requests.exceptions.Timeout("timeout")
     with patch(
-        "neuracore.core.endpoint.Session", return_value=mock_session
+        "neuracore.core.endpoint.thread_local_session", return_value=mock_session
     ), pytest.raises(EndpointError, match="Failed to set checkpoint: timeout"):
         endpoint.set_checkpoint(epoch=1)
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Cold sessions were causing interation tests to fail performance requirments, 
     - previously we introduced the global session to address this but due to it being not thread safe it ended up causing subtle issues that were difficult tyo debug
     - the indivual sessions did not have the concurrency issues but were slower than the global session
     - this approach is the best of both worlds by using `threading.local()` to have a safe shared per thread session

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - None

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-984](https://neuracore.atlassian.net/browse/NCP-984)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore/pull/610
 - https://github.com/NeuracoreAI/neuracore/pull/590

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
