### PR TITLE
chore: sync algorithm config yamls to __init__ defaults and guard drift

### DIFF
--- a/neuracore/ml/config/algorithm/act.yaml
+++ b/neuracore/ml/config/algorithm/act.yaml
@@ -21,3 +21,4 @@ algorithm:
 
   # Backbone
   freeze_backbone: false   # Whether to freeze image encoder backbone
+  use_resnet_stats: true   # Use ResNet normalization statistics

--- a/neuracore/ml/config/algorithm/diffusion_policy.yaml
+++ b/neuracore/ml/config/algorithm/diffusion_policy.yaml
@@ -13,6 +13,7 @@ algorithm:
   hidden_dim: 64                          # Output dim per image encoder (spatial_softmax_num_keypoints * 2)
   spatial_softmax_num_keypoints: 32       # Number of keypoints for spatial softmax pooling
   use_pretrained_weights: true            # Load pretrained ResNet weights
+  use_resnet_stats: true                  # Use ResNet normalization statistics
 
   # Generative process
   process_type: "diffusion"               # "diffusion" or "flow_matching"
@@ -33,9 +34,13 @@ algorithm:
   # Learning rates
   lr: 1e-4                                # Learning rate for main parameters
   lr_backbone: 1e-4                       # Learning rate for backbone parameters
-  weight_decay: 2e-6                      # AdamW weight decay
-  optimizer_betas: [0.95, 0.999]          # Adam beta parameters
+  weight_decay: 1e-6                      # AdamW weight decay
+  optimizer_betas: [0.9, 0.999]           # Adam beta parameters
   optimizer_eps: 1e-8                     # Adam epsilon
+
+  # LR scheduler
+  lr_scheduler_type: "cosine"             # Learning rate scheduler type
+  lr_scheduler_num_warmup_steps: 500      # Number of warmup steps
 
   # Backbone
   freeze_backbone: false                  # Whether to freeze image encoder backbone

--- a/neuracore/ml/config/algorithm/groot.yaml
+++ b/neuracore/ml/config/algorithm/groot.yaml
@@ -7,8 +7,9 @@ algorithm:
 
   # Denoising configuration
   num_denoising_steps: 4
-  use_relative_deltas: false  # Predict state-relative deltas and convert to absolute at output; false = predict absolute positions directly.
+  use_relative_deltas: true  # Predict state-relative deltas and convert to absolute at output; false = predict absolute positions directly.
   add_action_step_positional_encoding: true  # Add learned action-step positions across the predicted chunk, matching upstream GR00T behavior.
+  max_action_pos_embeddings: 1024  # Size of the action-step positional embedding table.
   use_alternate_vl_dit: true  # Alternate cross-attention over non-image vs image VLM tokens, matching upstream GR00T N1.6.
   attend_text_every_n_blocks: 2  # AlternateVLDiT schedule.
 
@@ -28,7 +29,7 @@ algorithm:
   # Fine-tuning component control (mirrors Isaac-GR00T tune_* flags)
   finetune_state_action_projector: true  # Train action head projector MLPs (proprio, action enc/dec, connector)
   finetune_action_expert: true           # Train DiT action head
-  finetune_vision_encoder: false         # Unfreeze visual encoder — only if visual domain differs significantly
+  finetune_vision_encoder: true          # Unfreeze visual encoder — only if visual domain differs significantly
   finetune_top_llm_layer: 0             # Unfreeze top N LLM layers (0 = fully frozen, NVIDIA uses 4 in N1.6 pretraining)
 
   # Flow matching time sampling (Beta distribution parameters)
@@ -41,13 +42,15 @@ algorithm:
   gradient_checkpointing: true  # Saves VRAM (~30% extra compute). Enable if OOM during training.
   use_torch_compile: false       # JIT-compile the DiT (PyTorch 2.0+). One-time compile overhead on first step.
   torch_compile_mode: "default"  # "max-autotune" for inference deployments; "default" is safe for training.
-  load_backbone_bf16: true      # Cast VLM backbone to bf16 (~halves memory). Trainable VLM modules (vision encoder, top LLM layers) also train in bf16.
+  load_backbone_bf16: false     # Cast VLM backbone to bf16 (~halves memory). Trainable VLM modules (vision encoder, top LLM layers) also train in bf16.
 
   # State augmentation (regularization, both default off)
   state_dropout_prob: 0.0   # Replace proprio token with learned mask token at this rate.
   state_noise_scale: 0.0    # Std of Gaussian noise added to proprio embedding during training.
 
   # Architecture hyperparameters (used when use_pretrained_weights is false)
+  use_pretrained_weights: true  # Load pretrained GR00T weights; false builds the model from the hyperparameters below.
+  use_tiny_vlm: false           # Use a tiny VLM backbone (testing only).
   num_dit_layers: 32
   num_attention_heads: 32
   attention_head_dim: 48

--- a/neuracore/ml/config/algorithm/pi0.yaml
+++ b/neuracore/ml/config/algorithm/pi0.yaml
@@ -39,7 +39,7 @@ algorithm:
 
   # Fine-tuning control
   finetune_action_expert_only: False   # Only train action expert parameters
-  freeze_language_model_only: True     # Freeze language model, train vision + action
+  freeze_language_model_only: False    # Freeze language model, train vision + action
 
   # Training speed / memory optimizations
   gradient_checkpointing: True         # Saves VRAM (~30% extra compute). Enable if OOM during training.

