### PR TITLE
feat: remove recording names from sync errors

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -398,26 +398,8 @@ class Dataset:
         )
         response.raise_for_status()
 
-    def _format_failure_summary(self, failed_recording_ids: list[str]) -> str:
-        id_to_name = {r.id: r.name for r in self._recordings_cache}
-        auth_headers = get_auth().get_headers()
-        for recording_id in failed_recording_ids:
-            if recording_id not in id_to_name:
-                try:
-                    session = thread_local_session()
-                    response = session.get(
-                        f"{API_URL}/org/{self.org_id}/recording/{recording_id}",
-                        headers=auth_headers,
-                    )
-                    response.raise_for_status()
-                    recording_model = RecordingModel.model_validate(response.json())
-                    id_to_name[recording_id] = recording_model.metadata.name
-                except Exception:
-                    logger.debug("Failed to fetch name for recording %s", recording_id)
-                    id_to_name[recording_id] = recording_id
-        return "".join(
-            f"\n{id_to_name[recording_id]}" for recording_id in failed_recording_ids
-        )
+    def _format_failed_recording_ids(self, failed_recording_ids: list[str]) -> str:
+        return "".join(f"\n{recording_id}" for recording_id in failed_recording_ids)
 
     def _raise_sync_failure(
         self,
@@ -425,7 +407,7 @@ class Dataset:
         processed: int | None = None,
         total: int | None = None,
     ) -> None:
-        recording_names = self._format_failure_summary(failed_recording_ids)
+        recording_ids = self._format_failed_recording_ids(failed_recording_ids)
         progress_line = (
             f"\n({processed}/{total} recordings synchronized)."
             if processed is not None and total is not None
@@ -433,7 +415,7 @@ class Dataset:
         )
         raise DatasetError(
             f"Synchronization failed for dataset '{self.name}'.\n\n"
-            f"Problematic recordings:\n{recording_names}\n\n"
+            f"Problematic recordings:\n{recording_ids}\n\n"
             "These recordings might have missing or extra sensor data or "
             f"invalid synchronization parameters were provided.{progress_line}"
         )

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -57,8 +57,7 @@ class Recording:
         self.instance = instance
         self.start_time = start_time
         self.end_time = end_time
-        # Store human-friendly recording name when available.
-        self.name = getattr(metadata, "name", None) or recording_id
+        self.name = recording_id
         self.metadata = metadata
         self.data_types: set[DataType] = data_types or set()
         self._raw = {

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -160,7 +160,7 @@ def recordings_list():
             start_time=0.0,
             end_time=10.0,
             total_bytes=512,
-            metadata=RecordingMetadata(name="recording1"),
+            metadata=RecordingMetadata(),
             data_types={DataType.JOINT_POSITIONS, DataType.RGB_IMAGES},
         ).model_dump(mode="json"),
         Recording(
@@ -171,7 +171,7 @@ def recordings_list():
             start_time=0.0,
             end_time=8.0,
             total_bytes=512,
-            metadata=RecordingMetadata(name="recording2"),
+            metadata=RecordingMetadata(),
         ).model_dump(mode="json"),
     ]
 

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -929,10 +929,10 @@ class TestDatasetSynchronization:
             dataset.synchronize(frequency=30)
 
     @pytest.mark.usefixtures("mock_login")
