### PR TITLE
refactor: update data spec references to embodiment description/union

### DIFF
--- a/docs/model_construction.md
+++ b/docs/model_construction.md
@@ -16,7 +16,7 @@ The true bottleneck was never model capacity or optimization strategy. It was re
 
 Neuracore addresses this problem by making structure explicit and declarative. Instead of allowing each robot to implicitly define tensor layout, Neuracore requires a specification that formally defines how data points map into a shared index space. That specification becomes the single source of truth for model construction.
 
-Rather than hard-coding tensor dimensions into model definitions, Neuracore derives input and output dimensionality directly from the declared robot data specification. The specification defines index positions, and index positions define semantic meaning. Once defined, this layout becomes fixed for the lifetime of the model.
+Rather than hard-coding tensor dimensions into model definitions, Neuracore derives input and output dimensionality directly from the declared embodiment description. The description defines index positions, and index positions define semantic meaning. Once defined, this layout becomes fixed for the lifetime of the model.
 
 Model shape is therefore spec-driven, not robot-driven.
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -31,20 +31,20 @@ Use `nc.start_training_run(...)` to start a cloud training job (see [example_lau
 
 ```python
 import neuracore as nc
-from neuracore_types import DataType, RobotDataSpec
+from neuracore_types import CrossEmbodimentDescription, DataType
 
 nc.login()
 dataset = nc.get_dataset("My Dataset")
 robot_id = dataset.robot_ids[0]
 full_spec = dataset.get_full_embodiment_description(robot_id)
 
-input_robot_data_spec: RobotDataSpec = {
+input_cross_embodiment_description: CrossEmbodimentDescription = {
     robot_id: {
         DataType.JOINT_POSITIONS: full_spec.get(DataType.JOINT_POSITIONS, []),
         DataType.RGB_IMAGES: full_spec.get(DataType.RGB_IMAGES, []),
     }
 }
-output_robot_data_spec: RobotDataSpec = {
+output_cross_embodiment_description: CrossEmbodimentDescription = {
     robot_id: {
         DataType.JOINT_TARGET_POSITIONS: full_spec.get(DataType.JOINT_TARGET_POSITIONS, []),
     }
@@ -57,8 +57,8 @@ job_data = nc.start_training_run(
     frequency=50,
     num_gpus=1,
     gpu_type="NVIDIA_TESLA_V100",
-    input_robot_data_spec=input_robot_data_spec,
-    output_robot_data_spec=output_robot_data_spec,
+    input_cross_embodiment_description=input_cross_embodiment_description,
+    output_cross_embodiment_description=output_cross_embodiment_description,
     algorithm_config={"batch_size": 32, "epochs": 100, "output_prediction_horizon": 50},
 )
 # Use name_auto_increment=True to auto-use MyTrainingJob_1, MyTrainingJob_2, etc. if the name already exists.

--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -119,10 +119,8 @@ def start_training_run(
         gpu_type: Type of GPU to use for training (e.g., "A100", "V100")
         num_gpus: Number of GPUs to use for training
         frequency: Frequency to sync training data to (in Hz)
-        input_cross_embodiment_description: Input robot data specification.
-            Preferred over input_robot_data_spec.
-        output_cross_embodiment_description: Output robot data specification.
-            Preferred over output_robot_data_spec.
+        input_cross_embodiment_description: Input cross-embodiment description.
+        output_cross_embodiment_description: Output cross-embodiment description.
         max_delay_s: Maximum allowable delay for data synchronization (in seconds)
         allow_duplicates: Whether to allow duplicate data during synchronization
         name_auto_increment: If True and a job with this name already exists, use

--- a/neuracore/core/cli/training_commands.py
+++ b/neuracore/core/cli/training_commands.py
@@ -273,7 +273,7 @@ def _render_local_inspect(metadata: dict) -> None:
             training_runs._format_cross_embodiment_description(
                 metadata.get("input_cross_embodiment_description", {})
             ),
-            title="Model Input Data Spec",
+            title="Model Input Embodiment Description",
             box=box.SQUARE,
         )
     )
@@ -282,7 +282,7 @@ def _render_local_inspect(metadata: dict) -> None:
             training_runs._format_cross_embodiment_description(
                 metadata.get("output_cross_embodiment_description", {})
             ),
-            title="Model Output Data Spec",
+            title="Model Output Embodiment Description",
             box=box.SQUARE,
         )
     )

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -545,7 +545,7 @@ class Dataset:
             robot_id: The robot ID to get the embodiment description for.
 
         Returns:
-            An EmbodimentDescription object containing the data spec for the robot.
+            An EmbodimentDescription object containing the data for the robot.
         """
         # Best-effort resolution without additional network calls.
         # If we can resolve a robot_name to an ID, do so; otherwise delegate to server.

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -61,7 +61,7 @@ class SynchronizedRecording:
             robot_id: The robot that created this recording.
             instance: The instance of the robot that created this recording.
             frequency: Frequency at which to synchronize the recording.
-            cross_embodiment_union: Union of robot data specifications for
+            cross_embodiment_union: Union of embodiment descriptions for
                 synchronization.
             prefetch_videos: Whether to prefetch video data to cache on initialization.
         """

--- a/neuracore/core/utils/embodiment_description_utils.py
+++ b/neuracore/core/utils/embodiment_description_utils.py
@@ -53,15 +53,16 @@ def convert_cross_embodiment_description_names_to_ids(
     the private robot will take priority.
 
     Args:
-        cross_embodiment_description: Robot data spec keyed by robot names or IDs.
+        cross_embodiment_description: Cross-embodiment description keyed by
+            robot names or IDs.
 
     Returns:
-        Robot data spec keyed by robot IDs.
+        Cross-embodiment description keyed by robot IDs.
 
     Raises:
         DatasetError: If a robot identifier is ambiguous.
     """
-    robot_data_spec_with_ids: CrossEmbodimentDescription = {}
+    cross_embodiment_description_with_ids: CrossEmbodimentDescription = {}
     seen_ids = []
 
     for (
@@ -73,10 +74,10 @@ def convert_cross_embodiment_description_names_to_ids(
             robot_name = robot_name_or_id
             # Assume it's a name and try to resolve to an ID
             robot_id = get_robot_id_from_name(robot_name)
-            robot_data_spec_with_ids[robot_id] = embodiment_description
+            cross_embodiment_description_with_ids[robot_id] = embodiment_description
         else:
             robot_id = robot_name_or_id
-            robot_data_spec_with_ids[robot_id] = embodiment_description
+            cross_embodiment_description_with_ids[robot_id] = embodiment_description
 
         seen_ids.append(robot_id)
 
@@ -86,23 +87,24 @@ def convert_cross_embodiment_description_names_to_ids(
             "Duplicate robot identifiers found after conversion. "
             "Please ensure all robot names and IDs are unique."
         )
-    return robot_data_spec_with_ids
+    return cross_embodiment_description_with_ids
 
 
 def merge_cross_embodiment_description(
-    data_spec_1: CrossEmbodimentDescription,
-    data_spec_2: CrossEmbodimentDescription,
+    cross_embodiment_description_1: CrossEmbodimentDescription,
+    cross_embodiment_description_2: CrossEmbodimentDescription,
 ) -> CrossEmbodimentUnion:
-    """Merge two cross-embodiment descriptions into ordered name lists.
+    """Merge two cross-embodiment descriptions into a cross-embodiment union.
 
-    Order is preserved: data_spec_1's order takes priority, then data_spec_2's
-    items are appended in their original order. Dict-backed item specs are
-    merged by their values, producing the list[str] order spec expected by
-    synchronization and ordering code.
+    Order is preserved: cross_embodiment_description_1's order takes priority,
+    then cross_embodiment_description_2's items are appended in their original
+    order. Indexed item names are merged by their values, producing the
+    list[str] order expected by synchronization and ordering code.
 
     Args:
-        data_spec_1: First dictionary to merge (order takes priority).
-        data_spec_2: Second dictionary to merge.
+        cross_embodiment_description_1: First dictionary to merge (order takes
+            priority).
+        cross_embodiment_description_2: Second dictionary to merge.
 
     Returns:
         Merged dictionary mapping each robot and data type to an ordered list of
@@ -118,27 +120,31 @@ def merge_cross_embodiment_description(
             return list(values.values())
         return list(values)
 
-    cross_embodiment_description: CrossEmbodimentUnion = {}
+    cross_embodiment_union: CrossEmbodimentUnion = {}
 
     # dict.fromkeys() preserves order and removes duplicates
-    all_robot_ids = list(dict.fromkeys(list(data_spec_1) + list(data_spec_2)))
+    all_robot_ids = list(
+        dict.fromkeys(
+            list(cross_embodiment_description_1) + list(cross_embodiment_description_2)
+        )
+    )
 
     for robot_id in all_robot_ids:
-        embodiment_desc_1 = data_spec_1.get(robot_id, {})
-        embodiment_desc_2 = data_spec_2.get(robot_id, {})
+        embodiment_desc_1 = cross_embodiment_description_1.get(robot_id, {})
+        embodiment_desc_2 = cross_embodiment_description_2.get(robot_id, {})
         all_data_types = list(
             dict.fromkeys(list(embodiment_desc_1) + list(embodiment_desc_2))
         )
 
-        cross_embodiment_description[robot_id] = {}
+        cross_embodiment_union[robot_id] = {}
         for data_type in all_data_types:
             items1 = _normalize_item_names(embodiment_desc_1.get(data_type))
             items2 = _normalize_item_names(embodiment_desc_2.get(data_type))
 
-            cross_embodiment_description[robot_id][data_type] = list(
+            cross_embodiment_union[robot_id][data_type] = list(
                 dict.fromkeys(items1 + items2)
             )
-    return cross_embodiment_description
+    return cross_embodiment_union
 
 
 def extract_data_types(

--- a/neuracore/core/utils/training_input_args_validation.py
+++ b/neuracore/core/utils/training_input_args_validation.py
@@ -1,7 +1,7 @@
 """Training parameter validation utilities.
 
 This module provides validation functions for training parameters, including
-algorithm existence, robot existence, and data spec compatibility.
+algorithm existence, robot existence, and embodiment description compatibility.
 """
 
 from __future__ import annotations
@@ -61,15 +61,15 @@ def _validate_algorithm_exists(algorithm_id: str | None, algorithm_name: str) ->
         raise ValueError(f"Algorithm {algorithm_name} not found.")
 
 
-def _validate_data_specs(
+def _validate_cross_embodiment_description(
     dataset: Dataset,
     dataset_name: str,
     algorithm_name: str,
     cross_embodiment_description: CrossEmbodimentDescription,
     supported_data_types: set[DataType],
-    spec_kind: str,
+    description_kind: str,
 ) -> None:
-    """Validate a cross-embodiment data spec against dataset and algorithm constraints.
+    """Validate a cross-embodiment description against dataset and algorithm limits.
 
     Args:
         dataset: Dataset metadata used to validate available robot IDs, data types,
@@ -77,40 +77,41 @@ def _validate_data_specs(
         dataset_name: Human-readable dataset name used in validation errors.
         algorithm_name: Algorithm name used in validation errors when unsupported
             data types are requested.
-        cross_embodiment_description: Requested data specification keyed by robot
+        cross_embodiment_description: Requested embodiment descriptions keyed by robot
             ID and grouped by data type.
-        supported_data_types: Data types supported by the algorithm for this spec.
-        spec_kind: Label describing the spec being validated, such as ``"input"``
-            or ``"output"``.
+        supported_data_types: Data types supported by the algorithm for this
+            description.
+        description_kind: Label describing the description being validated, such as
+            ``"input"`` or ``"output"``.
 
     Raises:
         AssertionError: If a key in ``cross_embodiment_description`` is not a valid
             robot ID.
-        ValueError: If the spec requests a data type or value that is not present
+        ValueError: If the description requests a data type or value not present
             in the dataset, if a requested data type is unsupported by the
             algorithm, or if a data value is in an invalid format.
     """
-    _validate_data_specs_against_dataset(
+    _validate_cross_embodiment_description_against_dataset(
         dataset=dataset,
         dataset_name=dataset_name,
         cross_embodiment_description=cross_embodiment_description,
-        spec_kind=spec_kind,
+        description_kind=description_kind,
     )
-    _validate_data_specs_against_algorithm(
+    _validate_cross_embodiment_description_against_algorithm(
         algorithm_name=algorithm_name,
         cross_embodiment_description=cross_embodiment_description,
         supported_data_types=supported_data_types,
-        spec_kind=spec_kind,
+        description_kind=description_kind,
     )
 
 
-def _validate_data_specs_against_dataset(
+def _validate_cross_embodiment_description_against_dataset(
     dataset: Dataset,
     dataset_name: str,
     cross_embodiment_description: CrossEmbodimentDescription,
-    spec_kind: str,
+    description_kind: str,
 ) -> None:
-    """Validate data spec robot IDs, types, and values against dataset metadata."""
+    """Validate description robot IDs, types, and values against dataset metadata."""
     for robot_id, robot_data in cross_embodiment_description.items():
         assert is_robot_id(robot_id), f"Expected robot_id format for {robot_id}"
         dataset_embodiment: EmbodimentDescription = (
@@ -120,14 +121,14 @@ def _validate_data_specs_against_dataset(
         for data_type, data_value in robot_data.items():
             if data_type not in dataset.data_types:
                 raise ValueError(
-                    f"{spec_kind} data type {data_type} is not present in dataset "
-                    f"{dataset_name}. Please check the dataset contents."
+                    f"{description_kind} data type {data_type} is not present in "
+                    f"dataset {dataset_name}. Please check the dataset contents."
                 )
 
             dataset_values = dataset_embodiment.get(data_type)
             if dataset_values is None:
                 raise ValueError(
-                    f"{spec_kind} data values {sorted(data_value)} for "
+                    f"{description_kind} data values {sorted(data_value)} for "
                     f"{data_type} are not present in dataset {dataset_name}."
                 )
 
@@ -137,8 +138,8 @@ def _validate_data_specs_against_dataset(
                 requested_values = set(data_value)
             else:
                 raise ValueError(
-                    f"Expected {spec_kind} data value for {data_type} to be a dict "
-                    f"of index to string, but got {data_value}."
+                    f"Expected {description_kind} data value for {data_type} to be "
+                    f"a dict of index to string, but got {data_value}."
                 )
 
             if isinstance(dataset_values, dict):
@@ -151,24 +152,25 @@ def _validate_data_specs_against_dataset(
             missing_values = requested_values - available_values
             if missing_values:
                 raise ValueError(
-                    f"{spec_kind} data values {sorted(missing_values)} for "
+                    f"{description_kind} data values {sorted(missing_values)} for "
                     f"{data_type} are not present in dataset {dataset_name}."
                 )
 
 
-def _validate_data_specs_against_algorithm(
+def _validate_cross_embodiment_description_against_algorithm(
     algorithm_name: str,
     cross_embodiment_description: CrossEmbodimentDescription,
     supported_data_types: set[DataType],
-    spec_kind: str,
+    description_kind: str,
 ) -> None:
     """Validate that requested data types are supported by the algorithm."""
     for robot_data in cross_embodiment_description.values():
         for data_type in robot_data:
             if data_type not in supported_data_types:
                 raise ValueError(
-                    f"{spec_kind} data type {data_type} is not supported by algorithm "
-                    f"{algorithm_name}. Please check the training job requirements."
+                    f"{description_kind} data type {data_type} is not supported by "
+                    f"algorithm {algorithm_name}. "
+                    "Please check the training job requirements."
                 )
 
 
@@ -255,7 +257,7 @@ def validate_training_params(
 
     This applies for both cloud and local algorithms and performs the
     following checks:
-      1) All robots referenced in input/output specs exist in the dataset.
+      1) All robots referenced in input/output descriptions exist in the dataset.
       2) All requested input data types are supported by the algorithm and present
          in the dataset.
       3) All requested output data types are supported by the algorithm and present
@@ -265,9 +267,9 @@ def validate_training_params(
         dataset: Dataset metadata object.
         dataset_name: Human-readable dataset name (used for error messages).
         algorithm_name: Algorithm name.
-        input_cross_embodiment_description: Input robot data specification
+        input_cross_embodiment_description: Input cross-embodiment description
             keyed by robot ID.
-        output_cross_embodiment_description: Output robot data specification
+        output_cross_embodiment_description: Output cross-embodiment description
             keyed by robot ID.
         supported_input_data_types: Supported input data types.
         supported_output_data_types: Supported output data types.
@@ -284,20 +286,20 @@ def validate_training_params(
         raise ValueError("Failed to start training run: no input datatypes specified.")
     _validate_per_recording_data_types(dataset, requested_input_types)
 
-    _validate_data_specs(
+    _validate_cross_embodiment_description(
         dataset=dataset,
         dataset_name=dataset_name,
         algorithm_name=algorithm_name,
         cross_embodiment_description=input_cross_embodiment_description,
         supported_data_types=supported_input_data_types,
-        spec_kind="input",
+        description_kind="input",
     )
 
-    _validate_data_specs(
+    _validate_cross_embodiment_description(
         dataset=dataset,
         dataset_name=dataset_name,
         algorithm_name=algorithm_name,
         cross_embodiment_description=output_cross_embodiment_description,
         supported_data_types=supported_output_data_types,
-        spec_kind="output",
+        description_kind="output",
     )

--- a/neuracore/ml/cli/training_runs_cloud.py
+++ b/neuracore/ml/cli/training_runs_cloud.py
@@ -64,14 +64,14 @@ def _format_duration(start_time: float | None, end_time: float | None) -> str:
 def _format_cross_embodiment_description(
     cross_embodiment_description: CrossEmbodimentDescription | None,
 ) -> str:
-    """Format robot data spec for display.
+    """Format cross-embodiment description for display.
 
     Args:
         cross_embodiment_description: Dictionary mapping robot IDs to data
             types and names.
 
     Returns:
-        Formatted string representation of the robot data spec.
+        Formatted string representation of the cross-embodiment description.
     """
     if not cross_embodiment_description:
         return "  (none)"
@@ -403,13 +403,13 @@ def run_inspect(
             typer.echo(f"  Synced Dataset ID: {job.synced_dataset_id}")
 
         # Model Input/Output Ordering
-        typer.echo("\n--- Model Input Data Spec ---")
-        input_spec = job.input_cross_embodiment_description
-        typer.echo(_format_cross_embodiment_description(input_spec))
+        typer.echo("\n--- Model Input Embodiment Description ---")
+        input_description = job.input_cross_embodiment_description
+        typer.echo(_format_cross_embodiment_description(input_description))
 
-        typer.echo("\n--- Model Output Data Spec ---")
-        output_spec = job.output_cross_embodiment_description
-        typer.echo(_format_cross_embodiment_description(output_spec))
+        typer.echo("\n--- Model Output Embodiment Description ---")
+        output_description = job.output_cross_embodiment_description
+        typer.echo(_format_cross_embodiment_description(output_description))
 
         # Synchronization Details
         sync_details = job.synchronization_details

--- a/neuracore/ml/datasets/pytorch_dummy_dataset.py
+++ b/neuracore/ml/datasets/pytorch_dummy_dataset.py
@@ -83,9 +83,9 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
 
         Args:
             input_cross_embodiment_description: Mapping from robot_id
-                to data spec for model inputs.
+                to embodiment description for model inputs.
             output_cross_embodiment_description: Mapping from robot_id
-                to data spec for model outputs.
+                to embodiment description for model outputs.
             num_samples: Total number of training samples to generate.
             num_episodes: Number of distinct episodes in the dataset.
             output_prediction_horizon: Length of output action sequences.
@@ -130,9 +130,9 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
         cross_embodiment_description: CrossEmbodimentDescription,
         data_type: DataType,
     ) -> int:
-        """Return padded width for a data type across all robots in a spec."""
+        """Return padded width for a data type across all robots in a description."""
         max_index: int | None = None
-        has_empty_spec = False
+        has_empty_description = False
 
         for embodiment_description in cross_embodiment_description.values():
             if data_type not in embodiment_description:
@@ -149,13 +149,13 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
                     else max(max_index, data_type_max_index)
                 )
             else:
-                has_empty_spec = True
+                has_empty_description = True
 
         if max_index is not None:
             return max_index + 1
-        if has_empty_spec:
+        if has_empty_description:
             return MAX_LEN_PER_DATA_TYPE
-        raise KeyError(f"Data type {data_type} not found in data specification.")
+        raise KeyError(f"Data type {data_type} not found in embodiment description.")
 
     def _initialize_dataset_statistics(self) -> None:
         """Create one statistics entry per padded slot for each merged data type."""
@@ -227,8 +227,8 @@ class PytorchDummyDataset(PytorchNeuracoreDataset):
         section: dict[DataType, list[BatchedNCData]] = {}
         section_mask: dict[DataType, torch.Tensor] = {}
 
-        robot_spec = cross_embodiment_description.get(robot_id, {})
-        for data_type, data_names in robot_spec.items():
+        embodiment_description = cross_embodiment_description.get(robot_id, {})
+        for data_type, data_names in embodiment_description.items():
             normalized_data_names = self._normalize_data_names(data_names)
             num_slots = self._get_num_slots_for_data_type(
                 cross_embodiment_description, data_type

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -25,7 +25,7 @@ from neuracore.core.const import DEFAULT_CACHE_DIR
 from neuracore.core.data.synced_dataset import SynchronizedDataset
 from neuracore.core.data.synced_recording import SynchronizedRecording
 from neuracore.core.utils.training_input_args_validation import (
-    _validate_data_specs_against_dataset,
+    _validate_cross_embodiment_description_against_dataset,
 )
 from neuracore.ml import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_neuracore_dataset import PytorchNeuracoreDataset
@@ -210,23 +210,23 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
 
         Args:
             synchronized_dataset: The synchronized dataset to validate against.
-            input_cross_embodiment_description: Input robot data specification.
-            output_cross_embodiment_description: Output robot data specification.
+            input_cross_embodiment_description: Input cross-embodiment description.
+            output_cross_embodiment_description: Output cross-embodiment description.
 
         Raises:
             ValueError: If robot IDs or data types are missing from the dataset.
         """
-        _validate_data_specs_against_dataset(
+        _validate_cross_embodiment_description_against_dataset(
             dataset=synchronized_dataset.dataset,
             dataset_name=f"synchronized dataset {synchronized_dataset.id}",
             cross_embodiment_description=input_cross_embodiment_description,
-            spec_kind="Input",
+            description_kind="Input",
         )
-        _validate_data_specs_against_dataset(
+        _validate_cross_embodiment_description_against_dataset(
             dataset=synchronized_dataset.dataset,
             dataset_name=f"synchronized dataset {synchronized_dataset.id}",
             cross_embodiment_description=output_cross_embodiment_description,
-            spec_kind="Output",
+            description_kind="Output",
         )
 
     def _get_episode_indices(self) -> list[int]:

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -77,10 +77,10 @@ def _resolve_recording_cache_dir(cfg: DictConfig) -> Path:
     return Path(str(configured_dir)).expanduser()
 
 
-def _serialize_robot_data_spec(
+def _serialize_cross_embodiment_description(
     cross_embodiment_description: CrossEmbodimentDescription,
 ) -> dict[str, dict[str, list[str]]]:
-    """Convert indexed robot data specs to JSON-serializable ordered name lists."""
+    """Convert a cross-embodiment description to JSON-serializable name lists."""
     serializable: dict[str, dict[str, list[str]]] = {}
     for robot_id, data_types in cross_embodiment_description.items():
         serializable[robot_id] = {}
@@ -95,7 +95,7 @@ def _serialize_robot_data_spec(
 def _serialize_cross_embodiment_union(
     cross_embodiment_union: CrossEmbodimentUnion,
 ) -> dict[str, dict[str, list[str]]]:
-    """Convert merged robot data specs to JSON-serializable form."""
+    """Convert a cross-embodiment union to JSON-serializable form."""
     serializable: dict[str, dict[str, list[str]]] = {}
     for robot_id, data_types in cross_embodiment_union.items():
         serializable[robot_id] = {}
@@ -133,10 +133,10 @@ def _save_local_training_metadata(
         "launch_time": time.time(),
         "local_output_dir": str(output_dir),
         "org_id": getattr(cfg, "org_id", None),
-        "input_cross_embodiment_description": _serialize_robot_data_spec(
+        "input_cross_embodiment_description": _serialize_cross_embodiment_description(
             input_cross_embodiment_description
         ),
-        "output_cross_embodiment_description": _serialize_robot_data_spec(
+        "output_cross_embodiment_description": _serialize_cross_embodiment_description(
             output_cross_embodiment_description
         ),
         "frequency": getattr(cfg, "frequency", None),

--- a/neuracore/ml/utils/training_config.py
+++ b/neuracore/ml/utils/training_config.py
@@ -355,10 +355,12 @@ def build_cross_embodiment_description_from_data_types(
 
     cross_embodiment_description: CrossEmbodimentDescription = {}
     for robot_id in robot_ids:
-        robot_full_spec = dataset.get_full_embodiment_description(robot_id)
+        robot_full_embodiment_description = dataset.get_full_embodiment_description(
+            robot_id
+        )
         robot_name = robot_names[robot_id] if is_robot_id(robot_id) else robot_id
         cross_embodiment_description[robot_name] = {
-            data_type: dict(robot_full_spec.get(data_type, {}))
+            data_type: dict(robot_full_embodiment_description.get(data_type, {}))
             for data_type in data_types
         }
 

--- a/neuracore/ml/utils/validate.py
+++ b/neuracore/ml/utils/validate.py
@@ -159,7 +159,7 @@ def run_validation(
             DataType.DEPTH_IMAGES: [ResizePad(size=(224, 224))],
         }
 
-        # Create dummy robot data specs
+        # Create dummy cross-embodiment descriptions
         input_cross_embodiment_description = {
             "robot_1": {
                 data_type: _indexed_names(data_type)

--- a/tests/integration/ml/test_algorithm_performance.py
+++ b/tests/integration/ml/test_algorithm_performance.py
@@ -82,11 +82,11 @@ def _indexed_names(names: list[str] | tuple[str, ...]) -> dict[int, str]:
     return {index: name for index, name in enumerate(names)}
 
 
-INPUT_DATA_SPEC = {
+INPUT_EMBODIMENT_DESCRIPTION = {
     DataType.RGB_IMAGES: _indexed_names([NC_CAM_NAME]),
     DataType.JOINT_POSITIONS: _indexed_names(JOINT_NAMES),
 }
-OUTPUT_DATA_SPEC = {
+OUTPUT_EMBODIMENT_DESCRIPTION = {
     DataType.JOINT_TARGET_POSITIONS: _indexed_names(BimanualViperXTask.ACTION_KEYS),
 }
 
@@ -194,8 +194,10 @@ class TestAlgorithmPerformance:
             algorithm_name=algorithm_name,
             dataset_name=DATASET_NAME,
             algorithm_config=algorithm_config_entry["algorithm_config"],
-            input_cross_embodiment_description={robot_id: INPUT_DATA_SPEC},
-            output_cross_embodiment_description={robot_id: OUTPUT_DATA_SPEC},
+            input_cross_embodiment_description={robot_id: INPUT_EMBODIMENT_DESCRIPTION},
+            output_cross_embodiment_description={
+                robot_id: OUTPUT_EMBODIMENT_DESCRIPTION
+            },
         )
         training_job_id = job_data["id"]
         logger.info(f"[{algorithm_name}] Training job started: {training_job_id}")
@@ -256,8 +258,8 @@ class TestAlgorithmPerformance:
             endpoint_data = nc.deploy_model(
                 job_id=training_job_id,
                 name=endpoint_name,
-                input_embodiment_description=INPUT_DATA_SPEC,
-                output_embodiment_description=OUTPUT_DATA_SPEC,
+                input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+                output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
                 ttl=60 * 30,
                 gpu_type=GPUType.NVIDIA_TESLA_V100,
             )

--- a/tests/unit/core/cli/test_training_runs.py
+++ b/tests/unit/core/cli/test_training_runs.py
@@ -183,13 +183,13 @@ class TestHelperFunctions:
         result = _format_duration(1704067200.0, None)
         assert result == "N/A"
 
-    def test_format_robot_data_spec_empty(self):
-        """Test formatting empty robot data spec."""
+    def test_format_cross_embodiment_description_empty(self):
+        """Test formatting empty cross-embodiment description."""
         result = _format_cross_embodiment_description({})
         assert "(none)" in result
 
-    def test_format_robot_data_spec_with_data(self):
-        """Test formatting robot data spec with data."""
+    def test_format_cross_embodiment_description_with_data(self):
+        """Test formatting cross-embodiment description with data."""
         spec = {
             "robot_1": {
                 "RGB_IMAGES": ["cam1", "cam2"],

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -364,7 +364,7 @@ class TestDatasetRetrieval:
         robot_id = "test-robot-id"
 
         # Mock the API response for get_full_embodiment_description
-        expected_data_spec = {
+        expected_embodiment_description = {
             DataType.RGB_IMAGES.value: _indexed_names("camera_left", "camera_right"),
             DataType.JOINT_POSITIONS.value: _indexed_names(
                 "joint_pos_1", "joint_pos_2"
@@ -373,7 +373,7 @@ class TestDatasetRetrieval:
 
         mock_data_requests.get(
             f"{API_URL}/org/{mocked_org_id}/datasets/{dataset.id}/full-embodiment-description/{robot_id}",
-            json=expected_data_spec,
+            json=expected_embodiment_description,
             status_code=200,
         )
 

--- a/tests/unit/core/utils/test_training_input_args_validation.py
+++ b/tests/unit/core/utils/test_training_input_args_validation.py
@@ -7,7 +7,7 @@ from neuracore.core.data.dataset import Dataset
 from neuracore.core.data.recording import Recording
 from neuracore.core.utils.training_input_args_validation import (
     _validate_algorithm_exists,
-    _validate_data_specs,
+    _validate_cross_embodiment_description,
     _validate_per_recording_data_types,
     validate_training_params,
 )
@@ -25,23 +25,27 @@ def dataset() -> Dataset:
     return dataset
 
 
-def test_validate_data_specs_rejects_missing_data_values(dataset: Dataset):
+def test_validate_cross_embodiment_description_rejects_missing_data_values(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     cross_embodiment_description = {
         TEST_ROBOT_ID: {DataType.RGB_IMAGES: _indexed_names("front", "side")}
     }
     with pytest.raises(ValueError, match="data values .* not present in dataset"):
-        _validate_data_specs(
+        _validate_cross_embodiment_description(
             dataset=dataset,
             dataset_name="test-dataset",
             algorithm_name="test-algorithm",
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.RGB_IMAGES},
-            spec_kind="input",
+            description_kind="input",
         )
 
 
-def test_validate_data_specs_rejects_robot_name_rather_than_id(dataset: Dataset):
+def test_validate_cross_embodiment_description_rejects_robot_name_rather_than_id(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     dataset.get_full_embodiment_description = MagicMock(
         return_value={DataType.RGB_IMAGES: _indexed_names("front")}
@@ -51,17 +55,19 @@ def test_validate_data_specs_rejects_robot_name_rather_than_id(dataset: Dataset)
     }
 
     with pytest.raises(AssertionError, match="Expected robot_id format for robot_name"):
-        _validate_data_specs(
+        _validate_cross_embodiment_description(
             dataset=dataset,
             dataset_name="test-dataset",
             algorithm_name="test-algorithm",
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.RGB_IMAGES},
-            spec_kind="input",
+            description_kind="input",
         )
 
 
-def test_validate_data_specs_allows_subset_of_dataset_values(dataset: Dataset):
+def test_validate_cross_embodiment_description_allows_subset_of_dataset_values(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     dataset.get_full_embodiment_description = MagicMock(
         return_value={DataType.RGB_IMAGES: _indexed_names("front", "side")}
@@ -70,13 +76,13 @@ def test_validate_data_specs_allows_subset_of_dataset_values(dataset: Dataset):
         TEST_ROBOT_ID: {DataType.RGB_IMAGES: _indexed_names("front")}
     }
 
-    _validate_data_specs(
+    _validate_cross_embodiment_description(
         dataset=dataset,
         dataset_name="test-dataset",
         algorithm_name="test-algorithm",
         cross_embodiment_description=cross_embodiment_description,
         supported_data_types={DataType.RGB_IMAGES},
-        spec_kind="input",
+        description_kind="input",
     )
 
 
@@ -85,7 +91,9 @@ def test_validate_algorithm_exists_raises_when_missing():
         _validate_algorithm_exists(None, "MissingAlgorithm")
 
 
-def test_validate_data_specs_rejects_unsupported_data_type(dataset: Dataset):
+def test_validate_cross_embodiment_description_rejects_unsupported_data_type(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     dataset.get_full_embodiment_description = MagicMock(
         return_value={DataType.RGB_IMAGES: _indexed_names("front")}
@@ -95,17 +103,19 @@ def test_validate_data_specs_rejects_unsupported_data_type(dataset: Dataset):
     }
 
     with pytest.raises(ValueError, match="data type .* is not present in dataset"):
-        _validate_data_specs(
+        _validate_cross_embodiment_description(
             dataset=dataset,
             dataset_name="test-dataset",
             algorithm_name="test-algorithm",
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.RGB_IMAGES},
-            spec_kind="input",
+            description_kind="input",
         )
 
 
-def test_validate_data_specs_rejects_missing_data_type_in_dataset(dataset: Dataset):
+def test_validate_cross_embodiment_description_rejects_missing_data_type_in_dataset(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     dataset.get_full_embodiment_description = MagicMock(
         return_value={DataType.RGB_IMAGES: _indexed_names("front")}
@@ -115,17 +125,19 @@ def test_validate_data_specs_rejects_missing_data_type_in_dataset(dataset: Datas
     }
 
     with pytest.raises(ValueError, match="data type .* is not present in dataset"):
-        _validate_data_specs(
+        _validate_cross_embodiment_description(
             dataset=dataset,
             dataset_name="test-dataset",
             algorithm_name="test-algorithm",
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.JOINT_POSITIONS},
-            spec_kind="input",
+            description_kind="input",
         )
 
 
-def test_validate_data_specs_rejects_missing_data_type_in_full_spec(dataset: Dataset):
+def test_validate_cross_embodiment_description_rejects_missing_data_type(
+    dataset: Dataset,
+):
     dataset.data_types = [DataType.RGB_IMAGES]
     dataset.get_full_embodiment_description = MagicMock(return_value={})
     cross_embodiment_description = {
@@ -133,13 +145,13 @@ def test_validate_data_specs_rejects_missing_data_type_in_full_spec(dataset: Dat
     }
 
     with pytest.raises(ValueError, match="data values .* not present in dataset"):
-        _validate_data_specs(
+        _validate_cross_embodiment_description(
             dataset=dataset,
             dataset_name="test-dataset",
             algorithm_name="test-algorithm",
             cross_embodiment_description=cross_embodiment_description,
             supported_data_types={DataType.RGB_IMAGES},
-            spec_kind="input",
+            description_kind="input",
         )
 
 

--- a/tests/unit/ml/datasets/test_pytorch_dummy_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_dummy_dataset.py
@@ -17,10 +17,10 @@ class TestPytorchDummyDataset:
     """Test suite for PytorchDummyDataset."""
 
     @pytest.fixture
-    def basic_robot_data_spec(self):
-        """Basic robot data specs for testing."""
+    def basic_cross_embodiment_descriptions(self):
+        """Basic cross-embodiment descriptions for testing."""
         return {
-            "input_spec": {
+            "input_description": {
                 "robot_0": {
                     DataType.JOINT_POSITIONS: {
                         0: "joint_0",
@@ -30,7 +30,7 @@ class TestPytorchDummyDataset:
                     DataType.RGB_IMAGES: {0: "camera_0"},
                 }
             },
-            "output_spec": {
+            "output_description": {
                 "robot_0": {
                     DataType.JOINT_TARGET_POSITIONS: {
                         0: "joint_0",
@@ -42,10 +42,10 @@ class TestPytorchDummyDataset:
         }
 
     @pytest.fixture
-    def all_data_types_robot_spec(self):
+    def all_data_types_cross_embodiment_descriptions(self):
         """All supported data types for comprehensive testing."""
         return {
-            "input_spec": {
+            "input_description": {
                 "robot_0": {
                     DataType.JOINT_POSITIONS: ["joint_0", "joint_1"],
                     DataType.JOINT_VELOCITIES: ["joint_0", "joint_1"],
@@ -61,7 +61,7 @@ class TestPytorchDummyDataset:
                     DataType.CUSTOM_1D: ["sensor_0", "sensor_1"],
                 }
             },
-            "output_spec": {
+            "output_description": {
                 "robot_0": {
                     DataType.JOINT_TARGET_POSITIONS: ["joint_0", "joint_1"],
                     DataType.RGB_IMAGES: ["camera_0"],
@@ -69,11 +69,15 @@ class TestPytorchDummyDataset:
             },
         }
 
-    def test_initialization_basic(self, basic_robot_data_spec):
+    def test_initialization_basic(self, basic_cross_embodiment_descriptions):
         """Test basic dataset initialization."""
         dataset = PytorchDummyDataset(
-            input_cross_embodiment_description=basic_robot_data_spec["input_spec"],
-            output_cross_embodiment_description=basic_robot_data_spec["output_spec"],
+            input_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "input_description"
+            ],
+            output_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "output_description"
+            ],
             num_samples=50,
             num_episodes=10,
         )
@@ -82,12 +86,16 @@ class TestPytorchDummyDataset:
         assert dataset.num_samples == 50
         assert dataset.output_prediction_horizon == 5  # default value
 
-    def test_initialization_all_data_types(self, all_data_types_robot_spec):
+    def test_initialization_all_data_types(
+        self, all_data_types_cross_embodiment_descriptions
+    ):
         """Test initialization with all supported data types."""
         dataset = PytorchDummyDataset(
-            input_cross_embodiment_description=all_data_types_robot_spec["input_spec"],
-            output_cross_embodiment_description=all_data_types_robot_spec[
-                "output_spec"
+            input_cross_embodiment_description=all_data_types_cross_embodiment_descriptions[
+                "input_description"
+            ],
+            output_cross_embodiment_description=all_data_types_cross_embodiment_descriptions[
+                "output_description"
             ],
             num_samples=20,
             output_prediction_horizon=8,
@@ -127,11 +135,15 @@ class TestPytorchDummyDataset:
             )
             assert len(dataset) == num_samples
 
-    def test_sample_generation_basic(self, basic_robot_data_spec):
+    def test_sample_generation_basic(self, basic_cross_embodiment_descriptions):
         """Test basic sample generation."""
         dataset = PytorchDummyDataset(
-            input_cross_embodiment_description=basic_robot_data_spec["input_spec"],
-            output_cross_embodiment_description=basic_robot_data_spec["output_spec"],
+            input_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "input_description"
+            ],
+            output_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "output_description"
+            ],
             num_samples=10,
         )
 
@@ -449,11 +461,15 @@ class TestPytorchDummyDataset:
             sample2.outputs[DataType.JOINT_TARGET_POSITIONS]
         )
 
-    def test_collate_fn_basic(self, basic_robot_data_spec):
+    def test_collate_fn_basic(self, basic_cross_embodiment_descriptions):
         """Test basic collation functionality."""
         dataset = PytorchDummyDataset(
-            input_cross_embodiment_description=basic_robot_data_spec["input_spec"],
-            output_cross_embodiment_description=basic_robot_data_spec["output_spec"],
+            input_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "input_description"
+            ],
+            output_cross_embodiment_description=basic_cross_embodiment_descriptions[
+                "output_description"
+            ],
             num_samples=10,
         )
 

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -50,7 +50,7 @@ def _indexed_names(data_type: DataType, count: int) -> dict[int, str]:
     return {i: f"{data_type.value}_{i}" for i in range(count)}
 
 
-def _full_data_spec() -> dict[DataType, dict[int, str]]:
+def _full_embodiment_description() -> dict[DataType, dict[int, str]]:
     return {
         DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
         DataType.JOINT_TARGET_POSITIONS: _indexed_names(
@@ -184,7 +184,7 @@ def mock_synchronized_dataset(
             ]
             self.dataset.get_full_embodiment_description.side_effect = (
                 lambda robot_id: (
-                    _full_data_spec()
+                    _full_embodiment_description()
                     if robot_id == ROBOT_ID
                     else (_ for _ in ()).throw(
                         ValueError(f"Input robot IDs [{robot_id}] not found")
@@ -233,8 +233,8 @@ def mock_synchronized_dataset(
 def _stats_cache_path(
     cache_root,
     synchronized_dataset,
-    input_spec,
-    output_spec,
+    input_description,
+    output_description,
 ):
     recording_fingerprint = [
         {
@@ -251,10 +251,10 @@ def _stats_cache_path(
         {
             "recordings": recording_fingerprint,
             "input_cross_embodiment_description": (
-                _cacheable_cross_embodiment_description(input_spec)
+                _cacheable_cross_embodiment_description(input_description)
             ),
             "output_cross_embodiment_description": (
-                _cacheable_cross_embodiment_description(output_spec)
+                _cacheable_cross_embodiment_description(output_description)
             ),
         },
         sort_keys=True,
@@ -393,7 +393,7 @@ def mock_synchronized_dataset_with_depth(
             self.dataset.get_full_embodiment_description.side_effect = (
                 lambda robot_id: (
                     {
-                        **_full_data_spec(),
+                        **_full_embodiment_description(),
                         DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
                     }
                     if robot_id == ROBOT_ID
@@ -517,12 +517,12 @@ def test_should_throw_error_with_missing_robot_id(
     mock_synchronized_dataset: SynchronizedDataset,
 ):
     """Test validation fails with missing robot ID."""
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         MISSING_ROBOT_ID: {  # Robot ID not in dataset
             DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                 DataType.JOINT_TARGET_POSITIONS, 3
@@ -533,8 +533,8 @@ def test_should_throw_error_with_missing_robot_id(
     with pytest.raises(ValueError, match="Input robot IDs .* not found"):
         PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=5,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -545,13 +545,13 @@ def test_should_throw_error_with_missing_data_type(
     mock_synchronized_dataset: SynchronizedDataset,
 ):
     """Test validation fails with missing data type."""
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
             DataType.POINT_CLOUDS: _indexed_names(DataType.POINT_CLOUDS, 1),
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                 DataType.JOINT_TARGET_POSITIONS, 3
@@ -562,8 +562,8 @@ def test_should_throw_error_with_missing_data_type(
     with pytest.raises(ValueError, match="Input data type .* is not present"):
         PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=5,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -596,7 +596,7 @@ def test_initialization_invalid_synchronized_dataset():
 
 
 def test_merge_cross_embodiment_description_uses_dict_values_in_order():
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: {
                 10: "joint_a",
@@ -604,7 +604,7 @@ def test_merge_cross_embodiment_description_uses_dict_values_in_order():
             }
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: {
                 99: "joint_c",
@@ -615,7 +615,9 @@ def test_merge_cross_embodiment_description_uses_dict_values_in_order():
         }
     }
 
-    assert merge_cross_embodiment_description(input_spec, output_spec) == {
+    assert merge_cross_embodiment_description(
+        input_description, output_description
+    ) == {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: ["joint_a", "joint_b", "joint_c"],
             DataType.JOINT_TARGET_POSITIONS: ["target_a"],
@@ -624,7 +626,7 @@ def test_merge_cross_embodiment_description_uses_dict_values_in_order():
 
 
 def test_merge_cross_embodiment_description_deduplicates_by_name_not_index():
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.RGB_IMAGES: {
                 1: "front_camera",
@@ -632,7 +634,7 @@ def test_merge_cross_embodiment_description_deduplicates_by_name_not_index():
             }
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.RGB_IMAGES: {
                 3: "wrist_camera",
@@ -641,7 +643,9 @@ def test_merge_cross_embodiment_description_deduplicates_by_name_not_index():
         }
     }
 
-    assert merge_cross_embodiment_description(input_spec, output_spec) == {
+    assert merge_cross_embodiment_description(
+        input_description, output_description
+    ) == {
         ROBOT_ID: {
             DataType.RGB_IMAGES: [
                 "front_camera",
@@ -654,14 +658,14 @@ def test_merge_cross_embodiment_description_deduplicates_by_name_not_index():
 
 def test_merge_cross_embodiment_description_preserves_robot_order():
     other_robot_id = "33333333-3333-3333-3333-333333333333"
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: {
                 0: "joint_0",
             }
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         other_robot_id: {
             DataType.JOINT_TARGET_POSITIONS: {
                 0: "target_0",
@@ -669,14 +673,16 @@ def test_merge_cross_embodiment_description_preserves_robot_order():
         }
     }
 
-    assert list(merge_cross_embodiment_description(input_spec, output_spec)) == [
+    assert list(
+        merge_cross_embodiment_description(input_description, output_description)
+    ) == [
         ROBOT_ID,
         other_robot_id,
     ]
 
 
 def test_merge_cross_embodiment_description_handles_config_dict_values():
-    input_spec: CrossEmbodimentDescription = {
+    input_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: {
                 0: "vx300s_right/wrist_angle",
@@ -687,7 +693,7 @@ def test_merge_cross_embodiment_description_handles_config_dict_values():
             },
         }
     }
-    output_spec: CrossEmbodimentDescription = {
+    output_description: CrossEmbodimentDescription = {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: {
                 0: "vx300s_right/wrist_angle",
@@ -696,7 +702,9 @@ def test_merge_cross_embodiment_description_handles_config_dict_values():
         }
     }
 
-    assert merge_cross_embodiment_description(input_spec, output_spec) == {
+    assert merge_cross_embodiment_description(
+        input_description, output_description
+    ) == {
         ROBOT_ID: {
             DataType.JOINT_POSITIONS: [
                 "vx300s_right/wrist_angle",
@@ -713,13 +721,13 @@ class TestDataLoading:
     @patch("neuracore.login")
     def test_load_sample_basic(self, mock_login, mock_synchronized_dataset):
         """Test basic sample loading."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -728,8 +736,8 @@ class TestDataLoading:
         }
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -752,13 +760,13 @@ class TestDataLoading:
     @patch("neuracore.login")
     def test_load_sample_memory_monitoring(self, mock_login, mock_synchronized_dataset):
         """Test memory monitoring during sample loading."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -768,8 +776,8 @@ class TestDataLoading:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -790,14 +798,14 @@ class TestDataLoading:
     def test_load_sample_applies_input_preprocessing(
         self, mock_login, mock_synchronized_dataset_with_depth
     ):
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
                 DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -812,8 +820,8 @@ class TestDataLoading:
         }
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset_with_depth,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=input_preprocessing_config,
             output_preprocessing_config=_default_preprocessing_config(),
@@ -832,14 +840,14 @@ class TestDataLoading:
     def test_load_sample_applies_output_preprocessing(
         self, mock_login, mock_synchronized_dataset_with_depth
     ):
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
                 DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
                 DataType.DEPTH_IMAGES: _indexed_names(DataType.DEPTH_IMAGES, 3),
@@ -856,8 +864,8 @@ class TestDataLoading:
         }
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset_with_depth,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=output_preprocessing_config,
@@ -880,13 +888,13 @@ class TestDataTypeProcessing:
     @patch("neuracore.login")
     def test_inputs_and_outputs_structure(self, mock_login, mock_synchronized_dataset):
         """Test that inputs and outputs have correct structure."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -896,8 +904,8 @@ class TestDataTypeProcessing:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=2,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -930,13 +938,13 @@ class TestDatasetIntegration:
     @patch("neuracore.login")
     def test_getitem_method(self, mock_login, mock_synchronized_dataset):
         """Test __getitem__ method."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -946,8 +954,8 @@ class TestDatasetIntegration:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -964,13 +972,13 @@ class TestDatasetIntegration:
     @patch("neuracore.login")
     def test_getitem_negative_index(self, mock_login, mock_synchronized_dataset):
         """Test __getitem__ with negative index."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -980,8 +988,8 @@ class TestDatasetIntegration:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -996,12 +1004,12 @@ class TestDatasetIntegration:
 
     def test_getitem_index_out_of_bounds(self, mock_synchronized_dataset):
         """Test __getitem__ with out of bounds index."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1011,8 +1019,8 @@ class TestDatasetIntegration:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1028,12 +1036,12 @@ class TestDatasetIntegration:
 
     def test_len_method(self, mock_synchronized_dataset):
         """Test __len__ method."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1043,8 +1051,8 @@ class TestDatasetIntegration:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1057,12 +1065,12 @@ class TestDatasetIntegration:
         self, mock_login, mock_synchronized_dataset
     ):
         """Test __getitem__ propagates load_sample failures."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1072,8 +1080,8 @@ class TestDatasetIntegration:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1093,12 +1101,12 @@ class TestPerformanceAndOptimization:
 
     def test_memory_monitoring_initialization(self, mock_synchronized_dataset):
         """Test memory monitor initialization."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1108,8 +1116,8 @@ class TestPerformanceAndOptimization:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1120,12 +1128,12 @@ class TestPerformanceAndOptimization:
 
     def test_episode_indices_creation(self, mock_synchronized_dataset):
         """Test episode indices are created correctly."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1135,8 +1143,8 @@ class TestPerformanceAndOptimization:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1159,13 +1167,13 @@ class TestIntegrationWithPyTorchDataLoader:
         """Test DataLoader with custom collate function."""
         from torch.utils.data import DataLoader
 
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 2),
                 DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 2),
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 2
@@ -1175,8 +1183,8 @@ class TestIntegrationWithPyTorchDataLoader:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1195,7 +1203,7 @@ class TestIntegrationWithPyTorchDataLoader:
 
             # Check that data is properly batched
             # Each data type should have batched data
-            for data_type in input_spec[ROBOT_ID].keys():
+            for data_type in input_description[ROBOT_ID].keys():
                 assert data_type in batch.inputs
                 assert isinstance(batch.inputs[data_type], list)
 
@@ -1205,12 +1213,12 @@ class TestDatasetStatistics:
 
     def test_dataset_statistics_property(self, mock_synchronized_dataset):
         """Test dataset_statistics property."""
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1220,8 +1228,8 @@ class TestDatasetStatistics:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1238,12 +1246,12 @@ class TestDatasetStatistics:
         import neuracore.ml.datasets.pytorch_synchronized_dataset as psd
 
         monkeypatch.setattr(psd, "DEFAULT_CACHE_DIR", tmp_path)
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1252,15 +1260,15 @@ class TestDatasetStatistics:
         }
         stats = SynchronizedDatasetStatistics(
             synchronized_dataset_id=mock_synchronized_dataset.id,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             dataset_statistics=dataset_statistics,
         )
         cache_path = _stats_cache_path(
             tmp_path,
             mock_synchronized_dataset,
-            input_spec,
-            output_spec,
+            input_description,
+            output_description,
         )
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         with cache_path.open("w", encoding="utf-8") as handle:
@@ -1272,8 +1280,8 @@ class TestDatasetStatistics:
 
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1292,12 +1300,12 @@ class TestDatasetStatistics:
         import neuracore.ml.datasets.pytorch_synchronized_dataset as psd
 
         monkeypatch.setattr(psd, "DEFAULT_CACHE_DIR", tmp_path)
-        input_spec: CrossEmbodimentDescription = {
+        input_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
             }
         }
-        output_spec: CrossEmbodimentDescription = {
+        output_description: CrossEmbodimentDescription = {
             ROBOT_ID: {
                 DataType.JOINT_TARGET_POSITIONS: _indexed_names(
                     DataType.JOINT_TARGET_POSITIONS, 3
@@ -1306,16 +1314,16 @@ class TestDatasetStatistics:
         }
         stats = SynchronizedDatasetStatistics(
             synchronized_dataset_id=mock_synchronized_dataset.id,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             dataset_statistics=dataset_statistics,
         )
         mock_synchronized_dataset.calculate_statistics = MagicMock(return_value=stats)
 
         PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset,
-            input_cross_embodiment_description=input_spec,
-            output_cross_embodiment_description=output_spec,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
             output_prediction_horizon=3,
             input_preprocessing_config=_default_preprocessing_config(),
             output_preprocessing_config=_default_preprocessing_config(),
@@ -1325,8 +1333,8 @@ class TestDatasetStatistics:
         cache_path = _stats_cache_path(
             tmp_path,
             mock_synchronized_dataset,
-            input_spec,
-            output_spec,
+            input_description,
+            output_description,
         )
         assert cache_path.exists()
 

--- a/tests/unit/ml/utils/test_embodiment_description_utils.py
+++ b/tests/unit/ml/utils/test_embodiment_description_utils.py
@@ -97,7 +97,7 @@ def mock_auth_requests_robots_paginated(
     )
 
 
-def test_convert_robot_data_spec_names_to_ids_resolves_name_across_pages(
+def test_convert_cross_embodiment_description_names_to_ids_resolves_name_across_pages(
     mock_auth_requests,
     mock_auth_requests_robots_paginated,
     mocked_org_id,
@@ -111,7 +111,7 @@ def test_convert_robot_data_spec_names_to_ids_resolves_name_across_pages(
     assert len(list_requests) == 3
 
 
-def test_convert_robot_data_spec_names_to_ids_raises_error_on_duplicates(
+def test_convert_cross_embodiment_description_names_to_ids_raises_error_on_duplicates(
     mock_auth_requests_robots,
 ):
     spec = {
@@ -122,7 +122,7 @@ def test_convert_robot_data_spec_names_to_ids_raises_error_on_duplicates(
         convert_cross_embodiment_description_names_to_ids(spec)
 
 
-def test_convert_robot_data_spec_names_to_ids_raises_on_ambiguous_name(
+def test_convert_cross_embodiment_description_names_to_ids_raises_on_ambiguous_name(
     mock_auth_requests_robots,
 ):
     spec = {"dup_name": {DataType.RGB_IMAGES: _indexed_names("cam")}}
@@ -130,7 +130,7 @@ def test_convert_robot_data_spec_names_to_ids_raises_on_ambiguous_name(
         convert_cross_embodiment_description_names_to_ids(spec)
 
 
-def test_convert_robot_data_spec_names_to_ids_raises_on_name_id_collision(
+def test_convert_cross_embodiment_description_names_to_ids_raises_on_name_id_collision(
     mock_auth_requests_robots,
 ):
     spec = {"robot_id_1": {DataType.RGB_IMAGES: _indexed_names("cam")}}


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Renamed leftover "data spec" / "robot data spec" identifiers and prose to the embodiment terminology, matching the type at each site (`CrossEmbodimentDescription`, `EmbodimentDescription`, `CrossEmbodimentUnion`, `EmbodimentUnion`): `_validate_data_specs*` → `_validate_cross_embodiment_description*`, `_serialize_robot_data_spec` → `_serialize_cross_embodiment_description`, `spec_kind` → `description_kind`, plus local variables, fixtures, and docstrings.
 - Updated CLI display strings: "Model Input/Output Data Spec" → "Model Input/Output Embodiment Description".
 - Fixed broken code sample in `docs/training.md`: it imported `RobotDataSpec` (no longer exported by `neuracore_types`) and passed `input_robot_data_spec=`/`output_robot_data_spec=` kwargs that `start_training_run` does not accept; now uses `CrossEmbodimentDescription` and `input_cross_embodiment_description=`/`output_cross_embodiment_description=`.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-635](https://neuracore.atlassian.net/browse/NCRL-635)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore_backend/pull/410
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/344
 - https://github.com/NeuracoreAI/neuracore_types/pull/92
