### PR TITLE
refactor: convert notebook `#@markdown` form blocks to markdown cells

### DIFF
--- a/examples/getting_started_with_neuracore.ipynb
+++ b/examples/getting_started_with_neuracore.ipynb
@@ -38,20 +38,24 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Installing dependencies**\n",
+        "- Neuracore from PyPI\n",
+        "- Bigym from GitHub\n",
+        "\n",
+        "This may take a few minutes."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "id": "u6iKnwYaBWsG"
       },
       "outputs": [],
       "source": [
-        "#@markdown ## **Installing dependencies**\n",
-        "#@markdown - Neuracore from PyPI\n",
-        "#@markdown - Bigym from GitHub\n",
-        "#@markdown\n",
-        "#@markdown This may take a few minutes.\n",
-        "\n",
         "# Installing neuracore\n",
         "!pip install \"neuracore[ml,mjcf]==11.0.0\" > /dev/null 2>&1\n",
         "\n",
@@ -62,41 +66,42 @@
         "\n",
         "# Installing bigym --- Commit at the time of creation: 79420b0abad6fa7d7dfd98569cb485f73a2c8e3b\n",
         "!git clone https://github.com/NeuracoreAI/bigym.git /content/bigym > /dev/null 2>&1\n",
-        "!pip install -e /content/bigym > /dev/null 2>&1"
+        "!pip install -e /content/bigym > /dev/null 2>&1\n"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {
-        "cellView": "form",
         "id": "43IrqfxO2ip1"
       },
-      "outputs": [],
       "source": [
-        "# @markdown ## ⚠️ **Restart runtime session**\n",
-        "# @markdown After installing dependencies, restart your runtime session via **Runtime** > **Restart session** (CTRL+M .)."
+        "## ⚠️ **Restart runtime session**\n",
+        "After installing dependencies, restart your runtime session via **Runtime** > **Restart session** (CTRL+M .)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Imports**\n",
+        "Run this cell to import packages.\n",
+        "\n",
+        "Make you sure you \"Restart runtime session\" after pip installing everything above. See cell above or press \"CTRL+M .\"\n",
+        "\n",
+        "**Troubleshooting**:\n",
+        "\n",
+        "- If you get `ModuleNotFoundError: No module named 'numpy.rec'`, restart your runtime session."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "collapsed": true,
         "id": "OlAX7IhiBWsH"
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Imports**\n",
-        "# @markdown Run this cell to import packages.\n",
-        "# @markdown\n",
-        "# @markdown Make you sure you \"Restart runtime session\" after pip installing everything above. See cell above or press \"CTRL+M .\"\n",
-        "# @markdown\n",
-        "# @markdown **Troubleshooting**:\n",
-        "# @markdown\n",
-        "# @markdown - If you get `ModuleNotFoundError: No module named 'numpy.rec'`, restart your runtime session.\n",
-        "\n",
         "import os\n",
         "# Headless OpenGL for Colab (no display server)\n",
         "os.environ[\"MUJOCO_GL\"] = \"egl\"\n",
@@ -112,22 +117,26 @@
         "import bigym\n",
         "from demonstrations.demo import Demo\n",
         "from demonstrations.demo_store import DemoStore\n",
-        "from demonstrations.utils import Metadata"
+        "from demonstrations.utils import Metadata\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Configuration and utils**\n",
+        "Run this cell to load Bigym helpers (joint names, observation converters, headless make_env)."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "collapsed": true,
         "id": "rJ8kUIi7BWsH"
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Configuration and utils**\n",
-        "# @markdown Run this cell to load Bigym helpers (joint names, observation converters, headless make_env).\n",
-        "\n",
         "# Bigym env config\n",
         "from bigym.action_modes import JointPositionActionMode\n",
         "from bigym.envs.reach_target import ReachTarget\n",
@@ -234,24 +243,28 @@
         "        ),\n",
         "        control_frequency=FREQUENCY,\n",
         "        render_mode=\"rgb_array\",\n",
-        "    )"
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Download Bigym demonstrations**\n",
+        "This cell only downloads the **Bigym demonstration data** for the **ReachTarget** Bigym environment.\n",
+        "\n",
+        "We use a **small subset** of the original Bigym demos (ReachTarget env only) for the sake of running this Notebook quickly."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "collapsed": true,
         "id": "KpT8FnTTYNTK"
       },
       "outputs": [],
       "source": [
-        "#@markdown ## **Download Bigym demonstrations**\n",
-        "#@markdown This cell only downloads the **Bigym demonstration data** for the **ReachTarget** Bigym environment.\n",
-        "#@markdown\n",
-        "#@markdown We use a **small subset** of the original Bigym demos (ReachTarget env only) for the sake of running this Notebook quickly.\n",
-        "\n",
         "demo_store = DemoStore()\n",
         "\n",
         "# Override cache path so we can use e.g. Google Drive. Mount Drive first if using /content/drive/MyDrive/.\n",
@@ -272,7 +285,16 @@
         "        zf.extractall(demo_store._cache_path.parent)\n",
         "    subset_zip_path.unlink(missing_ok=True)\n",
         "    demo_store.cached = True\n",
-        "    print(\"ReachTarget demos ready.\")"
+        "    print(\"ReachTarget demos ready.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Utility function to run one episode**\n",
+        "Function to run a single episode on the ReachTarget Bigym environment by replaying expert actions and log the data to Neuracore.\n",
+        "Pass a `policy` to run inference instead of replaying the expert actions."
       ]
     },
     {
@@ -283,10 +305,6 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Utility function to run one episode**\n",
-        "# @markdown Function to run a single episode on the ReachTarget Bigym environment by replaying expert actions and log the data to Neuracore.\n",
-        "# @markdown Pass a `policy` to run inference instead of replaying the expert actions.\n",
-        "\n",
         "def run_episode(\n",
         "    episode_idx: int,\n",
         "    env,\n",
@@ -408,7 +426,16 @@
         "        .numpy()\n",
         "    )\n",
         "\n",
-        "    return batched[0]  # shape: (horizon, num_joints)"
+        "    return batched[0]  # shape: (horizon, num_joints)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Step 1: Login to Neuracore**\n",
+        "Login to Neuracore to record data.\n",
+        "If you don't have an account, sign up for free at [neuracore.com](https://neuracore.com) before logging in."
       ]
     },
     {
@@ -420,16 +447,25 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Step 1: Login to Neuracore**\n",
-        "# @markdown Login to Neuracore to record data.\n",
-        "# @markdown If you don't have an account, sign up for free at [neuracore.com](https://neuracore.com) before logging in.\n",
-        "\n",
         "# The first time, this will prompt you to type in email and password for your account.\n",
         "# You can safely repeat this command multiple times to make sure you're logged in.\n",
         "nc.login()\n",
         "\n",
         "# Alternatively, from CLI\n",
-        "# !neuracore login"
+        "# !neuracore login\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Step 2: Connect a robot to Neuracore**\n",
+        "This step registers the H1 robot using a MuJoCo .xml configuration with your Neuracore account. Run this cell.\n",
+        "\n",
+        "**After running:** Open your Neuracore dashboard by logging into [Neuracore](https://www.neuracore.com/). Shortly after running this cell, the robot will appear among **Connected Robots** on the \"**Overview**\" page of your dashboard. You can view all registered robots on the \"**Robots**\" page.\n",
+        "\n",
+        "<br/>\n",
+        "<img src=\"https://drive.google.com/uc?id=1BLgdA_Xe0BVh5YrDgaSmM7Dh-A5DyTMc\" width=\"800\" />"
       ]
     },
     {
@@ -441,14 +477,6 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Step 2: Connect a robot to Neuracore**\n",
-        "# @markdown This step registers the H1 robot using a MuJoCo .xml configuration with your Neuracore account. Run this cell.\n",
-        "# @markdown\n",
-        "# @markdown **After running:** Open your Neuracore dashboard by logging into [Neuracore](https://www.neuracore.com/). Shortly after running this cell, the robot will appear among **Connected Robots** on the \"**Overview**\" page of your dashboard. You can view all registered robots on the \"**Robots**\" page.\n",
-        "# @markdown\n",
-        "# @markdown <br/>\n",
-        "# @markdown <img src=\"https://drive.google.com/uc?id=1BLgdA_Xe0BVh5YrDgaSmM7Dh-A5DyTMc\" width=\"800\" />\n",
-        "\n",
         "# Path to URDF or MJFC model format\n",
         "BIGYM_ROOT = \"/content/bigym\"\n",
         "mjcf_path = Path(BIGYM_ROOT) / \"bigym\" / \"envs\" / \"xmls\" / \"h1\" / \"h1.xml\"\n",
@@ -467,7 +495,29 @@
         "\"\"\"\n",
         "\n",
         "print(f\"Connected to robot: {robot.id}\")\n",
-        "print(f\"Organisation ID: {nc.get_current_org()}\")"
+        "print(f\"Organisation ID: {nc.get_current_org()}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Step 3: Monitor your robot in real time with `nc.log`**\n",
+        "\n",
+        "Once connected, **all data logs** collected via e.g., `nc.log_joint_positions(...)`,  are\n",
+        "automatically streamed to the web dashboard\n",
+        "**for real-time visualization and monitoring.**\n",
+        "\n",
+        "**Instructions:**\n",
+        "1. **Run this cell** to start 10 simulation episodes in loop\n",
+        "2. **Open the \"Robots\" page** on the web dashboard.\n",
+        "3. **Click on the active robot** named \"Mujoco UnitreeH1 Example\".\n",
+        "4. **Monitor your robot in real time**.\n",
+        "\n",
+        "NOTE: the streamed data is not being saved and is not persistent.\n",
+        "To start recording data, move to the next step.\n",
+        "\n",
+        "<img src=\"https://drive.google.com/uc?id=1K-5Eoo0Rxp8vCI5wGYK6fdYgwFuHkoAh\" width=\"800\" />"
       ]
     },
     {
@@ -478,23 +528,6 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Step 3: Monitor your robot in real time with `nc.log`**\n",
-        "# @markdown\n",
-        "# @markdown Once connected, **all data logs** collected via e.g., `nc.log_joint_positions(...)`,  are\n",
-        "# @markdown automatically streamed to the web dashboard\n",
-        "# @markdown **for real-time visualization and monitoring.**\n",
-        "# @markdown\n",
-        "# @markdown **Instructions:**\n",
-        "# @markdown 1. **Run this cell** to start 10 simulation episodes in loop\n",
-        "# @markdown 2. **Open the \"Robots\" page** on the web dashboard.\n",
-        "# @markdown 3. **Click on the active robot** named \"Mujoco UnitreeH1 Example\".\n",
-        "# @markdown 4. **Monitor your robot in real time**.\n",
-        "# @markdown\n",
-        "# @markdown NOTE: the streamed data is not being saved and is not persistent.\n",
-        "# @markdown To start recording data, move to the next step.\n",
-        "# @markdown\n",
-        "# @markdown <img src=\"https://drive.google.com/uc?id=1K-5Eoo0Rxp8vCI5wGYK6fdYgwFuHkoAh\" width=\"800\" />\n",
-        "\n",
         "# Create \"ReachTarget\" Bigym environment\n",
         "# Task: Reach the target with either left or right wrist.\n",
         "env = make_env()\n",
@@ -510,7 +543,21 @@
         "        episode_idx=episode_idx,\n",
         "        env=env,\n",
         "        demo=demos[episode_idx]\n",
-        "    )"
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Step 4: Create a dataset**\n",
+        "Create a new dataset in Neuracore that will hold your recorded robot data. Run this cell.\n",
+        "\n",
+        "**After running:** In the dashboard, go to the \"**Data**\" page. You will see the new dataset listed. The dataset is currently empty and has no recordings in it.\n",
+        "Move to the next step to start populating the dataset with robot data.\n",
+        "\n",
+        "<br/>\n",
+        "<img src=\"https://drive.google.com/uc?id=19ZFiKluk_aR4a1r_98BNVGWL_biMbg4Z\" width=\"800\" />"
       ]
     },
     {
@@ -521,22 +568,29 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Step 4: Create a dataset**\n",
-        "# @markdown Create a new dataset in Neuracore that will hold your recorded robot data. Run this cell.\n",
-        "# @markdown\n",
-        "# @markdown **After running:** In the dashboard, go to the \"**Data**\" page. You will see the new dataset listed. The dataset is currently empty and has no recordings in it.\n",
-        "# @markdown Move to the next step to start populating the dataset with robot data.\n",
-        "# @markdown\n",
-        "# @markdown <br/>\n",
-        "# @markdown <img src=\"https://drive.google.com/uc?id=19ZFiKluk_aR4a1r_98BNVGWL_biMbg4Z\" width=\"800\" />\n",
-        "\n",
         "DATASET_NAME = \"Getting started Bigym Example\"\n",
         "\n",
         "nc.create_dataset(\n",
         "    name=DATASET_NAME,\n",
         "    description=\"Data collection on the Bigym simulation environments\",\n",
         ")\n",
-        "print(\"Dataset created.\")"
+        "print(\"Dataset created.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **Step 5: Run simulation episodes and record data**\n",
+        "This step records and uploads 3 episodes of the ReachTarget environment to Neuracore.\n",
+        "We use Bigym to retrieve and replay expert demonstrations for this task; at each step of the episode, we log joint positions, velocities, camera images, and joint targets to Neuracore.\n",
+        "\n",
+        "**After running:** In the dataset page in your Neuracore dashboard, you will now see an item with a randomly-generated name under the \"**Recordings**\" section.\n",
+        "\n",
+        "NOTE: Recording and uploading each episode can take a minute in Google Colab.\n",
+        "\n",
+        "<br/>\n",
+        "<img src=\"https://drive.google.com/uc?id=1gGlvzFyvE8oV8dwNOOJg1Lc66zmKwvLn\" width=\"800\" />"
       ]
     },
     {
@@ -547,17 +601,6 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **Step 5: Run simulation episodes and record data**\n",
-        "# @markdown This step records and uploads 3 episodes of the ReachTarget environment to Neuracore.\n",
-        "# @markdown We use Bigym to retrieve and replay expert demonstrations for this task; at each step of the episode, we log joint positions, velocities, camera images, and joint targets to Neuracore.\n",
-        "# @markdown\n",
-        "# @markdown **After running:** In the dataset page in your Neuracore dashboard, you will now see an item with a randomly-generated name under the \"**Recordings**\" section.\n",
-        "# @markdown\n",
-        "# @markdown NOTE: Recording and uploading each episode can take a minute in Google Colab.\n",
-        "# @markdown\n",
-        "# @markdown <br/>\n",
-        "# @markdown <img src=\"https://drive.google.com/uc?id=1gGlvzFyvE8oV8dwNOOJg1Lc66zmKwvLn\" width=\"800\" />\n",
-        "\n",
         "# For Google Colab only: pre-warm the data collection daemon with a long timeout before recording\n",
         "from neuracore.data_daemon.lifecycle.daemon_os_control import ensure_daemon_running\n",
         "ensure_daemon_running(timeout_s=30)\n",
@@ -577,25 +620,23 @@
         "except KeyboardInterrupt:\n",
         "    print(\"\\nInterrupted by user.\")\n",
         "    if RECORD:\n",
-        "        nc.cancel_recording()"
+        "        nc.cancel_recording()\n"
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {
         "id": "rqB_Zh4Qbcaa"
       },
-      "outputs": [],
       "source": [
-        "#@markdown ## **Step 6: Visualize collected data**\n",
-        "#@markdown On the \"**Data**\" page of your Neuracore dashboard, click on the latest recording to open the **data visualizer**.\n",
-        "#@markdown\n",
-        "#@markdown Here, you can replay the episode and view the URDF animation, the RGB images, and the joint recordings.\n",
-        "#@markdown\n",
-        "#@markdown <br/>\n",
-        "#@markdown\n",
-        "#@markdown <img src=\"https://drive.google.com/uc?id=1yi_PaH33mZzNO_UrH0cnBduUaLlV9rgo\" width=\"800\" />"
+        "## **Step 6: Visualize collected data**\n",
+        "On the \"**Data**\" page of your Neuracore dashboard, click on the latest recording to open the **data visualizer**.\n",
+        "\n",
+        "Here, you can replay the episode and view the URDF animation, the RGB images, and the joint recordings.\n",
+        "\n",
+        "<br/>\n",
+        "\n",
+        "<img src=\"https://drive.google.com/uc?id=1yi_PaH33mZzNO_UrH0cnBduUaLlV9rgo\" width=\"800\" />"
       ]
     },
     {
@@ -636,6 +677,22 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### **Try it yourself: train a policy on the cloud** ☁️\n",
+        "Every account comes with **10 free credits / month** (=10 hours of cloud training on a NVIDIA T4 GPU).\n",
+        "\n",
+        "Use these credits to launch your very first training on the previously collected dataset by running this cell.\n",
+        "\n",
+        "**After running:** visit the \"**Training**\" page in your Neuracore dashboard, you will now see your first active training job named *\"Bigym example\"*.\n",
+        "Click on it to view training metrics, logs, plots, and hyperparameters — as shown below.\n",
+        "\n",
+        "<br/>\n",
+        "<img src=\"https://drive.google.com/uc?id=15EH9VkLl_Jzg5sIwpb3xHWEkPmepjsJ0\" width=\"800\" />"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -644,17 +701,6 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown ### **Try it yourself: train a policy on the cloud** ☁️\n",
-        "# @markdown Every account comes with **10 free credits / month** (=10 hours of cloud training on a NVIDIA T4 GPU).\n",
-        "# @markdown\n",
-        "# @markdown Use these credits to launch your very first training on the previously collected dataset by running this cell.\n",
-        "# @markdown\n",
-        "# @markdown **After running:** visit the \"**Training**\" page in your Neuracore dashboard, you will now see your first active training job named *\"Bigym example\"*.\n",
-        "# @markdown Click on it to view training metrics, logs, plots, and hyperparameters — as shown below.\n",
-        "# @markdown\n",
-        "# @markdown <br/>\n",
-        "# @markdown <img src=\"https://drive.google.com/uc?id=15EH9VkLl_Jzg5sIwpb3xHWEkPmepjsJ0\" width=\"800\" />\n",
-        "\n",
         "from neuracore_types import CrossEmbodimentDescription\n",
         "\n",
         "dataset = nc.get_dataset(DATASET_NAME)\n",
@@ -693,7 +739,7 @@
         "    algorithm_config={\"batch_size\": \"auto\", \"epochs\": 5, \"output_prediction_horizon\": 10}\n",
         ")\n",
         "\n",
-        "print(f'Training job \"{JOBNAME}\" launched')"
+        "print(f'Training job \"{JOBNAME}\" launched')\n"
       ]
     },
     {
@@ -750,17 +796,22 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### **Try it yourself: deploy your first policy locally**\n",
+        "This cell shows how to load a trained Neuracore model and run it directly in the Bigym `ReachTarget` environment.\n",
+        "**Run this cell** to test your policy, or load a publicly available pre-trained model with `USE_PRETRAINED_MODEL = True`.\n",
+        "\n",
+        "**After running:** the rollout will be recorded to Neuracore so you can inspect it in the dashboard in the newly created `DATASET_NAME+\"_Inference\"` Dataset."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
-        "# @markdown ### **Try it yourself: deploy your first policy locally**\n",
-        "# @markdown This cell shows how to load a trained Neuracore model and run it directly in the Bigym `ReachTarget` environment.\n",
-        "# @markdown **Run this cell** to test your policy, or load a publicly available pre-trained model with `USE_PRETRAINED_MODEL = True`.\n",
-        "# @markdown\n",
-        "# @markdown **After running:** the rollout will be recorded to Neuracore so you can inspect it in the dashboard in the newly created `DATASET_NAME+\"_Inference\"` Dataset.\n",
-        "\n",
         "from neuracore_types import EmbodimentDescription\n",
         "\n",
         "# For Google Colab only: pre-warm the data collection daemon with a long timeout before recording\n",
@@ -835,24 +886,28 @@
         "        nc.cancel_recording()\n",
         "finally:\n",
         "    print(f\"\\nFinished running {NUM_EPISODES} episodes → {success_count} succeeded.\")\n",
-        "    policy.disconnect()"
+        "    policy.disconnect()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## **[Extra] Retrieve a dataset from Neuracore cloud to a local client**\n",
+        "You can pull data from Neuracore using `nc.get_dataset(\"my dataset\")`.\n",
+        "\n",
+        "Run this cell to retrieve the previously recorded dataset \"Getting started Bigym Example\" into this notebook client.\n",
+        "You can then visualize the data locally, or train your models with it."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "id": "9iQtoqmzpYLM"
       },
       "outputs": [],
       "source": [
-        "# @markdown ## **[Extra] Retrieve a dataset from Neuracore cloud to a local client**\n",
-        "# @markdown You can pull data from Neuracore using `nc.get_dataset(\"my dataset\")`.\n",
-        "# @markdown\n",
-        "# @markdown Run this cell to retrieve the previously recorded dataset \"Getting started Bigym Example\" into this notebook client.\n",
-        "# @markdown You can then visualize the data locally, or train your models with it.\n",
-        "\n",
         "from neuracore_types import CrossEmbodimentUnion, DataType\n",
         "import imageio\n",
         "from IPython.display import Video, display\n",
@@ -883,7 +938,7 @@
         "video_path = \"/tmp/first_episode.mp4\"\n",
         "imageio.mimsave(video_path, frames, fps=FREQUENCY)\n",
         "print(\"First episode video (head camera):\")\n",
-        "display(Video(video_path, embed=True, width=420))"
+        "display(Video(video_path, embed=True, width=420))\n"
       ]
     }
   ],


### PR DESCRIPTION
### Bugfixes
- Convert the getting-started notebook's Colab-specific markdown form blocks into standard markdown cells, 