### PR TITLE
feat: add live-reloadable video_codec daemon setting

### DIFF
--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -211,6 +211,7 @@ These are the supported settings:
 | `offline` | If enabled, uploading is disabled and data is only stored locally. |
 | `api_key` | API key used for authenticating the daemon. |
 | `current_org_id` | Which organisation the daemon should operate under. |
+| `video_codec` |  Video encoding for RGB cameras. `h264_lossless` (default)/ `h264_medium` . |
 
 ---
 
@@ -262,6 +263,7 @@ Supported environment variables:
 | `offline` | `NCD_OFFLINE` |
 | `api_key` | `NCD_API_KEY` |
 | `current_org_id` | `NEURACORE_ORG_ID` (shared with the SDK) |
+| `video_codec` | `NCD_VIDEO_CODEC` |
 
 Note on `NEURACORE_ORG_ID`: the daemon uses it only as a fallback while
 `~/.neuracore/config.json` has no organization set. The config file is watched
@@ -329,19 +331,21 @@ neuracore data-daemon profile create laptop
 Update a named profile:
 
 ```bash
-neuracore data-daemon profile update <name> [--storage-limit <bytes|unit>] [--bandwidth-limit <bytes|unit>] [--spool-limit <bytes|unit>] [--storage-path <path>] [--num-threads <n>] [--wakelock|--no-wakelock] [--offline|--online] [--api-key <key>] [--current-org-id <org_id>]
+neuracore data-daemon profile update <name> [--storage-limit <bytes|unit>] [--bandwidth-limit <bytes|unit>] [--spool-limit <bytes|unit>] [--storage-path <path>] [--num-threads <n>] [--wakelock|--no-wakelock] [--offline|--online] [--api-key <key>] [--current-org-id <org_id>] [--video-codec <h264_lossless|h264_medium>]
 ```
 
 Update the default profile:
 
 ```bash
-neuracore data-daemon profile update [--storage-limit <bytes|unit>] [--bandwidth-limit <bytes|unit>] [--spool-limit <bytes|unit>] [--storage-path <path>] [--num-threads <n>] [--wakelock|--no-wakelock] [--offline|--online] [--api-key <key>] [--current-org-id <org_id>]
+neuracore data-daemon profile update [--storage-limit <bytes|unit>] [--bandwidth-limit <bytes|unit>] [--spool-limit <bytes|unit>] [--storage-path <path>] [--num-threads <n>] [--wakelock|--no-wakelock] [--offline|--online] [--api-key <key>] [--current-org-id <org_id>] [--video-codec <h264_lossless|h264_medium>]
 ```
 
 Example:
 
 ```bash
 neuracore data-daemon profile update laptop --storage-limit 2gb --offline
+neuracore data-daemon profile update laptop --video-codec h264_medium  # lossy-only uploads
+neuracore data-daemon profile update laptop --video-codec h264_lossless # back to the default
 ```
 
 ### `neuracore data-daemon profile get`

--- a/neuracore/__init__.py
+++ b/neuracore/__init__.py
@@ -9,6 +9,7 @@ from .api.endpoints import *  # noqa: F403
 from .api.logging import *  # noqa: F403
 from .api.training import *  # noqa: F403
 from .core.exceptions import *  # noqa: F403
+from .core.video_encoding import Codec  # noqa: F401
 
 try:
     # Version lives in pyproject.toml; read it from installed metadata so it

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -50,6 +50,13 @@ from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
 )
 from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
 from neuracore.core.utils.depth_utils import MAX_DEPTH
