### PR TITLE
fix: surface backend error detail on dataset merge/clone

### DIFF
--- a/neuracore/api/datasets.py
+++ b/neuracore/api/datasets.py
@@ -82,9 +82,8 @@ def merge_datasets(name: str, dataset_names: list[str]) -> Dataset:
         json={"name": name, "sourceDatasetIds": source_ids},
     )
     if not response.ok:
-        raise DatasetError(
-            f"Failed to merge datasets: {response.status_code} {response.text}"
-        )
+        detail = extract_error_detail(response)
+        raise DatasetError(detail or f"{response.status_code} {response.reason}")
     dataset_model = DatasetModel.model_validate(response.json())
     merged = Dataset(
         id=dataset_model.id,
@@ -150,8 +149,7 @@ def clone_dataset(
     )
     if not response.ok:
         detail = extract_error_detail(response)
-        error_message = detail or f"{response.status_code} {response.reason}"
-        raise DatasetError(f"Failed to clone dataset: {error_message}")
+        raise DatasetError(detail or f"{response.status_code} {response.reason}")
 
     dataset_model = DatasetModel.model_validate(response.json())
     cloned = Dataset(

--- a/tests/unit/api/test_datasets_api.py
+++ b/tests/unit/api/test_datasets_api.py
@@ -1,0 +1,203 @@
+"""Unit tests for dataset API."""
+
+import json
+
+import pytest
+
+from neuracore.api import datasets as api_datasets
+from neuracore.core.exceptions import DatasetError
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict | None = None,
+        reason: str = "",
+        raw_text: str | None = None,
+    ):
+        self.status_code = status_code
+        self.reason = reason
+        self._payload = payload
+        self._raw_text = raw_text
+        self.ok = 200 <= status_code < 300
+
+    def json(self) -> dict:
+        if self._raw_text is not None:
+            raise ValueError("not json")
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        if self._raw_text is not None:
+            return self._raw_text
+        return json.dumps(self._payload)
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.last_kwargs: dict | None = None
+
+    def post(self, *args, **kwargs) -> _FakeResponse:
+        self.last_kwargs = kwargs
+        return self._response
+
+
+class _DummyAuth:
+    def get_headers(self) -> dict:
+        return {}
+
+
+class _DummyDataset:
+    def __init__(self, name: str):
+        self.name = name
+        self.id = f"id-{name}"
+
+
+def _wire(monkeypatch, response: _FakeResponse) -> _FakeSession:
+    session = _FakeSession(response)
+    monkeypatch.setattr(api_datasets, "get_auth", lambda: _DummyAuth())
+    monkeypatch.setattr(api_datasets, "get_current_org", lambda: "org-1")
+    monkeypatch.setattr(
+        api_datasets.Dataset,
+        "get_by_name",
+        classmethod(lambda cls, name, non_exist_ok=False: _DummyDataset(name)),
+    )
+    monkeypatch.setattr(api_datasets, "thread_local_session", lambda: session)
+    return session
+
+
+def test_merge_datasets_surfaces_backend_error(monkeypatch):
+    """A failed merge surfaces the backend message without doubling the prefix."""
+    # Arrange
+    detail = "Failed to merge datasets: Dataset not found."
+    _wire(monkeypatch, _FakeResponse(404, {"detail": {"error": detail}}))
+
+    # Act
+    with pytest.raises(DatasetError) as exc_info:
+        api_datasets.merge_datasets("merged", ["a", "b"])
+
+    # Assert
+    assert str(exc_info.value) == detail
+
+
+def test_merge_datasets_falls_back_to_status_when_no_detail(monkeypatch):
+    """A failed merge without a parseable detail falls back to status and reason."""
+    # Arrange
+    _wire(monkeypatch, _FakeResponse(500, {"detail": {}}, reason="Server Error"))
+
+    # Act
+    with pytest.raises(DatasetError) as exc_info:
+        api_datasets.merge_datasets("merged", ["a", "b"])
+
+    # Assert
+    assert str(exc_info.value) == "500 Server Error"
+
+
+def test_merge_datasets_success_returns_dataset(monkeypatch):
+    """A successful merge posts resolved source ids and returns the new dataset."""
+    # Arrange
+    session = _wire(monkeypatch, _FakeResponse(200, {"id": "new-id"}))
+
+    class _FakeModel:
+        id = "new-id"
+        name = "merged"
+        size_bytes = 10
+        tags: list[str] = []
+        is_shared = False
+        all_data_types: dict = {}
+
+    class _FakeDataset:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        @classmethod
+        def get_by_name(cls, name, non_exist_ok=False):
+            return _DummyDataset(name)
+
+    monkeypatch.setattr(
+        api_datasets.DatasetModel,
+        "model_validate",
+        staticmethod(lambda payload: _FakeModel()),
+    )
+    monkeypatch.setattr(api_datasets, "Dataset", _FakeDataset)
+
+    # Act
+    result = api_datasets.merge_datasets("merged", ["a", "b"])
+
+    # Assert
+    assert result.id == "new-id"
+    assert session.last_kwargs["json"] == {
+        "name": "merged",
+        "sourceDatasetIds": ["id-a", "id-b"],
+    }
+
+
+def test_clone_dataset_surfaces_backend_error(monkeypatch):
+    """A failed clone surfaces the backend message without doubling the prefix."""
+    # Arrange
+    detail = "Failed to clone dataset: Dataset not found."
+    _wire(monkeypatch, _FakeResponse(404, {"detail": {"error": detail}}))
+
+    # Act
+    with pytest.raises(DatasetError) as exc_info:
+        api_datasets.clone_dataset(
+            "clone", source_dataset=_DummyDataset("src"), wait=False
+        )
+
+    # Assert
+    assert str(exc_info.value) == detail
+
+
+def test_clone_dataset_falls_back_to_status_when_no_detail(monkeypatch):
+    """A failed clone without a parseable detail falls back to status and reason."""
+    # Arrange
+    _wire(monkeypatch, _FakeResponse(500, {"detail": {}}, reason="Server Error"))
+
+    # Act
+    with pytest.raises(DatasetError) as exc_info:
+        api_datasets.clone_dataset(
+            "clone", source_dataset=_DummyDataset("src"), wait=False
+        )
+
+    # Assert
+    assert str(exc_info.value) == "500 Server Error"
+
+
+def test_clone_dataset_success_returns_dataset(monkeypatch):
+    """A successful clone posts the source id and returns the new dataset."""
+    # Arrange
+    session = _wire(monkeypatch, _FakeResponse(200, {"id": "clone-id"}))
+
+    class _FakeModel:
+        id = "clone-id"
+        name = "clone"
+        size_bytes = 10
+        tags: list[str] = []
+        is_shared = False
+        description = ""
+        all_data_types: dict = {}
+
+    class _FakeDataset:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(
+        api_datasets.DatasetModel,
+        "model_validate",
+        staticmethod(lambda payload: _FakeModel()),
+    )
+    monkeypatch.setattr(api_datasets, "Dataset", _FakeDataset)
+
+    # Act
+    result = api_datasets.clone_dataset(
+        "clone", source_dataset=_DummyDataset("src"), wait=False
+    )
+
+    # Assert
+    assert result.id == "clone-id"
+    assert session.last_kwargs["json"] == {
+        "name": "clone",
+        "sourceDatasetId": "id-src",
+    }

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -366,15 +366,42 @@ def test_nc_clone_dataset_api_error(
     )
     mock_data_requests.post(
         f"{API_URL}/org/{mocked_org_id}/datasets/clone",
-        json={"detail": {"error": "Dataset already exists"}},
+        json={"detail": {"error": "Failed to clone dataset: Dataset already exists"}},
         status_code=409,
     )
 
     with pytest.raises(
         DatasetError,
-        match="Failed to clone dataset: Dataset already exists",
+        match=r"^Failed to clone dataset: Dataset already exists$",
     ):
         nc.clone_dataset("clone", source_dataset=source)
+
+
+def test_nc_merge_dataset_api_error(
+    temp_config_dir,
+    mock_data_requests,
+    reset_neuracore,
+    dataset_response,
+    mocked_org_id,
+):
+    """Test that merge API errors include the backend detail."""
+    nc.login("test_api_key")
+    mock_data_requests.get(
+        f"{API_URL}/org/{mocked_org_id}/datasets/search/by-name",
+        json=dataset_response.model_dump(mode="json"),
+        status_code=200,
+    )
+    mock_data_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/datasets/merge",
+        json={"detail": {"error": "Failed to merge datasets: Dataset not found."}},
+        status_code=404,
+    )
+
+    with pytest.raises(
+        DatasetError,
+        match=r"^Failed to merge datasets: Dataset not found\.$",
+    ):
+        nc.merge_datasets("merged", ["source_a", "source_b"])
 
 
 class TestDatasetInitialization:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Show the backend's specific failure reason when merging or cloning a dataset fails, instead of a raw dump of the server response.
 - Fall back to the HTTP status and reason when the server sends no readable error detail, so the user always gets a meaningful message.
 - Add tests covering merge and clone for the error, fallback, and success paths.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-647](https://neuracore.atlassian.net/browse/NC-647)
 - [NC-673](https://neuracore.atlassian.net/browse/NC-673)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None
