### PR TITLE
fix: evict stale joint bindings on stream removal

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -243,13 +243,20 @@ class Robot:
         self._data_streams[stream_id] = stream
 
     def _remove_data_stream(self, stream_id: str, stream: DataStream) -> None:
-        """Remove a stream from the robot registry if it still matches."""
+        """Remove a stream from the robot registry and evict its cached bindings."""
         if self._data_streams.get(stream_id) is not stream:
             return
 
         self._data_streams.pop(stream_id)
         if self._data_stream_counts[stream.data_type] > 0:
             self._data_stream_counts[stream.data_type] -= 1
+
+        bindings = self._joint_stream_bindings.get(stream.data_type)
+        if bindings:
+            for joint_name, binding in list(bindings.items()):
+                if binding.stream is stream:
+                    bindings.pop(joint_name)
+        self._joint_group_cache.pop(stream.data_type, None)
 
     def get_data_stream(self, stream_id: str) -> DataStream | None:
         """Retrieve a data stream by its identifier.

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -169,6 +169,38 @@ def test_log_joint_group_rebuilds_on_middle_joint_change(
     assert "joint10" not in rebuilt_group.joint_names
 
 
+def test_pruned_joint_streams_reregister_on_next_log(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mock_urdf, mocked_org_id
+):
+    """Pruning a joint stream evicts its cached binding so the next log call
+    registers a live stream instead of reviving the pruned one."""
+    nc.login("test_api_key")
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json={"robot_id": "mock_robot_id", "has_urdf": True},
+        status_code=200,
+    )
+    robot = nc.connect_robot("test_robot", urdf_path=mock_urdf)
+
+    nc.log_joint_positions({"joint1": 0.5, "joint2": -0.3})
+    pruned_streams = list(robot._data_streams.values())
+    assert pruned_streams
+    for stream_id, stream in list(robot._data_streams.items()):
+        robot._remove_data_stream(stream_id, stream)
+    assert not robot._data_streams
+
+    nc.log_joint_positions({"joint1": 0.6, "joint2": -0.4})
+
+    bindings = robot._joint_stream_bindings[DataType.JOINT_POSITIONS]
+    assert len(bindings) == 2
+    for binding in bindings.values():
+        assert robot.get_data_stream(binding.stream_id) is binding.stream
+        assert binding.stream not in pruned_streams
+    group = robot._joint_group_cache[DataType.JOINT_POSITIONS]
+    for binding in group.bindings:
+        assert robot.get_data_stream(binding.stream_id) is binding.stream
+
+
 def test_log_joints_large_frame(
     temp_config_dir, mock_auth_requests, reset_neuracore, mock_urdf, mocked_org_id
 ):


### PR DESCRIPTION
### Bugfixes
 - Fixed recordings after the first one in a session being saved as empty. When a recording ended, the robot removed its data streams, but the joint logging cache still pointed at the removed stream objects. The next recording reused those untracked streams, so the stop message told the daemon there was no data to wait for, and the daemon closed the recording before the data arrived. Removing a stream now also clears its cache entries, so the next recording creates and tracks fresh streams.
 - Added a regression test that prunes the streams and checks the next log call registers live ones.

### Items
 - [NCRL-708](https://neuracore.atlassian.net/browse/NCRL-708)

### Related PRs
 - https://github.com/NeuracoreAI/neuracore/pull/719