+from neuracore.core.video_encoding import Codec
+from neuracore.data_daemon.communications_management.shared_transport.recording_context import (  # noqa: E501
+    notify_daemon_config_changed,
+)
+from neuracore.data_daemon.config_manager.video_codec import (
+    set_active_profile_video_codec,
+)
 from neuracore.data_daemon.models import (
     BatchedJointDataItemPayload,
     BatchedJointDataPayload,
@@ -1627,3 +1634,41 @@ def log_point_cloud(
         robot, DataType.POINT_CLOUDS, storage_name, point_data, timestamp
     )
     _publish_json_to_p2p(robot, str_id, DataType.POINT_CLOUDS, point_data)
+
+
+def set_video_encoding_options(codec: Codec | str) -> None:
+    """Configure how recorded camera video is encoded and uploaded.
+
+    Selects the global RGB video codec (see
+    :class:`~neuracore.core.video_encoding.Codec` for what each option produces).
+    Depth cameras always keep their lossless storage regardless of this setting.
+
+    The selection applies to every camera and is stored in the active daemon
+    profile, so it persists and is picked up for the next recording. Call it
+    before ``start_recording``. The ``NCD_VIDEO_CODEC`` environment variable
+    overrides the profile value.
+
+    Example:
+        >>> import neuracore as nc
+        >>> nc.set_video_encoding_options(codec=nc.Codec.H264_MEDIUM)
+        >>> nc.start_recording()
+        >>> ...  # log frames
+        >>> nc.stop_recording()
+
+    Args:
+        codec: The video codec to use, e.g. ``nc.Codec.H264_MEDIUM`` (lossy-only)
+            or the default ``nc.Codec.H264_LOSSLESS``.
+
+    Raises:
+        ValueError: If ``codec`` is not a recognised codec.
+    """
+    try:
+        resolved = Codec(codec).value
+    except ValueError as error:
+        valid = ", ".join(member.value for member in Codec)
+        raise ValueError(
+            f"Unknown video codec {codec!r}; expected one of: {valid}"
+        ) from error
+
+    set_active_profile_video_codec(resolved)
+    notify_daemon_config_changed()

--- a/neuracore/core/video_encoding.py
+++ b/neuracore/core/video_encoding.py
@@ -1,0 +1,92 @@
+"""Video encoding options for recorded camera streams.
+
+By default each RGB camera is stored as a lossless archive (``lossless.mp4``,
+used for training) plus a small lossy preview (``lossy.mp4``). Selecting a
+:class:`Codec` switches RGB cameras to a single, more compact lossy video that
+is also used for training -- trading a little image fidelity for much smaller
+uploads, which matters for long recordings.
+
+This module is the single source of truth for the codec identifiers and their
+ffmpeg/PyAV settings on the Python side. The Rust data daemon mirrors the same
+``h264_medium`` -> ``libx264 -crf 23 -preset medium`` mapping.
+
+Depth cameras always keep their lossless storage: their lossy proxy is a
+visualisation, not precise depth, so it is never a valid training source.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Codec(str, enum.Enum):
+    """Codecs available for recorded camera video.
+
+    Members are string values so they round-trip cleanly through the daemon
+    profile and the ``NCD_VIDEO_CODEC`` environment variable.
+
+    Attributes:
+        H264_LOSSLESS: The default — keep the lossless archive (used for
+            training) plus a small lossy preview. Select this to switch back
+            from a lossy mode.
+        H264_MEDIUM: Lossy-only — a single full-resolution libx264 CRF 23 video
+            (no lossless archive), used for both preview and training.
+    """
+
+    H264_LOSSLESS = "h264_lossless"
+    H264_MEDIUM = "h264_medium"
+
+
+_LOSSY_CODEC_OPTIONS: dict[Codec, dict[str, str]] = {
+    Codec.H264_MEDIUM: {"crf": "23", "preset": "medium"},
+}
+
+
+def resolve_codec(value: str | None) -> Codec | None:
+    """Resolve a config/env string to a :class:`Codec`, or ``None``.
+
+    Empty/unset values resolve to ``None`` silently; an unrecognised value also
+    resolves to ``None`` but logs a warning. Either way a stray env or config
+    value can never break recording -- it simply falls back to the default
+    lossless+lossy encoders.
+
+    Args:
+        value: The configured codec identifier, or ``None``.
+
+    Returns:
+        The matching :class:`Codec`, or ``None`` when unset/unknown.
+    """
+    if not value:
+        return None
+    try:
+        return Codec(value)
+    except ValueError:
+        logger.warning(
+            "Ignoring unknown video codec %r; expected one of: %s",
+            value,
+            ", ".join(member.value for member in Codec),
+        )
+        return None
+
+
+def codec_option_overrides(value: str | None) -> dict[str, str] | None:
+    """Return the lossy-only libx264 options for a codec string, or ``None``.
+
+    ``None`` selects the default lossless-plus-preview encoders; a dict selects a
+    single lossy RGB video with those options. A fresh copy is returned so the
+    caller can mutate it safely.
+
+    Args:
+        value: The configured codec identifier, or ``None``.
+
+    Returns:
+        A fresh options dict for the lossy encoder, or ``None`` for the default.
+    """
+    codec = resolve_codec(value)
+    if codec is None:
+        return None
+    options = _LOSSY_CODEC_OPTIONS.get(codec)
+    return dict(options) if options is not None else None

--- a/neuracore/data_daemon/communications_management/shared_transport/recording_context.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/recording_context.py
@@ -40,6 +40,19 @@ def _load_native() -> ModuleType:
     return _DATA_BRIDGE_MODULE
 
 
+def notify_daemon_config_changed() -> None:
+    """Try ask a running Rust daemon to reload its profile immediately.
+
+    This is a no-op under the legacy Python producer.
+    """
+    if not is_rust_daemon_enabled():
+        return
+    try:
+        _load_native().refresh_config()
+    except Exception as error:  # noqa: BLE001 - best-effort, never fatal
+        logger.debug("Could not notify the daemon of a config change: %s", error)
+
+
 class RecordingContext:
     """Recording-scoped interface to the data daemon.
 

--- a/neuracore/data_daemon/config_manager/args_handler.py
+++ b/neuracore/data_daemon/config_manager/args_handler.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import typer
 
 from neuracore.core.exceptions import AuthenticationError
+from neuracore.core.video_encoding import Codec
 from neuracore.data_daemon.config_manager.cli_options import (
     ApiKeyOption,
     AssumeYesOption,
@@ -26,6 +27,7 @@ from neuracore.data_daemon.config_manager.cli_options import (
     SpoolLimitOption,
     StorageLimitOption,
     StoragePathOption,
+    VideoCodecOption,
 )
 from neuracore.data_daemon.config_manager.helpers import collect_config_updates
 from neuracore.data_daemon.config_manager.profiles import (
@@ -66,6 +68,7 @@ def _update_profile(
     offline: bool | None,
     api_key: str | None,
     current_org_id: str | None,
+    video_codec: Codec | None,
 ) -> None:
     updates = collect_config_updates(
         storage_limit=storage_limit,
@@ -77,6 +80,7 @@ def _update_profile(
         offline=offline,
         api_key=api_key,
         current_org_id=current_org_id,
+        video_codec=video_codec.value if video_codec is not None else None,
     )
 
     if create_if_missing:
@@ -125,6 +129,7 @@ def run_profile_update(
     offline: OfflineOption = None,
     api_key: ApiKeyOption = None,
     current_org_id: CurrentOrgIdOption = None,
+    video_codec: VideoCodecOption = None,
 ) -> None:
     """Update an existing profile."""
     if not name:
@@ -142,6 +147,7 @@ def run_profile_update(
         offline=offline,
         api_key=api_key,
         current_org_id=current_org_id,
+        video_codec=video_codec,
     )
 
 

--- a/neuracore/data_daemon/config_manager/cli_options.py
+++ b/neuracore/data_daemon/config_manager/cli_options.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 import typer
 
+from neuracore.core.video_encoding import Codec
 from neuracore.data_daemon.config_manager.helpers import parse_bytes
 
 ProfileNameCreateArgument = Annotated[
@@ -109,6 +110,15 @@ CurrentOrgIdOption = Annotated[
         "--current-org-id",
         "--current_org_id",
         help="Active organisation ID for scoping daemon operations.",
+    ),
+]
+
+VideoCodecOption = Annotated[
+    Codec | None,
+    typer.Option(
+        "--video-codec",
+        "--video_codec",
+        help=("Global RGB video codec. 'h264_lossless' (default) or 'h264_medium' "),
     ),
 ]
 

--- a/neuracore/data_daemon/config_manager/config.py
+++ b/neuracore/data_daemon/config_manager/config.py
@@ -19,6 +19,7 @@ _ENV_MAP: dict[str, str] = {
     "offline": "NCD_OFFLINE",
     "api_key": "NCD_API_KEY",
     "current_org_id": "NEURACORE_ORG_ID",
+    "video_codec": "NCD_VIDEO_CODEC",
 }
 
 YES_CONFIRMATION = {"1", "true", "yes", "y"}

--- a/neuracore/data_daemon/config_manager/config_watcher.py
+++ b/neuracore/data_daemon/config_manager/config_watcher.py
@@ -1,0 +1,119 @@
+"""In-memory daemon-config cache with periodic + on-demand refresh."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+
+from neuracore.data_daemon.config_manager.config import ConfigManager
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
+from neuracore.data_daemon.config_manager.profiles import ProfileManager
+from neuracore.data_daemon.const import active_profile_name
+
+logger = logging.getLogger(__name__)
+
+# Matches the Rust daemon's CONFIG_POLL and ORG_CONFIG_POLL cadence: the profile
+# file is tiny and rarely changes, so a coarse one-second re-parse is ample.
+DEFAULT_CONFIG_POLL_SECONDS = 1.0
+
+
+class ConfigWatcher:
+    """Cache the effective daemon config, refreshed periodically in the background."""
+
+    def __init__(
+        self,
+        initial_config: DaemonConfig,
+        profile_name: str | None = None,
+        check_interval: float = DEFAULT_CONFIG_POLL_SECONDS,
+        resolver: Callable[[], DaemonConfig] | None = None,
+    ) -> None:
+        """Initialise the watcher.
+
+        Args:
+            initial_config: The launch-resolved effective config, used as the
+                seed so the cached value is valid before the first poll.
+            profile_name: Active profile to re-resolve; defaults to the launch
+                resolution (``NEURACORE_DAEMON_PROFILE`` or the default profile).
+            check_interval: Seconds between background re-resolves.
+            resolver: Optional injectable resolver returning the effective config.
+        """
+        self._config = initial_config
+        self._profile_name = profile_name or active_profile_name()
+        self._check_interval = check_interval
+        self._resolver = resolver or self._default_resolver
+        self._stopped = False
+        self._task: asyncio.Task | None = None
+
+    def _default_resolver(self) -> DaemonConfig:
+        """Resolve the effective config from the active profile + env overlay."""
+        config_manager = ConfigManager(ProfileManager(), profile=self._profile_name)
+        return config_manager.resolve_effective_config()
+
+    async def start(self) -> None:
+        """Start the background refresh loop."""
+        self._stopped = False
+        self._task = asyncio.create_task(self._check_loop())
+        logger.debug("ConfigWatcher started")
+
+    async def stop(self) -> None:
+        """Stop the background refresh loop."""
+        self._stopped = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.debug("ConfigWatcher stopped")
+
+    async def _check_loop(self) -> None:
+        """Periodically re-resolve the effective config into the cache."""
+        loop = asyncio.get_running_loop()
+        while not self._stopped:
+            await asyncio.sleep(self._check_interval)
+            await self._reload(loop)
+
+    async def _reload(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Re-resolve off the loop; keep the last-good value on failure."""
+        try:
+            self._config = await loop.run_in_executor(None, self._resolver)
+        except Exception as error:  # noqa: BLE001 - never crash the loop
+            logger.warning(
+                "Failed to resolve daemon config; keeping last-good value: %s",
+                error,
+            )
+
+    async def refresh(self) -> None:
+        """Force an immediate re-resolve (awaitable).
+
+        The Python daemon has no SDK-triggered refresh command, so production
+        relies on the periodic poll; this exists for tests and for parity with
+        the Rust daemon's on-demand refresh.
+        """
+        await self._reload(asyncio.get_running_loop())
+
+    def refresh_now(self) -> None:
+        """Synchronously re-resolve the effective config into the cache.
+
+        Unlike :meth:`refresh` (awaitable, driven off the General Loop), this
+        resolves inline so a caller on any thread can read config written moments
+        earlier without waiting for the periodic poll. The encoding path uses it
+        when building a new video encoder so a codec set via the SDK's
+        ``set_video_encoding_options`` immediately before ``start_recording`` is
+        honoured for that recording rather than lagging the ~1s poll.
+
+        Resolution failures keep the last-good value (never raised), so a caller
+        on the recording hot path is never broken by a transient profile read.
+        """
+        try:
+            self._config = self._resolver()
+        except Exception as error:  # noqa: BLE001 - never break the caller
+            logger.warning(
+                "Failed to resolve daemon config; keeping last-good value: %s",
+                error,
+            )
+
+    def video_codec(self) -> str | None:
+        """Return the currently-cached video codec id, or ``None`` for default."""
+        return self._config.video_codec

--- a/neuracore/data_daemon/config_manager/daemon_config.py
+++ b/neuracore/data_daemon/config_manager/daemon_config.py
@@ -17,6 +17,8 @@ class DaemonConfig(BaseModel):
         offline: when true, disable uploads and only store data locally.
         api_key: Neuracore API key for authentication.
         current_org_id: Organization ID for the authenticated user.
+        video_codec: global video codec selection (a Codec value, e.g.
+            "h264_medium"). None keeps the default lossless+lossy RGB encoders.
     """
 
     storage_limit: int | None = None
@@ -28,3 +30,4 @@ class DaemonConfig(BaseModel):
     offline: bool | None = None
     api_key: str | None = None
     current_org_id: str | None = None
+    video_codec: str | None = None

--- a/neuracore/data_daemon/config_manager/helpers.py
+++ b/neuracore/data_daemon/config_manager/helpers.py
@@ -89,6 +89,7 @@ def collect_config_updates(
     offline: bool | None,
     api_key: str | None,
     current_org_id: str | None,
+    video_codec: str | None = None,
 ) -> dict[str, Any]:
     """Normalize CLI inputs into validated daemon config updates."""
     raw_config_values = {
@@ -101,6 +102,7 @@ def collect_config_updates(
         "offline": offline,
         "api_key": api_key,
         "current_org_id": current_org_id,
+        "video_codec": video_codec,
     }
     return extract_config_updates(raw_config_values)
 

--- a/neuracore/data_daemon/config_manager/video_codec.py
+++ b/neuracore/data_daemon/config_manager/video_codec.py
@@ -1,0 +1,42 @@
+"""Persist the global video codec via the daemon profile system.
+
+The video codec is a daemon-profile setting (the same profile/`DaemonConfig`
+system as the other ``NCD_*`` options), not part of the SDK's ``config.json``.
+The SDK's ``set_video_encoding_options`` writes it into the active profile; the
+daemon reads it back from its in-memory config
+(:class:`~neuracore.data_daemon.config_manager.config_watcher.ConfigWatcher`),
+which is refreshed on a poll (and, on the Rust daemon, on a ``RefreshConfig``
+command), so the setting can change between recordings without restarting the
+daemon.
+
+The active profile is ``NEURACORE_DAEMON_PROFILE`` (or ``DEFAULT_PROFILE_NAME``
+when unset), matching how the daemon resolves its configuration at launch.
+"""
+
+from __future__ import annotations
+
+from neuracore.data_daemon.config_manager.profiles import (
+    ProfileAlreadyExist,
+    ProfileManager,
+)
+from neuracore.data_daemon.const import active_profile_name
+
+
+def set_active_profile_video_codec(codec: str) -> None:
+    """Persist the video codec into the active daemon profile.
+
+    Creates the active profile if missing, then writes ``video_codec`` so the
+    change is picked up by the daemon for the next recording.
+
+    Args:
+        codec: The codec identifier to store (e.g. ``"h264_medium"`` or the
+            ``"h264_lossless"`` default).
+    """
+    profile_name = active_profile_name()
+    manager = ProfileManager()
+    try:
+        manager.create_profile(profile_name)
+    except ProfileAlreadyExist:
+        pass
+
+    manager.update_profile(profile_name, {"video_codec": codec})

--- a/neuracore/data_daemon/const.py
+++ b/neuracore/data_daemon/const.py
@@ -86,3 +86,8 @@ COMPLETED_RECORDING_RETENTION_HOURS = 24 * 30
 
 # default profile name
 DEFAULT_PROFILE_NAME = "default_profile"
+
+
+def active_profile_name() -> str:
+    """Return the active daemon profile name, mirroring the launch resolution."""
+    return os.environ.get("NEURACORE_DAEMON_PROFILE") or DEFAULT_PROFILE_NAME

--- a/neuracore/data_daemon/runtime.py
+++ b/neuracore/data_daemon/runtime.py
@@ -25,6 +25,7 @@ from neuracore.data_daemon.const import (
     DEFAULT_SHARED_MEMORY_SIZE,
     DEFAULT_VIDEO_SLOT_COUNT,
     DEFAULT_VIDEO_SLOT_SIZE,
+    active_profile_name,
 )
 from neuracore.data_daemon.event_emitter import Emitter
 from neuracore.data_daemon.event_loop_manager import EventLoopManager
@@ -148,9 +149,7 @@ class DaemonRuntime:
     def _resolve_configuration(self) -> DaemonConfig | None:
         """Resolve daemon configuration from profiles, env, and CLI."""
         try:
-            profile_name = (
-                os.environ.get("NEURACORE_DAEMON_PROFILE") or DEFAULT_PROFILE_NAME
-            )
+            profile_name = active_profile_name()
 
             profile_manager = ProfileManager()
 

--- a/neuracore/data_daemon/services.py
+++ b/neuracore/data_daemon/services.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import aiohttp
 
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
 from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
 from neuracore.data_daemon.connection_management.connection_manager import (
     ConnectionManager,
@@ -48,6 +49,7 @@ class DaemonServices:
         upload_manager: UploadManager,
         connection_manager: ConnectionManager,
         progress_reporter: ProgressReporter,
+        config_watcher: ConfigWatcher,
     ) -> None:
         """Store fully-initialised service instances."""
         self.client_session = client_session
@@ -58,6 +60,7 @@ class DaemonServices:
         self.upload_manager = upload_manager
         self.connection_manager = connection_manager
         self.progress_reporter = progress_reporter
+        self.config_watcher = config_watcher
 
     @classmethod
     async def create(
@@ -108,6 +111,10 @@ class DaemonServices:
         progress_reporter = ProgressReporter(client_session, emitter)
         logger.debug("ProgressReporter initialized")
 
+        config_watcher = ConfigWatcher(initial_config=config)
+        await config_watcher.start()
+        logger.debug("ConfigWatcher started")
+
         logger.debug("Async services bootstrap complete")
 
         return cls(
@@ -119,6 +126,7 @@ class DaemonServices:
             upload_manager=upload_manager,
             connection_manager=connection_manager,
             progress_reporter=progress_reporter,
+            config_watcher=config_watcher,
         )
 
     async def shutdown(self) -> None:
@@ -130,6 +138,12 @@ class DaemonServices:
             logger.debug("ConnectionManager stopped")
         except Exception:
             logger.exception("Error stopping ConnectionManager")
+
+        try:
+            await self.config_watcher.stop()
+            logger.debug("ConfigWatcher stopped")
+        except Exception:
+            logger.exception("Error stopping ConfigWatcher")
 
         try:
             await self.registration_manager.shutdown()

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -11,10 +11,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use tokio::sync::{mpsc, watch};
 
 use crate::cli::coordinators::{build_api_client, spawn_cloud_coordinators};
 use crate::cli::launch_logging::{init_tracing, log_path_for, report_failure};
-use crate::cloud::{read_org_id_from_config, spawn_recording_reaper};
+use crate::cloud::{
+    read_org_id_from_config, spawn_config_watcher, spawn_recording_reaper, ConfigRefreshRequest,
+};
 use crate::config::env::RuntimeEnv;
 use crate::config::profile::{ProfileError, ProfileManager};
 use crate::config::{resolve_effective_config, DaemonConfig, DEFAULT_PROFILE_NAME};
@@ -36,6 +39,9 @@ use crate::storage::budget::{StorageBudget, StoragePolicy};
 /// timeout exists so a future bug that lets the listener exit without a
 /// shutdown signal degrades to a `?signal=sigterm` log rather than a hang.
 const SIGNAL_CAPTURE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Buffer for dispatcher → config-watcher refresh requests (rare, drained promptly).
+const CONFIG_REFRESH_CHANNEL_CAPACITY: usize = 8;
 
 /// Run the launch command.
 pub fn run(profile: Option<String>, background: bool, debug: bool) -> Result<()> {
@@ -76,6 +82,7 @@ pub fn run(profile: Option<String>, background: bool, debug: bool) -> Result<()>
             DaemonizeOutcome::Child(reporter) => run_daemon(
                 runtime_env,
                 config,
+                selected_profile,
                 effective_debug,
                 Some(reporter),
                 Some(log_path),
@@ -83,7 +90,14 @@ pub fn run(profile: Option<String>, background: bool, debug: bool) -> Result<()>
         }
     } else {
         print_preflight(&runtime_env, &config, &selected_profile);
-        run_daemon(runtime_env, config, effective_debug, None, None)
+        run_daemon(
+            runtime_env,
+            config,
+            selected_profile,
+            effective_debug,
+            None,
+            None,
+        )
     }
 }
 
@@ -115,6 +129,7 @@ fn handle_parent_readiness(reader: crate::lifecycle::daemonize::ReadinessReader)
 fn run_daemon(
     runtime_env: RuntimeEnv,
     config: DaemonConfig,
+    profile: String,
     debug: bool,
     reporter: Option<ReadinessReporter>,
     log_file: Option<PathBuf>,
@@ -308,6 +323,14 @@ fn run_daemon(
         // once the dispatcher and every actor (the last `JsonWriteHandle` holders)
         // are gone at shutdown.
         let (json_write_handle, _json_writer_owner) = crate::pipeline::json_writer::spawn();
+
+        // Seed the config watch channel with the launch-resolved config; the
+        // watcher (spawned below) refreshes it. `_config_rx` is held only to keep
+        // the channel open until consumers are wired up in a follow-up change.
+        let (config_tx, _config_rx) = watch::channel(config_for_runtime.clone());
+        let (config_refresh_tx, config_refresh_rx) =
+            mpsc::channel::<ConfigRefreshRequest>(CONFIG_REFRESH_CHANNEL_CAPACITY);
+
         let actor_context = Arc::new(
             TraceActorContext::new(
                 recordings_root.clone(),
@@ -344,6 +367,16 @@ fn run_daemon(
                 .unwrap_or_else(|| std::path::PathBuf::from(".neuracore/config.json"));
             let org_id = read_org_id_from_config(&config_path)
                 .or_else(|| config_for_runtime.current_org_id.clone());
+
+            // Spawn the daemon-config watcher unconditionally: offline mode skips
+            // the cloud coordinators, but per-trace actors still need the live codec.
+            let config_watcher = spawn_config_watcher(
+                Some(profile.clone()),
+                None,
+                config_tx,
+                config_refresh_rx,
+                shutdown_tx.subscribe(),
+            );
 
             // Spawn the cloud-side coordinators *before* the dispatcher so
             // they have an active subscription to the event bus by the time
@@ -391,6 +424,7 @@ fn run_daemon(
 
             let dispatcher_context = DispatcherContext {
                 event_bus: Some(event_bus.clone()),
+                config_refresh_tx: Some(config_refresh_tx),
             };
             let (dispatcher_tx, dispatcher_handle) = dispatcher::spawn_with_context(
                 state_store.clone(),
@@ -456,6 +490,10 @@ fn run_daemon(
             if let Some(handles) = cloud_handles {
                 handles.join_all().await;
             }
+            // The dispatcher (the last `config_refresh_tx` holder) is gone, so
+            // the watcher's refresh branch has closed; it exits on the shutdown
+            // broadcast.
+            config_watcher.join().await;
             if let Some(handle) = wakelock_handle {
                 handle.join().await;
             }

--- a/rust/data_daemon/src/cli/mod.rs
+++ b/rust/data_daemon/src/cli/mod.rs
@@ -121,6 +121,9 @@ enum ProfileCommand {
         /// Active organisation ID for scoping daemon operations.
         #[arg(long = "current-org-id", visible_alias = "current_org_id")]
         current_org_id: Option<String>,
+        /// Global RGB video codec: `h264_lossless` (default) or `h264_medium`.
+        #[arg(long = "video-codec", visible_alias = "video_codec")]
+        video_codec: Option<String>,
     },
     /// Get a profile's configuration.
     Get {

--- a/rust/data_daemon/src/cli/profile.rs
+++ b/rust/data_daemon/src/cli/profile.rs
@@ -32,6 +32,7 @@ pub fn run(command: ProfileCommand) {
             online,
             api_key,
             current_org_id,
+            video_codec,
         } => {
             let updates = DaemonConfig {
                 storage_limit,
@@ -43,6 +44,7 @@ pub fn run(command: ProfileCommand) {
                 offline: tristate(offline, online),
                 api_key,
                 current_org_id,
+                video_codec,
             };
             update(&profiles, name.as_deref(), &updates);
         }

--- a/rust/data_daemon/src/cloud/mod.rs
+++ b/rust/data_daemon/src/cloud/mod.rs
@@ -34,6 +34,7 @@ pub use notifiers::notifier::NotifierHandle;
 pub use notifiers::recording_cancel_notifier::spawn_recording_cancel_notifier;
 pub use notifiers::recording_start_notifier::spawn_recording_start_notifier;
 pub use notifiers::recording_stop_notifier::spawn_recording_stop_notifier;
+pub use watchers::config_watcher::{spawn_config_watcher, ConfigRefreshRequest};
 pub use watchers::org_watcher::{spawn_org_watcher, OrgIdRx, OrgWatcherHandle};
 pub use watchers::recording_reaper::spawn_recording_reaper;
 

--- a/rust/data_daemon/src/cloud/watchers/config_watcher.rs
+++ b/rust/data_daemon/src/cloud/watchers/config_watcher.rs
@@ -1,0 +1,301 @@
+//! Live daemon-profile resolution.
+//!
+//! The effective [`DaemonConfig`] (profile YAML + `NCD_*` env overlay) is held
+//! in memory and refreshed on an interval, so consumers — the per-trace actors
+//! and the registration coordinator — read the current video codec from a
+//! [`watch::channel`] instead of re-parsing the profile YAML on every trace.
+//! This mirrors the org watcher (`org_watcher.rs`), which does the same for
+//! `config.json`.
+//!
+//! Two things drive a refresh: the periodic [`crate::intervals::CONFIG_POLL`]
+//! tick (covers CLI `profile update` and external edits), and an on-demand
+//! request over an `mpsc`. The dispatcher sends the latter for a
+//! [`data_daemon_shared::Envelope::RefreshConfig`] command and awaits the paired `oneshot`
+//! ack, so the SDK's `set_video_encoding_options → start_recording` sequence
+//! observes the new codec before the recording's traces resolve it.
+
+use std::path::{Path, PathBuf};
+
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+use tokio::time::{interval, MissedTickBehavior};
+
+use crate::config::profile::ProfileManager;
+use crate::config::{resolve_effective_config, DaemonConfig};
+use crate::lifecycle::shutdown::ShutdownSignal;
+
+/// Shared read handle for the current effective [`DaemonConfig`]. Cheap to
+/// clone; read the current value with `config_rx.borrow()`.
+pub type ConfigRx = watch::Receiver<DaemonConfig>;
+
+/// A refresh request: the watcher fires the paired `oneshot` once the
+/// re-resolve has been published, letting the caller order subsequent work
+/// (e.g. dispatching `StartRecording`) strictly after the config update.
+pub type ConfigRefreshRequest = oneshot::Sender<()>;
+
+/// Handle for the config-watcher task.
+pub struct ConfigWatcherHandle {
+    join: JoinHandle<()>,
+}
+
+impl ConfigWatcherHandle {
+    /// Wait for the watcher task to exit.
+    pub async fn join(self) {
+        if let Err(error) = self.join.await {
+            tracing::warn!(?error, "config watcher join failed");
+        }
+    }
+}
+
+/// Spawn the config watcher.
+///
+/// The caller owns the [`watch::channel`] (seeded with the launch-resolved
+/// config, so the initial value is available before this task's first tick) and
+/// passes the [`watch::Sender`] here; the matching [`ConfigRx`] is handed to the
+/// actor context and the registration coordinator. `refresh_rx` receives
+/// on-demand refresh requests; `profile` is the active profile name to resolve.
+/// `home` overrides the profiles root — `None` uses the real user home (the
+/// production path); tests pass a temp dir to avoid touching env or the
+/// developer's profile.
+pub fn spawn_config_watcher(
+    profile: Option<String>,
+    home: Option<PathBuf>,
+    config_tx: watch::Sender<DaemonConfig>,
+    mut refresh_rx: mpsc::Receiver<ConfigRefreshRequest>,
+    mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
+) -> ConfigWatcherHandle {
+    let join = tokio::spawn(async move {
+        let mut ticker = interval(crate::intervals::CONFIG_POLL);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // Disabled once all refresh senders drop, so a closed channel can't
+        // busy-loop the `select!` (a closed `mpsc::recv` returns immediately).
+        let mut refresh_open = true;
+
+        loop {
+            tokio::select! {
+                biased;
+                signal = shutdown_rx.recv() => {
+                    tracing::debug!(?signal, "config watcher shutting down");
+                    break;
+                }
+                maybe_request = refresh_rx.recv(), if refresh_open => {
+                    match maybe_request {
+                        Some(ack) => {
+                            refresh(&config_tx, profile.as_deref(), home.as_deref()).await;
+                            // Best-effort: the requester may have timed out.
+                            let _ = ack.send(());
+                        }
+                        None => refresh_open = false,
+                    }
+                }
+                _ = ticker.tick() => {
+                    refresh(&config_tx, profile.as_deref(), home.as_deref()).await;
+                }
+            }
+        }
+    });
+
+    ConfigWatcherHandle { join }
+}
+
+/// Re-resolve the effective config off the runtime (the YAML read is blocking)
+/// and publish it when it changed. A resolve failure keeps the last-good value.
+async fn refresh(
+    config_tx: &watch::Sender<DaemonConfig>,
+    profile: Option<&str>,
+    home: Option<&Path>,
+) {
+    let profile = profile.map(str::to_owned);
+    let home = home.map(Path::to_path_buf);
+    let resolved = tokio::task::spawn_blocking(move || {
+        let profiles = match home {
+            Some(home) => ProfileManager::with_home(home),
+            None => ProfileManager::new(),
+        };
+        resolve_effective_config(&profiles, profile.as_deref(), None)
+    })
+    .await;
+
+    match resolved {
+        Ok(Ok(config)) => {
+            config_tx.send_if_modified(|existing| {
+                if *existing == config {
+                    false
+                } else {
+                    tracing::info!("daemon profile change picked up; updating in-memory config");
+                    *existing = config;
+                    true
+                }
+            });
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "failed to resolve daemon config; keeping last-good value");
+        }
+        Err(error) => {
+            tracing::warn!(%error, "config resolve task panicked; keeping last-good value");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+    use tokio::time::timeout;
+
+    fn channels() -> (
+        watch::Sender<DaemonConfig>,
+        ConfigRx,
+        mpsc::Sender<ConfigRefreshRequest>,
+        mpsc::Receiver<ConfigRefreshRequest>,
+    ) {
+        let (config_tx, config_rx) = watch::channel(DaemonConfig::default());
+        let (refresh_tx, refresh_rx) = mpsc::channel(4);
+        (config_tx, config_rx, refresh_tx, refresh_rx)
+    }
+
+    #[tokio::test]
+    async fn on_demand_refresh_picks_up_profile_codec() {
+        // Write a lossy codec into a profile under a temp home (no env / real
+        // profile touched), then force a refresh and assert the in-memory copy
+        // reflects it once the ack fires.
+        let home = TempDir::new().expect("temp home");
+        let manager = ProfileManager::with_home(home.path().to_path_buf());
+        manager.create_profile("default_profile").expect("create");
+        manager
+            .update_profile(
+                "default_profile",
+                &DaemonConfig {
+                    video_codec: Some("h264_medium".to_string()),
+                    ..DaemonConfig::default()
+                },
+            )
+            .expect("update");
+
+        let (config_tx, config_rx, refresh_tx, refresh_rx) = channels();
+        let (shutdown_tx, _) = broadcast::channel::<ShutdownSignal>(8);
+        let handle = spawn_config_watcher(
+            Some("default_profile".to_string()),
+            Some(home.path().to_path_buf()),
+            config_tx,
+            refresh_rx,
+            shutdown_tx.subscribe(),
+        );
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        refresh_tx.send(ack_tx).await.expect("send refresh");
+        timeout(Duration::from_secs(5), ack_rx)
+            .await
+            .expect("ack within 5s")
+            .expect("ack sender alive");
+        assert_eq!(
+            config_rx.borrow().video_codec.as_deref(),
+            Some("h264_medium")
+        );
+
+        let _ = shutdown_tx.send(ShutdownSignal::Sigterm);
+        handle.join().await;
+    }
+
+    #[tokio::test]
+    async fn periodic_tick_picks_up_profile_change() {
+        // The interval branch (not just the on-demand refresh) must pick up an
+        // external profile edit, and `send_if_modified` must publish it — proven
+        // by `changed()` firing only on a real change.
+        let home = TempDir::new().expect("temp home");
+        let manager = ProfileManager::with_home(home.path().to_path_buf());
+        manager.create_profile("default_profile").expect("create");
+        manager
+            .update_profile(
+                "default_profile",
+                &DaemonConfig {
+                    video_codec: Some("h264_medium".to_string()),
+                    ..DaemonConfig::default()
+                },
+            )
+            .expect("update");
+
+        // Seed with the default (no codec); the tick must overwrite it.
+        let (config_tx, mut config_rx) = watch::channel(DaemonConfig::default());
+        let (_refresh_tx, refresh_rx) = mpsc::channel(4);
+        let (shutdown_tx, _) = broadcast::channel::<ShutdownSignal>(8);
+        let handle = spawn_config_watcher(
+            Some("default_profile".to_string()),
+            Some(home.path().to_path_buf()),
+            config_tx,
+            refresh_rx,
+            shutdown_tx.subscribe(),
+        );
+
+        timeout(Duration::from_secs(5), config_rx.changed())
+            .await
+            .expect("periodic tick published a change within 5s")
+            .expect("sender alive");
+        assert_eq!(
+            config_rx.borrow().video_codec.as_deref(),
+            Some("h264_medium")
+        );
+
+        let _ = shutdown_tx.send(ShutdownSignal::Sigterm);
+        handle.join().await;
+    }
+
+    #[tokio::test]
+    async fn seed_value_is_available_immediately() {
+        // The caller seeds the channel, so the current value is readable before
+        // the watcher's first tick (no initial resolve latency).
+        let (config_tx, config_rx) = watch::channel(DaemonConfig {
+            video_codec: Some("h264_medium".to_string()),
+            ..DaemonConfig::default()
+        });
+        let (_refresh_tx, refresh_rx) = mpsc::channel(4);
+        let (shutdown_tx, _) = broadcast::channel::<ShutdownSignal>(8);
+        let handle =
+            spawn_config_watcher(None, None, config_tx, refresh_rx, shutdown_tx.subscribe());
+
+        assert_eq!(
+            config_rx.borrow().video_codec.as_deref(),
+            Some("h264_medium")
+        );
+
+        let _ = shutdown_tx.send(ShutdownSignal::Sigterm);
+        handle.join().await;
+    }
+
+    #[tokio::test]
+    async fn missing_profile_keeps_last_good_value() {
+        // Pointing at a home with no profile yields a resolve error; the watcher
+        // must keep the seeded value rather than clobbering it.
+        let home = TempDir::new().expect("temp home");
+        let (config_tx, config_rx) = watch::channel(DaemonConfig {
+            video_codec: Some("h264_medium".to_string()),
+            ..DaemonConfig::default()
+        });
+        let (refresh_tx, refresh_rx) = mpsc::channel(4);
+        let (shutdown_tx, _) = broadcast::channel::<ShutdownSignal>(8);
+        let handle = spawn_config_watcher(
+            Some("does_not_exist".to_string()),
+            Some(home.path().to_path_buf()),
+            config_tx,
+            refresh_rx,
+            shutdown_tx.subscribe(),
+        );
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        refresh_tx.send(ack_tx).await.expect("send refresh");
+        timeout(Duration::from_secs(5), ack_rx)
+            .await
+            .expect("ack within 5s")
+            .expect("ack sender alive");
+        assert_eq!(
+            config_rx.borrow().video_codec.as_deref(),
+            Some("h264_medium"),
+            "a failed resolve must not clobber the last-good value"
+        );
+
+        let _ = shutdown_tx.send(ShutdownSignal::Sigterm);
+        handle.join().await;
+    }
+}

--- a/rust/data_daemon/src/cloud/watchers/mod.rs
+++ b/rust/data_daemon/src/cloud/watchers/mod.rs
@@ -1,6 +1,8 @@
 //! Periodic watchers: the org-id config poller that publishes the live org for
-//! every coordinator, and the recording reaper that reclaims durably-settled
-//! recordings.
+//! every coordinator, the daemon-profile config poller that publishes the live
+//! effective config (chiefly the video codec), and the recording reaper that
+//! reclaims durably-settled recordings.
 
+pub mod config_watcher;
 pub mod org_watcher;
 pub mod recording_reaper;

--- a/rust/data_daemon/src/intervals.rs
+++ b/rust/data_daemon/src/intervals.rs
@@ -21,6 +21,13 @@ use std::time::Duration;
 /// than mtime gating.
 pub const ORG_CONFIG_POLL: Duration = Duration::from_secs(1);
 
+/// Daemon-profile config poll: re-resolves the effective `DaemonConfig` (profile
+/// YAML + env) so the trace actors and registration coordinator observe profile
+/// changes — chiefly the video codec — from an in-memory copy rather than
+/// re-reading the YAML per trace. Matches [`ORG_CONFIG_POLL`]; a `RefreshConfig`
+/// command additionally forces an immediate re-resolve for the SDK path.
+pub const CONFIG_POLL: Duration = Duration::from_secs(1);
+
 /// Registration drain fallback: the coordinator is event-driven off the bus and
 /// only falls back to this poll when the bus is quiet.
 pub const REGISTRATION_POLL: Duration = Duration::from_millis(500);

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -70,6 +70,12 @@ const IDLE_REAP: Duration = Duration::from_secs(30);
 /// negligible against the holdback.
 const HOUSEKEEP_INTERVAL: Duration = Duration::from_millis(25);
 
+/// Upper bound on how long a `RefreshConfig` may park the dispatcher loop
+/// waiting for the watcher's ack. The refresh is a fast `spawn_blocking` profile
+/// read, so this only guards against a stalled watcher wedging the hot path; on
+/// timeout we proceed and let the periodic poll pick the change up.
+const REFRESH_CONFIG_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Bounded per-trace queue size. A smaller cap acts as a forced flush throttle;
 /// 256 absorbs the high-dimensionality burst at the cost of ~10 KiB of message
 /// headers per trace.
@@ -111,6 +117,11 @@ impl DispatcherHandle {
 pub struct DispatcherContext {
     /// Daemon event bus, used to publish recording/trace lifecycle events.
     pub event_bus: Option<crate::state::EventBus>,
+    /// Refresh-request sender to the config watcher, used to service a
+    /// `RefreshConfig` command (see [`Dispatcher::handle_refresh_config`]).
+    /// `None` in tests / when no watcher is wired, where `RefreshConfig` is a
+    /// no-op.
+    pub config_refresh_tx: Option<tokio::sync::mpsc::Sender<crate::cloud::ConfigRefreshRequest>>,
 }
 
 /// Spawn the dispatcher task and return its inbound `mpsc::Sender`.
@@ -441,6 +452,31 @@ impl Dispatcher {
                     },
                 });
             }
+            Envelope::RefreshConfig {} => self.handle_refresh_config().await,
+        }
+    }
+
+    /// Force the config watcher to re-resolve the profile and wait for it to
+    /// finish before handling the next envelope, so the SDK's ordered
+    /// `set_video_encoding_options → start_recording` sequence never races the
+    /// async refresh (see [`crate::cloud::watchers::config_watcher`] for the
+    /// full rationale). The wait is bounded by [`REFRESH_CONFIG_ACK_TIMEOUT`] so
+    /// a stalled watcher can't wedge the routing loop. A missing sender (tests /
+    /// no watcher) or a closed channel (watcher gone at shutdown) is a no-op.
+    async fn handle_refresh_config(&self) {
+        let Some(refresh_tx) = self.context.config_refresh_tx.as_ref() else {
+            return;
+        };
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        if refresh_tx.send(ack_tx).await.is_err() {
+            tracing::debug!("config watcher gone; ignoring RefreshConfig");
+            return;
+        }
+        if tokio::time::timeout(REFRESH_CONFIG_ACK_TIMEOUT, ack_rx)
+            .await
+            .is_err()
+        {
+            tracing::warn!("config refresh ack timed out; proceeding (poll will catch up)");
         }
     }
 
@@ -1029,13 +1065,14 @@ fn remove_spool_nut(path: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud::ConfigRefreshRequest;
     use crate::encoding::video_encoder::VideoEncoder;
     use crate::state::{SqliteStateStore, TraceWriteStatus};
     use crate::storage::budget::{StorageBudget, StoragePolicy};
     use crate::storage::paths::TracePath;
     use std::path::PathBuf;
     use tempfile::TempDir;
-    use tokio::sync::broadcast;
+    use tokio::sync::{broadcast, mpsc};
     use tokio::time::{timeout, Duration};
 
     async fn open_store() -> (SqliteStateStore, TempDir) {
@@ -1117,6 +1154,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn refresh_config_forwards_to_watcher_and_awaits_ack() {
+        // The RefreshConfig arm must hand a refresh request to the config
+        // watcher and await its ack. Because the commands channel is in-order
+        // and the dispatcher processes envelopes sequentially, awaiting here is
+        // what guarantees the in-memory config is updated before a following
+        // StartRecording / VideoChunkReady resolves its codec. A stand-in
+        // watcher acks the request; the test proves the request is delivered and
+        // the dispatcher keeps running after the ack.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let (refresh_tx, mut refresh_rx) = mpsc::channel::<ConfigRefreshRequest>(4);
+        let dispatcher_context = DispatcherContext {
+            event_bus: None,
+            config_refresh_tx: Some(refresh_tx),
+        };
+        let (tx, handle) =
+            spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
+
+        // Stand-in watcher: ack the first refresh request it receives.
+        let watcher = tokio::spawn(async move {
+            match refresh_rx.recv().await {
+                Some(ack) => ack.send(()).is_ok(),
+                None => false,
+            }
+        });
+
+        tx.send(Envelope::RefreshConfig {}).await.unwrap();
+        let acked = timeout(Duration::from_secs(5), watcher)
+            .await
+            .expect("watcher observed the refresh within 5s")
+            .expect("watcher task joined");
+        assert!(
+            acked,
+            "dispatcher must forward RefreshConfig to the watcher"
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+    }
+
+    #[tokio::test]
+    async fn refresh_config_without_watcher_is_noop() {
+        // With no `config_refresh_tx` wired (tests / no watcher) a RefreshConfig
+        // must be a harmless no-op: the dispatcher neither blocks nor dies, and
+        // keeps routing afterwards.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let dispatcher_context = DispatcherContext {
+            event_bus: None,
+            config_refresh_tx: None,
+        };
+        let (tx, handle) =
+            spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
+
+        timeout(Duration::from_secs(5), tx.send(Envelope::RefreshConfig {}))
+            .await
+            .expect("send did not block")
+            .expect("dispatcher accepted the envelope");
+
+        drop(tx);
+        timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+    }
+
+    #[tokio::test]
     async fn routes_data_into_its_window_by_timestamp() {
         fast_holdback();
         let (store, dir) = open_store().await;
@@ -1125,6 +1232,7 @@ mod tests {
         let bus = crate::state::EventBus::new();
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
+            config_refresh_tx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -1411,6 +1519,7 @@ mod tests {
         let mut sub = bus.subscribe();
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
+            config_refresh_tx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -1463,6 +1572,7 @@ mod tests {
             context,
             DispatcherContext {
                 event_bus: Some(bus.clone()),
+                config_refresh_tx: None,
             },
         );
 

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -426,6 +426,22 @@ fn get_recording_id(
     })
 }
 
+/// Ask the running daemon to reload its profile config immediately (see
+/// [`Envelope::RefreshConfig`]). Published on the caller thread's command port
+/// so it is strictly ordered ahead of a subsequent `start_recording` from the
+/// same thread.
+///
+/// Best-effort: the SDK caller ignores failures. With no daemon running the
+/// command reaches zero subscribers (a no-op); the profile write already
+/// persisted, so the daemon picks it up on its next poll or at launch.
+#[pyfunction]
+fn refresh_config(py: Python<'_>) -> PyResult<()> {
+    py.detach(|| -> PyResult<()> {
+        publish(&Envelope::RefreshConfig {})?;
+        Ok(())
+    })
+}
+
 /// Python module entrypoint registered as `neuracore.data_daemon._data_bridge`.
 #[pymodule]
 fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -436,5 +452,6 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
+    module.add_function(wrap_pyfunction!(refresh_config, module)?)?;
     Ok(())
 }

--- a/rust/data_daemon_shared/src/config/env.rs
+++ b/rust/data_daemon_shared/src/config/env.rs
@@ -145,6 +145,9 @@ pub fn env_config_overrides() -> DaemonConfig {
     if let Some(value) = env_var("NEURACORE_ORG_ID") {
         config.current_org_id = Some(value);
     }
+    if let Some(value) = env_var("NCD_VIDEO_CODEC") {
+        config.video_codec = Some(value);
+    }
 
     config
 }
@@ -296,6 +299,7 @@ mod tests {
         "NCD_OFFLINE",
         "NCD_API_KEY",
         "NEURACORE_ORG_ID",
+        "NCD_VIDEO_CODEC",
         "NEURACORE_DAEMON_PROFILE",
     ];
 
@@ -319,6 +323,7 @@ mod tests {
         std::env::set_var("NCD_OFFLINE", "1");
         std::env::set_var("NCD_API_KEY", "secret-key");
         std::env::set_var("NEURACORE_ORG_ID", "org-42");
+        std::env::set_var("NCD_VIDEO_CODEC", "h264_medium");
         std::env::set_var("NEURACORE_DAEMON_PROFILE", "lab");
 
         let config = env_config_overrides();
@@ -334,6 +339,7 @@ mod tests {
         assert_eq!(config.offline, Some(true));
         assert_eq!(config.api_key.as_deref(), Some("secret-key"));
         assert_eq!(config.current_org_id.as_deref(), Some("org-42"));
+        assert_eq!(config.video_codec.as_deref(), Some("h264_medium"));
         assert_eq!(active_profile_name().as_deref(), Some("lab"));
 
         // 2) An empty string is treated as unset; an unparseable numeric is
@@ -368,6 +374,7 @@ mod tests {
         assert_eq!(config.offline, None);
         assert_eq!(config.api_key, None);
         assert_eq!(config.current_org_id, None);
+        assert_eq!(config.video_codec, None);
         assert_eq!(active_profile_name(), None);
 
         // Restore the pre-test environment for other tests in this binary.

--- a/rust/data_daemon_shared/src/config/mod.rs
+++ b/rust/data_daemon_shared/src/config/mod.rs
@@ -69,6 +69,8 @@ pub struct DaemonConfig {
     pub api_key: Option<String>,
     /// Organisation ID for the authenticated user.
     pub current_org_id: Option<String>,
+    /// Global video codec selection (a Codec value, e.g. "h264_medium").
+    pub video_codec: Option<String>,
 }
 
 impl DaemonConfig {
@@ -104,6 +106,9 @@ impl DaemonConfig {
         if other.current_org_id.is_some() {
             self.current_org_id = other.current_org_id.clone();
         }
+        if other.video_codec.is_some() {
+            self.video_codec = other.video_codec.clone();
+        }
     }
 }
 
@@ -135,6 +140,7 @@ pub fn build_default_daemon_config() -> std::io::Result<DaemonConfig> {
         offline: Some(false),
         api_key: None,
         current_org_id: None,
+        video_codec: None,
     })
 }
 
@@ -246,6 +252,7 @@ mod tests {
             offline: Some(false),
             api_key: None,
             current_org_id: None,
+            video_codec: None,
         };
         let json = serde_json::to_string_pretty(&config).unwrap();
         let keys: Vec<&str> = json
@@ -265,6 +272,7 @@ mod tests {
                 "offline",
                 "api_key",
                 "current_org_id",
+                "video_codec",
             ]
         );
     }

--- a/rust/data_daemon_shared/src/config/profile.rs
+++ b/rust/data_daemon_shared/src/config/profile.rs
@@ -50,8 +50,10 @@ impl ProfileManager {
         }
     }
 
-    /// Create a `ProfileManager` rooted at an explicit home directory.
-    #[cfg(test)]
+    /// Create a `ProfileManager` rooted at an explicit home directory. Used to
+    /// resolve against an injected root (the config watcher's tests, and any
+    /// test avoiding the developer's real profiles); production uses `new`,
+    /// which resolves the real home.
     pub fn with_home(home: PathBuf) -> Self {
         ProfileManager { home }
     }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -381,6 +381,14 @@ pub enum Envelope {
         /// postcard for the metadata sidecar.
         frame_timestamps_s: Vec<f64>,
     },
+    /// Force the daemon to re-read its profile config immediately, rather than
+    /// waiting for the config watcher's next poll. Sent by the SDK's
+    /// `set_video_encoding_options` after it writes the profile so a
+    /// `set → start_recording → log_frame` sequence observes the new codec.
+    /// Carries no fields — the config is daemon-global — and touches no
+    /// recording window; the dispatcher handles it by refreshing the in-memory
+    /// config (see `cloud::config_watcher`).
+    RefreshConfig {},
 }
 
 /// One sensor's sample inside an [`Envelope::BatchedData`] batch.
@@ -409,6 +417,7 @@ impl Envelope {
             Envelope::Data { .. } => "data",
             Envelope::BatchedData { .. } => "batched_data",
             Envelope::VideoChunkReady { .. } => "video_chunk_ready",
+            Envelope::RefreshConfig {} => "refresh_config",
         }
     }
 
@@ -671,6 +680,14 @@ mod tests {
         let bytes = cancel.encode().expect("encode");
         assert_eq!(cancel, Envelope::decode(&bytes).expect("decode"));
         assert_eq!(cancel.kind(), "cancel_recording");
+    }
+
+    #[test]
+    fn refresh_config_round_trips() {
+        let refresh = Envelope::RefreshConfig {};
+        let bytes = refresh.encode().expect("encode");
+        assert_eq!(refresh, Envelope::decode(&bytes).expect("decode"));
+        assert_eq!(refresh.kind(), "refresh_config");
     }
 
     #[test]

--- a/tests/unit/core/test_video_encoding.py
+++ b/tests/unit/core/test_video_encoding.py
@@ -1,0 +1,64 @@
+"""Tests for the SDK video encoding codec helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from neuracore.core.video_encoding import Codec, codec_option_overrides, resolve_codec
+
+_MODULE_LOGGER = "neuracore.core.video_encoding"
+
+
+def test_h264_medium_resolves_and_maps_to_crf_23_medium() -> None:
+    assert resolve_codec("h264_medium") is Codec.H264_MEDIUM
+    assert codec_option_overrides("h264_medium") == {
+        "crf": "23",
+        "preset": "medium",
+    }
+
+
+def test_h264_lossless_resolves_but_uses_default_encoders() -> None:
+    # H264_LOSSLESS is a recognised codec (no warning) that maps to the default
+    # lossless+lossy encoders, so it is the explicit "switch back" value.
+    assert resolve_codec("h264_lossless") is Codec.H264_LOSSLESS
+    assert codec_option_overrides("h264_lossless") is None
+
+
+def test_unset_and_unknown_resolve_to_default() -> None:
+    for value in (None, "", "not-a-codec"):
+        assert resolve_codec(value) is None
+        assert codec_option_overrides(value) is None
+
+
+def test_options_are_a_fresh_copy_each_call() -> None:
+    first = codec_option_overrides("h264_medium")
+    assert first is not None
+    first["crf"] = "0"
+    # Mutating the returned dict must not corrupt the source-of-truth mapping.
+    assert codec_option_overrides("h264_medium") == {
+        "crf": "23",
+        "preset": "medium",
+    }
+
+
+def test_unknown_codec_logs_a_warning(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
+        assert resolve_codec("not-a-codec") is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "not-a-codec" in warnings[0].getMessage()
+
+
+def test_known_and_unset_codecs_do_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The explicit default and unset/empty values are silent — only a genuinely
+    # unrecognised value warns.
+    with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
+        resolve_codec("h264_lossless")
+        resolve_codec("h264_medium")
+        resolve_codec(None)
+        resolve_codec("")
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/tests/unit/data_daemon/cli/test_update_profiles_cli.py
+++ b/tests/unit/data_daemon/cli/test_update_profiles_cli.py
@@ -6,6 +6,7 @@ import pytest
 import typer
 
 import neuracore.data_daemon.config_manager.args_handler as ah
+from neuracore.core.video_encoding import Codec
 
 
 def test_run_profile_create_happy_path(
@@ -50,6 +51,33 @@ def test_run_profile_update_validates_and_updates(
     assert called["name"] == "demo"
     assert called["updates"] == {"storage_limit": 2048, "bandwidth_limit": 4096}
     assert "Updated profile 'demo'." in capsys.readouterr().out
+
+
+def test_run_profile_update_sets_video_codec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: dict[str, Any] = {}
+
+    def fake_update_profile(name: str, updates: dict[str, Any]) -> None:
+        called["updates"] = updates
+
+    monkeypatch.setattr(ah.profile_manager, "update_profile", fake_update_profile)
+
+    ah.run_profile_update(
+        name="demo",
+        storage_limit=None,
+        bandwidth_limit=None,
+        path_to_store_record=None,
+        num_threads=None,
+        keep_wakelock_while_upload=None,
+        offline=None,
+        api_key=None,
+        current_org_id=None,
+        video_codec=Codec.H264_MEDIUM,
+    )
+
+    # The enum is persisted as its plain string value.
+    assert called["updates"] == {"video_codec": "h264_medium"}
 
 
 def test_run_profile_get_prints_json(

--- a/tests/unit/data_daemon/communications_management/test_recording_context_notify.py
+++ b/tests/unit/data_daemon/communications_management/test_recording_context_notify.py
@@ -1,0 +1,46 @@
+"""Tests for notify_daemon_config_changed (the best-effort daemon reload nudge)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from neuracore.data_daemon.communications_management.shared_transport import (
+    recording_context,
+)
+
+MODULE = (
+    "neuracore.data_daemon.communications_management.shared_transport.recording_context"
+)
+
+
+def test_notify_is_noop_when_rust_daemon_disabled() -> None:
+    native = MagicMock()
+    with (
+        patch(f"{MODULE}.is_rust_daemon_enabled", return_value=False),
+        patch(f"{MODULE}._load_native", return_value=native) as load_native,
+    ):
+        recording_context.notify_daemon_config_changed()
+    load_native.assert_not_called()
+    native.refresh_config.assert_not_called()
+
+
+def test_notify_calls_refresh_config_when_rust_daemon_enabled() -> None:
+    native = MagicMock()
+    with (
+        patch(f"{MODULE}.is_rust_daemon_enabled", return_value=True),
+        patch(f"{MODULE}._load_native", return_value=native),
+    ):
+        recording_context.notify_daemon_config_changed()
+    native.refresh_config.assert_called_once_with()
+
+
+def test_notify_swallows_native_errors() -> None:
+    # Contract: never raises to the SDK caller even if the native call fails.
+    native = MagicMock()
+    native.refresh_config.side_effect = RuntimeError("daemon gone")
+    with (
+        patch(f"{MODULE}.is_rust_daemon_enabled", return_value=True),
+        patch(f"{MODULE}._load_native", return_value=native),
+    ):
+        recording_context.notify_daemon_config_changed()  # must not raise
+    native.refresh_config.assert_called_once_with()

--- a/tests/unit/data_daemon/config_manager/test_profiles_api.py
+++ b/tests/unit/data_daemon/config_manager/test_profiles_api.py
@@ -226,6 +226,50 @@ def test_resolve_effective_config_env_overrides_profile(
     assert effective_config.offline is True
 
 
+def test_resolve_effective_config_env_sets_video_codec(
+    profile_manager: ProfileManager,
+    profiles_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NCD_VIDEO_CODEC should populate the resolved DaemonConfig.video_codec."""
+    profile_name = "recording"
+    profiles_directory.mkdir(parents=True, exist_ok=True)
+    profile_path = profiles_directory / f"{profile_name}.yaml"
+    with profile_path.open("w") as profile_file:
+        yaml.safe_dump({"offline": False}, profile_file)
+
+    monkeypatch.setenv("NCD_VIDEO_CODEC", "h264_medium")
+
+    config_manager = ConfigManager(
+        profile_manager=profile_manager, profile=profile_name
+    )
+    effective_config = config_manager.resolve_effective_config(cli_config={})
+
+    assert effective_config.video_codec == "h264_medium"
+
+
+def test_resolve_effective_config_env_video_codec_overrides_profile(
+    profile_manager: ProfileManager,
+    profiles_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NCD_VIDEO_CODEC must win over a conflicting profile video_codec value."""
+    profile_name = "recording"
+    profiles_directory.mkdir(parents=True, exist_ok=True)
+    profile_path = profiles_directory / f"{profile_name}.yaml"
+    with profile_path.open("w") as profile_file:
+        yaml.safe_dump({"video_codec": "h264_lossless"}, profile_file)
+
+    monkeypatch.setenv("NCD_VIDEO_CODEC", "h264_medium")
+
+    config_manager = ConfigManager(
+        profile_manager=profile_manager, profile=profile_name
+    )
+    effective_config = config_manager.resolve_effective_config(cli_config={})
+
+    assert effective_config.video_codec == "h264_medium"
+
+
 def test_resolve_effective_config_env_supports_unit_suffixed_values(
     profile_manager: ProfileManager,
     profiles_directory: Path,

--- a/tests/unit/data_daemon/config_manager/test_video_codec.py
+++ b/tests/unit/data_daemon/config_manager/test_video_codec.py
@@ -1,0 +1,172 @@
+"""Tests for the profile-backed video codec writer and the ConfigWatcher cache."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
+from neuracore.data_daemon.config_manager.profiles import ProfileManager
+from neuracore.data_daemon.config_manager.video_codec import (
+    set_active_profile_video_codec,
+)
+from neuracore.data_daemon.const import active_profile_name
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Root the profile system and recordings dir under a temporary home."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("NEURACORE_DAEMON_RECORDINGS_ROOT", str(tmp_path / "rec"))
+    monkeypatch.delenv("NEURACORE_DAEMON_PROFILE", raising=False)
+    monkeypatch.delenv("NCD_VIDEO_CODEC", raising=False)
+    return home
+
+
+def _profile_codec() -> str | None:
+    """Read the codec back from the active profile on disk."""
+    return ProfileManager().get_profile(active_profile_name()).video_codec
+
+
+# --- Writer: set_active_profile_video_codec / nc.set_video_encoding_options ---
+
+
+def test_set_persists_codec_to_profile(isolated_home: Path) -> None:
+    set_active_profile_video_codec("h264_medium")
+    assert _profile_codec() == "h264_medium"
+
+
+def test_set_lossless_reverts_to_the_default_codec(isolated_home: Path) -> None:
+    # There is no "clear" — switching back from a lossy mode persists the
+    # explicit h264_lossless default, which resolves to the default encoders.
+    set_active_profile_video_codec("h264_medium")
+    set_active_profile_video_codec("h264_lossless")
+    assert _profile_codec() == "h264_lossless"
+
+
+def test_set_video_encoding_options_api_writes_profile(isolated_home: Path) -> None:
+    # nc imported lazily so the isolated_home fixture has already patched
+    # Path.home before the (heavy) package import resolves any config.
+    import neuracore as nc
+
+    nc.set_video_encoding_options(nc.Codec.H264_MEDIUM)
+    assert _profile_codec() == "h264_medium"
+
+    nc.set_video_encoding_options(nc.Codec.H264_LOSSLESS)
+    assert _profile_codec() == "h264_lossless"
+
+
+def test_set_video_encoding_options_rejects_unknown_codec(isolated_home: Path) -> None:
+    import neuracore as nc
+
+    with pytest.raises(ValueError, match="Unknown video codec"):
+        nc.set_video_encoding_options("not-a-codec")
+
+
+def test_set_video_encoding_options_nudges_daemon(isolated_home: Path) -> None:
+    # A successful set persists the codec AND nudges a running daemon to reload
+    # (so a set -> start_recording sequence picks it up immediately).
+    import neuracore as nc
+    from neuracore.api import logging as logging_api
+
+    with patch.object(logging_api, "notify_daemon_config_changed") as notify:
+        nc.set_video_encoding_options(nc.Codec.H264_MEDIUM)
+    notify.assert_called_once_with()
+    assert _profile_codec() == "h264_medium"
+
+
+def test_set_video_encoding_options_does_not_nudge_on_invalid_codec(
+    isolated_home: Path,
+) -> None:
+    # An invalid codec must raise before persisting or nudging the daemon.
+    import neuracore as nc
+    from neuracore.api import logging as logging_api
+
+    with patch.object(logging_api, "notify_daemon_config_changed") as notify:
+        with pytest.raises(ValueError, match="Unknown video codec"):
+            nc.set_video_encoding_options("not-a-codec")
+    notify.assert_not_called()
+
+
+# --- ConfigWatcher: the in-memory cache the daemon actually reads ---
+
+
+def test_watcher_seed_value_is_available_immediately() -> None:
+    # The launch-resolved config is the seed, so the value is valid before the
+    # first background poll.
+    watcher = ConfigWatcher(initial_config=DaemonConfig(video_codec="h264_medium"))
+    assert watcher.video_codec() == "h264_medium"
+
+
+@pytest.mark.asyncio
+async def test_watcher_refresh_picks_up_change() -> None:
+    watcher = ConfigWatcher(
+        initial_config=DaemonConfig(video_codec="h264_lossless"),
+        resolver=lambda: DaemonConfig(video_codec="h264_medium"),
+    )
+    assert watcher.video_codec() == "h264_lossless"
+    await watcher.refresh()
+    assert watcher.video_codec() == "h264_medium"
+
+
+@pytest.mark.asyncio
+async def test_watcher_keeps_last_good_on_resolve_error() -> None:
+    def boom() -> DaemonConfig:
+        raise RuntimeError("profile read failed")
+
+    watcher = ConfigWatcher(
+        initial_config=DaemonConfig(video_codec="h264_medium"),
+        resolver=boom,
+    )
+    await watcher.refresh()
+    assert watcher.video_codec() == "h264_medium"
+
+
+def test_watcher_refresh_now_picks_up_change() -> None:
+    # The synchronous variant the encoding path uses on the recording hot path:
+    # re-resolves inline (off the loop) so a codec set just before recording is
+    # honoured for the new encoder without waiting for the ~1s poll.
+    watcher = ConfigWatcher(
+        initial_config=DaemonConfig(video_codec="h264_lossless"),
+        resolver=lambda: DaemonConfig(video_codec="h264_medium"),
+    )
+    assert watcher.video_codec() == "h264_lossless"
+    watcher.refresh_now()
+    assert watcher.video_codec() == "h264_medium"
+
+
+def test_watcher_refresh_now_keeps_last_good_on_resolve_error() -> None:
+    def boom() -> DaemonConfig:
+        raise RuntimeError("profile read failed")
+
+    watcher = ConfigWatcher(
+        initial_config=DaemonConfig(video_codec="h264_medium"),
+        resolver=boom,
+    )
+    watcher.refresh_now()
+    assert watcher.video_codec() == "h264_medium"
+
+
+@pytest.mark.asyncio
+async def test_watcher_background_loop_refreshes() -> None:
+    watcher = ConfigWatcher(
+        initial_config=DaemonConfig(video_codec="h264_lossless"),
+        check_interval=0.01,
+        resolver=lambda: DaemonConfig(video_codec="h264_medium"),
+    )
+    await watcher.start()
+    try:
+        for _ in range(200):
+            if watcher.video_codec() == "h264_medium":
+                break
+            await asyncio.sleep(0.01)
+        assert watcher.video_codec() == "h264_medium"
+    finally:
+        await watcher.stop()

--- a/tests/unit/data_daemon/test_runtime.py
+++ b/tests/unit/data_daemon/test_runtime.py
@@ -68,6 +68,7 @@ class TestDaemonRuntimeInitialize:
         mock_rdm = MagicMock()
         mock_comm = MagicMock()
         mock_services = MagicMock(spec=DaemonServices)
+        mock_services.config_watcher = MagicMock()
         mock_services.state_store = MagicMock()
         mock_loop_mgr = MagicMock()
 
@@ -470,6 +471,7 @@ class TestDaemonRuntimeShutdown:
         mock_rdm = MagicMock()
         mock_rdm.shutdown = AsyncMock()
         mock_services = MagicMock(spec=DaemonServices)
+        mock_services.config_watcher = MagicMock()
         mock_services.state_store = MagicMock()
         mock_loop_mgr = MagicMock()
 
@@ -597,6 +599,7 @@ class TestDaemonRuntimeShutdown:
         """
         mock_rdm = MagicMock()
         mock_services = MagicMock(spec=DaemonServices)
+        mock_services.config_watcher = MagicMock()
         mock_loop_mgr = MagicMock()
 
         context = DaemonContext(
@@ -701,6 +704,7 @@ class TestDaemonRuntimeContext:
         mock_rdm = MagicMock()
         mock_comm = MagicMock()
         mock_services = MagicMock(spec=DaemonServices)
+        mock_services.config_watcher = MagicMock()
         mock_services.state_store = MagicMock()
         mock_loop_mgr = MagicMock()
 

--- a/tests/unit/data_daemon/test_services.py
+++ b/tests/unit/data_daemon/test_services.py
@@ -50,6 +50,9 @@ def mock_daemon_services() -> DaemonServices:
     mock_connection_manager = MagicMock()
     mock_connection_manager.stop = AsyncMock()
 
+    mock_config_watcher = MagicMock()
+    mock_config_watcher.stop = AsyncMock()
+
     return DaemonServices(
         client_session=mock_session,
         state_store=mock_state_store,
@@ -59,6 +62,7 @@ def mock_daemon_services() -> DaemonServices:
         upload_manager=mock_upload_manager,
         connection_manager=mock_connection_manager,
         progress_reporter=MagicMock(),
+        config_watcher=mock_config_watcher,
     )
 
 
@@ -82,6 +86,7 @@ class TestDaemonServicesCreate:
     ) -> None:
         with (
             patch("neuracore.data_daemon.services.ConnectionManager") as MockConnMgr,
+            patch("neuracore.data_daemon.services.ConfigWatcher") as MockConfigWatcher,
             patch("neuracore.data_daemon.services.UploadManager") as MockUploadMgr,
             patch(
                 "neuracore.data_daemon.services.ProgressReporter"
@@ -92,6 +97,10 @@ class TestDaemonServicesCreate:
             mock_conn_instance = AsyncMock()
             mock_conn_instance.start = AsyncMock()
             MockConnMgr.return_value = mock_conn_instance
+
+            mock_config_watcher_instance = AsyncMock()
+            mock_config_watcher_instance.start = AsyncMock()
+            MockConfigWatcher.return_value = mock_config_watcher_instance
 
             mock_upload_instance = MagicMock()
             MockUploadMgr.return_value = mock_upload_instance
@@ -117,9 +126,11 @@ class TestDaemonServicesCreate:
             assert services.upload_manager is mock_upload_instance
             assert services.connection_manager is mock_conn_instance
             assert services.progress_reporter is mock_progress_instance
+            assert services.config_watcher is mock_config_watcher_instance
 
             mock_state_store_instance.init_async_store.assert_called_once()
             mock_conn_instance.start.assert_called_once()
+            mock_config_watcher_instance.start.assert_called_once()
             await services.client_session.close()
 
 
@@ -132,6 +143,7 @@ class TestDaemonServicesShutdown:
         await mock_daemon_services.shutdown()
 
         mock_daemon_services.connection_manager.stop.assert_called_once()
+        mock_daemon_services.config_watcher.stop.assert_called_once()
         mock_daemon_services.upload_manager.shutdown.assert_called_once()
         mock_daemon_services.trace_status_updater.shutdown.assert_called_once()
         mock_daemon_services.state_store.close.assert_called_once()


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Added a `video_codec` setting and a `set_video_encoding_options` method so users can select the RGB video codec. Also settable via the `--video-codec` CLI option, the `NCD_VIDEO_CODEC` environment variable, and the daemon profile. The daemon picks up a change live (config watcher + on-demand refresh) so it applies to the next recording without a restart. This PR only wires up and propagates the setting — encoding output is unchanged; the behaviour that acts on the codec follows in the stacked PR.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-945](https://neuracore.atlassian.net/browse/NCP-945)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - #752 — stacked on top of this PR (the lossy encoding behaviour)

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->