### PR TITLE
test: fix wrong expected recording count in resume training

### DIFF
--- a/tests/integration/ml/shared/data_collection.py
+++ b/tests/integration/ml/shared/data_collection.py
@@ -100,6 +100,7 @@ def collect_demo_data(
             overwrite=False,
         )
         dataset = nc.create_dataset(name=dataset_name)
+        recording_count = len(dataset)
         for ep_idx in range(num_episodes):
             logger.info(f"Collecting episode {ep_idx + 1}/{num_episodes}")
             action_traj = rollout_policy()
@@ -197,7 +198,7 @@ def collect_demo_data(
             nc.stop_recording(wait=False, robot_name=robot_name, instance=instance_id)
             wait_for_dataset_ready(
                 dataset_name,
-                expected_recording_count=ep_idx + 1,
+                expected_recording_count=recording_count + ep_idx + 1,
                 timeout_s=500,
                 poll_interval_s=5,
             )


### PR DESCRIPTION
### Stuck Recordings Investigation in ML Resume Training Integration Test

This document here has all the details from the investigation into this issue.
[Stuck Recordings Investigation](https://docs.google.com/document/d/1pqDPPBEWyBSTXMrWliNboWyO6kF68H3kUIhWXGqwblM/edit?tab=t.0
)

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Fixed expected recording count passed by using absolute counts for recrordings in the dataset

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1027](https://neuracore.atlassian.net/browse/NCP-1027)
