### PR TITLE
fix: only start data daemon for recordings on connected robots

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -175,7 +175,7 @@ def connect_robot(
     if robot.id is None:
         raise RobotError("Robot not initialized. Call init() first.")
     StreamManagerOrchestrator().get_provider_manager(robot.id, robot.instance)
-    get_recording_state_manager()
+    get_recording_state_manager().register_connected_robot(robot.id)
     robot._register_remote_stop_handler()
     return robot
 

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -81,6 +81,7 @@ class RecordingStateManager(BaseSSEConsumer):
         self.org_id = org_id or get_current_org()
         self.auth = auth if auth is not None else get_auth()
 
+        self._connected_robot_id: str | None = None
         self.recording_robot_instances: dict[RobotInstanceIdentifier, str] = dict()
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
@@ -270,6 +271,11 @@ class RecordingStateManager(BaseSSEConsumer):
                 details, RecordingStartPayload
             ), "recording must be started by a start event"
 
+            # Only react to the robot this client connected to, not other
+            # robots in the org that may be recording concurrently.
+            if robot_id != self._connected_robot_id:
+                return
+
             assert (
                 len(details.dataset_ids) == 1
             ), "Recording can only be started in one dataset"
@@ -306,6 +312,14 @@ class RecordingStateManager(BaseSSEConsumer):
                 instance=instance,
                 recording_id=recording_id,
             )
+
+    def register_connected_robot(self, robot_id: str) -> None:
+        """Register the robot that this client is connected to.
+
+        Args:
+            robot_id: The ID of the robot that was connected.
+        """
+        self._connected_robot_id = robot_id
 
     def register_remote_stop_handler(
         self, robot_id: str, instance: int, callback: Callable[[str], None]


### PR DESCRIPTION
This issue has been revealed from the integration tests running in parallel using the same org,

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - we now only start the data daemon when the recording is for a robot this client actually connected to. Recordings from other tests or robots in the org are ignored.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1022](https://neuracore.atlassian.net/browse/NCP-1022)

