### PR TITLE
feat: load pretrained weights from bucket

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -174,6 +174,7 @@ frombuffer
 fromlist
 frontleft
 frontright
+fspath
 ftruncate
 gdown
 geglu

--- a/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
+++ b/neuracore/ml/algorithms/cnnmlp/cnnmlp.py
@@ -7,6 +7,7 @@ and outputs entire action sequences.
 """
 
 import os
+from functools import partial
 from typing import Any, cast
 
 import torch
@@ -43,6 +44,8 @@ from neuracore.ml.algorithm_utils.modules import (
     PoseEncoder,
 )
 from neuracore.ml.algorithm_utils.normalizer import MeanStdNormalizer
+from neuracore.ml.utils.hf_hub_retry import call_with_hf_hub_retry
+from neuracore.ml.utils.pretrained_cache import ensure_pretrained_model
 
 from .modules import ImageEncoder
 
@@ -261,7 +264,10 @@ class CNNMLP(NeuracoreModel):
         if DataType.LANGUAGE in self.input_data_types:
             from transformers import AutoTokenizer
 
-            _tokenizer = AutoTokenizer.from_pretrained(LANGUAGE_MODEL_NAME)
+            ensure_pretrained_model(LANGUAGE_MODEL_NAME)
+            _tokenizer = call_with_hf_hub_retry(
+                partial(AutoTokenizer.from_pretrained, LANGUAGE_MODEL_NAME)
+            )
             self.embedding_encoder = nn.Embedding(_tokenizer.vocab_size, 128)
             self.encoder_output_dims[DataType.LANGUAGE] = cnn_output_dim
             self.encoders[DataType.LANGUAGE] = nn.Sequential(

--- a/neuracore/ml/algorithms/groot/utils.py
+++ b/neuracore/ml/algorithms/groot/utils.py
@@ -19,10 +19,17 @@ import json
 import logging
 import os
 from contextlib import AbstractContextManager, nullcontext
+from functools import partial
 from typing import Any
 
 import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from neuracore.ml.utils.hf_hub_retry import call_with_hf_hub_retry
+from neuracore.ml.utils.pretrained_cache import (
+    ensure_pretrained_model,
+    is_hf_hub_repo_id,
+)
 
 from .eagle_config.eagle3_vl_dataconfig import Eagle3VLDataConfig
 
@@ -129,6 +136,9 @@ def load_pretrained_state_dict(model_path: str) -> dict[str, torch.Tensor]:
     """
     from safetensors.torch import load_file
 
+    if is_hf_hub_repo_id(model_path):
+        ensure_pretrained_model(model_path)
+
     # --- Try local single-file checkpoint ---
     local_file = os.path.join(model_path, "model.safetensors")
     if os.path.exists(local_file):
@@ -145,16 +155,18 @@ def load_pretrained_state_dict(model_path: str) -> dict[str, torch.Tensor]:
     try:
         from huggingface_hub import hf_hub_download
 
-        # Try single-file first
         try:
-            weight_path = hf_hub_download(model_path, "model.safetensors")
+            weight_path = call_with_hf_hub_retry(
+                partial(hf_hub_download, model_path, "model.safetensors")
+            )
             logger.info("Downloaded single-file checkpoint from HF Hub.")
             return load_file(weight_path)
         except Exception:
             pass
 
-        # Try sharded checkpoint
-        index_path = hf_hub_download(model_path, "model.safetensors.index.json")
+        index_path = call_with_hf_hub_retry(
+            partial(hf_hub_download, model_path, "model.safetensors.index.json")
+        )
         logger.info("Downloaded sharded checkpoint index from HF Hub.")
         return load_sharded_safetensors_from_hub(model_path, index_path)
 
