### PR TITLE
fix: gate hard tests from the legacy daemon

### DIFF
--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 import pytest
 
+from neuracore.data_daemon.rust_selection import rust_daemon_enabled
 from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
 )
@@ -53,6 +54,20 @@ def skip_marked_cases(request: pytest.FixtureRequest) -> None:
     case = request.getfixturevalue("case")
     if getattr(case, "skip", False):
         pytest.skip("case marked skip=True")
+
+
+@pytest.fixture(autouse=True)
+def skip_rust_only_cases(request: pytest.FixtureRequest) -> None:
+    """Skip cases flagged ``requires_rust_daemon`` on the legacy Python daemon.
+
+    Gating them on the active daemon keeps them running under Rust while restoring the
+    Python suite to its green baseline.
+    """
+    if "case" not in request.fixturenames:
+        return
+    case = request.getfixturevalue("case")
+    if getattr(case, "requires_rust_daemon", False) and not rust_daemon_enabled():
+        pytest.skip("case requires the Rust data daemon (NCD_RUST_DAEMON)")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -76,6 +76,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_channels=PRODUCER_PER_THREAD,
         timestamp_mode=TIMESTAMP_MODE_REAL,
         wait=False,
+        requires_rust_daemon=True,
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -88,6 +89,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_channels=PRODUCER_PER_THREAD,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
         wait=False,
+        requires_rust_daemon=True,
     ),
 )
 

--- a/tests/integration/platform/data_daemon/performance/test_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_network.py
@@ -39,6 +39,7 @@ CASES = DataDaemonTestBatch(
     cases=NETWORK_PERFORMANCE_CASES,
     storage_state_action=STORAGE_STATE_DELETE,
     stop_method=STOP_METHOD_CLI,
+    requires_rust_daemon=True,
 ).as_cases()
 
 

--- a/tests/integration/platform/data_daemon/performance/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_pre_network.py
@@ -29,10 +29,13 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
     scoped_storage_state,
 )
 
+# Performance workloads target the Rust daemon's throughput ceiling; the legacy
+# Python daemon cannot sustain them, so the whole suite is Rust-only.
 _CASES = DataDaemonTestBatch(
     cases=PRE_NETWORK_PERFORMANCE_CASES,
     storage_state_action=STORAGE_STATE_DELETE,
     stop_method=STOP_METHOD_CLI,
+    requires_rust_daemon=True,
 ).as_cases()
 
 

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -156,6 +156,12 @@ class DataDaemonTestCase:
             in the suite (documented and discoverable) without running.  A
             batch with ``skip=True`` forces every case to skip regardless of
             this per-case value.
+        requires_rust_daemon: When ``True``, the case only runs against the
+            Rust data daemon and is skipped when the legacy Python daemon is
+            active (``NCD_RUST_DAEMON`` unset).  High-contention, high-rate, and
+            long-running workloads that the Python daemon cannot sustain use
+            this flag so they still exercise the Rust daemon in CI without
+            failing the legacy suite.
 
     Note:
         ``mode="staggered"`` and ``context_duration_mode="variable"``:
@@ -184,6 +190,7 @@ class DataDaemonTestCase:
     video_fps: int = 60
     timestamp_mode: TimestampMode = TIMESTAMP_MODE_MANUAL
     skip: bool = False
+    requires_rust_daemon: bool = False
 
     @property
     def has_video(self) -> bool:
@@ -235,6 +242,10 @@ class DataDaemonTestBatch:
         skip: When ``True``, every case in the batch is skipped at collection
             time.  When ``False`` (default), each case keeps its own per-case
             ``skip`` value, so individual cases can still opt out.
+        requires_rust_daemon: When ``True``, every case in the batch runs only
+            against the Rust data daemon and is skipped on the legacy Python
+            daemon.  When ``False`` (default), each case keeps its own per-case
+            ``requires_rust_daemon`` value.
     """
 
     cases: tuple[DataDaemonTestCase, ...]
@@ -244,6 +255,7 @@ class DataDaemonTestBatch:
     stop_method: StopMethod = STOP_METHOD_CLI
     timestamp_mode: TimestampMode | None = None
     skip: bool = False
+    requires_rust_daemon: bool = False
 
     def as_cases(self) -> list[DataDaemonTestCase]:
         """Return cases with batch-level infrastructure params applied."""
@@ -257,6 +269,8 @@ class DataDaemonTestBatch:
             batch_overrides["timestamp_mode"] = self.timestamp_mode
         if self.skip:
             batch_overrides["skip"] = True
+        if self.requires_rust_daemon:
+            batch_overrides["requires_rust_daemon"] = True
         return [
             DataDaemonTestCase(**{
                 **{


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Gates the intergration tests for the python deamon so it runs the same cases as before and only the rust deamon runs the new cases 


#### Runs 

 - A fresh run on this branch with the reduced set: https://github.com/NeuracoreAI/neuracore/actions/runs/28506434303
 

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1071](https://neuracore.atlassian.net/browse/NCP-1071)
