### PR TITLE
fix: concurrent login causes dataloader to fail

### DIFF
--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -92,8 +92,9 @@ class Auth(metaclass=SingletonMetaclass):
                 # only clear if the saved org isn’t in the new account’s org list.
                 config_manager.config.current_org_id = None
 
-            # always persist the API key.
             config_manager.config.api_key = api_key
+
+            # Persist the config if the config has changed.
             config_manager.save_config()
 
         except requests.exceptions.ConnectionError:

--- a/neuracore/core/config/config_manager.py
+++ b/neuracore/core/config/config_manager.py
@@ -72,12 +72,26 @@ class ConfigManager:
         """
         self._config = config
 
+    @staticmethod
+    def _read_persisted_config(config_file: Path) -> Config | None:
+        """Read on-disk config without updating the in-memory cache.
+
+        Returns:
+            Parsed config, or None if the file is missing, empty, or unreadable.
+        """
+        try:
+            content = config_file.read_text(encoding=CONFIG_ENCODING).strip()
+            return Config.model_validate_json(content) if content else None
+        except (OSError, ValidationError):
+            return None
+
     def save_config(self) -> None:
         """Save current authentication configuration to persistent storage.
 
         Creates the configuration directory if it doesn't exist and saves
         the current configuration to a JSON configuration file in the user's
         home directory.
+        Skips the write when on-disk config already matches the in-memory state.
 
         Raises:
             ConfigError: If saving the config fails.
@@ -86,8 +100,12 @@ class ConfigManager:
             # Nothing to save
             return
 
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         config_file = CONFIG_DIR / CONFIG_FILE
+        persisted = self._read_persisted_config(config_file)
+        if persisted is not None and persisted == self._config:
+            return
+
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
         try:
             with open(config_file, "w", encoding=CONFIG_ENCODING) as f:

