### PR TITLE
test: cancel training on timeout

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -336,6 +336,31 @@ def get_training_job_logs(
         raise ValueError(f"Error getting training job logs: {e}")
 
 
+def cancel_training_job(job_id: str) -> None:
+    """Cancel a training job without deleting it.
+
+    Args:
+        job_id: The ID of the training job to cancel
+
+    Raises:
+        ValueError: If there is an error cancelling the job
+        requests.exceptions.HTTPError: If the API request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+        ConfigError: If there is an error trying to get the current org
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    try:
+        session = thread_local_session()
+        response = session.post(
+            f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
+            headers=auth.get_headers(),
+        )
+        response.raise_for_status()
+    except Exception as e:
+        raise ValueError(f"Error cancelling training job: {e}")
+
+
 def delete_training_job(job_id: str, org_id: str | None = None) -> None:
     """Delete a training job and free its resources.
 

--- a/tests/integration/ml/shared/training.py
+++ b/tests/integration/ml/shared/training.py
@@ -13,6 +13,27 @@ logger = logging.getLogger(__name__)
 TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED", "ERROR"}
 
 
+def cancel_incomplete_training_jobs(
+    job_ids: list[str],
+    completed_statuses: dict[str, str] | None = None,
+) -> None:
+    """Cancel training jobs that have not reached a terminal state."""
+    completed_statuses = completed_statuses or {}
+    for job_id in job_ids:
+        if job_id in completed_statuses:
+            continue
+        try:
+            status = nc.get_training_job_status(job_id=job_id)
+            if status in TERMINAL_STATES:
+                continue
+            logger.warning(
+                f"Cancelling incomplete training job {job_id} (status={status})"
+            )
+            nc.cancel_training_job(job_id)
+        except Exception:
+            logger.warning(f"Failed to cancel training job {job_id}", exc_info=True)
+
+
 def wait_for_training(
     job_id: str,
     timeout_minutes: int = 120,
@@ -24,9 +45,11 @@ def wait_for_training(
         logger.info(f"Training job {job_id}: {status}")
         if status in TERMINAL_STATES:
             return status
-        assert (
-            time.time() < deadline
-        ), f"Training job {job_id} did not finish within {timeout_minutes} minutes"
+        if time.time() >= deadline:
+            cancel_incomplete_training_jobs([job_id])
+            assert (
+                False
+            ), f"Training job {job_id} did not finish within {timeout_minutes} minutes"
         time.sleep(poll_seconds)
 
 
@@ -51,9 +74,12 @@ def wait_for_all_training(
         if len(final_statuses) == len(job_ids):
             return final_statuses
 
-        assert (
-            time.time() < deadline
-        ), f"Training job(s) {job_ids} did not finish within {timeout_minutes} minutes"
+        if time.time() >= deadline:
+            cancel_incomplete_training_jobs(job_ids, final_statuses)
+            assert False, (
+                f"Training job(s) {job_ids} did not finish within "
+                f"{timeout_minutes} minutes"
+            )
         time.sleep(poll_seconds)
 
 

--- a/tests/unit/api/test_training.py
+++ b/tests/unit/api/test_training.py
@@ -521,6 +521,30 @@ def test_get_training_job_status(
     assert status == "pending"
 
 
+def test_cancel_training_job(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+):
+    """Test cancelling a training job."""
+    nc.login("test_api_key")
+
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/training/jobs/train_job_123",
+        status_code=200,
+    )
+
+    nc.cancel_training_job("train_job_123")
+
+    assert mock_auth_requests.called
+    last_request = mock_auth_requests.last_request
+    assert last_request.method == "POST"
+    assert (
+        last_request.url == f"{API_URL}/org/{mocked_org_id}/training/jobs/train_job_123"
+    )
+
+
 def test_delete_training_job(
     temp_config_dir,
     mock_auth_requests,


### PR DESCRIPTION
### Features
- Cancel training runs on timeout so they don't keep VM alive

### Items
 - [NCRL-627](https://neuracore.atlassian.net/browse/NCRL-627)