--- a/neuracore/ml/config/algorithm/pi05.yaml
+++ b/neuracore/ml/config/algorithm/pi05.yaml
@@ -40,7 +40,7 @@ algorithm:
 
   # Fine-tuning control
   finetune_action_expert_only: False                  # Only train action expert parameters
-  finetune_vision_encoder_and_action_expert: True     # Train vision encoder and action expert
+  finetune_vision_encoder_and_action_expert: False    # Train vision encoder and action expert
 
   # Training speed / memory optimizations
   gradient_checkpointing: True         # Saves VRAM (~30% extra compute). Enable if OOM during training.

--- a/tests/unit/ml/algorithms/test_config_sync.py
+++ b/tests/unit/ml/algorithms/test_config_sync.py
@@ -1,0 +1,92 @@
+"""Guard that each algorithm hydra config matches its model ``__init__`` defaults.
+
+The ``__init__`` signature is the single source of truth for algorithm
+hyperparameters; the ``config/algorithm/*.yaml`` files are an override layer that
+``hydra.utils.instantiate`` passes as kwargs. This test fails if the two drift.
+"""
+
+import inspect
+import math
+from pathlib import Path
+
+import hydra
+import pytest
+from omegaconf import OmegaConf
+
+import neuracore.ml as nc_ml
+
+CONFIG_DIR = Path(nc_ml.__file__).parent / "config" / "algorithm"
+
+CONFIG_FILES = sorted(CONFIG_DIR.glob("*.yaml"))
+
+
+def _load_algorithm_block(path: Path) -> dict:
+    """Return the ``algorithm:`` mapping from a hydra config yaml.
+
+    Loaded via OmegaConf so values parse exactly as ``hydra.utils.instantiate``
+    sees them (e.g. ``1e-4`` is a float, not a string).
+    """
+    cfg = OmegaConf.load(path)
+    block = OmegaConf.to_container(cfg.algorithm, resolve=True)
+    assert isinstance(block, dict)
+    return block
+
+
+def _init_defaults(cls: type) -> dict:
+    """Return ``{param: default}`` for every defaulted ``__init__`` param."""
+    signature = inspect.signature(cls.__init__)
+    return {
+        name: param.default
+        for name, param in signature.parameters.items()
+        if param.default is not inspect.Parameter.empty
+    }
+
+
+def _values_equal(yaml_value: object, default_value: object) -> bool:
+    """Compare a yaml value with an ``__init__`` default, tolerant of list/tuple
+    and float representation differences."""
+    if isinstance(default_value, (list, tuple)) or isinstance(
+        yaml_value, (list, tuple)
+    ):
+        yaml_seq = list(yaml_value)  # type: ignore[arg-type]
+        default_seq = list(default_value)  # type: ignore[arg-type]
+        if len(yaml_seq) != len(default_seq):
+            return False
+        return all(_values_equal(y, d) for y, d in zip(yaml_seq, default_seq))
+    if isinstance(default_value, bool) or isinstance(yaml_value, bool):
+        return yaml_value == default_value
+    if isinstance(default_value, (int, float)) and isinstance(yaml_value, (int, float)):
+        return math.isclose(yaml_value, default_value, rel_tol=1e-9, abs_tol=0.0)
+    return yaml_value == default_value
+
+
+@pytest.mark.parametrize("config_path", CONFIG_FILES, ids=lambda p: p.stem)
+def test_config_hydra_yaml_values_match_init_defaults(config_path: Path) -> None:
+    """Every yaml key matches its ``__init__`` default, and every defaulted
+    ``__init__`` param is present in the yaml."""
+    algorithm = _load_algorithm_block(config_path)
+    target = algorithm["_target_"]
+    cls = hydra.utils.get_object(target)
+    defaults = _init_defaults(cls)
+
+    yaml_keys = {key for key in algorithm if key != "_target_"}
+
+    unknown = yaml_keys - defaults.keys()
+    assert (
+        not unknown
+    ), f"{config_path.name}: keys not in {cls.__name__}.__init__: {sorted(unknown)}"
+
+    missing = defaults.keys() - yaml_keys
+    assert (
+        not missing
+    ), f"{config_path.name}: __init__ params absent from yaml: {sorted(missing)}"
+
+    mismatched = {
+        key: (algorithm[key], defaults[key])
+        for key in yaml_keys
+        if not _values_equal(algorithm[key], defaults[key])
+    }
+    assert not mismatched, (
+        f"{config_path.name}: yaml values differ from {cls.__name__}.__init__ "
+        f"defaults (yaml, default): {mismatched}"
+    )


### PR DESCRIPTION
### Bugfixes
- The training configuration files for each algorithm had drifted from the model code. The values a model uses when run through Hydra come from these config files, and several no longer matched the defaults written in the model classes. This change makes every config file agree with its model, so the settings are consistent in both places.
- Corrected values that disagreed: Diffusion Policy (`weight_decay`, `optimizer_betas`), GR00T (`finetune_vision_encoder`, `load_backbone_bf16`, `use_relative_deltas`), Pi0 (`freeze_language_model_only`), Pi05 (`finetune_vision_encoder_and_action_expert`). These adjust how the affected models train.
- Added settings missing from the config files (they previously fell back to code defaults): ACT and Diffusion Policy (`use_resnet_stats`), Diffusion Policy (`lr_scheduler_type`, `lr_scheduler_num_warmup_steps`), GR00T (`use_pretrained_weights`, `use_tiny_vlm`, `max_action_pos_embeddings`).
- Added a test that checks every config file matches its model's defaults, so this drift cannot recur unnoticed.
