### PR TITLE
feat: expose data_types on client Recording wrapper

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -113,6 +113,7 @@ class Dataset:
             start_time=recording_model.start_time,
             end_time=recording_model.end_time,
             metadata=recording_model.metadata,
+            data_types=recording_model.data_types,
         )
 
     def _initialize_num_recordings(self) -> None:

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -35,6 +35,7 @@ class Recording:
         start_time: float,
         end_time: float,
         metadata: RecordingMetadata,
+        data_types: set[DataType] | None = None,
     ):
         """Initialize episode iterator for a specific recording.
 
@@ -47,6 +48,7 @@ class Recording:
             start_time: Unix timestamp when recording started.
             end_time: Unix timestamp when recording ended.
             metadata: Metadata associated with the recording.
+            data_types: Set of DataTypes present in this recording.
         """
         self.dataset = dataset
         self.id = recording_id
@@ -58,6 +60,7 @@ class Recording:
         # Store human-friendly recording name when available.
         self.name = getattr(metadata, "name", None) or recording_id
         self.metadata = metadata
+        self.data_types: set[DataType] = data_types or set()
         self._raw = {
             "id": recording_id,
             "total_bytes": total_bytes,

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -161,6 +161,7 @@ def recordings_list():
             end_time=10.0,
             total_bytes=512,
             metadata=RecordingMetadata(name="recording1"),
+            data_types={DataType.JOINT_POSITIONS, DataType.RGB_IMAGES},
         ).model_dump(mode="json"),
         Recording(
             id="rec2",

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -755,6 +755,13 @@ class TestDatasetIteration:
         assert all(isinstance(r, Recording) for r in recordings)
         assert recordings[0].id == "rec1"
         assert recordings[1].id == "rec2"
+        # data_types populated when present in API response
+        assert recordings[0].data_types == {
+            DataType.JOINT_POSITIONS,
+            DataType.RGB_IMAGES,
+        }
+        # data_types defaults to empty set when absent from API response
+        assert recordings[1].data_types == set()
 
     def test_iteration_multiple_times(self, dataset_dict, recordings_list):
         """Test that dataset can be iterated multiple times."""


### PR DESCRIPTION
## Features
- Adds `data_types: set[DataType]` field to the client `Recording` wrapper class
- Populates it from `RecordingModel.data_types` in `Dataset._wrap_raw_recording`
- Enables downstream per-recording validation to inspect which datatypes each recording contains

## Items
- [NCRL-604](https://neuracore.atlassian.net/browse/NCRL-604)

## Related PRs
- #680
- #681