### PR TITLE
chore: start algorithm eval test earlier

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
@@ -2,7 +2,7 @@ name: Integration ML - Algorithm Performance Evaluate (Production)
 
 on:
   schedule:
-    - cron: "0 8 * * *"  # 8 hours after training starts; training cap is 6 hours
+    - cron: "0 4 * * *"  # 4 hours after training starts
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -2,7 +2,7 @@ name: Integration ML - Algorithm Performance Evaluate (Staging)
 
 on:
   schedule:
-    - cron: "0 8 * * *"  # 8 hours after training starts; training cap is 6 hours
+    - cron: "0 4 * * *"  # 4 hours after training starts
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Features
- Update algorithm eval test to run 4 hours after training starts