### PR TITLE
feat: pin maximum version to future manage roll out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "fastapi==0.135.2",
         "psutil",
         "typer>=0.20.0",
-        "neuracore_types>=9.0.0",
+        "neuracore_types>=9.0.0,<10.0.0",
         "ordered_set",
         "pyzmq==27.1.0",
         "sqlalchemy>=2.0.0",


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Restrict neuracore_types version to be less than 10.0.0 and more than or equal to 9.0.0
   - this will give us more control when it comes to rolling out the next major version

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore_backend/pull/411
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/345

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->