### PR TITLE
chore: update neuracore types to v9

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,5 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+Upgraded to neuracore_types 9.x, which removes NVIDIA Tesla P100 and P4 from GPUType.

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "fastapi==0.135.2",
         "psutil",
         "typer>=0.20.0",
-        "neuracore_types==8.0.0",
+        "neuracore_types>=9.0.0",
         "ordered_set",
         "pyzmq==27.1.0",
         "sqlalchemy>=2.0.0",


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Update `neuracore_types` to `>=9.0.0`, adopting the v9 contract that removes P100/P4 from `GPUType`

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - None

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-631](https://neuracore.atlassian.net/browse/NCRL-631)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - NeuracoreAI/neuracore_backend#407
 - NeuracoreAI/neuracore_frontend#341
 - NeuracoreAI/neuracore_types#90

