### PR TITLE
fix: fix the training data out of index error. 

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import threading
 import time
 from collections.abc import Generator, Iterator
 from typing import Optional, Union
@@ -91,6 +92,10 @@ class Dataset:
         )
         self._num_recordings: int | None = len(recordings) if recordings else None
         self._start_after: dict | None = None
+        # Protects concurrent page fetches: _start_after and _recordings_cache are
+        # shared mutable state, and SynchronizedDataset prefetches recordings
+        # from multiple threads.
+        self._page_lock = threading.Lock()
         self._robot_ids: list[str] | None = None
         self._robot_names: dict[str, str] | None = None
 
@@ -135,36 +140,42 @@ class Dataset:
             self._num_recordings = 0
 
     def _fetch_next_page(self) -> list[Recording]:
-        """Fetch the next page of recordings and append to cache (lazy)."""
-        if (
-            self._num_recordings is not None
-            and len(self._recordings_cache) >= self._num_recordings
-        ):
-            return []
+        """Fetch the next page of recordings and append to cache (lazy).
 
-        params = {"limit": PAGE_SIZE, "is_shared": self.is_shared}
-        payload = self._start_after or None
+        Thread-safe: concurrent callers are serialized so each page is
+        fetched exactly once. A caller that waited on the lock re-checks the
+        cache size and may find its data already fetched by another thread.
+        """
+        with self._page_lock:
+            if (
+                self._num_recordings is not None
+                and len(self._recordings_cache) >= self._num_recordings
+            ):
+                return []
 
-        session = thread_local_session()
-        response = session.post(
-            f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
-            headers=get_auth().get_headers(),
-            params=params,
-            json=payload,
-        )
-        response.raise_for_status()
-        data = response.json()
+            params = {"limit": PAGE_SIZE, "is_shared": self.is_shared}
+            payload = self._start_after or None
 
