### PR TITLE
fix: check shared status when creating dataset

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -311,11 +311,12 @@ class Dataset:
         tags: list[str] | None = None,
         shared: bool = False,
     ) -> "Dataset":
-        """Create a new dataset or return existing one with the same name.
+        """Create a new dataset or return an existing one in the same namespace.
 
         Creates a new dataset with the specified parameters. If a dataset
-        with the same name already exists, returns the existing dataset
-        instead of creating a duplicate.
+        with the same name already exists in the same namespace (private or
+        shared), returns the existing dataset instead of creating a duplicate.
+        If a dataset exists in the other namespace, a new dataset is created.
 
         Args:
             name: Unique name for the dataset.
@@ -326,11 +327,19 @@ class Dataset:
                 members allocated by the Neuracore team.
 
         Returns:
-            The newly created Dataset instance, or existing dataset if
-            name already exists.
+            The newly created Dataset instance, or the existing dataset if one
+            already exists in the same namespace.
         """
         ds = Dataset.get_by_name(name, non_exist_ok=True)
         if ds is None:
+            ds = Dataset._create_dataset(name, description, tags, shared=shared)
+        elif shared != ds.is_shared:
+            existing_namespace = "shared" if ds.is_shared else "private"
+            requested_namespace = "shared" if shared else "private"
+            logger.info(
+                f"Dataset '{name}' already exists as a {existing_namespace} "
+                f"dataset; creating a new {requested_namespace} dataset."
+            )
             ds = Dataset._create_dataset(name, description, tags, shared=shared)
         else:
             logger.info(f"Dataset '{name}' already exist.")

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -470,6 +470,80 @@ class TestDatasetCreation:
         assert dataset.is_shared is True
 
     @pytest.mark.usefixtures("mock_login")
+    @pytest.mark.parametrize(
+        "shared,existing_is_shared,found,expect_create",
+        [
+            pytest.param(False, False, True, False, id="private_reuses_private"),
+            pytest.param(
+                False, True, True, True, id="private_creates_when_shared_exists"
+            ),
+            pytest.param(False, False, False, True, id="private_creates_when_none"),
+            pytest.param(
+                True, False, True, True, id="shared_creates_when_private_exists"
+            ),
+            pytest.param(True, True, True, False, id="shared_reuses_shared"),
+            pytest.param(True, False, False, True, id="shared_creates_when_none"),
+        ],
+    )
+    def test_create_dataset_namespace(
+        self,
+        shared,
+        existing_is_shared,
+        found,
+        expect_create,
+        dataset_model,
+        mocked_org_id,
+    ):
+        """Test create reuses same-namespace datasets and creates across namespaces."""
+        existing = copy.deepcopy(dataset_model)
+        existing.is_shared = existing_is_shared
+
+        created = copy.deepcopy(dataset_model)
+        created.is_shared = shared
+        if expect_create and found:
+            created.id = "dataset456"
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{API_URL}/org-management/my-orgs",
+                json=[{"org": {"id": mocked_org_id, "name": "test organization"}}],
+            )
+            if found:
+                m.get(
+                    f"{API_URL}/org/{mocked_org_id}/datasets/search/by-name",
+                    json=existing.model_dump(mode="json"),
+                    status_code=200,
+                )
+            else:
+                m.get(
+                    f"{API_URL}/org/{mocked_org_id}/datasets/search/by-name",
+                    json={},
+                    status_code=404,
+                )
+            m.post(
+                f"{API_URL}/org/{mocked_org_id}/datasets",
+                json=created.model_dump(mode="json"),
+                status_code=200,
+            )
+
+            dataset = Dataset.create("test_dataset", shared=shared)
+
+            post_calls = [
+                call
+                for call in m.request_history
+                if call.method == "POST"
+                and call.url == f"{API_URL}/org/{mocked_org_id}/datasets"
+            ]
+            if expect_create:
+                assert len(post_calls) == 1
+                assert dataset.id == created.id
+                assert dataset.is_shared == shared
+            else:
+                assert len(post_calls) == 0
+                assert dataset.id == existing.id
+                assert dataset.is_shared == existing_is_shared
+
+    @pytest.mark.usefixtures("mock_login")
     def test_create_dataset_unauthorized_error_detail(self, dataset_model):
         """Test dataset creation errors include backend details."""
         mocked_org_id = "test-org-id"


### PR DESCRIPTION
### Bugfixes
- Creating private dataset while having a shared dataset with the same name was not allowed
- Creating shared dataset while having a private dataset with the same name was not allowed
- Fix: check shared status of found dataset

### Items
 - [NCRL-583](https://neuracore.atlassian.net/browse/NCRL-583)