### PR TITLE
fix: upgrade lerobot and torch to drop P100/P4 gpus

### DIFF
--- a/neuracore/importer/lerobot_importer.py
+++ b/neuracore/importer/lerobot_importer.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import shutil
 import time
 import traceback
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
+from lerobot.datasets.backward_compatibility import BackwardCompatibilityError
 from lerobot.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
+from lerobot.datasets.v30.convert_dataset_v21_to_v30 import (
+    convert_data,
+    convert_episodes_metadata,
+    convert_info,
+    convert_tasks,
+    convert_videos,
+)
 from neuracore_types import (
     DataType,
     EndEffectorPoseInputTypeConfig,
@@ -190,9 +199,42 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
             )
         self.logger.info("[%s] Completed episode %s", worker_label, episode_id)
 
+    def _convert_v21_to_v30(self) -> None:
+        """Convert a v2.1 dataset in-place to v3.0 format required by lerobot>=0.4.x."""
+        root = self.dataset_root
+        new_root = root.parent / f"{root.name}_v30"
+        old_root = root.parent / f"{root.name}_old"
+        self.logger.info(
+            "Converting dataset '%s' from v2.1 to v3.0 format at %s",
+            self.dataset_name,
+            root,
+        )
+        if new_root.is_dir():
+            shutil.rmtree(new_root)
+        convert_info(
+            root, new_root, data_file_size_in_mb=100, video_file_size_in_mb=200
+        )
+        convert_tasks(root, new_root)
+        episodes_metadata = convert_data(root, new_root, data_file_size_in_mb=100)
+        episodes_videos_metadata = convert_videos(
+            root, new_root, video_file_size_in_mb=200
+        )
+        convert_episodes_metadata(
+            root, new_root, episodes_metadata, episodes_videos_metadata
+        )
+        shutil.move(str(root), str(old_root))
+        shutil.move(str(new_root), str(root))
+        self.logger.info(
+            "Conversion complete. Original dataset preserved at %s", old_root
+        )
+
     def _load_metadata(self) -> LeRobotDatasetMetadata:
         """Fetch metadata without pulling down the entire dataset."""
-        ds_meta = LeRobotDatasetMetadata(self.dataset_name, root=self.dataset_root)
+        try:
+            ds_meta = LeRobotDatasetMetadata(self.dataset_name, root=self.dataset_root)
+        except BackwardCompatibilityError:
+            self._convert_v21_to_v30()
+            ds_meta = LeRobotDatasetMetadata(self.dataset_name, root=self.dataset_root)
         self.logger.info(
             "Dataset metadata loaded: name=%s root=%s episodes=%s "
             "camera_keys=%s fps=%s",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "tqdm>=4.66.0",
         "requests-oauthlib==2.0.0",
         "pydantic>=2.10",
-        "av==14.2.0",
+        "av==15.1.0",
         "aiortc==1.14.0",
         "aiohttp-sse-client==0.2.1",
         "numpy-stl",
@@ -72,15 +72,17 @@ setup(
             "mujoco>3",
         ],
         "ml": [
-            # Pinned at 2.7.1 to match [import], allowing both extras to be
-            # installed together. Can be upgraded up to 2.10.0 (inclusive) at
-            # the cost of making [ml] and [import] mutually exclusive. Do NOT
-            # upgrade to 2.11.0+: it defaults to CUDA 13 which drops V100
-            # support, which Neuracore still uses.
-            "torch==2.7.1",
-            "torchvision==0.22.1",
+            # torch==2.8.0 is minimum version defaulting to CUDA 12.8.
+            # Do NOT upgrade to 2.11.0+: it defaults to CUDA 13 which drops
+            # V100 support, which Neuracore still uses.
+            # hub pinned to 0.35.3 to match lerobot==0.4.4's
+            # <0.36.0 constraint, allowing [ml] and [import] to coexist.
+            # We have dropped support for P100 and P4 due to CUDA 12.8
+            # dropping support for them.
+            "torch==2.10.0",
+            "torchvision==0.25.0",
             "transformers==4.53.2",
-            "huggingface-hub==0.36.0",
+            "huggingface-hub==0.35.3",
             "diffusers==0.35.1",
             "safetensors==0.6.2",
             "einops",
@@ -105,19 +107,15 @@ setup(
             # lerobot is used only for dataset importing
             # (LeRobotDataset/LeRobotDatasetMetadata).
             # Do NOT install lerobot[transformers-dep] — that extra requires
-            # transformers<4.52.0 which conflicts with our transformers==4.53.2 pin.
-            # Pinned at 0.3.3 to retain dataset v2 format support;
-            # lerobot>=0.4.x drops v2 datasets and requires av>=15.0.0
-            # and huggingface-hub<0.36.0.
-            # torch is pinned to lerobot 0.3.3's max supported version (2.7.1)
-            # and matches [ml], allowing both extras to coexist. Once [ml] is
-            # upgraded beyond 2.7.1, this pin will intentionally conflict with
-            # [ml], enforcing mutual exclusion. The importer only uses torch for
-            # CPU tensor ops (data loading + .numpy()), so CUDA version does
-            # not matter.
-            "lerobot==0.3.3",
-            "torch==2.7.1",
-            "huggingface-hub==0.36.0",
+            # transformers>=4.57.1 which conflicts with our transformers==4.53.2 pin.
+            # lerobot>=0.4.x drops v2 dataset format support.
+            # torch is not pinned here as lerobot==0.4.4 constrains it to
+            # >=2.2.1,<2.11.0, compatible with [ml]'s torch==2.10.0.
+            # hub pinned to match [ml], allowing both extras to coexist.
+            # The importer only uses torch for CPU tensor ops
+            # (data loading + .numpy()), so CUDA version does not matter.
+            "lerobot==0.4.4",
+            "huggingface-hub==0.35.3",
             "tensorflow-datasets>=4.9.9",
             "tensorflow-cpu>=2.20.0",
             "pin==3.9.0",


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Ugrade lerobot version used by neuracore importer.
 - Pin torch to 2.10.0 and other dependencies to appropriate versions to enable this.
 - Drop support for older GPUs (P100 and P4) as a result of this.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-614](https://neuracore.atlassian.net/browse/NCRL-614)
 
 ### Related PRs
 - https://github.com/NeuracoreAI/neuracore_types/pull/90