### PR TITLE
test: increase recording duration assertion

### DIFF
--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -646,7 +646,7 @@ def _verify_recording_structure(
     # Duration bounds: variable mode allows 0.75–1.25× base; fixed mode uses exact
     # base duration.
     base_duration_s = float(result.duration_sec)
-    clock_tolerance_s = 8.0
+    clock_tolerance_s = 15.0
     if case.context_duration_mode == DURATION_MODE_VARIABLE:
         min_duration_s = (
             base_duration_s * DURATION_VARIABLE_MIN_FACTOR - clock_tolerance_s


### PR DESCRIPTION

<!-- Please explain any existing functionality improved/changed -->
 - Increased the clock tolerance for recording duration assertion in platform integration tests.
 - The tests were being flaky because our recording duration now depends on the start_recording api call as start and end time is sent from client side, so I have increased it to a max number we should allow.
 
 **Note:** We also need to look into improving the start_recording api as this latency comes from a chain of sequential firestore round trips. I have created a ticket for this here: https://neuracore.atlassian.net/browse/NCP-1046

