### PR TITLE
test: skip connect robot in algorithm eval

### DIFF
--- a/tests/integration/ml/test_algorithm_performance.py
+++ b/tests/integration/ml/test_algorithm_performance.py
@@ -269,7 +269,6 @@ class TestAlgorithmPerformance:
                     f"{endpoint_status}"
                 )
 
-            nc.connect_robot("Mujoco VX300s")
             policy = nc.policy_remote_server(endpoint_name)
             env = make_sim_env(seed=42)
             success_rate = eval_model(


### PR DESCRIPTION
### Bugfixes
- Skip connecting to robot in algorithm eval since we pass in sync points directly
