### PR TITLE
fix: importer random sample

### DIFF
--- a/neuracore/importer/core/base.py
+++ b/neuracore/importer/core/base.py
@@ -945,7 +945,8 @@ class NeuracoreDatasetImporter(ABC):
 
         if self.random_sample is not None:
             n = min(self.random_sample, len(items))
-            items = random.sample(items, n)
+            start = random.randint(0, max(0, len(items) - n))
+            items = items[start : start + n]
             self.logger.info(
                 "Sampling %s random episode(s) from %s episodes.",
                 n,


### PR DESCRIPTION
### Bug fixes
- Importer uploads misses recordings if random sample is set and the start index > len(items) - number of samples
- [Stuck Recordings Investigation](https://docs.google.com/document/d/1pqDPPBEWyBSTXMrWliNboWyO6kF68H3kUIhWXGqwblM/edit?tab=t.0)
- This is because when building the dataset split (RLDS) the items must be contiguous but random sample returns non-contiguous items
- This fix forces the random samples to be contiguous