### PR TITLE
ci: rename integration workflows for consistency

### DIFF
--- a/.github/workflows/integration-importer-production.yaml
+++ b/.github/workflows/integration-importer-production.yaml
@@ -1,4 +1,4 @@
-name: Integration Importer (Production)
+name: Integration PF - Importer (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration Importer (Staging)
+name: Integration PF - Importer (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Performance - Evaluate (Production)
+name: Integration ML - Algorithm Performance Evaluate (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Performance - Evaluate (Staging)
+name: Integration ML - Algorithm Performance Evaluate (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Performance - Start Training (Production)
+name: Integration ML - Algorithm Performance Start Training (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Performance - Start Training (Staging)
+name: Integration ML - Algorithm Performance Start Training (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-validation-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Validation - Production
+name: Integration ML - Algorithm Validation (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-algorithm-validation-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Algorithm Validation - Staging
+name: Integration ML - Algorithm Validation (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Auto Batch Size - Production
+name: Integration ML - Auto Batch Size (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Auto Batch Size - Staging
+name: Integration ML - Auto Batch Size (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-back-to-back-training-prod.yaml
+++ b/.github/workflows/integration-ml-back-to-back-training-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Back To Back Training - Production
+name: Integration ML - Back To Back Training (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-back-to-back-training-staging.yaml
+++ b/.github/workflows/integration-ml-back-to-back-training-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Back To Back Training - Staging
+name: Integration ML - Back To Back Training (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-dataset-datatype-validation-prod.yaml
+++ b/.github/workflows/integration-ml-dataset-datatype-validation-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Dataset Datatype Validation - Production
+name: Integration ML - Dataset Datatype Validation (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
+++ b/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Dataset Datatype Validation - Staging
+name: Integration ML - Dataset Datatype Validation (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-failure-reporting-prod.yaml
+++ b/.github/workflows/integration-ml-failure-reporting-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Failure Reporting - Production
+name: Integration ML - Failure Reporting (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-failure-reporting-staging.yaml
+++ b/.github/workflows/integration-ml-failure-reporting-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Failure Reporting - Staging
+name: Integration ML - Failure Reporting (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-inference-prod.yaml
+++ b/.github/workflows/integration-ml-inference-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Inference - Production
+name: Integration ML - Inference (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-inference-staging.yaml
+++ b/.github/workflows/integration-ml-inference-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Inference - Staging
+name: Integration ML - Inference (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-resume-training-prod.yaml
+++ b/.github/workflows/integration-ml-resume-training-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Resume Training - Production
+name: Integration ML - Resume Training (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-resume-training-staging.yaml
+++ b/.github/workflows/integration-ml-resume-training-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Resume Training - Staging
+name: Integration ML - Resume Training (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-training-flow-prod.yaml
+++ b/.github/workflows/integration-ml-training-flow-prod.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Training Flow - Production
+name: Integration ML - Training Flow (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-ml-training-flow-staging.yaml
+++ b/.github/workflows/integration-ml-training-flow-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration ML Training Flow - Staging
+name: Integration ML - Training Flow (Staging)
 
 on:
   schedule:

--- a/.github/workflows/integration-platform-production.yaml
+++ b/.github/workflows/integration-platform-production.yaml
@@ -1,4 +1,4 @@
-name: Integration Platform (Production)
+name: Integration PF (Production)
 
 on:
   schedule:

--- a/.github/workflows/integration-platform-staging.yaml
+++ b/.github/workflows/integration-platform-staging.yaml
@@ -1,4 +1,4 @@
-name: Integration Platform (Staging)
+name: Integration PF (Staging)
 
 on:
   schedule:

--- a/docs/workflow_naming.md
+++ b/docs/workflow_naming.md
@@ -1,0 +1,39 @@
+# Workflow Naming Convention
+
+## Integration Workflows
+
+Integration workflow `name:` fields follow this pattern:
+
+```
+Integration <Category> - <Test Name> (<Environment>)
+```
+
+| Part | Values | Example |
+|---|---|---|
+| Category | `ML` or `PF` | `ML` |
+| Test Name | Short description of what is tested | `Resume Training` |
+| Environment | `Production` or `Staging` | `(Staging)` |
+
+### Examples
+
+```
+Integration ML - Resume Training (Production)
+Integration ML - Algorithm Validation (Staging)
+Integration PF - Data Flow (Production)
+Integration PF - Importer (Staging)
+```
+
+### Category Definitions
+
+- **ML** — tests ML training, inference, or algorithm behaviour (e.g. training flow, auto batch size, back-to-back training)
+- **PF** — tests client/SDK functionality against the live API (e.g. data daemon, stream consumption, dataset importer)
+
+### File Naming
+
+Workflow files use kebab-case with environment suffix:
+
+```
+integration-<category>-<test-name>-<prod|staging>.yaml
+```
+
+Example: `integration-ml-resume-training-prod.yaml`


### PR DESCRIPTION
### Features
 - Renamed workflows for consistency
 - All of them now use the following convention: `Integration <ML|PF> - <Test Name> (<Production|Staging>)`

### Bugfixes
 - None

### Items
 - [NC-645](https://neuracore.atlassian.net/browse/NC-645)

### Related PRs
 - None