### PR TITLE
feat: add per-recording datatype validation before training run

### DIFF
--- a/neuracore/core/utils/training_input_args_validation.py
+++ b/neuracore/core/utils/training_input_args_validation.py
@@ -6,11 +6,45 @@ algorithm existence, robot existence, and data spec compatibility.
 
 from __future__ import annotations
 
+from collections import defaultdict
+
 from neuracore_types import CrossEmbodimentDescription, DataType
 from omegaconf import DictConfig
 
 from neuracore.core.data.dataset import Dataset, EmbodimentDescription
 from neuracore.core.utils.embodiment_description_utils import is_robot_id
+
+
+def _validate_per_recording_data_types(
+    dataset: Dataset,
+    requested_input_types: set[DataType],
+) -> None:
+    """Validate every recording has all requested input datatypes.
+
+    Args:
+        dataset: Dataset whose recordings will be inspected.
+        requested_input_types: DataTypes that every recording must contain.
+
+    Raises:
+        ValueError: If any recording is missing a requested type, with a
+            grouped message listing affected recording names per type.
+    """
+    missing_per_type: dict[DataType, list[str]] = defaultdict(list)
+    for recording in dataset:
+        for data_type in requested_input_types - recording.data_types:
+            missing_per_type[data_type].append(recording.name)
+
+    if not missing_per_type:
+        return
+
+    lines = [
+        "Failed to start training run: some recordings are missing requested datatypes."
+    ]
+    for data_type in sorted(missing_per_type, key=lambda dt: dt.value):
+        lines.append(f"\nMissing {data_type.value}:")
+        for recording_name in missing_per_type[data_type]:
+            lines.append(f"- {recording_name}")
+    raise ValueError("\n".join(lines))
 
 
 def _validate_algorithm_exists(algorithm_id: str | None, algorithm_name: str) -> None:
@@ -241,6 +275,15 @@ def validate_training_params(
     Raises:
         ValueError: If any validation check fails.
     """
+    requested_input_types: set[DataType] = {
+        dt
+        for robot_data in input_cross_embodiment_description.values()
+        for dt in robot_data.keys()
+    }
+    if not requested_input_types:
+        raise ValueError("Failed to start training run: no input datatypes specified.")
+    _validate_per_recording_data_types(dataset, requested_input_types)
+
     _validate_data_specs(
         dataset=dataset,
         dataset_name=dataset_name,

--- a/tests/unit/core/utils/test_training_input_args_validation.py
+++ b/tests/unit/core/utils/test_training_input_args_validation.py
@@ -4,9 +4,12 @@ import pytest
 from neuracore_types import DataType
 
 from neuracore.core.data.dataset import Dataset
+from neuracore.core.data.recording import Recording
 from neuracore.core.utils.training_input_args_validation import (
     _validate_algorithm_exists,
     _validate_data_specs,
+    _validate_per_recording_data_types,
+    validate_training_params,
 )
 
 TEST_ROBOT_ID = "20a621b7-2f9b-4699-a08e-7d080488a5a1"
@@ -137,4 +140,148 @@ def test_validate_data_specs_rejects_missing_data_type_in_full_spec(dataset: Dat
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.RGB_IMAGES},
             spec_kind="input",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _validate_per_recording_data_types
+# ---------------------------------------------------------------------------
+
+
+def _make_recording(name: str, data_types: set[DataType]) -> Recording:
+    """Return a minimal mock Recording with the given name and data_types."""
+    rec = MagicMock(spec=Recording)
+    rec.name = name
+    rec.data_types = data_types
+    return rec
+
+
+def _dataset_with_recordings(recordings: list) -> Dataset:
+    ds = MagicMock(spec=Dataset)
+    ds.__iter__ = MagicMock(return_value=iter(recordings))
+    return ds
+
+
+def test_validate_per_recording_data_types_passes_when_all_present():
+    ds = _dataset_with_recordings([
+        _make_recording("rec_a", {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}),
+        _make_recording("rec_b", {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}),
+    ])
+    _validate_per_recording_data_types(
+        ds, {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}
+    )
+
+
+def test_validate_per_recording_data_types_passes_with_superset():
+    """Recording with extra datatypes beyond requested must not fail."""
+    ds = _dataset_with_recordings([
+        _make_recording(
+            "rec_a",
+            {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES, DataType.JOINT_VELOCITIES},
+        ),
+    ])
+    _validate_per_recording_data_types(ds, {DataType.JOINT_POSITIONS})
+
+
+def test_validate_per_recording_data_types_passes_empty_requested():
+    ds = _dataset_with_recordings([_make_recording("rec_a", set())])
+    _validate_per_recording_data_types(ds, set())
+
+
+def test_validate_per_recording_data_types_raises_grouped_error():
+    ds = _dataset_with_recordings([
+        _make_recording("joint_rec", {DataType.JOINT_POSITIONS}),
+        _make_recording("rgb_rec", {DataType.RGB_IMAGES}),
+        _make_recording("all_rec", {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}),
+    ])
+    with pytest.raises(ValueError) as exc_info:
+        _validate_per_recording_data_types(
+            ds, {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}
+        )
+    msg = str(exc_info.value)
+    assert "Failed to start training run" in msg
+    assert "some recordings are missing requested datatypes" in msg
+    assert "Missing RGB_IMAGES" in msg
+    assert "- joint_rec" in msg
+    assert "Missing JOINT_POSITIONS" in msg
+    assert "- rgb_rec" in msg
+    assert "all_rec" not in msg
+
+
+def test_validate_per_recording_data_types_error_lists_all_missing_types():
+    """A recording missing two types must appear under both type sections."""
+    ds = _dataset_with_recordings([
+        _make_recording("partial", {DataType.RGB_IMAGES}),
+    ])
+    with pytest.raises(ValueError) as exc_info:
+        _validate_per_recording_data_types(
+            ds,
+            {DataType.JOINT_POSITIONS, DataType.JOINT_VELOCITIES, DataType.RGB_IMAGES},
+        )
+    msg = str(exc_info.value)
+    assert "Missing JOINT_POSITIONS" in msg
+    assert "Missing JOINT_VELOCITIES" in msg
+    assert msg.count("- partial") == 2
+
+
+# ---------------------------------------------------------------------------
+# validate_training_params wiring
+# ---------------------------------------------------------------------------
+
+
+def test_validate_training_params_raises_per_recording_error_before_algo_check():
+    """validate_training_params must fire per-recording check before algorithm check."""
+    ds = MagicMock(spec=Dataset)
+    ds.data_types = [DataType.JOINT_POSITIONS, DataType.RGB_IMAGES]
+    ds.get_full_embodiment_description = MagicMock(
+        return_value={
+            DataType.JOINT_POSITIONS: _indexed_names("j0"),
+            DataType.RGB_IMAGES: _indexed_names("front"),
+        }
+    )
+    ds.__iter__ = MagicMock(
+        return_value=iter([
+            _make_recording("partial_rec", {DataType.JOINT_POSITIONS}),
+            _make_recording(
+                "full_rec", {DataType.JOINT_POSITIONS, DataType.RGB_IMAGES}
+            ),
+        ])
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_training_params(
+            dataset=ds,
+            dataset_name="test-dataset",
+            algorithm_name="test-algorithm",
+            input_cross_embodiment_description={
+                TEST_ROBOT_ID: {
+                    DataType.JOINT_POSITIONS: _indexed_names("j0"),
+                    DataType.RGB_IMAGES: _indexed_names("front"),
+                }
+            },
+            output_cross_embodiment_description={},
+            supported_input_data_types={DataType.JOINT_POSITIONS, DataType.RGB_IMAGES},
+            supported_output_data_types=set(),
+        )
+
+    msg = str(exc_info.value)
+    assert "Failed to start training run" in msg
+    assert "Missing RGB_IMAGES" in msg
+    assert "- partial_rec" in msg
+
+
+def test_validate_training_params_raises_when_no_input_types():
+    """validate_training_params raises if no input datatypes specified."""
+    ds = MagicMock(spec=Dataset)
+    ds.data_types = []
+
+    with pytest.raises(ValueError, match="no input datatypes specified"):
+        validate_training_params(
+            dataset=ds,
+            dataset_name="test-dataset",
+            algorithm_name="test-algorithm",
+            input_cross_embodiment_description={},
+            output_cross_embodiment_description={},
+            supported_input_data_types=set(),
+            supported_output_data_types=set(),
         )


### PR DESCRIPTION
## Features
- Adds `_validate_per_recording_data_types(dataset, requested_input_types)` that iterates all recordings and collects missing datatypes grouped by type
- Wires it into `validate_training_params` so it fires before the training job API call
- Raises `ValueError` with a grouped message listing which recordings are missing which types

**Example error:**
```
Failed to start training run: some recordings are missing requested datatypes.

Missing JOINT_POSITIONS:
- Recording A
- Recording B

Missing RGB_IMAGES:
- Recording C
```

## Items
- [NCRL-604](https://neuracore.atlassian.net/browse/NCRL-604)

## Related PRs
- #679 (needs to go in first)
- #681 (needs to go in after this)