### PR TITLE
fix: ignore duplicate RECORDING_STOPPED in trace lifecycle coordinator

### DIFF
--- a/neuracore/data_daemon/communications_management/consumer/trace_lifecycle_coordinator.py
+++ b/neuracore/data_daemon/communications_management/consumer/trace_lifecycle_coordinator.py
@@ -319,6 +319,17 @@ class TraceLifecycleCoordinator:
             )
             return
 
+        if self._closing_recordings.is_closed(recording_id):
+            # A duplicate stop message would re-enter the closing set and
+            # trigger a second close that reports expected_trace_count=0
+            # (unique traces were cleared on the first close), permanently
+            # stranding the recording as pending on the backend.
+            logger.warning(
+                "Ignoring RECORDING_STOPPED for already-closed recording_id=%s",
+                recording_id,
+            )
+            return
+
         producer_stop_sequence_numbers_raw = payload.get(
             "producer_stop_sequence_numbers", {}
         )

--- a/tests/unit/data_daemon/communications_management/test_trace_lifecycle_coordinator.py
+++ b/tests/unit/data_daemon/communications_management/test_trace_lifecycle_coordinator.py
@@ -267,6 +267,81 @@ def test_finalize_closing_recordings_closes_recording_after_cutoffs() -> None:
     assert stopped_recordings == ["recording-1"]
 
 
+def test_duplicate_recording_stopped_does_not_close_recording_twice() -> None:
+    """A duplicate RECORDING_STOPPED must not re-close the recording.
+
+    The first close clears the unique-trace registry, so a second close would
+    emit SET_EXPECTED_TRACE_COUNT with 0 and overwrite the correct count on
+    the backend, stranding the recording as pending forever.
+    """
+    loop = asyncio.new_event_loop()
+    emitter = Emitter(loop=loop)
+    expected_trace_counts: list[tuple[str, int]] = []
+    stopped_recordings: list[str] = []
+    emitter.on(
+        Emitter.SET_EXPECTED_TRACE_COUNT,
+        lambda recording_id, count: expected_trace_counts.append((recording_id, count)),
+    )
+    emitter.on(
+        Emitter.STOP_RECORDING,
+        lambda recording_id: stopped_recordings.append(recording_id),
+    )
+    coordinator = TraceLifecycleCoordinator(
+        emitter=emitter,
+        enqueue_final_trace=lambda _: None,
+        set_channel_trace_id=lambda *_: None,
+    )
+    channel = ChannelState(producer_id="producer-1", trace_id="trace-1")
+    stop_message = MessageEnvelope(
+        producer_id=None,
+        command=CommandType.RECORDING_STOPPED,
+        payload={
+            "recording_stopped": {
+                "recording_id": "recording-1",
+                "producer_stop_sequence_numbers": {"producer-1": 5},
+            }
+        },
+    )
+
+    coordinator.register_trace("recording-1", "trace-1")
+    coordinator.register_trace_metadata(
+        TraceMetadataRegistrationRequest(
+            trace_id="trace-1",
+            metadata=TraceMetadataSnapshot(
+                data_type=DataType.RGB_IMAGES.value,
+                data_type_name="camera",
+            ),
+        )
+    )
+    coordinator.handle_trace_end(
+        channel,
+        MessageEnvelope(
+            producer_id="producer-1",
+            command=CommandType.TRACE_END,
+            payload={
+                "trace_end": {
+                    "trace_id": "trace-1",
+                    "recording_id": "recording-1",
+                }
+            },
+            sequence_number=5,
+        ),
+    )
+    coordinator.handle_recording_stopped(stop_message)
+    coordinator.note_producer_sequence("producer-1", 5)
+    coordinator.cleanup_trace_written("trace-1")
+
+    assert expected_trace_counts == [("recording-1", 1)]
+    assert stopped_recordings == ["recording-1"]
+
+    coordinator.handle_recording_stopped(stop_message)
+    coordinator.set_max_producer_sequence("producer-1", 5)
+    coordinator.finalize_closing_recordings()
+
+    assert expected_trace_counts == [("recording-1", 1)]
+    assert stopped_recordings == ["recording-1"]
+
+
 def test_note_producer_sequence_ignores_non_cutoff_updates() -> None:
     loop = asyncio.new_event_loop()
     emitter = Emitter(loop=loop)


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - A duplicate RECORDING_STOPPED message re-entered the closing set after the first close had already cleared the unique-trace registry. The second close then reported expected_trace_count=0 to the backend, overwriting the correct count and stranding the recording as pending forever (all traces uploaded but the save task never enqueued).

cc @muneebneura 

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-622](https://neuracore.atlassian.net/browse/NCRL-622)