### PR TITLE
fix: pad input in policy inference

### DIFF
--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -392,76 +392,79 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         for data_type in self.input_cross_embodiment_description[robot_id]:
             batched_nc_data_class = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type]
             inputs[data_type] = []
-            mask = []
 
-            max_items_for_this_data_type = 0
+            max_items_trained_on = 0
             # Iterate through all robots and find the max index for this data
             # type across all robots to determine padding length.
             for other_robot_id in self.input_cross_embodiment_description:
                 for index in self.input_cross_embodiment_description[other_robot_id][
                     data_type
                 ].keys():
-                    if index > max_items_for_this_data_type:
-                        max_items_for_this_data_type = index
+                    if index > max_items_trained_on:
+                        max_items_trained_on = index
 
-            for index in range(max_items_for_this_data_type + 1):
+            max_items_trained_on += 1
+            input_mask_values: list[float] = [0.0] * max_items_trained_on
+            for index in range(max_items_trained_on):
                 name = self.input_cross_embodiment_description[robot_id][data_type].get(
                     index
                 )
 
-                if name is not None:
-                    # If the current robot has a name for this index, use it to
-                    # get the data. Otherwise, pad with zeros.
-                    nc_data = sync_point.data[data_type][name]
-                    batched_nc_data = batched_nc_data_class.from_nc_data(nc_data)
-                    batched_nc_data = apply_preprocessing_methods(
-                        batched_data=batched_nc_data,
-                        methods=self._input_preprocessing_config.get(data_type, []),
-                    )
-                    inputs[data_type].append(batched_nc_data)
-                    mask.append(1.0)
-
-                else:
-                    # Pad missing data with zeros
+                if name is None:
+                    # Pad missing data with zeros.
                     batched_nc_data = batched_nc_data_class.sample(
                         batch_size=1, time_steps=1
                     )
-                    batched_nc_data = apply_preprocessing_methods(
-                        batched_data=batched_nc_data,
-                        methods=self._input_preprocessing_config.get(data_type, []),
-                    )
-                    inputs[data_type].append(batched_nc_data)
-                    mask.append(0.0)
+                else:
+                    # If the current robot has a name for this index, use it to
+                    # get the data.
+                    nc_data = sync_point.data[data_type][name]
+                    batched_nc_data = batched_nc_data_class.from_nc_data(nc_data)
+                    input_mask_values[index] = 1.0
+
+                batched_nc_data = apply_preprocessing_methods(
+                    batched_data=batched_nc_data,
+                    methods=self._input_preprocessing_config.get(data_type, []),
+                )
+                inputs[data_type].append(batched_nc_data)
 
             # Create mask for inputs
-            inputs_mask[data_type] = torch.tensor(mask, dtype=torch.float32)
+            inputs_mask[data_type] = torch.tensor(
+                input_mask_values, dtype=torch.float32
+            )
 
         outputs: dict[DataType, list[BatchedNCData]] = {}
         outputs_mask: dict[DataType, torch.Tensor] = {}
         for data_type in self.output_cross_embodiment_description[robot_id]:
             batched_nc_data_class = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type]
             outputs[data_type] = []
-            mask = []
 
-            max_items_for_this_data_type = 0
+            max_items_trained_on = 0
             # Iterate through all robots and find the max index for this data
             # type across all robots to determine padding length.
             for other_robot_id in self.output_cross_embodiment_description:
                 for index in self.output_cross_embodiment_description[other_robot_id][
                     data_type
                 ].keys():
-                    if index > max_items_for_this_data_type:
-                        max_items_for_this_data_type = index
+                    if index > max_items_trained_on:
+                        max_items_trained_on = index
 
-            # Need to add action prediction horizon for outputs.
-            for index in range(max_items_for_this_data_type + 1):
+            max_items_trained_on += 1
+            output_mask_values: list[float] = [0.0] * max_items_trained_on
+            for index in range(max_items_trained_on):
                 name = self.output_cross_embodiment_description[robot_id][
                     data_type
                 ].get(index)
 
-                if name is not None:
+                if name is None:
+                    # Pad missing data with zeros.
+                    batched_nc_data = batched_nc_data_class.sample(
+                        batch_size=1,
+                        time_steps=self.output_prediction_horizon,
+                    )
+                else:
                     # If the current robot has a name for this index, use it to
