### PR TITLE
fix: capture end time before stream drain

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -346,6 +346,7 @@ class Robot:
         if not self.id:
             raise RobotError("Robot not initialized. Call init() first.")
 
+        end_time = time.time()
         get_recording_state_manager().recording_stopped(
             robot_id=self.id, instance=self.instance, recording_id=recording_id
         )
@@ -360,7 +361,7 @@ class Robot:
                 headers=self._auth.get_headers(),
                 json={
                     "recording_id": recording_id,
-                    "end_time": time.time(),
+                    "end_time": end_time,
                 },
             )
 
@@ -727,6 +728,7 @@ class Robot:
         if not self.id:
             raise RobotError("Robot not initialized. Call init() first.")
 
+        end_time = time.time()
         self._stop_all_streams()
         self._get_daemon_recording_context().stop_recording(recording_id=recording_id)
 
@@ -737,7 +739,7 @@ class Robot:
                 headers=self._auth.get_headers(),
                 json={
                     "recording_id": recording_id,
-                    "end_time": time.time(),
+                    "end_time": end_time,
                 },
             )
             response.raise_for_status()

--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -646,7 +646,7 @@ def _verify_recording_structure(
     # Duration bounds: variable mode allows 0.75–1.25× base; fixed mode uses exact
     # base duration.
     base_duration_s = float(result.duration_sec)
-    clock_tolerance_s = 2.5
+    clock_tolerance_s = 8.0
     if case.context_duration_mode == DURATION_MODE_VARIABLE:
         min_duration_s = (
             base_duration_s * DURATION_VARIABLE_MIN_FACTOR - clock_tolerance_s


### PR DESCRIPTION

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Updated cancel recording api with the new shape
 - end_time is now captured before we call drain steams and notify daemon
 - Updated duration assertion as recording start and stop times are sent from client side.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1045](https://neuracore.atlassian.net/browse/NCP-1045)

Successful test run here on thios branch: https://github.com/NeuracoreAI/neuracore/actions/runs/27464202095/job/81183523997

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
