### PR TITLE
ci: add emergency_deploy option to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,16 @@
 name: Release
-run-name: ${{ inputs.dry_run && 'Release (Dry Run)' || 'Release' }}
+run-name: ${{ inputs.emergency_deploy && 'Release (Emergency)' || (inputs.dry_run && 'Release (Dry Run)' || 'Release') }}
 
 on:
   workflow_dispatch:
     inputs:
       dry_run:
         description: 'Dry run mode (only show what would happen, no commits/pushes/publishing)'
+        required: false
+        type: boolean
+        default: false
+      emergency_deploy:
+        description: '⚠️ Emergency deploy - bypasses tag format and release verification checks'
         required: false
         type: boolean
         default: false
@@ -22,11 +27,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: main
+        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
         fetch-depth: 0
 
     - name: Get latest release tag
       id: get_tag
+      if: ${{ !inputs.emergency_deploy }}
       run: |
         LATEST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
         if [ -z "$LATEST_TAG" ]; then
@@ -37,6 +43,7 @@ jobs:
         echo "Found latest release tag: $LATEST_TAG"
 
     - name: Check for new commits since last tag
+      if: ${{ !inputs.emergency_deploy }}
       run: |
         COMMITS_SINCE=$(git rev-list --count ${{ steps.get_tag.outputs.latest_tag }}..HEAD)
 
@@ -50,6 +57,7 @@ jobs:
 
     - name: Get PRs merged to main since last release
       id: get_prs
+      if: ${{ !inputs.emergency_deploy }}
       run: |
         TAG="${{ steps.get_tag.outputs.latest_tag }}"
 
@@ -73,8 +81,17 @@ jobs:
       uses: actions/github-script@v7
       env:
         PR_NUMBERS: ${{ steps.get_prs.outputs.pr_numbers || '[]' }}
+        EMERGENCY: ${{ inputs.emergency_deploy }}
       with:
         script: |
+          if (process.env.EMERGENCY === 'true') {
+            core.setOutput('should_release', true);
+            core.setOutput('bump_type', 'patch');
+            core.setOutput('pr_data', '[]');
+            console.log('Emergency deploy: forcing a patch release and skipping PR/label verification');
+            return;
+          }
+
           const prNumbers = JSON.parse(process.env.PR_NUMBERS);
           const versionLabels = ['version:major', 'version:minor', 'version:patch', 'version:none'];
           const versionPriority = { 'major': 4, 'minor': 3, 'patch': 2, 'none': 1 };
@@ -145,7 +162,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: main
+        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
         fetch-depth: 0
 
     - name: Calculate new version
@@ -299,7 +316,7 @@ jobs:
 
   release:
     needs: [analyze-changes, generate-changelog]
-    if: needs.analyze-changes.outputs.should_release == 'true' && inputs.dry_run == false
+    if: (needs.analyze-changes.outputs.should_release == 'true' || inputs.emergency_deploy) && inputs.dry_run == false
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -317,7 +334,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: main
+        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
         token: ${{ steps.generate-token.outputs.token }}
         fetch-depth: 0
 
@@ -354,9 +371,11 @@ jobs:
 
         git add .bumpversion.cfg neuracore/__init__.py changelogs/pending-changelog.md
         git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
-        git push origin main
 
-        echo "Pushed version bump to main"
+        TARGET_BRANCH="${{ inputs.emergency_deploy && github.ref_name || 'main' }}"
+        git push origin "HEAD:${TARGET_BRANCH}"
+
+        echo "Pushed version bump to ${TARGET_BRANCH}"
 
     - name: Build Python package
       run: python -m build
@@ -483,7 +502,7 @@ jobs:
 
   no-release-needed:
     needs: [analyze-changes, generate-changelog]
-    if: always() && needs.analyze-changes.outputs.should_release != 'true' && inputs.dry_run == false
+    if: always() && needs.analyze-changes.outputs.should_release != 'true' && inputs.dry_run == false && inputs.emergency_deploy == false
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Adds an emergency_deploy input that bypasses the tag/PR verification checks. needed so we could patch the floating version for neuracore types

used to deploy version `v12.2.2`
https://github.com/NeuracoreAI/neuracore/actions/runs/27412705970

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1041](https://neuracore.atlassian.net/browse/NCP-1041)