-                    # get the data. Otherwise, pad with zeros.
+                    # get the data.
                     nc_data_list = [
                         future_sp.data[data_type][name]
                         for future_sp in future_sync_points
@@ -469,27 +472,18 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     batched_nc_data = batched_nc_data_class.from_nc_data_list(
                         nc_data_list
                     )
-                    batched_nc_data = apply_preprocessing_methods(
-                        batched_data=batched_nc_data,
-                        methods=self._output_preprocessing_config.get(data_type, []),
-                    )
-                    outputs[data_type].append(batched_nc_data)
-                    mask.append(1.0)
-                else:
-                    # Pad missing data with zeros.
-                    batched_nc_data = batched_nc_data_class.sample(
-                        batch_size=1,
-                        time_steps=self.output_prediction_horizon,
-                    )
-                    batched_nc_data = apply_preprocessing_methods(
-                        batched_data=batched_nc_data,
-                        methods=self._output_preprocessing_config.get(data_type, []),
-                    )
-                    outputs[data_type].append(batched_nc_data)
-                    mask.append(0.0)
+                    output_mask_values[index] = 1.0
+
+                batched_nc_data = apply_preprocessing_methods(
+                    batched_data=batched_nc_data,
+                    methods=self._output_preprocessing_config.get(data_type, []),
+                )
+                outputs[data_type].append(batched_nc_data)
 
             # Create mask for outputs.
-            outputs_mask[data_type] = torch.tensor(mask, dtype=torch.float32)
+            outputs_mask[data_type] = torch.tensor(
+                output_mask_values, dtype=torch.float32
+            )
 
         return TrainingSample(
             inputs=inputs,

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -142,34 +142,45 @@ class PolicyInference:
         # We need to go from sync_point (single time step) to BatchedNCData
         for data_type in sync_point.data.keys():
             inputs[data_type] = []
-            max_items_for_this_data_type = len(sync_point.data[data_type])
+            embodiment_names = self.input_embodiment_description[data_type]
             trained_statistics = self.input_dataset_statistics.get(data_type)
             if trained_statistics is None:
                 raise ValueError(
                     f"Model was not trained with input statistics for {data_type}."
                 )
             max_items_trained_on = len(trained_statistics)
-            if max_items_for_this_data_type > max_items_trained_on:
+            max_items_received = len(sync_point.data[data_type])
+            if max_items_received > max_items_trained_on:
                 raise ValueError(
-                    f"Received {max_items_for_this_data_type} items for data type "
+                    f"Received {max_items_received} items for data type "
                     f"{data_type}, but model was trained on maximum of "
                     f"{max_items_trained_on} items."
                 )
-            inputs_mask[data_type] = torch.tensor(
-                [1.0] * max_items_for_this_data_type
-                + [0.0] * (max_items_trained_on - max_items_for_this_data_type),
-                dtype=torch.float32,
+
+            mask: list[float] = [0.0] * max_items_trained_on
+            batched_nc_data_class: type[BatchedNCData] = (
+                DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type]
             )
-            inputs_mask[data_type].unsqueeze_(0)  # Add batch dimension
-            for _, nc_data in sync_point.data[data_type].items():
-                tensor = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type].from_nc_data(
-                    nc_data
-                )
+            preprocessing_methods = self.input_preprocessing_config.get(data_type, [])
+
+            for index in range(max_items_trained_on):
+                name = embodiment_names.get(index)
+                if name is None or name not in sync_point.data[data_type]:
+                    tensor = batched_nc_data_class.sample(batch_size=1, time_steps=1)
+                else:
+                    nc_data = sync_point.data[data_type][name]
+                    tensor = batched_nc_data_class.from_nc_data(nc_data)
+                    mask[index] = 1.0
+
                 tensor = apply_preprocessing_methods(
                     batched_data=tensor,
-                    methods=self.input_preprocessing_config.get(data_type, []),
+                    methods=preprocessing_methods,
                 )
                 inputs[data_type].append(tensor)
+
+            inputs_mask[data_type] = torch.tensor(mask, dtype=torch.float32).unsqueeze(
+                0
+            )
         return BatchedInferenceInputs(
             inputs=inputs,
             inputs_mask=inputs_mask,

--- a/tests/unit/ml/utils/test_policy_inference.py
+++ b/tests/unit/ml/utils/test_policy_inference.py
@@ -178,6 +178,10 @@ def test_validate_input_sync_point_raises_when_required_data_type_missing() -> N
 
 def test_preprocess_builds_inputs_and_masks_for_multiple_data_types() -> None:
     policy_inference = _make_policy_inference()
+    policy_inference.input_embodiment_description = {
+        DataType.JOINT_POSITIONS: {0: "joint1"},
+        DataType.JOINT_VELOCITIES: {0: "joint1"},
+    }
     policy_inference.input_dataset_statistics = {
         DataType.JOINT_POSITIONS: [{"joint1": {}}, {"joint2": {}}],
         DataType.JOINT_VELOCITIES: [{"joint1": {}}],
@@ -203,12 +207,47 @@ def test_preprocess_builds_inputs_and_masks_for_multiple_data_types() -> None:
     }
     assert batch.inputs_mask[DataType.JOINT_POSITIONS].tolist() == [[1.0, 0.0]]
     assert batch.inputs_mask[DataType.JOINT_VELOCITIES].tolist() == [[1.0]]
-    assert len(batch.inputs[DataType.JOINT_POSITIONS]) == 1
+    assert len(batch.inputs[DataType.JOINT_POSITIONS]) == 2
     assert len(batch.inputs[DataType.JOINT_VELOCITIES]) == 1
+
+
+def test_preprocess_pads_missing_cross_embodiment_indices() -> None:
+    policy_inference = _make_policy_inference()
+    policy_inference.input_embodiment_description = {
+        DataType.JOINT_POSITIONS: {
+            0: "joint1",
+            1: "joint2",
+        },
+    }
+    policy_inference.input_dataset_statistics = {
+        DataType.JOINT_POSITIONS: [{"joint1": {}}, {"joint2": {}}, {"joint3": {}}],
+    }
+    sync_point = SynchronizedPoint(
+        timestamp=123.0,
+        data={
+            DataType.JOINT_POSITIONS: {
+                "joint1": JointData(timestamp=123.0, value=0.1),
+                "joint2": JointData(timestamp=123.0, value=0.2),
+            },
+        },
+    )
+
+    batch = policy_inference._preprocess(sync_point)
+
+    assert batch.inputs_mask[DataType.JOINT_POSITIONS].tolist() == [[1.0, 1.0, 0.0]]
+    assert len(batch.inputs[DataType.JOINT_POSITIONS]) == 3
+    joint_values = torch.cat(
+        [joint.value for joint in batch.inputs[DataType.JOINT_POSITIONS]], dim=-1
+    )
+    assert joint_values.shape[-1] == 3
+    assert joint_values[0, -1, 2].item() == 0.0
 
 
 def test_preprocess_raises_when_statistics_for_data_type_missing() -> None:
     policy_inference = _make_policy_inference()
+    policy_inference.input_embodiment_description = {
+        DataType.JOINT_POSITIONS: {0: "joint1"},
+    }
     policy_inference.input_dataset_statistics = {}
     sync_point = SynchronizedPoint(
         timestamp=123.0,
@@ -228,6 +267,9 @@ def test_preprocess_raises_when_statistics_for_data_type_missing() -> None:
 
 def test_preprocess_raises_when_received_items_exceed_training_limit() -> None:
     policy_inference = _make_policy_inference()
+    policy_inference.input_embodiment_description = {
+        DataType.JOINT_POSITIONS: {0: "joint1", 1: "joint2"},
+    }
     policy_inference.input_dataset_statistics = {
         DataType.JOINT_POSITIONS: [{"joint1": {}}],
     }


### PR DESCRIPTION
### Bugfixes
- For cross-embodiment training with 2 robots of different number of joints, the inference fails when using the robot with less joint because the input is not padded
- This fix pads the input data to the max items trained on similar to what we do in training
- Improve handling of padding in training
### Items
 - [NCRL-599](https://neuracore.atlassian.net/browse/NCRL-599)