### PR TITLE
fix: preserve RGB bytes and unskip network integrity tests

### DIFF
--- a/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
+++ b/neuracore/core/streaming/bucket_uploaders/streaming_video_uploader.py
@@ -56,8 +56,8 @@ class StreamingVideoUploader(BucketUploader):
         width: int,
         height: int,
         transform_frame: Callable[[np.ndarray], np.ndarray] | None = None,
-        codec: str = "libx264",
-        pixel_format: str = "yuv444p10le",
+        codec: str = "libx264rgb",
+        pixel_format: str = "rgb24",
         chunk_size: int = CHUNK_SIZE,
         video_name: str = "lossless.mp4",
         codec_context_options: dict[str, str] | None = None,
@@ -77,8 +77,8 @@ class StreamingVideoUploader(BucketUploader):
             height: Frame height in pixels.
             transform_frame: Optional function to transform frames before encoding.
                 Should accept and return numpy arrays of shape (height, width, 3).
-            codec: Video codec to use for encoding (e.g., "libx264", "libx265").
-            pixel_format: Pixel format for encoding (e.g., "yuv444p10le", "yuv420p").
+            codec: Video codec to use for encoding (e.g., "libx264rgb", "libx264").
+            pixel_format: Pixel format for encoding (e.g., "rgb24", "yuv420p").
             chunk_size: Size in bytes of each upload chunk. Will be adjusted
                 to be a multiple of 256 KiB if necessary.
             video_name: Filename for the output video file.
@@ -93,7 +93,11 @@ class StreamingVideoUploader(BucketUploader):
         self.pixel_format = pixel_format
         self.chunk_size = chunk_size
         self.video_name = video_name
-        self.codec_context_options = codec_context_options
+        self.codec_context_options = (
+            {"crf": "0", "preset": "ultrafast"}
+            if codec_context_options is None
+            else codec_context_options
+        )
         self._streaming_done = False
         self.container_format = "mp4"
         self._check_codec_support()

--- a/neuracore/data_daemon/recording_encoding_disk_manager/encoding/video_trace.py
+++ b/neuracore/data_daemon/recording_encoding_disk_manager/encoding/video_trace.py
@@ -221,9 +221,9 @@ class VideoTrace:
                 filepath=self.lossless_path,
                 width=self.width,
                 height=self.height,
-                codec="libx264",
-                pixel_format="yuv444p10le",
-                codec_context_options={"qp": "0", "preset": "ultrafast"},
+                codec="libx264rgb",
+                pixel_format="rgb24",
+                codec_context_options={"crf": "0", "preset": "ultrafast"},
                 chunk_size=self.chunk_size,
             )
 

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -105,7 +105,6 @@ NETWORK_INTEGRITY_CASES = (
         video_count=1,
         image_height=64,
         image_width=64,
-        skip=True,
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -117,7 +116,6 @@ NETWORK_INTEGRITY_CASES = (
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         joint_fps=15,
-        skip=True,
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -132,7 +130,6 @@ NETWORK_INTEGRITY_CASES = (
         producer_channels=PRODUCER_PER_THREAD,
         parallel_contexts=2,
         mode=MODE_STAGGERED,
-        skip=True,
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -148,7 +145,6 @@ NETWORK_INTEGRITY_CASES = (
         parallel_contexts=2,
         mode=MODE_STAGGERED,
         timestamp_mode=TIMESTAMP_MODE_REAL,
-        skip=True,
     ),
     # DataDaemonTestCase(
     #     duration_sec=10,
@@ -197,7 +193,6 @@ NETWORK_INTEGRITY_CASES = (
         mode=MODE_STAGGERED,
         timestamp_mode=TIMESTAMP_MODE_REAL,
         wait=True,
-        skip=True,
     ),
 )
 


### PR DESCRIPTION
### Bugfixes
- Updated the lossless RGB video encoding path to preserve byte-exact RGB frame data through cloud upload/sync.
- Switched the lossless RGB encoder from `libx264` with `yuv444p10le` to `libx264rgb` with `rgb24` and `crf=0`, avoiding RGB to YUV colour-space conversion that could alter pixel values.
- Unskipped the RGB network data integrity cases now that synced RGB frame-code verification passes with the strict byte-level assertion intact.

https://neuracore.atlassian.net/browse/NCP-1024