### PR TITLE
feat: direct url for banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- fullWidth: false tocVisible: false tableWrap: true -->
 <div align="center">
-  <img src="./docs/assets/neuracore_logo.jpg" alt="Neuracore Logo" width="100%">
+  <img src="https://raw.githubusercontent.com/NeuracoreAI/neuracore/main/docs/assets/neuracore_logo.jpg" alt="Neuracore Logo" width="100%">
 </div>
 
 <br>


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Banner Image is missing on PyPi I belive this may because it is a relitive not absolute path 
 
 
 <img width="834" height="410" alt="image" src="https://github.com/user-attachments/assets/d51fbd4c-ccb0-45ed-b21c-6e3e015d289a" />