### PR TITLE
feat: Add nightly deleted dataset resume workflows

### DIFF
--- a/.github/workflows/integration-ml-deleted-dataset-resume-prod.yaml
+++ b/.github/workflows/integration-ml-deleted-dataset-resume-prod.yaml
@@ -1,0 +1,98 @@
+name: Integration ML - Deleted Dataset Resume (Production)
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # 7. test_deleted_dataset_on_resume_training.py
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Checkout repository metadata
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve latest release tag
+        id: release-tag
+        run: |
+          latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          if [ -z "$latest_release_tag" ]; then
+            echo "::error::No release tag matching v* found"
+            exit 1
+          fi
+          echo "latest_release_tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: $latest_release_tag"
+
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-tag.outputs.latest_release_tag }}
+          fetch-depth: 0
+
+      - name: Pull LFS objects
+        run: git lfs pull
+
+      - name: Verify production test harness ref
+        run: |
+          checked_out_ref="$(git describe --tags --exact-match HEAD)"
+          expected_ref="${{ steps.release-tag.outputs.latest_release_tag }}"
+          if [ "$checked_out_ref" != "$expected_ref" ]; then
+            echo "::error::Expected production test harness ref $expected_ref, got $checked_out_ref"
+            exit 1
+          fi
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --no-cache-dir --upgrade pip
+          VERSION="${{ steps.release-tag.outputs.latest_release_tag }}"
+          pip install --no-cache-dir "neuracore[dev,ml,examples]==${VERSION#v}"
+
+      - name: Resolve test harness
+        run: |
+          echo "Test harness environment: production"
+          echo "Test harness ref: ${{ steps.release-tag.outputs.latest_release_tag }}"
+          echo "Test harness commit: $(git rev-parse HEAD)"
+          echo "Test harness path: tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted"
+          python - << 'EOF'
+          import neuracore
+
+          print(f"Installed neuracore version: {neuracore.__version__}")
+          EOF
+
+      - name: Run Integration Test
+        env:
+          NEURACORE_API_URL: https://api.neuracore.com/api
+          NEURACORE_API_KEY: ${{ secrets.PROD_SERVICE_API_KEY }}
+          NEURACORE_ORG_ID: ${{ vars.PROD_SERVICE_ORG_ID }}
+          NEURACORE_ENDPOINT_TIMEOUT: 30
+          DISPLAY: :0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+          Xvfb $DISPLAY -screen 0 1280x1024x24 &
+          pytest \
+            -o log_cli=true \
+            --log-cli-level=INFO \
+            --log-cli-format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s" \
+            --log-cli-date-format="%H:%M:%S" \
+            -v \
+            tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted

--- a/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
+++ b/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
@@ -1,0 +1,72 @@
+name: Integration ML - Deleted Dataset Resume (Staging)
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # 7. test_deleted_dataset_on_resume_training.py
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Pull LFS objects
+        run: git lfs pull
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --no-cache-dir --upgrade pip
+          pip install --no-cache-dir ".[dev,ml,examples]"
+
+      - name: Resolve test harness
+        run: |
+          echo "Test harness environment: staging"
+          echo "Test harness ref: ${{ github.ref_name }}"
+          echo "Test harness commit: $(git rev-parse HEAD)"
+          echo "Test harness path: tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted"
+          python - << 'EOF'
+          import neuracore
+
+          print(f"Installed neuracore version: {neuracore.__version__}")
+          EOF
+
+      - name: Run Integration Test
+        env:
+          NEURACORE_API_URL: https://staging.api.neuracore.com/api
+          NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
+          NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
+          NEURACORE_ENDPOINT_TIMEOUT: 30
+          DISPLAY: :0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+          Xvfb $DISPLAY -screen 0 1280x1024x24 &
+          pytest \
+            -o log_cli=true \
+            --log-cli-level=INFO \
+            --log-cli-format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s" \
+            --log-cli-date-format="%H:%M:%S" \
+            -v \
+            tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted


### PR DESCRIPTION

Adds dedicated nightly GitHub Actions coverage for `test_resume_fails_when_training_dataset_has_been_deleted` in both staging and production.