### PR TITLE
fix: make the video frame cache crash- and concurrency-safe

### DIFF
--- a/neuracore/core/data/cache_manager.py
+++ b/neuracore/core/data/cache_manager.py
@@ -1,7 +1,6 @@
 """Cache manager to handle disk space usage for cache files."""
 
 import logging
-import random
 import shutil
 from pathlib import Path
 
@@ -59,41 +58,36 @@ class CacheManager:
         return total_size
 
     def cleanup_cache(self, percent_to_remove: float = 20.0) -> None:
-        """Remove random cache files to free up space.
+        """Evict whole cached recordings to free space.
+
+        Recordings are evicted as complete units, never partially: a reader treats
+        a present recording directory as fully decoded, so deleting individual
+        frame files would leave undetectable holes that surface later as
+        ``FileNotFoundError``. Recordings with an active decoding lock are skipped
+        so an in-progress decode is not destroyed; an evicted recording is simply
+        re-decoded the next time it is needed.
 
         Args:
-            percent_to_remove: Percentage of cache files to remove
+            percent_to_remove: Percentage of eligible recordings to remove.
         """
-        # Get all cache files
-        cache_files = []
-        for entry in self.cache_dir.glob("**/*"):
-            if entry.is_file():
-                cache_files.append(entry)
-
-        if not cache_files:
+        candidates = [
+            d
+            for d in self.cache_dir.iterdir()
+            if d.is_dir() and not self._is_recording_locked(d)
+        ]
+        if not candidates:
             return
 
-        # Calculate how many files to remove
-        num_files_to_remove = max(1, int(len(cache_files) * percent_to_remove / 100))
+        num_to_remove = max(1, int(len(candidates) * percent_to_remove / 100))
+        for recording_dir in candidates[:num_to_remove]:
+            shutil.rmtree(recording_dir, ignore_errors=True)
 
-        # Randomly select files to remove
-        files_to_remove = random.sample(cache_files, num_files_to_remove)
+        logger.info(f"Cache cleanup: evicted {num_to_remove} recording(s)")
 
-        # Delete selected files
-        bytes_removed = 0
-        for file_path in files_to_remove:
-            try:
-                file_size = file_path.stat().st_size
-                file_path.unlink()
-                bytes_removed += file_size
-                logger.debug(f"Removed cache file: {file_path}")
-            except Exception:
-                logger.error(f"Error removing cache file {file_path}.", exc_info=True)
-
-        logger.info(
-            f"Cache cleanup: removed {num_files_to_remove} "
-            f"files ({bytes_removed / (1024*1024):.2f} MB)"
-        )
+    @staticmethod
+    def _is_recording_locked(recording_dir: Path) -> bool:
+        """Return True if a decoding lock exists anywhere under the recording."""
+        return any(recording_dir.rglob("*recording.lock"))
 
     def ensure_space_available(self, force_check: bool = False) -> bool:
         """Check if cache is using too much space and clean up if necessary.

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -30,6 +30,9 @@ from ..exceptions import AuthenticationError, DatasetError
 from ..utils.http_errors import extract_error_detail
 from ..utils.http_session import thread_local_session
 
+# Cursor pagination is inherently sequential (each page needs the previous
+# page's cursor), so a larger page size would mean fewer serial round-trips
+# The backend clamps `limit` to MAX_PAGE_SIZE (30) in the backend.
 PAGE_SIZE = 30
 SYNC_PROGRESS_POLL_INTERVAL_S = 5.0
 
@@ -159,14 +162,25 @@ class Dataset:
             logger.error(f"Failed to fetch recording count for Dataset {self.id}: {e}")
             self._num_recordings = 0
 
-    def _fetch_next_page(self) -> list[Recording]:
+    def _fetch_next_page(self, required_len: int | None = None) -> list[Recording]:
         """Fetch the next page of recordings and append to cache (lazy).
 
         Thread-safe: concurrent callers are serialized so each page is
         fetched exactly once. A caller that waited on the lock re-checks the
         cache size and may find its data already fetched by another thread.
+
+        Args:
+            required_len: If given, the caller only needs the cache to reach
+                this length. A caller that waited on the lock and finds the
+                cache already long enough returns immediately instead of
+                firing a redundant page fetch (avoids a thundering-herd of
+                over-fetches when many threads block on the lock at once).
         """
         with self._page_lock:
+            # Another thread may have loaded what we need while we waited.
+            if required_len is not None and len(self._recordings_cache) >= required_len:
+                return []
+
             if (
                 self._num_recordings is not None
                 and len(self._recordings_cache) >= self._num_recordings
@@ -651,7 +665,7 @@ class Dataset:
 
             # Load pages until index is available in cache
             while index >= len(self._recordings_cache):
-                fetched = self._fetch_next_page()
+                fetched = self._fetch_next_page(required_len=index + 1)
                 # An empty fetch can mean another thread loaded our page
                 # while we waited on the lock, so re-check the cache.
                 if not fetched and index >= len(self._recordings_cache):

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -92,6 +92,12 @@ class SynchronizedDataset:
         Args:
             max_prefetch_workers: Number of threads to use for prefetching synced data.
         """
+        # Indexing the last recording pages in all metadata up front, so the
+        # threaded prefetch below just reads cache instead of paging concurrently.
+        num_recordings = len(self.dataset)
+        if num_recordings > 0:
+            self.dataset[num_recordings - 1]
+
         desc = "Prefetching synced data"
         if self._prefetch_videos_needed:
             desc += " and videos"

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -1,6 +1,7 @@
 """Synchronized recording iterator."""
 
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -217,23 +218,42 @@ class SynchronizedRecording:
             camera_id: Unique identifier for the camera.
             video_frame_cache_path: Path to the directory where video frames are cached.
         """
-        lock_file = video_frame_cache_path / ".recording.lock"
+        # The lock lives beside the frames directory (not inside it) so that the
+        # frames directory can be published atomically with os.replace.
+        video_frame_cache_path.parent.mkdir(parents=True, exist_ok=True)
+        # The lock is a sibling of the frames directory (not inside it) so the
+        # frames directory can be published atomically once decoding completes.
+        lock_file = (
+            video_frame_cache_path.parent
+            / f"{video_frame_cache_path.name}.recording.lock"
+        )
         lock_acquired = self._create_decoding_lock(lock_file, camera_id)
 
         try:
-            # Create a temporary video file path
+            # Another process may have published this cache while we waited for
+            # the lock; nothing left to do.
+            if video_frame_cache_path.exists():
+                return
+
             self.cache_manager.ensure_space_available()
 
-            with tempfile.TemporaryDirectory() as temp_dir:
-                # Download video to temporary directory
+            # Stage the download+decode in a temp dir on the same filesystem, then
+            # publish atomically. A reader sees either a complete frames directory
+            # or none at all -- never a partially decoded one.
+            with tempfile.TemporaryDirectory(
+                dir=video_frame_cache_path.parent
+            ) as temp_dir:
+                staging_dir = Path(temp_dir) / "frames"
+                staging_dir.mkdir()
                 video_location = Path(temp_dir) / f"{camera_id}{camera_type.value}.mp4"
                 wget.download(
                     self._get_video_url(camera_type, camera_id),
                     str(video_location),
                     bar=None if self._suppress_wget_progress else wget.bar_thermometer,
                 )
-                # Decode video to frames and cache them to disk
-                self._decode_video(video_location, video_frame_cache_path)
+                # Decode into staging, then atomically move into place.
+                self._decode_video(video_location, staging_dir)
+                os.replace(staging_dir, video_frame_cache_path)
         finally:
             if lock_acquired:
                 self._delete_decoding_lock(lock_file)
@@ -317,12 +337,17 @@ class SynchronizedRecording:
         result = {}
         for cam_id, cam_data in camera_data.items():
             cam_id_rgb_root = self.cache_dir / f"{self.id}" / camera_type.value / cam_id
-            lock_file = cam_id_rgb_root / ".recording.lock"
+            # The lock is a sibling of the frames directory (not inside it) so
+            # the frames directory can be published atomically once decoding
+            # completes.
+            lock_file = (
+                cam_id_rgb_root.parent / f"{cam_id_rgb_root.name}.recording.lock"
+            )
             self._wait_for_lock_release(lock_file, cam_id_rgb_root)
 
             if not cam_id_rgb_root.exists():
-                # Not in cache, download video and cache frames to disk
-                cam_id_rgb_root.mkdir(parents=True, exist_ok=True)
+                # Not in cache: download and decode. The frames directory is
+                # published atomically, so its existence means it is complete.
                 self._download_video_and_cache_frames_to_disk(
                     camera_type, cam_id, cam_id_rgb_root
                 )

--- a/tests/unit/core/data/test_cache_manager.py
+++ b/tests/unit/core/data/test_cache_manager.py
@@ -1,0 +1,52 @@
+"""Tests for CacheManager eviction behavior."""
+
+from neuracore.core.data.cache_manager import CacheManager
+
+
+def _make_recording(cache_dir, rec_id, num_frames=5):
+    """Create a fake cached recording dir with frame files."""
+    frames_dir = cache_dir / rec_id / "rgb_images" / "cam1"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(num_frames):
+        (frames_dir / f"{i}.png").write_bytes(b"x" * 10)
+    return cache_dir / rec_id
+
+
+def test_cleanup_evicts_whole_recordings_never_partial(tmp_path):
+    """Eviction removes entire recording dirs, leaving survivors fully intact.
+
+    Deleting individual frame files would leave undetectable holes (a present
+    directory is assumed complete), so eviction must be all-or-nothing per
+    recording.
+    """
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    rec_a = _make_recording(cache_dir, "recA", num_frames=5)
+    rec_b = _make_recording(cache_dir, "recB", num_frames=5)
+
+    cm = CacheManager(cache_dir)
+    cm.cleanup_cache(percent_to_remove=50.0)  # 50% of 2 recordings -> 1 removed
+
+    survivors = [d for d in (rec_a, rec_b) if d.exists()]
+    removed = [d for d in (rec_a, rec_b) if not d.exists()]
+    assert len(survivors) == 1
+    assert len(removed) == 1
+    # The survivor keeps ALL of its frames -- no partial deletion.
+    survivor_frames = list((survivors[0] / "rgb_images" / "cam1").glob("*.png"))
+    assert len(survivor_frames) == 5
+
+
+def test_cleanup_skips_recordings_with_active_lock(tmp_path):
+    """A recording with an in-progress decode lock is never evicted."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    locked = _make_recording(cache_dir, "locked")
+    unlocked = _make_recording(cache_dir, "unlocked")
+    # Active decode lock somewhere inside the locked recording.
+    (locked / "rgb_images" / "cam1" / ".recording.lock").write_bytes(b"")
+
+    cm = CacheManager(cache_dir)
+    cm.cleanup_cache(percent_to_remove=50.0)
+
+    assert locked.exists()  # skipped despite the lock
+    assert not unlocked.exists()  # the unlocked one is evicted instead

--- a/tests/unit/core/data/test_synchronized_episode.py
+++ b/tests/unit/core/data/test_synchronized_episode.py
@@ -428,3 +428,51 @@ class TestSynchronizedRecording:
         synced_recording._delete_decoding_lock(lock_file)
 
         assert not lock_file.exists()
+
+    def test_decode_failure_does_not_publish_partial_cache(
+        self, synced_recording, mock_wget_download, dataset_mock
+    ):
+        """A decode that fails mid-way must not leave a partial frames dir.
+
+        Readers treat an existing frames dir as complete, so a partially written
+        dir would later surface as a missing-frame FileNotFoundError. The frames
+        dir must appear only once decoding has fully succeeded.
+        """
+        final_dir = dataset_mock.cache_dir / "rec1" / DataType.RGB_IMAGES.value / "cam1"
+
+        def partial_then_fail(video_location, frames_dir):
+            # Simulate the decoder writing some frames, then crashing.
+            Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8)).save(
+                frames_dir / "0.png"
+            )
+            raise RuntimeError("decode crashed")
+
+        with patch.object(
+            synced_recording, "_decode_video", side_effect=partial_then_fail
+        ):
+            with pytest.raises(RuntimeError, match="decode crashed"):
+                synced_recording._download_video_and_cache_frames_to_disk(
+                    DataType.RGB_IMAGES, "cam1", final_dir
+                )
+
+        assert not final_dir.exists()  # nothing published on failure
+
+    def test_successful_decode_publishes_complete_dir_without_leftovers(
+        self, synced_recording, mock_wget_download, dataset_mock
+    ):
+        """A successful decode publishes the complete frames dir and cleans up.
+
+        No decoding lock and no staging temp directory should remain afterwards.
+        """
+        final_dir = dataset_mock.cache_dir / "rec1" / DataType.RGB_IMAGES.value / "cam1"
+
+        synced_recording._download_video_and_cache_frames_to_disk(
+            DataType.RGB_IMAGES, "cam1", final_dir
+        )
+
+        assert final_dir.exists()
+        assert len(list(final_dir.glob("*.png"))) == 10  # mock video has 10 frames
+        # No decoding lock and no staging temp dirs left behind.
+        assert not any(final_dir.parent.rglob("*recording.lock"))
+        leftovers = [p for p in final_dir.parent.iterdir() if p != final_dir]
+        assert leftovers == []


### PR DESCRIPTION
The video fetch is easy to crash when the fetch is interrupted (because backend is too busy and memory is full) and resume fetch. This is because the video is partially fetched and is regarded as complete when resume again, but cause errors when decoding.

### Features

- rewrite batch-size tuning with an affine memory model: replace the binary-search autotuner with a memory-model estimator: probe a few batch sizes, fit peak GPU memory as an affine function of batch size, and solve
for the batch that fills the VRAM budget, then apply a safety factor. Details see the doc: https://github.com/NeuracoreAI/neuracore/blob/feat/rewrite_autobatch/docs/batch_size_autotuning.md


### Items
 - https://neuracore.atlassian.net/browse/NCRL-670