### PR TITLE
fix: improve error message when using robot from different org

### DIFF
--- a/neuracore/core/exceptions.py
+++ b/neuracore/core/exceptions.py
@@ -51,3 +51,9 @@ class TrainingRunError(Exception):
     """Exception raised for errors related to training runs."""
 
     pass
+
+
+class RobotMismatchError(ValueError):
+    """Raised when inference robot_id is not in the model's training spec."""
+
+    pass

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -981,3 +981,69 @@ def get_robot_id_from_name(robot_name: str, org_id: str | None = None) -> str:
         f"Robot with name '{robot_name}' not found in organization '{org_id}' "
         "or shared robots."
     )
+
+
+def get_robot_name_by_id(robot_id: str, org_id: str | None = None) -> str:
+    """Resolve a robot ID to its display name.
+
+    Args:
+        robot_id: Robot ID to look up.
+        org_id: Organization ID. Uses the current org when omitted.
+
+    Returns:
+        The robot's display name.
+
+    Raises:
+        RobotError: If not authenticated, no org is selected, or the robot is unknown.
+    """
+    names = get_robot_names_by_ids([robot_id], org_id=org_id)
+    name = names.get(robot_id)
+    if name is None:
+        raise RobotError(f"Robot with ID '{robot_id}' was not found.")
+    return name
+
+
+def get_robot_names_by_ids(
+    robot_ids: list[str], org_id: str | None = None
+) -> dict[str, str]:
+    """Resolve robot IDs to display names via the Neuracore API.
+
+    Args:
+        robot_ids: Robot IDs to resolve. Duplicates are ignored.
+        org_id: Organization ID. Uses the current org when omitted.
+
+    Returns:
+        Mapping of robot ID to display name for IDs that were found.
+        Unknown IDs are omitted from the result.
+
+    Raises:
+        RobotError: If not authenticated, no org is selected, or the API call fails.
+    """
+    if not robot_ids:
+        return {}
+    if not get_auth().is_authenticated:
+        raise RobotError("Not authenticated. Please call nc.login() first.")
+    if org_id is None:
+        org_id = get_current_org()
+    if not org_id:
+        raise RobotError("No organization selected. Please call nc.select_org() first.")
+
+    unique_robot_ids = list(dict.fromkeys(robot_ids))
+    try:
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{org_id}/robots/names",
+            headers=get_auth().get_headers(),
+            json={"robot_ids": unique_robot_ids},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return {robot["id"]: robot["name"] for robot in payload.get("robots", [])}
+    except requests.exceptions.ConnectionError:
+        raise RobotError(
+            "Failed to connect to neuracore server, "
+            "please check your internet connection and try again."
+        )
+    except requests.exceptions.RequestException as e:
+        raise RobotError(f"Failed to resolve robot names: {str(e)}")

