### PR TITLE
fix: contiguous memoryview

### DIFF
--- a/neuracore/core/streaming/data_stream.py
+++ b/neuracore/core/streaming/data_stream.py
@@ -373,7 +373,10 @@ class VideoDataStream(DataStream):
             # `_latest_data` for live-data consumers.
             return
 
-        frame_view = memoryview(frame).cast("B")
+        frame_source = (
+            frame if frame.flags.c_contiguous else np.ascontiguousarray(frame)
+        )
+        frame_view = memoryview(frame_source).cast("B")
 
         # Legacy daemon: pack [metadata_len (4 bytes)] [metadata_json] [frame_bytes]
         metadata_dict = metadata.model_dump(mode="json", exclude={"frame"})


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - re-introduces the `np.ascontiguousarray(frame)` line removed in the previous pr 

```
ERROR:neuracore.importer.lerobot_importer.LeRobotDatasetImporter:[worker 0 item 0] memoryview: casts are restricted to C-contiguous views
ERROR:neuracore.importer.lerobot_importer.LeRobotDatasetImporter:[worker 0 item 1] memoryview: casts are restricted to C-contiguous views
```


https://github.com/NeuracoreAI/neuracore/pull/719#discussion_r3481467049