--- a/tests/unit/core/config/test_config_manager.py
+++ b/tests/unit/core/config/test_config_manager.py
@@ -1,0 +1,71 @@
+"""Tests for neuracore.core.config.config_manager."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neuracore.core.config.config_manager import CONFIG_FILE, Config, ConfigManager
+from neuracore.core.exceptions import ConfigError
+
+
+def test_save_config_skips_when_unchanged(temp_config_dir: Path) -> None:
+    config_file = temp_config_dir / CONFIG_FILE
+    config_file.write_text(
+        '{"api_key":"nrc_test","current_org_id":"org-1"}',
+        encoding="utf-8",
+    )
+    mtime_before = config_file.stat().st_mtime
+
+    manager = ConfigManager()
+    manager.config = Config(api_key="nrc_test", current_org_id="org-1")
+    manager.save_config()
+
+    assert config_file.stat().st_mtime == mtime_before
+
+
+def test_save_config_overwrites_when_changed(temp_config_dir: Path) -> None:
+    config_file = temp_config_dir / CONFIG_FILE
+    config_file.write_text(
+        '{"api_key":"nrc_old","current_org_id":"org-old"}',
+        encoding="utf-8",
+    )
+
+    manager = ConfigManager()
+    manager.config = Config(api_key="nrc_new", current_org_id="org-new")
+    manager.save_config()
+
+    loaded = json.loads(config_file.read_text(encoding="utf-8"))
+    assert loaded == {"api_key": "nrc_new", "current_org_id": "org-new"}
+
+
+def test_save_config_overwrites_when_empty(temp_config_dir: Path) -> None:
+    config_file = temp_config_dir / CONFIG_FILE
+    config_file.write_text("", encoding="utf-8")
+
+    manager = ConfigManager()
+    manager.config = Config(api_key="nrc_test", current_org_id="org-1")
+    manager.save_config()
+
+    loaded = json.loads(config_file.read_text(encoding="utf-8"))
+    assert loaded == {"api_key": "nrc_test", "current_org_id": "org-1"}
+
+
+def test_save_config_writes_json(temp_config_dir: Path) -> None:
+    config_file = temp_config_dir / CONFIG_FILE
+    manager = ConfigManager()
+    manager.config = Config(api_key="nrc_test", current_org_id="org-1")
+    manager.save_config()
+
+    assert config_file.exists()
+    loaded = json.loads(config_file.read_text(encoding="utf-8"))
+    assert loaded == {"api_key": "nrc_test", "current_org_id": "org-1"}
+
+
+def test_load_config_raises_on_invalid_json(temp_config_dir: Path) -> None:
+    config_file = temp_config_dir / CONFIG_FILE
+    config_file.write_text("{not json")
+
+    manager = ConfigManager()
+    with pytest.raises(ConfigError, match="invalid structure"):
+        _ = manager.config


### PR DESCRIPTION
### Bugfixes
https://github.com/NeuracoreAI/neuracore/actions/runs/26810753745/job/79039797580
```
Batch size validation failed
Traceback (most recent call last):
  File "/opt/neuracore/neuracore/ml/train.py", line 303, in assert_valid_batch_size
    valid = is_valid_batch_size(
            ^^^^^^^^^^^^^^^^^^^^
  File "/opt/neuracore/neuracore/ml/trainers/batch_autotuner.py", line 599, in is_valid_batch_size
    valid = validator.test_batch_size(batch_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/neuracore/neuracore/ml/trainers/batch_autotuner.py", line 86, in test_batch_size
    return self._run_in_subprocess(batch_size)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/neuracore/neuracore/ml/trainers/batch_autotuner.py", line 139, in _run_in_subprocess
    raise RuntimeError(
RuntimeError: Unexpected failure while probing batch size 2: ConfigError('Caught ConfigError in DataLoader worker process 0.\nOriginal Traceback (most recent call last):\n  File "/opt/neuracore/neuracore/core/config/config_manager.py", line 52, in config\n    self._config = Config.model_validate_json(f.read())\n                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/.venv/lib/python3.11/site-packages/pydantic/main.py", line 782, in model_validate_json\n    return cls.__pydantic_validator__.validate_json(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\npydantic_core._pydantic_core.ValidationError: 1 validation error for Config\n  Invalid JSON: EOF while parsing a value at line 1 column 0 [type=json_invalid, input_value=\'\', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.13/v/json_invalid\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/opt/neuracore/.venv/lib/python3.11/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop\n    data = fetcher.fetch(index)  # type: ignore[possibly-undefined]\n           ^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/.venv/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 50, in fetch\n    data = self.dataset.__getitems__(possibly_batched_index)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/.venv/lib/python3.11/site-packages/torch/utils/data/dataset.py", line 416, in __getitems__\n    return [self.dataset[self.indices[idx]] for idx in indices]\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/.venv/lib/python3.11/site-packages/torch/utils/data/dataset.py", line 416, in <listcomp>\n    return [self.dataset[self.indices[idx]] for idx in indices]\n            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/neuracore/ml/datasets/pytorch_synchronized_dataset.py", line 531, in __getitem__\n    return self.load_sample(episode_idx, timestep)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/neuracore/ml/datasets/pytorch_synchronized_dataset.py", line 344, in load_sample\n    nc.login()\n  File "/opt/neuracore/neuracore/api/core.py", line 94, in login\n    get_auth().login(api_key)\n  File "/opt/neuracore/neuracore/core/auth.py", line 78, in login\n    prev_org_id = config_manager.config.current_org_id\n                  ^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/neuracore/neuracore/core/config/config_manager.py", line 55, in config\n    raise ConfigError("Error loading config: invalid structure")\nneuracore.core.exceptions.ConfigError: Error loading config: invalid structure\n')
```

- Auto batchsizing fails when train workers > 1
- This is because the dataloaders tries to call nc.login() independently and tries to write to the config.json file at the same time
- This fix checks if the current config is the same as the config we are trying to write, if so skip it
- This stops the failure in Auto batchsizing because we first call nc.login() in the main process so config.json should already be populated

### Items
 - [NCRL-601](https://neuracore.atlassian.net/browse/NCRL-601)