--- a/neuracore/core/utils/embodiment_description_utils.py
+++ b/neuracore/core/utils/embodiment_description_utils.py
@@ -6,6 +6,7 @@ merge_cross_embodiment_description. Both packages depend on neuracore_types, so 
 would be the natural home for these shared utilities.
 """
 
+import logging
 import re
 from collections.abc import Mapping
 from pathlib import Path
@@ -22,7 +23,10 @@ from ordered_set import OrderedSet
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL
+from neuracore.core.exceptions import RobotMismatchError
 from neuracore.core.robot import get_robot_id_from_name
+
+logger = logging.getLogger(__name__)
 
 ID_REGEX = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
@@ -165,20 +169,122 @@ def normalize_embodiment_description(
     }
 
 
+def _trained_robot_ids_for_model(
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+) -> list[str]:
+    """Return robot IDs that the model was trained to support."""
+    input_ids = set(input_cross_embodiment_description)
+    output_ids = set(output_cross_embodiment_description)
+    trained_ids = sorted(input_ids & output_ids)
+    if trained_ids:
+        return trained_ids
+    return sorted(input_ids | output_ids)
+
+
+def _resolve_robot_display_names(robot_ids: list[str]) -> dict[str, str]:
+    """Best-effort lookup of robot display names; returns partial results on failure."""
+    if not robot_ids:
+        return {}
+    try:
+        from neuracore.core.robot import get_robot_names_by_ids
+
+        return get_robot_names_by_ids(robot_ids)
+    except Exception:
+        logger.debug(
+            "Failed to resolve robot names for embodiment mismatch", exc_info=True
+        )
+        return {}
+
+
+def _format_robot_label(robot_id: str, names_by_id: dict[str, str]) -> str:
+    """Format a robot for user-facing error text."""
+    name = names_by_id.get(robot_id)
+    if name:
+        return f'"{name}" ({robot_id})'
+    return robot_id
+
+
+def _build_robot_mismatch_message(
+    *,
+    robot_id: str,
+    trained_robot_ids: list[str],
+    names_by_id: dict[str, str],
+    current_org_id: str | None,
+) -> str:
+    """Build a user-facing error for robot-record mismatch at inference time."""
+    requested_name = names_by_id.get(robot_id)
+    if trained_robot_ids:
+        trained_lines = "\n".join(
+            f"  - {_format_robot_label(trained_id, names_by_id)}"
+            for trained_id in trained_robot_ids
+        )
+        trained_section = (
+            f"This model was trained only for these robot records:\n{trained_lines}"
+        )
+    else:
+        trained_section = (
+            "This model has no robots registered in its training specification."
+        )
+
+    lines = ["This model cannot run on the requested robot record."]
+    if requested_name:
+        lines.append(f'Requested robot name: "{requested_name}"')
+    lines.append(f"Requested robot ID: {robot_id}")
+    if current_org_id:
+        lines.append(f"Current organization: {current_org_id}")
+    lines.extend([
+        trained_section,
+        "",
+        "Neuracore matches inference by globally unique robot record ID, "
+        "not by robot name or physical hardware type. A robot with the same "
+        "name or the same hardware in another organization is still a "
+        "different robot record.",
+        "",
+        "This commonly happens when a model.nc.zip file is downloaded from "
+        "one organization and used with the matching physical robot in "
+        "another organization: the robot name may resolve successfully, but "
+        "it resolves to a different robot record ID than the one used "
+        "during training.",
+        "",
+        "What you can do:",
+        "  1. Connect to or select one of the robot records listed above "
+        "(the exact record used during training).",
+        "  2. Pass explicit input_embodiment_description and "
+        "output_embodiment_description to policy().",
+        "  3. Re-train the model using recordings from your current robot record.",
+    ])
+    return "\n".join(lines)
+
+
 def resolve_embodiment_descriptions(
     input_cross_embodiment_description: CrossEmbodimentDescription,
     output_cross_embodiment_description: CrossEmbodimentDescription,
     robot_id: str,
 ) -> tuple[EmbodimentDescription, EmbodimentDescription]:
     """Resolve concrete input/output embodiments for a specific robot."""
+    trained_robot_ids = _trained_robot_ids_for_model(
+        input_cross_embodiment_description,
+        output_cross_embodiment_description,
+    )
+    names_by_id = _resolve_robot_display_names(
+        list(dict.fromkeys([robot_id, *trained_robot_ids]))
+    )
+    try:
+        current_org_id = get_current_org()
+    except Exception:
+        current_org_id = None
+    mismatch_message = _build_robot_mismatch_message(
+        robot_id=robot_id,
+        trained_robot_ids=trained_robot_ids,
+        names_by_id=names_by_id,
+        current_org_id=current_org_id,
+    )
+
     if robot_id not in input_cross_embodiment_description:
-        raise ValueError(
-            f"Robot ID '{robot_id}' not found in input cross-embodiment description."
-        )
+        raise RobotMismatchError(mismatch_message)
     if robot_id not in output_cross_embodiment_description:
-        raise ValueError(
-            f"Robot ID '{robot_id}' not found in output cross-embodiment description."
-        )
+        raise RobotMismatchError(mismatch_message)
     return (
         normalize_embodiment_description(input_cross_embodiment_description[robot_id]),
         normalize_embodiment_description(output_cross_embodiment_description[robot_id]),

--- a/tests/unit/ml/utils/test_embodiment_description_utils.py
+++ b/tests/unit/ml/utils/test_embodiment_description_utils.py
@@ -5,12 +5,15 @@ from neuracore_types import DataType
 
 import neuracore as nc
 from neuracore.core.const import API_URL
+from neuracore.core.exceptions import RobotMismatchError
 from neuracore.core.utils.embodiment_description_utils import (
     convert_cross_embodiment_description_names_to_ids,
+    resolve_embodiment_descriptions,
     resolve_embodiment_descriptions_with_override,
 )
 
 TEST_ROBOT_ID = "20a621b7-2f9b-4699-a08e-7d080488a5a3"
+TEST_ARCHIVE_ROBOT_ID = "11111111-1111-4111-8111-111111111111"
 
 
 def _indexed_names(*names: str) -> dict[int, str]:
@@ -135,6 +138,120 @@ def test_convert_robot_data_spec_names_to_ids_raises_on_name_id_collision(
         convert_cross_embodiment_description_names_to_ids(spec)
 
 
+def test_resolve_embodiment_descriptions_raises_mismatch_with_robot_names(
+    requests_mock, monkeypatch: pytest.MonkeyPatch, mocked_org_id: str
+) -> None:
+    class _Auth:
+        is_authenticated = True
+
+        def get_headers(self):
+            return {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        "neuracore.core.utils.embodiment_description_utils.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.robot.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.utils.embodiment_description_utils.get_current_org",
+        lambda: mocked_org_id,
+    )
+    monkeypatch.setattr(
+        "neuracore.core.robot.get_current_org",
+        lambda: mocked_org_id,
+    )
+    trained_robot_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    requested_robot_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    requests_mock.post(
+        f"{API_URL}/org/{mocked_org_id}/robots/names",
+        json={
+            "robots": [
+                {"id": trained_robot_id, "name": "lab-franka"},
+                {"id": requested_robot_id, "name": "lab-franka-2"},
+            ],
+            "missing_robot_ids": [],
+        },
+        status_code=200,
+    )
+    input_cross = {trained_robot_id: {DataType.JOINT_POSITIONS: {0: "joint1"}}}
+    output_cross = {trained_robot_id: {DataType.JOINT_TARGET_POSITIONS: {0: "joint1"}}}
+
+    with pytest.raises(RobotMismatchError) as exc_info:
+        resolve_embodiment_descriptions(
+            input_cross_embodiment_description=input_cross,
+            output_cross_embodiment_description=output_cross,
+            robot_id=requested_robot_id,
+        )
+
+    message = str(exc_info.value)
+    assert "This model cannot run on the requested robot record." in message
+    assert 'Requested robot name: "lab-franka-2"' in message
+    assert f"Requested robot ID: {requested_robot_id}" in message
+    assert f"Current organization: {mocked_org_id}" in message
+    assert '"lab-franka"' in message
+    assert "globally unique robot record ID" in message
+    assert "same hardware in another organization" in message
+
+
+def test_resolve_embodiment_descriptions_raises_mismatch_with_partial_name_resolution(
+    requests_mock, monkeypatch: pytest.MonkeyPatch, mocked_org_id: str
+) -> None:
+    class _Auth:
+        is_authenticated = True
+
+        def get_headers(self):
+            return {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        "neuracore.core.utils.embodiment_description_utils.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.robot.get_auth",
+        lambda: _Auth(),
+    )
+    monkeypatch.setattr(
+        "neuracore.core.utils.embodiment_description_utils.get_current_org",
+        lambda: mocked_org_id,
+    )
+    monkeypatch.setattr(
+        "neuracore.core.robot.get_current_org",
+        lambda: mocked_org_id,
+    )
+    trained_robot_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    requested_robot_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    requests_mock.post(
+        f"{API_URL}/org/{mocked_org_id}/robots/names",
+        json={
+            "robots": [
+                {"id": requested_robot_id, "name": "org-b-franka"},
+            ],
+            "missing_robot_ids": [trained_robot_id],
+        },
+        status_code=200,
+    )
+    input_cross = {trained_robot_id: {DataType.JOINT_POSITIONS: {0: "joint1"}}}
+    output_cross = {trained_robot_id: {DataType.JOINT_TARGET_POSITIONS: {0: "joint1"}}}
+
+    with pytest.raises(RobotMismatchError) as exc_info:
+        resolve_embodiment_descriptions(
+            input_cross_embodiment_description=input_cross,
+            output_cross_embodiment_description=output_cross,
+            robot_id=requested_robot_id,
+        )
+
+    message = str(exc_info.value)
+    assert 'Requested robot name: "org-b-franka"' in message
+    assert f"Requested robot ID: {requested_robot_id}" in message
+    assert f"Current organization: {mocked_org_id}" in message
+    assert trained_robot_id in message
+    assert "model.nc.zip file is downloaded from one organization" in message
+    assert "robot name may resolve successfully" in message
+
+
 def test_resolve_embodiments_with_override_returns_explicit_descriptions() -> None:
     input_emb = {DataType.JOINT_POSITIONS: _indexed_names("joint1")}
     output_emb = {DataType.JOINT_TARGET_POSITIONS: _indexed_names("joint1")}
@@ -153,6 +270,8 @@ def test_resolve_embodiments_with_override_loads_from_job_metadata(
     requests_mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class _Auth:
+        is_authenticated = True
+
         def get_headers(self):
             return {"Authorization": "Bearer test-token"}
 
@@ -168,10 +287,10 @@ def test_resolve_embodiments_with_override_loads_from_job_metadata(
         f"{API_URL}/org/test-org-id/training/jobs/job-123",
         json={
             "input_cross_embodiment_description": {
-                "robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}
+                TEST_ARCHIVE_ROBOT_ID: {"JOINT_POSITIONS": {"0": "joint1"}}
             },
             "output_cross_embodiment_description": {
-                "robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
+                TEST_ARCHIVE_ROBOT_ID: {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}
             },
         },
         status_code=200,
@@ -180,7 +299,7 @@ def test_resolve_embodiments_with_override_loads_from_job_metadata(
     resolved_input, resolved_output = resolve_embodiment_descriptions_with_override(
         input_embodiment_description=None,
         output_embodiment_description=None,
-        robot_id="robot-1",
+        robot_id=TEST_ARCHIVE_ROBOT_ID,
         job_id="job-123",
     )
 
@@ -196,15 +315,15 @@ def test_resolve_embodiments_with_override_loads_from_model_archive(
         "neuracore.ml.utils.nc_archive."
         "load_cross_embodiment_descriptions_from_nc_archive",
         lambda model_file: (
-            {"robot-1": {"JOINT_POSITIONS": {"0": "joint1"}}},
-            {"robot-1": {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
+            {TEST_ARCHIVE_ROBOT_ID: {"JOINT_POSITIONS": {"0": "joint1"}}},
+            {TEST_ARCHIVE_ROBOT_ID: {"JOINT_TARGET_POSITIONS": {"0": "joint1"}}},
         ),
     )
 
     resolved_input, resolved_output = resolve_embodiment_descriptions_with_override(
         input_embodiment_description=None,
         output_embodiment_description=None,
-        robot_id="robot-1",
+        robot_id=TEST_ARCHIVE_ROBOT_ID,
         model_file=Path("dummy.nc.zip"),
     )
 
@@ -218,6 +337,8 @@ def test_resolve_embodiments_with_override_raises_when_training_job_not_found(
     """Job metadata fetch returns 404, so cross-embodiment specs are never loaded."""
 
     class _Auth:
+        is_authenticated = True
+
         def get_headers(self):
             return {"Authorization": "Bearer test-token"}
 
@@ -242,7 +363,7 @@ def test_resolve_embodiments_with_override_raises_when_training_job_not_found(
         ),
     ):
         resolve_embodiment_descriptions_with_override(
-            robot_id="robot-1",
+            robot_id=TEST_ARCHIVE_ROBOT_ID,
             job_id="job-123",
         )
 
@@ -251,6 +372,8 @@ def test_resolve_embodiments_override_raises_when_job_lacks_cross_embodiment(
     requests_mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class _Auth:
+        is_authenticated = True
+
         def get_headers(self):
             return {"Authorization": "Bearer test-token"}
 
@@ -276,7 +399,7 @@ def test_resolve_embodiments_override_raises_when_job_lacks_cross_embodiment(
         ),
     ):
         resolve_embodiment_descriptions_with_override(
-            robot_id="robot-1",
+            robot_id=TEST_ARCHIVE_ROBOT_ID,
             job_id="job-123",
         )
 
@@ -299,7 +422,7 @@ def test_resolve_embodiments_override_raises_when_archive_lacks_cross_embodiment
         ),
     ):
         resolve_embodiment_descriptions_with_override(
-            robot_id="robot-1",
+            robot_id=TEST_ARCHIVE_ROBOT_ID,
             model_file=Path("dummy.nc.zip"),
         )
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Better error message when using a model trained on robots in different org but doing inference in users org.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-578](https://neuracore.atlassian.net/browse/NCRL-578)