@@ -213,7 +225,9 @@ def load_sharded_safetensors_from_hub(
     shard_files = set(index["weight_map"].values())
     state_dict: dict[str, torch.Tensor] = {}
     for shard_file in sorted(shard_files):
-        local_path = hf_hub_download(model_path, shard_file)
+        local_path = call_with_hf_hub_retry(
+            partial(hf_hub_download, model_path, shard_file)
+        )
         state_dict.update(load_file(local_path))
     return state_dict
 
@@ -233,11 +247,16 @@ def load_config_json(model_path: str) -> dict:
         with open(local_file) as f:
             return json.load(f)
 
+    if is_hf_hub_repo_id(model_path):
+        ensure_pretrained_model(model_path)
+
     # Try HuggingFace Hub
     try:
         from huggingface_hub import hf_hub_download
 
-        config_path = hf_hub_download(model_path, "config.json")
+        config_path = call_with_hf_hub_retry(
+            partial(hf_hub_download, model_path, "config.json")
+        )
         with open(config_path) as f:
             return json.load(f)
     except Exception:

--- a/neuracore/ml/algorithms/pi0/modules.py
+++ b/neuracore/ml/algorithms/pi0/modules.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -36,6 +37,11 @@ from neuracore.ml.algorithms.pi0.utils import (
     _create_sinusoidal_pos_embedding,
     _make_att_2d_masks,
     _sample_beta,
+)
+from neuracore.ml.utils.hf_hub_retry import call_with_hf_hub_retry
+from neuracore.ml.utils.pretrained_cache import (
+    ensure_pretrained_model,
+    is_hf_hub_repo_id,
 )
 
 T = TypeVar("T")
@@ -599,16 +605,23 @@ class PI0Policy(nn.Module):
             return model
 
         try:
-            resolved_file = cached_file(
-                pretrained_name_or_path,
-                "model.safetensors",
-                cache_dir=kwargs.get("cache_dir"),
-                force_download=kwargs.get("force_download", False),
-                resume_download=kwargs.get("resume_download"),
-                proxies=kwargs.get("proxies"),
-                token=kwargs.get("token") or kwargs.get("use_auth_token"),
-                revision=kwargs.get("revision"),
-                local_files_only=kwargs.get("local_files_only", False),
+            repo_id = str(pretrained_name_or_path)
+            if is_hf_hub_repo_id(repo_id):
+                ensure_pretrained_model(repo_id)
+
+            resolved_file = call_with_hf_hub_retry(
+                partial(
+                    cached_file,
+                    pretrained_name_or_path,
+                    "model.safetensors",
+                    cache_dir=kwargs.get("cache_dir"),
+                    force_download=kwargs.get("force_download", False),
+                    resume_download=kwargs.get("resume_download"),
+                    proxies=kwargs.get("proxies"),
+                    token=kwargs.get("token") or kwargs.get("use_auth_token"),
+                    revision=kwargs.get("revision"),
+                    local_files_only=kwargs.get("local_files_only", False),
+                )
             )
             original_state_dict = load_file(resolved_file)
             logging.info("Loaded state dict from %s", resolved_file)

--- a/neuracore/ml/algorithms/pi05/modules.py
+++ b/neuracore/ml/algorithms/pi05/modules.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -34,6 +35,11 @@ from neuracore.ml.algorithms.pi05.utils import (
     _create_sinusoidal_pos_embedding,
     _make_att_2d_masks,
     _sample_beta,
+)
+from neuracore.ml.utils.hf_hub_retry import call_with_hf_hub_retry
+from neuracore.ml.utils.pretrained_cache import (
+    ensure_pretrained_model,
+    is_hf_hub_repo_id,
 )
 
 T = TypeVar("T")
@@ -556,16 +562,23 @@ class PI05Policy(nn.Module):
             return model
 
         try:
-            resolved_file = cached_file(
-                pretrained_name_or_path,
-                "model.safetensors",
-                cache_dir=kwargs.get("cache_dir"),
-                force_download=kwargs.get("force_download", False),
-                resume_download=kwargs.get("resume_download"),
-                proxies=kwargs.get("proxies"),
-                token=kwargs.get("token") or kwargs.get("use_auth_token"),
-                revision=kwargs.get("revision"),
-                local_files_only=kwargs.get("local_files_only", False),
+            repo_id = str(pretrained_name_or_path)
+            if is_hf_hub_repo_id(repo_id):
+                ensure_pretrained_model(repo_id)
+
+            resolved_file = call_with_hf_hub_retry(
+                partial(
+                    cached_file,
+                    pretrained_name_or_path,
+                    "model.safetensors",
+                    cache_dir=kwargs.get("cache_dir"),
+                    force_download=kwargs.get("force_download", False),
+                    resume_download=kwargs.get("resume_download"),
+                    proxies=kwargs.get("proxies"),
+                    token=kwargs.get("token") or kwargs.get("use_auth_token"),
+                    revision=kwargs.get("revision"),
+                    local_files_only=kwargs.get("local_files_only", False),
+                )
             )
             original_state_dict = load_file(resolved_file)
             logging.info("Loaded state dict from %s", resolved_file)

--- a/neuracore/ml/algorithms/pi05/utils.py
+++ b/neuracore/ml/algorithms/pi05/utils.py
@@ -13,6 +13,7 @@ import logging
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Literal
 
 import torch
@@ -21,6 +22,12 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.errors import EntryNotFoundError
 from torch import Tensor
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from neuracore.ml.utils.hf_hub_retry import call_with_hf_hub_retry
+from neuracore.ml.utils.pretrained_cache import (
+    ensure_pretrained_model,
+    is_hf_hub_repo_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -360,15 +367,19 @@ def resize_with_pad_torch(
 
 def _load_tokenizer(name_or_path: str) -> PreTrainedTokenizerBase:
     """Load a tokenizer, with local fallback for Hub path regressions."""
+    if is_hf_hub_repo_id(name_or_path):
+        ensure_pretrained_model(name_or_path)
     try:
-        return AutoTokenizer.from_pretrained(name_or_path)
+        return call_with_hf_hub_retry(
+            partial(AutoTokenizer.from_pretrained, name_or_path)
+        )
     except EntryNotFoundError:
         logger.warning(
             "Tokenizer '%s' could not be loaded directly from the Hub. "
             "Falling back to a local tokenizer-only snapshot.",
             name_or_path,
         )
-        local_snapshot_path = snapshot_download(
-            repo_id=name_or_path,
+        local_snapshot_path = call_with_hf_hub_retry(
+            partial(snapshot_download, repo_id=name_or_path)
         )
         return AutoTokenizer.from_pretrained(local_snapshot_path, local_files_only=True)

--- a/neuracore/ml/utils/hf_hub_retry.py
+++ b/neuracore/ml/utils/hf_hub_retry.py
@@ -1,0 +1,95 @@
+"""Hugging Face Hub download helpers with rate-limit retries."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_BASE_DELAY_S = 2.0
+_DEFAULT_MAX_DELAY_S = 120.0
+
+
+def _exception_indicates_rate_limit(exc: BaseException) -> bool:
+    """Return True if a single exception indicates an HF Hub rate limit."""
+    try:
+        from huggingface_hub.errors import HfHubHTTPError
+    except ImportError:
+        HfHubHTTPError = ()  # type: ignore[misc, assignment]
+
+    if isinstance(exc, HfHubHTTPError):
+        return exc.response is not None and exc.response.status_code == 429
+
+    response = getattr(exc, "response", None)
+    return response is not None and getattr(response, "status_code", None) == 429
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Return True if the exception or its cause chain indicates HTTP 429.
+
+    Transformers often wraps ``HfHubHTTPError`` in ``OSError`` without
+    including ``429`` in the outer message, so the cause chain must be walked.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if _exception_indicates_rate_limit(current):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def call_with_hf_hub_retry(
+    func: Callable[[], T],
+    *,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
+    base_delay_s: float = _DEFAULT_BASE_DELAY_S,
+    max_delay_s: float = _DEFAULT_MAX_DELAY_S,
+) -> T:
+    """Call ``func`` with exponential backoff on Hugging Face Hub rate limits.
+
+    Bind call arguments with :func:`functools.partial` before passing ``func``.
+
+    Args:
+        func: Zero-argument callable that may raise on Hub download failure.
+        max_retries: Maximum number of attempts after the first failure.
+        base_delay_s: Initial backoff delay in seconds.
+        max_delay_s: Maximum backoff delay in seconds.
+
+    Returns:
+        Return value of ``func``.
+
+    Raises:
+        The last exception if all retries are exhausted.
+    """
+    if max_retries < 0:
+        raise ValueError(f"max_retries must be >= 0, got {max_retries}")
+
+    last_exc: BaseException | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except Exception as exc:
+            last_exc = exc
+            if not _is_rate_limit_error(exc) or attempt >= max_retries:
+                raise
+            delay = min(base_delay_s * (2**attempt), max_delay_s)
+            logger.warning(
+                "Hugging Face Hub rate limit (attempt %d/%d); retrying in %.1fs: %s",
+                attempt + 1,
+                max_retries + 1,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+
+    if last_exc is not None:
+        raise last_exc
+    raise ValueError(f"max_retries must be >= 0, got {max_retries}")

--- a/neuracore/ml/utils/pretrained_cache.py
+++ b/neuracore/ml/utils/pretrained_cache.py
@@ -1,0 +1,166 @@
+"""Pull individual Hugging Face pretrained models via Neuracore signed URLs."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+import requests
+from huggingface_hub.constants import HF_HUB_CACHE
+
+logger = logging.getLogger(__name__)
+
+
+def is_hf_hub_repo_id(model_path: str | os.PathLike[str]) -> bool:
+    """Return True if ``model_path`` looks like a Hugging Face repo id."""
+    path = os.fspath(model_path)
+    if not path or path.startswith((".", "/")):
+        return False
+    if os.path.isdir(path) or os.path.isfile(path):
+        return False
+    if "/" in path:
+        return True
+    return not path.endswith(
+        (".safetensors", ".json", ".pt", ".bin", ".ckpt", ".tar.gz")
+    )
+
+
+def hf_hub_cache_dir_name(repo_id: str) -> str:
+    """Return the Hugging Face hub cache directory name for a repo id."""
+    return "models--" + repo_id.replace("/", "--")
+
+
+def _repo_cached_locally(repo_id: str) -> bool:
+    snapshots_dir = Path(HF_HUB_CACHE) / hf_hub_cache_dir_name(repo_id) / "snapshots"
+    if not snapshots_dir.is_dir():
+        return False
+    return any(child.is_dir() for child in snapshots_dir.iterdir())
+
+
+def _get_pretrained_download_url(repo_id: str) -> str | None:
+    try:
+        import neuracore as nc
+        from neuracore.core.auth import get_auth
+        from neuracore.core.config.get_current_org import get_current_org
+        from neuracore.core.const import API_URL
+        from neuracore.core.utils.http_session import thread_local_session
+    except ImportError:
+        return None
+
+    try:
+        auth = get_auth()
+        if not auth.is_authenticated:
+            nc.login()
+        org_id = get_current_org()
+        session = thread_local_session()
+        url = f"{API_URL}/org/{org_id}/pretrained-models/download_url"
+        response = session.get(
+            url,
+            params={"repo_id": repo_id},
+            headers=get_auth().get_headers(),
+            timeout=60,
+        )
+        if response.status_code == 401:
+            nc.login()
+            response = session.get(
+                url,
+                params={"repo_id": repo_id},
+                headers=get_auth().get_headers(),
+                timeout=60,
+            )
+        if response.status_code != 200:
+            logger.warning(
+                "Pretrained model download URL request failed for %s: %s %s",
+                repo_id,
+                response.status_code,
+                response.text,
+            )
+            return None
+        download_url = response.json().get("url")
+        if not isinstance(download_url, str) or not download_url:
+            logger.warning("Pretrained model download URL missing for %s", repo_id)
+            return None
+        return download_url
+    except Exception as exc:
+        logger.warning(
+            "Failed to request pretrained model download URL for %s: %s",
+            repo_id,
+            exc,
+        )
+        return None
+
+
+def _download_and_extract_archive(download_url: str, repo_id: str) -> bool:
+    archive_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+            archive_path = tmp.name
+            with requests.get(download_url, stream=True, timeout=300) as response:
+                response.raise_for_status()
+                shutil.copyfileobj(response.raw, tmp)
+
+        with tarfile.open(archive_path, "r:gz") as archive:
+            archive.extractall(path=Path(HF_HUB_CACHE))
+
+        return _repo_cached_locally(repo_id)
+    except Exception as exc:
+        logger.warning(
+            "Failed to download or extract pretrained model archive for %s: %s",
+            repo_id,
+            exc,
+        )
+        return False
+    finally:
+        if archive_path and os.path.exists(archive_path):
+            os.unlink(archive_path)
+
+
+def ensure_pretrained_model(repo_id: str) -> bool:
+    """Ensure a Hugging Face repo is present in the local hub cache.
+
+    Requests a signed download URL from the Neuracore API, downloads the model
+    archive, and extracts it into the standard Hugging Face hub cache. Falls
+    back silently when unauthenticated or the download fails (callers may still
+    use Hugging Face Hub).
+
+    Args:
+        repo_id: Hugging Face model id (e.g. ``lerobot/pi0_base``).
+
+    Returns:
+        True if the repo is available locally after this call (including cache hit).
+    """
+    logger.info("Ensuring pretrained model %s is cached locally", repo_id)
+    if not is_hf_hub_repo_id(repo_id):
+        return False
+
+    if _repo_cached_locally(repo_id):
+        logger.info("Pretrained model already cached locally: %s", repo_id)
+        return True
+
+    logger.info(
+        "Pretrained model %s not in local cache; requesting Neuracore archive",
+        repo_id,
+    )
+    download_url = _get_pretrained_download_url(repo_id)
+    if not download_url:
+        logger.info(
+            "No Neuracore archive available for %s; falling back to Hugging Face Hub",
+            repo_id,
+        )
+        return False
+
+    logger.info("Downloading pretrained model archive for %s", repo_id)
+    if _download_and_extract_archive(download_url, repo_id):
+        logger.info("Loaded pretrained model %s from Neuracore archive", repo_id)
+        return True
+
+    logger.warning(
+        "Pretrained model %s archive did not produce a local cache; "
+        "falling back to Hugging Face Hub",
+        repo_id,
+    )
+    return False

--- a/tests/unit/ml/utils/test_hf_hub_retry.py
+++ b/tests/unit/ml/utils/test_hf_hub_retry.py
@@ -1,0 +1,71 @@
+"""Tests for Hugging Face Hub retry helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from huggingface_hub.errors import HfHubHTTPError
+
+from neuracore.ml.utils.hf_hub_retry import _is_rate_limit_error, call_with_hf_hub_retry
+
+
+def test_is_rate_limit_error_from_hf_hub_http_error() -> None:
+    response_429 = MagicMock()
+    response_429.status_code = 429
+    assert _is_rate_limit_error(
+        HfHubHTTPError("429 Client Error: Too Many Requests", response=response_429)
+    )
+
+    response_500 = MagicMock()
+    response_500.status_code = 500
+    assert not _is_rate_limit_error(
+        HfHubHTTPError("500 Server Error", response=response_500)
+    )
+    assert not _is_rate_limit_error(Exception("connection refused"))
+
+
+def test_is_rate_limit_error_from_wrapped_oserror() -> None:
+    response = MagicMock()
+    response.status_code = 429
+    hub_error = HfHubHTTPError(
+        "429 Client Error: Too Many Requests",
+        response=response,
+    )
+    wrapped = OSError(
+        "We couldn't connect to 'https://huggingface.co' to load the files, "
+        "and couldn't find them in the cached files."
+    )
+    wrapped.__cause__ = hub_error
+    assert _is_rate_limit_error(wrapped)
+
+
+def test_call_with_hf_hub_retry_succeeds_on_second_attempt() -> None:
+    response = MagicMock()
+    response.status_code = 429
+    rate_limit_error = HfHubHTTPError(
+        "429 Client Error: Too Many Requests",
+        response=response,
+    )
+    func = MagicMock(side_effect=[rate_limit_error, "ok"])
+    assert call_with_hf_hub_retry(func, max_retries=2, base_delay_s=0) == "ok"
+    assert func.call_count == 2
+
+
+def test_call_with_hf_hub_retry_succeeds_on_wrapped_oserror() -> None:
+    response = MagicMock()
+    response.status_code = 429
+    hub_error = HfHubHTTPError(
+        "429 Client Error: Too Many Requests",
+        response=response,
+    )
+    wrapped = OSError("couldn't connect to huggingface.co")
+    wrapped.__cause__ = hub_error
+
+    func = MagicMock(side_effect=[wrapped, "ok"])
+    assert call_with_hf_hub_retry(func, max_retries=2, base_delay_s=0) == "ok"
+    assert func.call_count == 2
+
+
+def test_call_with_hf_hub_retry_raises_non_rate_limit() -> None:
+    func = MagicMock(side_effect=ValueError("bad config"))
+    with pytest.raises(ValueError, match="bad config"):
+        call_with_hf_hub_retry(func, max_retries=3, base_delay_s=0)

--- a/tests/unit/ml/utils/test_pretrained_cache.py
+++ b/tests/unit/ml/utils/test_pretrained_cache.py
@@ -1,0 +1,78 @@
+"""Tests for Neuracore pretrained model archive cache helpers."""
+
+from unittest.mock import MagicMock, patch
+
+from neuracore.ml.utils.pretrained_cache import (
+    ensure_pretrained_model,
+    hf_hub_cache_dir_name,
+    is_hf_hub_repo_id,
+)
+
+
+def test_is_hf_hub_repo_id() -> None:
+    assert is_hf_hub_repo_id("lerobot/pi0_base")
+    assert is_hf_hub_repo_id("nvidia/GR00T-N1.6-3B")
+    assert is_hf_hub_repo_id("distilbert-base-uncased")
+    assert not is_hf_hub_repo_id("/tmp/checkpoint")
+    assert not is_hf_hub_repo_id("model.safetensors")
+
+
+def test_hf_hub_cache_dir_name() -> None:
+    assert hf_hub_cache_dir_name("lerobot/pi0_base") == "models--lerobot--pi0_base"
+
+
+@patch("neuracore.ml.utils.pretrained_cache._repo_cached_locally", return_value=True)
+def test_ensure_pretrained_model_cache_hit(_cached: MagicMock) -> None:
+    assert ensure_pretrained_model("lerobot/pi0_base") is True
+    _cached.assert_called_once_with("lerobot/pi0_base")
+
+
+@patch(
+    "neuracore.ml.utils.pretrained_cache._download_and_extract_archive",
+    return_value=True,
+)
+@patch(
+    "neuracore.ml.utils.pretrained_cache._get_pretrained_download_url",
+    return_value="https://signed.example/archive.tar.gz",
+)
+@patch("neuracore.ml.utils.pretrained_cache._repo_cached_locally", return_value=False)
+def test_ensure_pretrained_model_downloads_archive(
+    _cached: MagicMock,
+    get_url: MagicMock,
+    extract: MagicMock,
+) -> None:
+    assert ensure_pretrained_model("distilbert-base-uncased") is True
+    get_url.assert_called_once_with("distilbert-base-uncased")
+    extract.assert_called_once_with(
+        "https://signed.example/archive.tar.gz",
+        "distilbert-base-uncased",
+    )
+
+
+@patch(
+    "neuracore.ml.utils.pretrained_cache._get_pretrained_download_url",
+    return_value=None,
+)
+@patch("neuracore.ml.utils.pretrained_cache._repo_cached_locally", return_value=False)
+def test_ensure_pretrained_model_skips_without_download_url(
+    _cached: MagicMock,
+    _get_url: MagicMock,
+) -> None:
+    assert ensure_pretrained_model("lerobot/pi05_base") is False
+
+
+@patch(
+    "neuracore.ml.utils.pretrained_cache._download_and_extract_archive",
+    return_value=False,
+)
+@patch(
+    "neuracore.ml.utils.pretrained_cache._get_pretrained_download_url",
+    return_value="https://signed.example/archive.tar.gz",
+)
+@patch("neuracore.ml.utils.pretrained_cache._repo_cached_locally", return_value=False)
+def test_ensure_pretrained_model_handles_extract_failure(
+    _cached: MagicMock,
+    _get_url: MagicMock,
+    _extract: MagicMock,
+) -> None:
+    assert ensure_pretrained_model("lerobot/pi05_base") is False


### PR DESCRIPTION
### Features
- Host pretrained huggingface weights on bucket
- Pull pretrained weights from bucket with huggingface download as backup (with exponential back off to prevent 429 too many request error)

### Items
 - [NCRL-659](https://neuracore.atlassian.net/browse/NCRL-659)

### Related PRs
- https://github.com/NeuracoreAI/neuracore_backend/pull/436