-        batch = data.get("data", [])
-        if not batch:
-            return []
+            session = thread_local_session()
+            response = session.post(
+                f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
+                headers=get_auth().get_headers(),
+                params=params,
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
 
-        self._start_after = batch[-1]
-        self._num_recordings = data.get("total", self._num_recordings)
+            batch = data.get("data", [])
+            if not batch:
+                return []
 
-        wrapped = [self._wrap_raw_recording(r) for r in batch]
-        self._recordings_cache.extend(wrapped)
-        return wrapped
+            self._start_after = batch[-1]
+            self._num_recordings = data.get("total", self._num_recordings)
+
+            wrapped = [self._wrap_raw_recording(r) for r in batch]
+            self._recordings_cache.extend(wrapped)
+            return wrapped
 
     def _recordings_generator(self) -> Generator[Recording, None, None]:
         """A generator yielding Recordings for this dataset.
@@ -620,7 +631,10 @@ class Dataset:
 
             # Load pages until index is available in cache
             while index >= len(self._recordings_cache):
-                if not self._fetch_next_page():
+                fetched = self._fetch_next_page()
+                # An empty fetch can mean another thread loaded our page
+                # while we waited on the lock, so re-check the cache.
+                if not fetched and index >= len(self._recordings_cache):
                     raise IndexError("Dataset index out of range")
             return self._recordings_cache[index]
 

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -35,6 +35,7 @@ class SynchronizedDataset:
         cross_embodiment_union: CrossEmbodimentUnion | None = None,
         prefetch_videos: bool = False,
         max_prefetch_workers: int = 1,
+        synced_recording_cache: dict[int, SynchronizedRecording] | None = None,
     ):
         """Initialize a dataset from server response data.
 
@@ -45,14 +46,20 @@ class SynchronizedDataset:
             cross_embodiment_union: Cross-embodiment union for synchronization.
             prefetch_videos: Whether to prefetch video data to cache on initialization.
             max_prefetch_workers: Number of threads to use for prefetching videos.
+            synced_recording_cache: Already-fetched synced recordings keyed by
+                index, used when slicing to avoid re-fetching data the parent
+                dataset already loaded.
         """
         self.id = id
         self.dataset = dataset
         self.frequency = frequency
         self.cross_embodiment_union = cross_embodiment_union
         self._prefetch_videos = prefetch_videos
+        self._max_prefetch_workers = max_prefetch_workers
         self._recording_idx = 0
-        self._synced_recording_cache: dict[int, SynchronizedRecording] = {}
+        self._synced_recording_cache: dict[int, SynchronizedRecording] = (
+            dict(synced_recording_cache) if synced_recording_cache else {}
+        )
 
         self._prefetch_videos_needed = False
         if prefetch_videos:
@@ -68,7 +75,16 @@ class SynchronizedDataset:
                     #  other download is in progress fails, we can retry
                     self._prefetch_videos_needed = True
                     break
-        self._perform_synced_data_prefetch(max_prefetch_workers=max_prefetch_workers)
+        if not self._is_synced_recording_cache_complete():
+            self._perform_synced_data_prefetch(
+                max_prefetch_workers=max_prefetch_workers
+            )
+
+    def _is_synced_recording_cache_complete(self) -> bool:
+        """Check whether every recording is already in the synced cache."""
+        return all(
+            idx in self._synced_recording_cache for idx in range(len(self.dataset))
+        )
 
     def _perform_synced_data_prefetch(self, max_prefetch_workers: int) -> None:
         """Prefetch synced data for all recordings using multiple threads.
@@ -129,12 +145,22 @@ class SynchronizedDataset:
         if isinstance(idx, slice):
             # Handle slice
             dataset = self.dataset[idx.start : idx.stop : idx.step]
+            # Hand already-fetched recordings to the slice (re-indexed) so it
+            # does not prefetch data this instance already loaded.
+            start, stop, step = idx.indices(len(self.dataset))
+            sliced_cache = {
+                new_idx: self._synced_recording_cache[old_idx]
+                for new_idx, old_idx in enumerate(range(start, stop, step))
+                if old_idx in self._synced_recording_cache
+            }
             return SynchronizedDataset(
                 id=self.id,
                 dataset=cast("Dataset", dataset),
                 frequency=self.frequency,
                 cross_embodiment_union=self.cross_embodiment_union,
                 prefetch_videos=False,  # Avoid prefetching again
+                max_prefetch_workers=self._max_prefetch_workers,
+                synced_recording_cache=sliced_cache,
             )
         else:
             # Handle single index

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -2,16 +2,21 @@
 
 import copy
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests_mock
 from neuracore_types import Dataset as DatasetModel
 from neuracore_types import DataType
+from neuracore_types import Recording as RecordingModel
+from neuracore_types import RecordingMetadata
 
 import neuracore as nc
 from neuracore.api.globals import GlobalSingleton
 from neuracore.core.const import API_URL, DEFAULT_RECORDING_CACHE_DIR
-from neuracore.core.data.dataset import Dataset
+from neuracore.core.data.dataset import PAGE_SIZE, Dataset
 from neuracore.core.data.recording import Recording
 from neuracore.core.data.synced_dataset import SynchronizedDataset
 from neuracore.core.exceptions import DatasetError
@@ -1168,3 +1173,66 @@ class TestDatasetMixedOperations:
         dataset = Dataset(**dataset_dict, recordings=recordings_list)
 
         assert dataset.cache_dir == DEFAULT_RECORDING_CACHE_DIR
+
+
+class TestDatasetConcurrentPagination:
+    """Regression tests for thread-safety of lazy page fetching.
+
+    SynchronizedDataset prefetches recordings from a thread pool, so
+    concurrent Dataset[idx] calls race on the shared pagination cursor and
+    recordings cache. Without locking, the same page could be fetched and
+    appended multiple times, duplicating recordings and dropping the tail.
+    """
+
+    def test_concurrent_getitem_no_duplicate_pages(self, dataset_dict):
+        """Concurrent indexing must fetch each page exactly once."""
+        import neuracore.core.data.dataset as ds_mod
+
+        total = 496
+        all_recordings = [
+            RecordingModel(
+                id=f"rec-{i:04d}",
+                robot_id=TEST_ROBOT_ID,
+                instance=1,
+                org_id="test-org-id",
+                start_time=float(i),
+                end_time=float(i) + 1.0,
+                total_bytes=512,
+                metadata=RecordingMetadata(),
+            ).model_dump(mode="json")
+            for i in range(total)
+        ]
+        request_count = 0
+        count_lock = threading.Lock()
+
+        def fake_post(url, headers=None, params=None, json=None, timeout=None):
+            nonlocal request_count
+            with count_lock:
+                request_count += 1
+            start = 0 if json is None else int(json["id"].split("-")[1]) + 1
+            batch = all_recordings[start : start + params.get("limit", PAGE_SIZE)]
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"data": batch, "total": total}
+            response.raise_for_status = MagicMock()
+            return response
+
+        session = MagicMock()
+        session.post.side_effect = fake_post
+
+        with (
+            patch.object(ds_mod, "thread_local_session", return_value=session),
+            patch.object(ds_mod, "get_auth", return_value=MagicMock(get_headers=dict)),
+        ):
+            for _ in range(10):
+                dataset = Dataset(**dataset_dict)
+                dataset._num_recordings = total
+                with ThreadPoolExecutor(max_workers=8) as executor:
+                    recordings = list(executor.map(lambda i: dataset[i], range(total)))
+
+                ids = [r.id for r in recordings]
+                assert len(set(ids)) == total, "duplicate recordings from page race"
+                assert ids == sorted(ids), "recording order corrupted by page race"
+
+        num_pages = (total + PAGE_SIZE - 1) // PAGE_SIZE
+        assert request_count == 10 * num_pages, "pages fetched more than once"

