### PR TITLE
fix: prevent closed recordings from re-entering the closing set

### DIFF
--- a/neuracore/data_daemon/communications_management/consumer/models.py
+++ b/neuracore/data_daemon/communications_management/consumer/models.py
@@ -835,7 +835,14 @@ class RecordingCloseRegistry:
         recording_id: str,
         closing_state: RecordingClosingState,
     ) -> None:
-        """Store closing state for a recording awaiting finalization."""
+        """Store closing state for a recording awaiting finalization.
+
+        Ignored for recordings that are already closed: re-entering the
+        closing set would allow a second close to report a zeroed
+        expected_trace_count after the unique-trace history was cleared.
+        """
+        if self.is_closed(recording_id):
+            return
         self._closing_by_recording[recording_id] = closing_state
 
     def get_closing(self, recording_id: str) -> RecordingClosingState | None:

--- a/tests/unit/data_daemon/communications_management/test_recording_close_registry.py
+++ b/tests/unit/data_daemon/communications_management/test_recording_close_registry.py
@@ -1,0 +1,57 @@
+"""Tests for RecordingCloseRegistry close-state transitions."""
+
+from datetime import datetime, timezone
+
+from neuracore.data_daemon.communications_management.consumer.models import (
+    RecordingCloseRegistry,
+    RecordingClosingState,
+)
+
+
+def _closing_state() -> RecordingClosingState:
+    return RecordingClosingState(
+        producer_stop_sequence_numbers={"producer-1": 5},
+        stop_requested_at=datetime.now(timezone.utc),
+    )
+
+
+def test_mark_closing_then_close_marks_recording_closed() -> None:
+    registry = RecordingCloseRegistry()
+    registry.mark_closing("recording-1", _closing_state())
+
+    assert not registry.is_closed("recording-1")
+    assert registry.get_closing("recording-1") is not None
+
+    registry.close("recording-1")
+
+    assert registry.is_closed("recording-1")
+    assert registry.get_closing("recording-1") is None
+    assert list(registry.items()) == []
+
+
+def test_mark_closing_ignored_for_closed_recording() -> None:
+    """A closed recording must never re-enter the closing set.
+
+    Re-entering would allow a second close to emit a zeroed
+    expected_trace_count after the unique-trace registry was cleared.
+    """
+    registry = RecordingCloseRegistry()
+    registry.mark_closing("recording-1", _closing_state())
+    registry.close("recording-1")
+
+    registry.mark_closing("recording-1", _closing_state())
+
+    assert registry.get_closing("recording-1") is None
+    assert list(registry.items()) == []
+    assert registry.is_closed("recording-1")
+
+
+def test_mark_closing_unrelated_recording_unaffected_by_closed_one() -> None:
+    registry = RecordingCloseRegistry()
+    registry.mark_closing("recording-1", _closing_state())
+    registry.close("recording-1")
+
+    registry.mark_closing("recording-2", _closing_state())
+
+    assert registry.get_closing("recording-2") is not None
+    assert [recording_id for recording_id, _ in registry.items()] == ["recording-2"]


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - `RecordingCloseRegistry.mark_closing` now ignores recordings that are already closed. Previously any code path could re-enter a closed recording into the closing set, allowing a second close to report `expected_trace_count=0` after the unique-trace history was cleared, stranding the recording as pending on the backend. The registry now enforces the closed state itself, complementing the duplicate-stop guard from #689.
 - Added `tests/unit/data_daemon/communications_management/test_recording_close_registry.py` covering the close transition, re-mark rejection, and isolation between recordings.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - None yet

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - NeuracoreAI/neuracore_backend#412
