### PR TITLE
chore: update neuracore types to v8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "fastapi==0.135.2",
         "psutil",
         "typer>=0.20.0",
-        "neuracore_types>=7.1.0",
+        "neuracore_types==8.0.0",
         "ordered_set",
         "pyzmq==27.1.0",
         "sqlalchemy>=2.0.0",


### PR DESCRIPTION
Updated `neuracore_types` to `8.0.0` so the client package uses the v8 recording metadata contract that removes `RecordingMetadata.name`.