--- a/tests/unit/core/data/test_synchronized_dataset.py
+++ b/tests/unit/core/data/test_synchronized_dataset.py
@@ -317,6 +317,68 @@ class TestSynchronizedDataset:
         # The sliced dataset should not have prefetch_videos enabled
         assert sliced._prefetch_videos_needed is False
 
+    def test_slice_reuses_parent_cache(self, synced_dataset, mock_data_requests):
+        """Slicing must hand already-fetched recordings to the new instance."""
+        nc.login()
+        # Populate the parent cache (as the constructor prefetch would)
+        rec0 = synced_dataset[0]
+        rec1 = synced_dataset[1]
+
+        with patch.object(
+            SynchronizedDataset, "_perform_synced_data_prefetch"
+        ) as mock_prefetch:
+            sliced = synced_dataset[0:2]
+            # Cache is complete, so no second prefetch pass
+            mock_prefetch.assert_not_called()
+
+        assert sliced[0] is rec0
+        assert sliced[1] is rec1
+
+    def test_slice_reindexes_parent_cache(self, synced_dataset, mock_data_requests):
+        """A slice not starting at 0 must re-index the inherited cache."""
+        nc.login()
+        rec1 = synced_dataset[1]
+
+        with patch.object(
+            SynchronizedDataset, "_perform_synced_data_prefetch"
+        ) as mock_prefetch:
+            sliced = synced_dataset[1:2]
+            mock_prefetch.assert_not_called()
+
+        assert sliced[0] is rec1
+
+    def test_slice_with_partial_cache_prefetches_missing(
+        self, synced_dataset, mock_data_requests
+    ):
+        """A slice covering uncached recordings still prefetches."""
+        nc.login()
+        # Only recording 0 cached; slice covers both recordings
+        rec0 = synced_dataset[0]
+
+        with patch.object(
+            SynchronizedDataset, "_perform_synced_data_prefetch"
+        ) as mock_prefetch:
+            sliced = synced_dataset[0:2]
+            mock_prefetch.assert_called_once()
+
+        # The cached entry is still inherited rather than re-fetched
+        assert sliced._synced_recording_cache[0] is rec0
+
+    def test_slice_forwards_max_prefetch_workers(self, dataset_mock):
+        """Slicing must preserve the parent's prefetch worker count."""
+        with patch.object(SynchronizedDataset, "_perform_synced_data_prefetch"):
+            parent = SynchronizedDataset(
+                id="synced_dataset_id",
+                dataset=dataset_mock,
+                frequency=30,
+                cross_embodiment_union=None,
+                prefetch_videos=False,
+                max_prefetch_workers=8,
+            )
+            sliced = parent[0:1]
+
+        assert sliced._max_prefetch_workers == 8
+
     def test_getitem_with_instance_info(self, synced_dataset, mock_data_requests):
         """Test that getitem preserves instance information."""
         recording = synced_dataset[0]


### PR DESCRIPTION
We had this `index out of range` error during training, it happened frequently around 50% of time. The issue get fixed and improved by:

- It turns out to be the race condition of concurrent workers fetching the synchronised cached data and not protected. I added the lock to prevent this.
- Prevent the double prefetch happen by adding a syncedDataset cache
- Add test with regard to these