-    def test_synchronize_error_shows_recording_name_from_cache(
+    def test_synchronize_error_shows_recording_id_from_cache(
         self, mock_data_requests, dataset_dict, recordings_list, monkeypatch
     ):
-        """Error message shows recording name when recording is in cache."""
+        """Error message shows recording ID when recording is in cache."""
         dataset = Dataset(**dataset_dict, recordings=recordings_list)
 
         def failed_progress(_: str) -> SynchronizationProgress:
@@ -949,25 +949,17 @@ class TestDatasetSynchronization:
         with pytest.raises(DatasetError) as exc_info:
             dataset.synchronize(frequency=30)
 
-        assert "recording1" in str(exc_info.value)
+        assert "rec1" in str(exc_info.value)
 
     @pytest.mark.usefixtures("mock_login")
-    def test_synchronize_error_fetches_recording_name_on_cache_miss(
+    def test_synchronize_error_shows_recording_id_on_cache_miss(
         self,
         mock_data_requests,
         dataset_dict,
-        recordings_list,
-        mocked_org_id,
         monkeypatch,
     ):
-        """Error message fetches recording name via API when not in cache."""
+        """Error message shows recording ID when recording is not in cache."""
         dataset = Dataset(**dataset_dict)
-
-        mock_data_requests.get(
-            f"{API_URL}/org/{mocked_org_id}/recording/rec1",
-            json=recordings_list[0],
-            status_code=200,
-        )
 
         def failed_progress(_: str) -> SynchronizationProgress:
             return SynchronizationProgress(
@@ -983,7 +975,7 @@ class TestDatasetSynchronization:
         with pytest.raises(DatasetError) as exc_info:
             dataset.synchronize(frequency=30)
 
-        assert "recording1" in str(exc_info.value)
+        assert "rec1" in str(exc_info.value)
 
     @pytest.mark.usefixtures("mock_login")
     def test_synchronize_error_falls_back_to_id_when_name_fetch_fails(
@@ -1033,11 +1025,12 @@ class TestDatasetSynchronization:
             dataset._get_synchronization_progress("synced_dataset_123")
 
     @pytest.mark.usefixtures("mock_login")
-    def test_get_synchronization_progress_409_shows_recording_name(
-        self, mock_data_requests, dataset_dict, recordings_list, mocked_org_id
+    def test_get_synchronization_progress_409_shows_recording_id(
+        self, mock_data_requests, dataset_dict, mocked_org_id
     ):
-        """409 error message resolves recording name from cache."""
-        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        """409 error message shows failed recording ID."""
+        dataset = Dataset(**dataset_dict)
+
         mock_data_requests.get(
             f"{API_URL}/org/{mocked_org_id}/synchronize/synchronization-progress/synced_dataset_123",
             json={
@@ -1052,7 +1045,7 @@ class TestDatasetSynchronization:
         with pytest.raises(DatasetError) as exc_info:
             dataset._get_synchronization_progress("synced_dataset_123")
 
-        assert "recording1" in str(exc_info.value)
+        assert "rec1" in str(exc_info.value)
 
 
 class TestDatasetMixedOperations:

--- a/tests/unit/core/data/test_episode.py
+++ b/tests/unit/core/data/test_episode.py
@@ -28,7 +28,7 @@ class TestRecording:
 
     @pytest.fixture
     def recording_model(self, mocked_org_id) -> RecordingModel:
-        """Create a mock recording metadata."""
+        """Create a mock recording model."""
         return RecordingModel(
             id="rec1",
             org_id=mocked_org_id,
@@ -37,11 +37,7 @@ class TestRecording:
             instance=1,
             start_time=0,
             end_time=10,
-            metadata=RecordingMetadata(
-                name="recording1",
-                org_id="test-org-id",
-                created_at="2023-01-01T00:00:00Z",
-            ),
+            metadata=RecordingMetadata(),
         )
 
     @pytest.fixture
@@ -53,6 +49,7 @@ class TestRecording:
         """Test Recording initialization."""
         assert recording.dataset == dataset_mock
         assert recording.id == "rec1"
+        assert recording.name == "rec1"
         assert recording.total_bytes == 512
         assert recording.robot_id == "robot1"
         assert recording.instance == 1


### PR DESCRIPTION
### Features
- Removed recording name usage from SDK recording metadata handling.
- Updated synchronization failure messages to show failed recording IDs instead of recording metadata names.

related pr - https://github.com/NeuracoreAI/neuracore_backend/pull/397