### PR TITLE
feat: encode lossy-only RGB video for the selected codec

### DIFF
--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -312,6 +312,57 @@ export NEURACORE_DAEMON_RECORDINGS_ROOT=/workspaces/neuracore/recordings
 
 ---
 
+## Video encoding options
+
+By default every RGB camera is uploaded twice: a **lossless** archive
+(`lossless.mp4`, used for training) and a small **lossy** preview
+(`lossy.mp4`). For long recordings the lossless archive dominates upload size,
+disk, and CPU.
+
+Selecting the `h264_medium` codec switches RGB cameras to a single
+full-resolution **libx264 CRF 23** video (`lossy.mp4`) and **drops the lossless
+archive**. That one video is used for both preview and training, trading a
+little image fidelity for much smaller uploads. Depth cameras always keep their
+lossless storage (their lossy proxy is a visualisation, not precise depth).
+
+This is **irreversible for recordings made under it**: the lossless archive is
+never written, so switching back to `h264_lossless` only affects *future*
+recordings — it cannot restore lossless data for episodes already captured in
+lossy-only mode.
+
+The setting is **global** (it applies to every camera) and lives in the daemon
+profile, so it persists and is picked up for the next recording. The two codecs
+are `h264_lossless` (the default) and `h264_medium` (lossy-only). Set it three
+ways, exactly like the other profile options:
+
+- **From the SDK** (writes the active profile):
+
+  ```python
+  import neuracore as nc
+
+  nc.set_video_encoding_options(codec=nc.Codec.H264_MEDIUM)    # lossy-only
+  nc.start_recording()
+  # ... log frames ...
+  nc.stop_recording()
+
+  nc.set_video_encoding_options(codec=nc.Codec.H264_LOSSLESS)  # back to default
+  ```
+
+- **With the CLI**, via `profile update`:
+
+  ```bash
+  neuracore data-daemon profile update --video-codec h264_medium
+  neuracore data-daemon profile update --video-codec h264_lossless
+  ```
+
+- **With an environment variable**: `export NCD_VIDEO_CODEC=h264_medium`
+  (overrides the profile value).
+
+The daemon re-reads the codec at the start of each recording, so a change takes
+effect for the next recording without restarting the daemon.
+
+---
+
 ## CLI reference
 
 ### `neuracore data-daemon profile create`

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
+import requests
 import wget
 from neuracore_types import (
     CameraData,
@@ -37,6 +38,9 @@ if TYPE_CHECKING:
 
 MAX_DECODING_ATTEMPTS = 3
 _FFMPEG_AVAILABLE: bool | None = None
+
+_RGB_VIDEO_FILENAME_PREFERENCE = ("lossless.mp4", "lossy.mp4")
+_DEPTH_VIDEO_FILENAME_PREFERENCE = ("lossless.mp4",)
 
 
 class SynchronizedRecording:
@@ -133,17 +137,35 @@ class SynchronizedRecording:
             URL string for downloading the video file.
 
         Raises:
-            requests.HTTPError: If the API request fails.
+            requests.HTTPError: If every candidate is absent (404), or for any
+                non-404 HTTP error.
         """
         auth = get_auth()
         session = thread_local_session()
-        response = session.get(
-            f"{API_URL}/org/{self.dataset.org_id}/recording/{self.id}/download_url",
-            params={"filepath": f"{camera_type.value}/{camera_id}/lossless.mp4"},
-            headers=auth.get_headers(),
+
+        filename_preference = (
+            _DEPTH_VIDEO_FILENAME_PREFERENCE
+            if camera_type == DataType.DEPTH_IMAGES
+            else _RGB_VIDEO_FILENAME_PREFERENCE
         )
-        response.raise_for_status()
-        return response.json()["url"]
+
+        for video_filename in filename_preference:
+            response = session.get(
+                f"{API_URL}/org/{self.dataset.org_id}/recording/{self.id}/download_url",
+                params={
+                    "filepath": f"{camera_type.value}/{camera_id}/{video_filename}"
+                },
+                headers=auth.get_headers(),
+            )
+            if response.status_code == 404:
+                continue
+            response.raise_for_status()
+            return response.json()["url"]
+
+        raise requests.HTTPError(
+            f"No candidate filename found for recording {self.id} "
+            f"(camera {camera_type.value}/{camera_id}); tried: {filename_preference}"
+        )
 
     def _decode_video(self, video_location: Path, video_frame_cache_path: Path) -> None:
         """Extract frames from video and cache them to disk.
@@ -152,7 +174,6 @@ class SynchronizedRecording:
             video_location: Path to the video file.
             video_frame_cache_path: Path to the directory where video frames are cached.
         """
-        """Extract frames from video and cache them to disk."""
         global _FFMPEG_AVAILABLE
 
         # Lazily determine ffmpeg availability once

--- a/neuracore/core/video_encoding.py
+++ b/neuracore/core/video_encoding.py
@@ -16,8 +16,10 @@ visualisation, not precise depth, so it is never a valid training source.
 
 from __future__ import annotations
 
+import copy
 import enum
 import logging
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,14 @@ class Codec(str, enum.Enum):
     H264_MEDIUM = "h264_medium"
 
 
-_LOSSY_CODEC_OPTIONS: dict[Codec, dict[str, str]] = {
+class Libx264Options(TypedDict, total=False):
+    """libx264 codec-context options for the lossy RGB encoder."""
+
+    crf: str
+    preset: str
+
+
+_LOSSY_CODEC_OPTIONS: dict[Codec, Libx264Options] = {
     Codec.H264_MEDIUM: {"crf": "23", "preset": "medium"},
 }
 
@@ -72,7 +81,7 @@ def resolve_codec(value: str | None) -> Codec | None:
         return None
 
 
-def codec_option_overrides(value: str | None) -> dict[str, str] | None:
+def codec_option_overrides(value: str | None) -> Libx264Options | None:
     """Return the lossy-only libx264 options for a codec string, or ``None``.
 
     ``None`` selects the default lossless-plus-preview encoders; a dict selects a
@@ -89,4 +98,4 @@ def codec_option_overrides(value: str | None) -> dict[str, str] | None:
     if codec is None:
         return None
     options = _LOSSY_CODEC_OPTIONS.get(codec)
-    return dict(options) if options is not None else None
+    return copy.copy(options) if options is not None else None

--- a/neuracore/data_daemon/recording_encoding_disk_manager/encoding/video_trace.py
+++ b/neuracore/data_daemon/recording_encoding_disk_manager/encoding/video_trace.py
@@ -7,7 +7,7 @@ import logging
 import pathlib
 import struct
 import time
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -16,6 +16,7 @@ from neuracore.core.utils.depth_utils import (
     depth_to_rgb_storage,
     depth_to_rgb_visualization,
 )
+from neuracore.core.video_encoding import Libx264Options
 from neuracore.data_daemon.recording_encoding_disk_manager.encoding.disk_video_encoder import (  # noqa: E501
     BaseDiskVideoEncoder,
     DiskVideoEncoder,
@@ -43,6 +44,7 @@ class VideoTrace:
         chunk_size: int = CHUNK_SIZE,
         lossy_name: str = LOSSY_VIDEO_NAME,
         lossless_name: str = LOSSLESS_VIDEO_NAME,
+        codec_option_overrides: Libx264Options | None = None,
     ) -> None:
         """Initialise a video trace writer.
 
@@ -51,6 +53,8 @@ class VideoTrace:
             chunk_size: Buffered write chunk size for video outputs.
             lossy_name: Filename for the lossy MP4 output.
             lossless_name: Filename for the lossless MP4 output.
+            codec_option_overrides: When provided, encode a single video with these
+                    codec-context options and skip the lossless archive.
 
         Returns:
             None
@@ -63,6 +67,7 @@ class VideoTrace:
         self.trace_path = self.output_dir / TRACE_FILE
 
         self.chunk_size = chunk_size
+        self._codec_option_overrides = codec_option_overrides
 
         self.width: int | None = None
         self.height: int | None = None
@@ -216,6 +221,21 @@ class VideoTrace:
                 "VideoTrace needs width/height before frames. Send metadata first."
             )
 
+        if self._codec_option_overrides is not None:
+            if self._lossy_encoder is None:
+                self._lossy_encoder = DiskVideoEncoder(
+                    filepath=self.lossy_path,
+                    width=self.width,
+                    height=self.height,
+                    codec="libx264",
+                    pixel_format="yuv420p",
+                    codec_context_options=cast(
+                        "dict[str, str]", self._codec_option_overrides
+                    ),
+                    chunk_size=self.chunk_size,
+                )
+            return
+
         if self._lossless_encoder is None:
             self._lossless_encoder = DiskVideoEncoder(
                 filepath=self.lossless_path,
@@ -253,7 +273,10 @@ class VideoTrace:
             raise RuntimeError(
                 "VideoTrace missing width/height after encoder initialisation"
             )
-        if self._lossless_encoder is None or self._lossy_encoder is None:
+        lossless_required = self._codec_option_overrides is None
+        if self._lossy_encoder is None or (
+            lossless_required and self._lossless_encoder is None
+        ):
             raise RuntimeError(
                 "VideoTrace encoders unexpectedly None after initialisation"
             )
@@ -298,9 +321,10 @@ class VideoTrace:
         self._expected_raw_frame_bytes_total += len(frame_bytes)
 
         timestamp_value = self._get_frame_timestamp()
-        self._lossless_encoder.add_frame(
-            timestamp=timestamp_value, np_frame=np_frame_lossless
-        )
+        if self._lossless_encoder is not None:
+            self._lossless_encoder.add_frame(
+                timestamp=timestamp_value, np_frame=np_frame_lossless
+            )
         self._lossy_encoder.add_frame(
             timestamp=timestamp_value, np_frame=np_frame_lossy
         )

--- a/neuracore/data_daemon/recording_encoding_disk_manager/lifecycle/encoder_manager.py
+++ b/neuracore/data_daemon/recording_encoding_disk_manager/lifecycle/encoder_manager.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+from neuracore_types import DataType
+
+from neuracore.core.video_encoding import Libx264Options, codec_option_overrides
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
 from neuracore.data_daemon.event_emitter import Emitter
 from neuracore.data_daemon.models import get_content_type
 from neuracore.data_daemon.recording_encoding_disk_manager.encoding.json_trace import (
@@ -37,6 +41,7 @@ class _EncoderManager:
         filesystem: _TraceFilesystem,
         abort_trace: Callable[[TraceKey], None],
         emitter: Emitter,
+        config_watcher: ConfigWatcher,
     ) -> None:
         """Initialise _EncoderManager.
 
@@ -44,9 +49,12 @@ class _EncoderManager:
             filesystem: Filesystem helper for path resolution.
             abort_trace: Callback used to abort traces on failure.
             emitter: Event emitter for cross-component signaling.
+            config_watcher: In-memory daemon config, read for the video codec for new
+                encoders.
         """
         self._filesystem = filesystem
         self._abort_trace = abort_trace
+        self._config_watcher = config_watcher
 
         self._encoders: dict[TraceKey, JsonTrace | VideoTrace] = {}
 
@@ -87,7 +95,12 @@ class _EncoderManager:
 
         try:
             if content_kind == "RGB":
-                created_encoder = VideoTrace(output_dir=trace_dir)
+                created_encoder = VideoTrace(
+                    output_dir=trace_dir,
+                    codec_option_overrides=self._resolve_lossy_only_options(
+                        trace_key.data_type
+                    ),
+                )
             else:
                 created_encoder = JsonTrace(output_dir=trace_dir)
         except Exception:
@@ -96,6 +109,18 @@ class _EncoderManager:
 
         self._encoders[trace_key] = created_encoder
         return created_encoder
+
+    def _resolve_lossy_only_options(self, data_type: DataType) -> Libx264Options | None:
+        """Resolve lossy-only encoder options for a trace, or None for default.
+
+        Returns:
+            Lossy codec-context options (dropping the lossless archive), or None
+            to keep the default lossless+lossy encoders.
+        """
+        if data_type != DataType.RGB_IMAGES:
+            return None
+        self._config_watcher.refresh_now()
+        return codec_option_overrides(self._config_watcher.video_codec())
 
     def safe_get_encoder(self, trace_key: TraceKey) -> JsonTrace | VideoTrace | None:
         """Get or create an encoder for a trace, converting failures into a trace abort.

--- a/neuracore/data_daemon/recording_encoding_disk_manager/recording_disk_manager.py
+++ b/neuracore/data_daemon/recording_encoding_disk_manager/recording_disk_manager.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from neuracore_types import DataType
 
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
 from neuracore.data_daemon.config_manager.helpers import calculate_storage_limit
 from neuracore.data_daemon.const import (
     DEFAULT_FLUSH_BYTES,
@@ -54,6 +55,7 @@ class RecordingDiskManager:
         *,
         loop_manager: EventLoopManager,
         emitter: Emitter,
+        config_watcher: ConfigWatcher,
         flush_bytes: int | None = None,
         storage_limit_bytes: int | None = None,
         recordings_root: str | None = None,
@@ -63,10 +65,12 @@ class RecordingDiskManager:
         Args:
             loop_manager: EventLoopManager instance for scheduling workers.
             emitter: Event emitter for cross-component signaling.
+            config_watcher: In-memory daemon config
             flush_bytes: Flush threshold for buffered raw writes.
             storage_limit_bytes: Max bytes allowed for on-disk trace storage.
             recordings_root: Root directory for per-recording trace folders.
         """
+        self._config_watcher = config_watcher
         self._emitter = emitter
         self.flush_bytes = flush_bytes or DEFAULT_FLUSH_BYTES
         self.storage_limit_bytes = storage_limit_bytes
@@ -134,6 +138,7 @@ class RecordingDiskManager:
             filesystem=self._filesystem,
             abort_trace=self._controller.abort_trace_due_to_storage,
             emitter=self._emitter,
+            config_watcher=self._config_watcher,
         )
 
         self._writer = _RawBatchWriter(

--- a/neuracore/data_daemon/registration_management/registration_manager.py
+++ b/neuracore/data_daemon/registration_management/registration_manager.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 import aiohttp
@@ -45,22 +46,49 @@ FAILED_TRACES_KEY = "failed_traces"
 
 
 def get_cloud_file_list(
-    data_type: DataType, data_type_name: str
+    data_type: DataType, data_type_name: str, trace_dir: str | None = None
 ) -> list[dict[str, str]]:
-    """Derive the cloud file list for a trace from its data type."""
+    """Derive the cloud file list for a trace from its data type.
+
+    For RGB content the lossless archive is registered only when it actually
+    exists on disk: in lossy-only mode (e.g. nc.Codec.H264_MEDIUM) the daemon
+    produces just ``lossy.mp4``. Deriving the lossless entry from disk keeps
+    registration in lock-step with the uploader (which uploads exactly the
+    files present in the trace directory), independent of any between-recording
+    codec change.
+
+    Args:
+        data_type: The trace's data type.
+        data_type_name: The sensor/stream name.
+        trace_dir: The local trace directory. When omitted, the lossless
+            archive is assumed present (the default behaviour).
+    """
     prefix = f"{data_type.value}/{data_type_name}"
     files = []
     if get_content_type(data_type) == "RGB":
         files.append(
             {"filepath": f"{prefix}/{LOSSY_VIDEO_NAME}", "content_type": "video/mp4"}
         )
-        files.append(
-            {"filepath": f"{prefix}/{LOSSLESS_VIDEO_NAME}", "content_type": "video/mp4"}
-        )
+        if _lossless_archive_present(trace_dir):
+            files.append({
+                "filepath": f"{prefix}/{LOSSLESS_VIDEO_NAME}",
+                "content_type": "video/mp4",
+            })
     files.append(
         {"filepath": f"{prefix}/{TRACE_FILE}", "content_type": "application/json"}
     )
     return files
+
+
+def _lossless_archive_present(trace_dir: str | None) -> bool:
+    """Return whether the lossless archive should be registered for a trace.
+
+    True when ``trace_dir`` is unknown (preserving the default both-files
+    behaviour) or when ``lossless.mp4`` is present in the trace directory.
+    """
+    if trace_dir is None:
+        return True
+    return (Path(trace_dir) / LOSSLESS_VIDEO_NAME).exists()
 
 
 @dataclass(frozen=True)
@@ -71,6 +99,7 @@ class RegistrationCandidate:
     recording_id: str
     data_type: DataType
     data_type_name: str
+    path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -281,7 +310,7 @@ class RegistrationManager:
                         "data_type": trace.data_type.value,
                         "trace_id": str(trace.trace_id),
                         "cloud_files": get_cloud_file_list(
-                            trace.data_type, trace.data_type_name
+                            trace.data_type, trace.data_type_name, trace.path
                         ),
                     }
                     for trace in traces

--- a/neuracore/data_daemon/runtime.py
+++ b/neuracore/data_daemon/runtime.py
@@ -217,6 +217,7 @@ class DaemonRuntime:
                 loop_manager=loop_manager,
                 emitter=emitter,
                 recordings_root=config.path_to_store_record,
+                config_watcher=services.config_watcher,
             )
             logger.debug("       _RawBatchWriter: scheduled on General Loop")
             logger.debug("       _BatchEncoderWorker: scheduled on Encoder Loop")

--- a/neuracore/data_daemon/state_management/state_manager.py
+++ b/neuracore/data_daemon/state_management/state_manager.py
@@ -635,6 +635,7 @@ class StateManager:
                     recording_id=trace.recording_id,
                     data_type=trace.data_type,
                     data_type_name=trace.data_type_name,
+                    path=trace.path,
                 )
             )
         return candidates

--- a/rust/data_daemon/src/cli/coordinators.rs
+++ b/rust/data_daemon/src/cli/coordinators.rs
@@ -15,7 +15,7 @@ use crate::api::client::{ApiClient, ApiClientOptions};
 use crate::cloud::{
     spawn_org_watcher, spawn_progress_reporter, spawn_recording_cancel_notifier,
     spawn_recording_start_notifier, spawn_recording_stop_notifier, spawn_registration,
-    spawn_status_updater, spawn_uploader, OrgWatcherHandle, StatusUpdate,
+    spawn_status_updater, spawn_uploader, ConfigRx, OrgWatcherHandle, StatusUpdate,
 };
 use crate::connection::spawn_connection_monitor;
 use crate::state::{EventBus, SqliteStateStore, TraceWriteHandle};
@@ -71,6 +71,7 @@ pub(crate) fn spawn_cloud_coordinators(
     config_path: PathBuf,
     fallback_org_id: Option<String>,
     shutdown_tx: crate::lifecycle::shutdown::ShutdownBroadcaster,
+    config_rx: ConfigRx,
 ) -> CloudHandles {
     let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<StatusUpdate>();
     // Watch the SDK config for the current org; every coordinator reads the
@@ -88,6 +89,7 @@ pub(crate) fn spawn_cloud_coordinators(
         event_bus.clone(),
         Arc::clone(&client),
         org_rx.clone(),
+        config_rx,
         shutdown_tx.subscribe(),
     );
     let uploader = spawn_uploader(

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -324,10 +324,13 @@ fn run_daemon(
         // are gone at shutdown.
         let (json_write_handle, _json_writer_owner) = crate::pipeline::json_writer::spawn();
 
-        // Seed the config watch channel with the launch-resolved config; the
-        // watcher (spawned below) refreshes it. `_config_rx` is held only to keep
-        // the channel open until consumers are wired up in a follow-up change.
-        let (config_tx, _config_rx) = watch::channel(config_for_runtime.clone());
+        // In-memory daemon config: seed the watch channel with the
+        // launch-resolved effective config so its value is available before the
+        // watcher's first tick, then let the config watcher (spawned below, once
+        // the shutdown broadcaster exists) refresh it on an interval and on
+        // demand. The trace actors and registration coordinator read the codec
+        // from this channel instead of re-parsing the profile YAML per trace.
+        let (config_tx, config_rx) = watch::channel(config_for_runtime.clone());
         let (config_refresh_tx, config_refresh_rx) =
             mpsc::channel::<ConfigRefreshRequest>(CONFIG_REFRESH_CHANNEL_CAPACITY);
 
@@ -339,7 +342,8 @@ fn run_daemon(
                 trace_write_handle.clone(),
                 json_write_handle,
             )
-            .with_event_bus(event_bus.clone()),
+            .with_event_bus(event_bus.clone())
+            .with_config_rx(config_rx.clone()),
         );
 
         // Run the wait loop in a nested block so the state store can be
@@ -368,8 +372,13 @@ fn run_daemon(
             let org_id = read_org_id_from_config(&config_path)
                 .or_else(|| config_for_runtime.current_org_id.clone());
 
-            // Spawn the daemon-config watcher unconditionally: offline mode skips
-            // the cloud coordinators, but per-trace actors still need the live codec.
+            // Spawn the daemon-config watcher. Unconditional — offline mode
+            // skips the cloud coordinators, but the per-trace actors still need
+            // the live codec, so the watcher must run regardless. It owns
+            // `config_tx` / `config_refresh_rx`; the seeded `config_rx` is
+            // already wired into the actor context and, below, the registration
+            // coordinator, and `config_refresh_tx` goes to the dispatcher for
+            // the `RefreshConfig` command path.
             let config_watcher = spawn_config_watcher(
                 Some(profile.clone()),
                 None,
@@ -401,6 +410,7 @@ fn run_daemon(
                         config_path.clone(),
                         org_id.clone(),
                         shutdown_tx.clone(),
+                        config_rx.clone(),
                     )),
                     Err(error) => {
                         tracing::warn!(%error, "failed to build API client; cloud uploads disabled");

--- a/rust/data_daemon/src/cloud/cloud_files.rs
+++ b/rust/data_daemon/src/cloud/cloud_files.rs
@@ -34,6 +34,12 @@ enum ContentKind {
 /// the same `lossy.mp4` + `lossless.mp4` artefact pair to carry depth frames
 /// packed into RGB channels. Diverging here would register a different
 /// cloud-file set than the backend expects and break wire compatibility.
+///
+/// This is the video-family artefact predicate; it is deliberately broader than
+/// the lossy-codec predicate ([`crate::encoding::video_encoder::LossyVideoCodec::for_trace`]),
+/// which is RGB-only (depth is video-family but never lossy-eligible). Any new
+/// video-family type added here must be considered there too, or it could lose
+/// its lossless archive.
 fn content_type_for(data_type: &str) -> ContentKind {
     match data_type {
         "RGB_IMAGES" | "DEPTH_IMAGES" => ContentKind::Rgb,
@@ -59,12 +65,30 @@ pub fn content_type_for_filename(filename: &str) -> &'static str {
 /// `data_type` is the wire label. `data_type_name` is the producer-supplied
 /// alias (e.g. camera name); when missing we fall back to a single underscore
 /// so the path is well-formed.
-pub fn cloud_file_list(data_type: &str, data_type_name: Option<&str>) -> Vec<CloudFile> {
+///
+/// For RGB content the lossless archive is registered unless `lossy_only` is set
+/// (`nc.Codec.H264_MEDIUM`), where the daemon writes just `lossy.mp4`. The caller
+/// derives `lossy_only` from the resolved codec — the same source and predicate
+/// the encoder uses (see [`crate::encoding::video_encoder::LossyVideoCodec::for_trace`]);
+/// because the codec is fixed for a recording (set before start), the file list
+/// matches what the encoder produces. `lossy_only` is ignored for non-RGB content.
+///
+/// The decision is NOT taken from disk: registration runs *while the recording
+/// is still writing* ("pre-registration", see the module docs on the
+/// registration coordinator), so the video files do not exist yet when this is
+/// called.
+pub fn cloud_file_list(
+    data_type: &str,
+    data_type_name: Option<&str>,
+    lossy_only: bool,
+) -> Vec<CloudFile> {
     let prefix = format!("{data_type}/{}", data_type_name.unwrap_or("_"));
     let mut filenames = Vec::with_capacity(3);
     if matches!(content_type_for(data_type), ContentKind::Rgb) {
         filenames.push(LOSSY_VIDEO_NAME);
-        filenames.push(LOSSLESS_VIDEO_NAME);
+        if !lossy_only {
+            filenames.push(LOSSLESS_VIDEO_NAME);
+        }
     }
     filenames.push(TRACE_FILE);
     filenames
@@ -82,7 +106,7 @@ mod tests {
 
     #[test]
     fn scalar_trace_lists_only_trace_json() {
-        let files = cloud_file_list("JOINT_POSITIONS", Some("arm0"));
+        let files = cloud_file_list("JOINT_POSITIONS", Some("arm0"), false);
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].filepath, "JOINT_POSITIONS/arm0/trace.json");
         assert_eq!(files[0].content_type, "application/json");
@@ -90,7 +114,7 @@ mod tests {
 
     #[test]
     fn rgb_trace_lists_both_mp4_outputs_plus_sidecar() {
-        let files = cloud_file_list("RGB_IMAGES", Some("cam_0"));
+        let files = cloud_file_list("RGB_IMAGES", Some("cam_0"), false);
         let paths: Vec<&str> = files.iter().map(|f| f.filepath.as_str()).collect();
         assert_eq!(
             paths,
@@ -106,8 +130,70 @@ mod tests {
     }
 
     #[test]
+    fn rgb_trace_lossy_only_omits_lossless() {
+        // Lossy-only (nc.Codec.H264_MEDIUM): register just the lossy video plus
+        // its sidecar. Regression guard for the phantom-lossless bug — the
+        // daemon must not register a lossless.mp4 it never writes, or the
+        // uploader fails the RGB trace on the missing artefact.
+        let files = cloud_file_list("RGB_IMAGES", Some("cam_0"), true);
+        let paths: Vec<&str> = files.iter().map(|f| f.filepath.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["RGB_IMAGES/cam_0/lossy.mp4", "RGB_IMAGES/cam_0/trace.json"]
+        );
+    }
+
+    #[test]
+    fn depth_trace_ignores_lossy_only_and_keeps_lossless() {
+        // Depth always keeps its lossless storage even when a lossy codec is
+        // selected: the RGB-only gate lives in `LossyVideoCodec::for_trace`, so
+        // a DEPTH_IMAGES trace never reaches here with `lossy_only == true`, but
+        // pin the both-files layout regardless as a belt-and-braces guard.
+        let files = cloud_file_list("DEPTH_IMAGES", Some("cam_0"), false);
+        let paths: Vec<&str> = files.iter().map(|f| f.filepath.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "DEPTH_IMAGES/cam_0/lossy.mp4",
+                "DEPTH_IMAGES/cam_0/lossless.mp4",
+                "DEPTH_IMAGES/cam_0/trace.json",
+            ]
+        );
+    }
+
+    #[test]
     fn missing_data_type_name_falls_back_to_underscore() {
-        let files = cloud_file_list("JOINT_POSITIONS", None);
+        let files = cloud_file_list("JOINT_POSITIONS", None, false);
         assert_eq!(files[0].filepath, "JOINT_POSITIONS/_/trace.json");
+    }
+
+    #[test]
+    fn registration_decision_matches_encoder_output() {
+        use crate::encoding::video_encoder::LossyVideoCodec;
+
+        // Reproduce the registration coordinator's per-trace decision end to end
+        // (`for_trace(...).is_lossy_only()` feeding `cloud_file_list`) so the
+        // wiring can't regress into the phantom-lossless bug: the registered
+        // file set must match exactly what the encoder writes for that codec.
+        let registered = |data_type: &str, codec: Option<&str>| {
+            let lossy_only = LossyVideoCodec::for_trace(data_type, codec).is_lossy_only();
+            cloud_file_list(data_type, Some("cam"), lossy_only)
+                .into_iter()
+                .map(|file| file.filepath)
+                .collect::<Vec<_>>()
+        };
+
+        // RGB + h264_medium: lossy-only, so NO lossless is registered (C1).
+        assert_eq!(
+            registered("RGB_IMAGES", Some("h264_medium")),
+            vec!["RGB_IMAGES/cam/lossy.mp4", "RGB_IMAGES/cam/trace.json"]
+        );
+        // RGB default and depth-under-lossy both still register the lossless.
+        assert!(registered("RGB_IMAGES", None)
+            .iter()
+            .any(|path| path.ends_with("lossless.mp4")));
+        assert!(registered("DEPTH_IMAGES", Some("h264_medium"))
+            .iter()
+            .any(|path| path.ends_with("lossless.mp4")));
     }
 }

--- a/rust/data_daemon/src/cloud/coordinators/registration.rs
+++ b/rust/data_daemon/src/cloud/coordinators/registration.rs
@@ -24,7 +24,8 @@ use tokio::time::{interval, MissedTickBehavior};
 use crate::api::models::RegisterTraceRequest;
 use crate::api::ApiClient;
 use crate::cloud::cloud_files::cloud_file_list;
-use crate::cloud::OrgIdRx;
+use crate::cloud::{ConfigRx, OrgIdRx};
+use crate::encoding::video_encoder::LossyVideoCodec;
 use crate::lifecycle::shutdown::ShutdownSignal;
 use crate::state::store::TraceUpdate;
 use crate::state::{
@@ -66,6 +67,7 @@ pub fn spawn_registration(
     bus: EventBus,
     client: Arc<ApiClient>,
     org_rx: OrgIdRx,
+    config_rx: ConfigRx,
     mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) -> RegistrationHandle {
     let mut subscriber = bus.subscribe();
@@ -90,7 +92,7 @@ pub fn spawn_registration(
                 event = subscriber.recv() => {
                     match event {
                         Ok(DaemonEvent::TraceWritten { .. }) => {
-                            drain_once(&store, &bus, &client, &org_rx, MAX_WAIT, &mut registration_attempts).await;
+                            drain_once(&store, &bus, &client, &org_rx, &config_rx, MAX_WAIT, &mut registration_attempts).await;
                         }
                         Ok(_) => {}
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -99,13 +101,13 @@ pub fn spawn_registration(
                                 "registration coordinator missed bus events; \
                                 falling back to a drain"
                             );
-                            drain_once(&store, &bus, &client, &org_rx, MAX_WAIT, &mut registration_attempts).await;
+                            drain_once(&store, &bus, &client, &org_rx, &config_rx, MAX_WAIT, &mut registration_attempts).await;
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                     }
                 }
                 _ = ticker.tick() => {
-                    drain_once(&store, &bus, &client, &org_rx, MAX_WAIT, &mut registration_attempts).await;
+                    drain_once(&store, &bus, &client, &org_rx, &config_rx, MAX_WAIT, &mut registration_attempts).await;
                 }
             }
         }
@@ -118,6 +120,7 @@ async fn drain_once(
     bus: &EventBus,
     client: &Arc<ApiClient>,
     org_rx: &OrgIdRx,
+    config_rx: &ConfigRx,
     max_wait: Duration,
     registration_attempts: &mut HashMap<String, u32>,
 ) {
@@ -141,7 +144,16 @@ async fn drain_once(
         return;
     }
     tracing::debug!(count = claimed.len(), "claimed traces for registration");
-    submit_batch(store, bus, client, org_rx, claimed, registration_attempts).await;
+    submit_batch(
+        store,
+        bus,
+        client,
+        org_rx,
+        config_rx,
+        claimed,
+        registration_attempts,
+    )
+    .await;
     publish_ready_traces(store, bus).await;
 }
 
@@ -150,6 +162,7 @@ async fn submit_batch(
     bus: &EventBus,
     client: &Arc<ApiClient>,
     org_rx: &OrgIdRx,
+    config_rx: &ConfigRx,
     traces: Vec<TraceRecord>,
     registration_attempts: &mut HashMap<String, u32>,
 ) {
@@ -201,16 +214,29 @@ async fn submit_batch(
             continue;
         };
 
+        // Read the global video codec from the in-memory config the watcher
+        // keeps current. Registration runs while the recording is still writing,
+        // so we can't probe the (not-yet-written) files on disk; instead derive
+        // the lossy-only decision from the same codec source and predicate the
+        // encoder uses (`LossyVideoCodec::for_trace`). The codec is fixed for a
+        // recording (set before start), so this matches what the encoder writes.
+        let codec_value = config_rx.borrow().video_codec.clone();
         let payload: Vec<RegisterTraceRequest> = traces
             .iter()
-            .map(|trace| RegisterTraceRequest {
-                recording_id: cloud_id.clone(),
-                data_type: trace.data_type.clone().unwrap_or_default(),
-                trace_id: trace.trace_id.clone(),
-                cloud_files: cloud_file_list(
-                    trace.data_type.as_deref().unwrap_or(""),
-                    trace.data_type_name.as_deref(),
-                ),
+            .map(|trace| {
+                let data_type = trace.data_type.as_deref().unwrap_or("");
+                let lossy_only =
+                    LossyVideoCodec::for_trace(data_type, codec_value.as_deref()).is_lossy_only();
+                RegisterTraceRequest {
+                    recording_id: cloud_id.clone(),
+                    data_type: trace.data_type.clone().unwrap_or_default(),
+                    trace_id: trace.trace_id.clone(),
+                    cloud_files: cloud_file_list(
+                        data_type,
+                        trace.data_type_name.as_deref(),
+                        lossy_only,
+                    ),
+                }
             })
             .collect();
 
@@ -390,6 +416,7 @@ mod tests {
     use super::*;
     use crate::api::auth::StaticAuthProvider;
     use crate::api::client::ApiClientOptions;
+    use crate::config::DaemonConfig;
     use crate::state::store::TraceUpdate;
     use crate::state::{NewRecording, TraceUploadStatus, TraceWriteStatus};
     use std::time::Duration;
@@ -412,6 +439,18 @@ mod tests {
         let (org_tx, org_rx) = tokio::sync::watch::channel(org.map(str::to_string));
         Box::leak(Box::new(org_tx));
         org_rx
+    }
+
+    /// A seeded [`ConfigRx`] carrying the given codec. Leaks the sender so the
+    /// channel stays open and `borrow()` keeps returning the seeded value,
+    /// mirroring [`org_rx`].
+    fn config_rx(video_codec: Option<&str>) -> ConfigRx {
+        let (config_tx, config_rx) = tokio::sync::watch::channel(DaemonConfig {
+            video_codec: video_codec.map(str::to_string),
+            ..DaemonConfig::default()
+        });
+        Box::leak(Box::new(config_tx));
+        config_rx
     }
 
     /// Seed a recording plus a single written trace under it, returning the
@@ -504,6 +543,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             claimed,
             &mut HashMap::new(),
         )
@@ -573,6 +613,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             claimed,
             &mut HashMap::new(),
         )
@@ -627,6 +668,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(None),
+            &config_rx(None),
             claimed,
             &mut HashMap::new(),
         )
@@ -672,6 +714,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             claimed,
             &mut HashMap::new(),
         )
@@ -728,6 +771,7 @@ mod tests {
                 &bus,
                 &api,
                 &org_rx(Some("org-1")),
+                &config_rx(None),
                 claimed,
                 &mut attempts,
             )
@@ -750,6 +794,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             claimed,
             &mut attempts,
         )
@@ -795,6 +840,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             claimed,
             &mut HashMap::new(),
         )
@@ -839,6 +885,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             Duration::from_secs(0),
             &mut HashMap::new(),
         )
@@ -883,6 +930,7 @@ mod tests {
             &bus,
             &api,
             &org_rx(Some("org-1")),
+            &config_rx(None),
             Duration::from_secs(0),
             &mut HashMap::new(),
         )

--- a/rust/data_daemon/src/cloud/mod.rs
+++ b/rust/data_daemon/src/cloud/mod.rs
@@ -34,7 +34,7 @@ pub use notifiers::notifier::NotifierHandle;
 pub use notifiers::recording_cancel_notifier::spawn_recording_cancel_notifier;
 pub use notifiers::recording_start_notifier::spawn_recording_start_notifier;
 pub use notifiers::recording_stop_notifier::spawn_recording_stop_notifier;
-pub use watchers::config_watcher::{spawn_config_watcher, ConfigRefreshRequest};
+pub use watchers::config_watcher::{spawn_config_watcher, ConfigRefreshRequest, ConfigRx};
 pub use watchers::org_watcher::{spawn_org_watcher, OrgIdRx, OrgWatcherHandle};
 pub use watchers::recording_reaper::spawn_recording_reaper;
 

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -88,6 +88,70 @@ pub const ENCODE_THREADS_PER_OUTPUT: usize = 2;
 /// scrub/preview proxy.
 const LOSSY_PREVIEW_MAX_HEIGHT: u32 = 480;
 
+/// Lossy RGB video codec selection for a trace, resolved once at the trace's
+/// first chunk (and by the registration coordinator, from the same source).
+///
+/// The default produces the lossless archive plus a downscaled lossy preview.
+/// `H264MediumLossyOnly` (the SDK's `nc.Codec.H264_MEDIUM`) instead produces a
+/// single full-resolution `libx264 -crf 23 -preset medium` video and skips the
+/// lossless archive — smaller uploads, with that one video used for training.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LossyVideoCodec {
+    /// Default: lossless archive (`libx264rgb -qp 0`) plus a preview-resolution
+    /// lossy proxy (`libx264 -qp 23`). Both outputs are produced.
+    #[default]
+    LosslessPlusPreview,
+    /// `nc.Codec.H264_MEDIUM`: one full-resolution `libx264 -crf 23 -preset
+    /// medium` video; no lossless archive, no preview downscale.
+    H264MediumLossyOnly,
+}
+
+impl LossyVideoCodec {
+    /// Resolve a codec from a config/env string. Only `"h264_medium"` selects
+    /// lossy-only; `"h264_lossless"` and unset/empty keep the default silently.
+    /// An unrecognised value also keeps the default but logs a warning (parity
+    /// with the SDK's `resolve_codec`), so a typo can't silently change codecs.
+    /// Callers gate this to RGB traces — depth always keeps lossless storage.
+    pub fn from_config_str(value: Option<&str>) -> Self {
+        match value {
+            Some("h264_medium") => Self::H264MediumLossyOnly,
+            None | Some("") | Some("h264_lossless") => Self::LosslessPlusPreview,
+            Some(other) => {
+                tracing::warn!(
+                    codec = other,
+                    "Ignoring unknown video codec; expected one of: \
+                     h264_lossless, h264_medium"
+                );
+                Self::LosslessPlusPreview
+            }
+        }
+    }
+
+    /// Resolve the codec for a trace of `data_type` given the configured global
+    /// codec string (the resolved `NCD_VIDEO_CODEC` / active-profile
+    /// `video_codec`).
+    ///
+    /// Only RGB cameras honour the selection — a depth trace's lossy proxy is a
+    /// visualisation, not precise depth, so depth (and every non-RGB stream)
+    /// always keeps the default lossless archive. This RGB-only gate is
+    /// deliberately narrower than the video-family predicate in
+    /// [`crate::cloud::cloud_files`] (which includes depth). Kept pure (the
+    /// config string is passed in, not read here) so the encoder path and the
+    /// registration coordinator resolve from the same source, and the gate is
+    /// unit-testable without touching the environment.
+    pub fn for_trace(data_type: &str, codec_value: Option<&str>) -> Self {
+        if data_type != "RGB_IMAGES" {
+            return Self::LosslessPlusPreview;
+        }
+        Self::from_config_str(codec_value)
+    }
+
+    /// Whether this codec produces only the lossy output (no lossless archive).
+    pub fn is_lossy_only(self) -> bool {
+        matches!(self, Self::H264MediumLossyOnly)
+    }
+}
+
 /// Inputs to one per-chunk transcode invocation.
 #[derive(Debug, Clone)]
 pub struct ChunkEncodeRequest {
@@ -95,8 +159,12 @@ pub struct ChunkEncodeRequest {
     pub raw_nut: PathBuf,
     /// Destination for the per-chunk lossy mp4 segment.
     pub lossy_out: PathBuf,
-    /// Destination for the per-chunk lossless mp4 segment.
+    /// Destination for the per-chunk lossless mp4 segment. Unused in lossy-only
+    /// mode (no lossless output is produced).
     pub lossless_out: PathBuf,
+    /// Lossy codec selection for this trace. Controls whether a lossless
+    /// archive is produced and how the lossy output is encoded.
+    pub codec: LossyVideoCodec,
 }
 
 /// Outcome of a successful per-chunk transcode.
@@ -377,7 +445,11 @@ impl VideoEncoder {
         encode_threads: usize,
     ) -> Result<ChunkEncodeOutcome, VideoEncodeError> {
         ensure_parent_dirs(&request.lossy_out)?;
-        ensure_parent_dirs(&request.lossless_out)?;
+        // No lossless output is produced in lossy-only mode, so don't prepare a
+        // directory for a file that will never be written.
+        if !request.codec.is_lossy_only() {
+            ensure_parent_dirs(&request.lossless_out)?;
+        }
 
         // `-y` overwrites existing outputs (resume safety: a previous failed
         // run may have left a partial mp4). `-fflags +genpts` rebuilds the
@@ -405,15 +477,14 @@ impl VideoEncoder {
         // mode, but `-fps_mode` is unrecognised by ffmpeg < 5.1 (e.g. the 4.4
         // build shipped on Ubuntu 22.04 / the integration host), where it aborts
         // the encode with "Unrecognized option 'fps_mode'". `-vsync` is accepted
-        // on both (only deprecated, not removed, on 5.1+). Two `-map 0:v -c:v ...`
-        // blocks emit both outputs from a single demux pass.
+        // on both (only deprecated, not removed, on 5.1+). The default branch
+        // emits two `-map 0:v -c:v ...` output blocks from a single demux pass;
+        // lossy-only emits a single block (no preview/archive split).
         // Bound each output's libx264 thread pool to the caller-sized value
         // (see `adaptive_encode_threads`) so the transcode fleet fills idle
         // cores at low concurrency without oversubscribing at high concurrency.
         let encode_threads = encode_threads.to_string();
-        // Downscale the lossy preview proxy (only) to keep the dominant pass
-        // cheap at high resolution. The lossless output stays native.
-        let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
+        let lossy_only = request.codec.is_lossy_only();
         let mut command = Command::new(&self.binary);
         command
             .arg("-y")
@@ -428,42 +499,65 @@ impl VideoEncoder {
             .arg("-map")
             .arg("0:v")
             .arg("-vsync")
-            .arg("passthrough")
-            // Lossy preview proxy only: cap to preview resolution (see
-            // `preview_scale_filter`). vsync passthrough still emits every
-            // input frame, so the lossy frame count matches the lossless
-            // output and the per-frame timestamp sidecar.
-            .arg("-vf")
-            .arg(&preview_filter)
-            .arg("-c:v")
-            .arg("libx264")
-            .arg("-threads")
-            .arg(&encode_threads)
-            .arg("-pix_fmt")
-            .arg("yuv420p")
-            .arg("-preset")
-            .arg("ultrafast")
-            .arg("-qp")
-            .arg("23")
-            .arg(&request.lossy_out)
-            .arg("-map")
-            .arg("0:v")
-            .arg("-vsync")
-            .arg("passthrough")
-            // libx264rgb encodes the rgb24 frames directly: bit-exact to the
-            // captured pixels, ~2.5× faster than a yuv444p10le pass, and the
-            // format the Python reference encoder writes.
-            .arg("-c:v")
-            .arg("libx264rgb")
-            .arg("-threads")
-            .arg(&encode_threads)
-            .arg("-pix_fmt")
-            .arg("rgb24")
-            .arg("-preset")
-            .arg("ultrafast")
-            .arg("-qp")
-            .arg("0")
-            .arg(&request.lossless_out)
+            .arg("passthrough");
+        if lossy_only {
+            // Single full-resolution training-quality video: libx264 CRF 23 at
+            // `-preset medium`. No preview downscale and no lossless pass — this
+            // is the canonical (and only) upload for the trace.
+            command
+                .arg("-c:v")
+                .arg("libx264")
+                .arg("-threads")
+                .arg(&encode_threads)
+                .arg("-pix_fmt")
+                .arg("yuv420p")
+                .arg("-preset")
+                .arg("medium")
+                .arg("-crf")
+                .arg("23")
+                .arg(&request.lossy_out);
+        } else {
+            // Downscale the lossy preview proxy (only) to keep this dominant
+            // pass cheap at high resolution; the lossless output stays native.
+            let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
+            command
+                // Lossy preview proxy only: cap to preview resolution (see
+                // `preview_scale_filter`). vsync passthrough still emits every
+                // input frame, so the lossy frame count matches the lossless
+                // output and the per-frame timestamp sidecar.
+                .arg("-vf")
+                .arg(&preview_filter)
+                .arg("-c:v")
+                .arg("libx264")
+                .arg("-threads")
+                .arg(&encode_threads)
+                .arg("-pix_fmt")
+                .arg("yuv420p")
+                .arg("-preset")
+                .arg("ultrafast")
+                .arg("-qp")
+                .arg("23")
+                .arg(&request.lossy_out)
+                .arg("-map")
+                .arg("0:v")
+                .arg("-vsync")
+                .arg("passthrough")
+                // libx264rgb encodes the rgb24 frames directly: bit-exact to the
+                // captured pixels, ~2.5× faster than a yuv444p10le pass, and the
+                // format the Python reference encoder writes.
+                .arg("-c:v")
+                .arg("libx264rgb")
+                .arg("-threads")
+                .arg(&encode_threads)
+                .arg("-pix_fmt")
+                .arg("rgb24")
+                .arg("-preset")
+                .arg("ultrafast")
+                .arg("-qp")
+                .arg("0")
+                .arg(&request.lossless_out);
+        }
+        command
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -502,7 +596,13 @@ impl VideoEncoder {
         }
 
         let lossy_bytes = non_empty_file_size(&request.lossy_out)?;
-        let lossless_bytes = non_empty_file_size(&request.lossless_out)?;
+        // In lossy-only mode no lossless archive is produced, so there is no
+        // file to size — report zero rather than erroring on a missing output.
+        let lossless_bytes = if lossy_only {
+            0
+        } else {
+            non_empty_file_size(&request.lossless_out)?
+        };
 
         Ok(ChunkEncodeOutcome {
             lossy_bytes,
@@ -938,6 +1038,7 @@ mod tests {
             raw_nut: raw.clone(),
             lossy_out: lossy.clone(),
             lossless_out: lossless.clone(),
+            codec: LossyVideoCodec::LosslessPlusPreview,
         };
         let outcome = encoder
             .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
@@ -1003,6 +1104,7 @@ mod tests {
                     raw_nut: raw,
                     lossy_out: lossy.clone(),
                     lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1065,6 +1167,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn encode_chunk_lossy_only_writes_single_full_res_h264() {
+        let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping lossy-only encode test.");
+            return;
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let raw = tempdir.path().join("chunk_0000.nut");
+        let lossy = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless = tempdir.path().join("chunk_0000_lossless.mp4");
+
+        // 1280x720 source, above the 480-line preview cap. Lossy-only must NOT
+        // downscale — the single output is the training-quality video.
+        write_synthetic_nut_sized(&ffmpeg, &raw, 6, 1280, 720);
+
+        let encoder = VideoEncoder::new();
+        let outcome = encoder
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::H264MediumLossyOnly,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("transcode");
+
+        // No lossless archive is produced in lossy-only mode.
+        assert_eq!(outcome.lossless_bytes, 0, "no lossless output expected");
+        assert!(!lossless.exists(), "lossless.mp4 must not be written");
+        assert!(outcome.lossy_bytes > 0);
+
+        // The single video keeps native resolution, is H.264, and carries every
+        // source frame so it stays aligned with the per-frame timestamp sidecar.
+        let probe = StdCommand::new(&ffprobe)
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-count_frames",
+                "-show_entries",
+                "stream=width,height,nb_read_frames,codec_name",
+                "-of",
+                "json",
+            ])
+            .arg(&lossy)
+            .output()
+            .expect("spawn ffprobe");
+        assert!(probe.status.success());
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&probe.stdout).expect("ffprobe JSON");
+        let stream = &parsed["streams"][0];
+        assert_eq!(stream["codec_name"], "h264");
+        assert_eq!(stream["width"], 1280);
+        assert_eq!(stream["height"], 720);
+        let frames: u64 = stream["nb_read_frames"]
+            .as_u64()
+            .or_else(|| {
+                stream["nb_read_frames"]
+                    .as_str()
+                    .and_then(|value| value.parse().ok())
+            })
+            .expect("frame count");
+        assert_eq!(frames, 6, "all source frames must be encoded");
+    }
+
+    #[test]
+    fn lossy_video_codec_resolves_from_config_str() {
+        assert_eq!(
+            LossyVideoCodec::from_config_str(Some("h264_medium")),
+            LossyVideoCodec::H264MediumLossyOnly
+        );
+        assert!(LossyVideoCodec::from_config_str(Some("h264_medium")).is_lossy_only());
+        // h264_lossless is the explicit default; unset/unknown also default.
+        for value in [None, Some(""), Some("unknown"), Some("h264_lossless")] {
+            assert_eq!(
+                LossyVideoCodec::from_config_str(value),
+                LossyVideoCodec::LosslessPlusPreview,
+                "{value:?} should map to the default codec"
+            );
+            assert!(!LossyVideoCodec::from_config_str(value).is_lossy_only());
+        }
+    }
+
+    #[test]
+    fn for_trace_gates_lossy_codec_to_rgb_only() {
+        // Only RGB honours a lossy codec; depth and every non-RGB stream keep
+        // the lossless archive even when h264_medium is configured. This is the
+        // core RGB-only invariant of the feature — a regression that dropped a
+        // depth lossless archive would corrupt depth training data.
+        assert_eq!(
+            LossyVideoCodec::for_trace("RGB_IMAGES", Some("h264_medium")),
+            LossyVideoCodec::H264MediumLossyOnly
+        );
+        for data_type in ["DEPTH_IMAGES", "JOINT_POSITIONS", "CUSTOM_1D", ""] {
+            assert_eq!(
+                LossyVideoCodec::for_trace(data_type, Some("h264_medium")),
+                LossyVideoCodec::LosslessPlusPreview,
+                "{data_type} must keep lossless regardless of the codec"
+            );
+            assert!(!LossyVideoCodec::for_trace(data_type, Some("h264_medium")).is_lossy_only());
+        }
+        // RGB with the default/unset codec stays on the lossless+preview path.
+        for value in [None, Some(""), Some("h264_lossless")] {
+            assert_eq!(
+                LossyVideoCodec::for_trace("RGB_IMAGES", value),
+                LossyVideoCodec::LosslessPlusPreview
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn concat_segments_produces_single_mp4() {
         let ffmpeg = match locate_binary("ffmpeg") {
             Some(path) => path,
@@ -1101,6 +1319,7 @@ mod tests {
                         raw_nut: raw,
                         lossy_out: lossy.clone(),
                         lossless_out: lossless,
+                        codec: LossyVideoCodec::LosslessPlusPreview,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -1157,6 +1376,7 @@ mod tests {
             raw_nut: tempdir.path().join("does-not-exist.nut"),
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
+            codec: LossyVideoCodec::LosslessPlusPreview,
         };
         let encoder = VideoEncoder::new();
         let error = encoder
@@ -1178,6 +1398,7 @@ mod tests {
             raw_nut: raw,
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
+            codec: LossyVideoCodec::LosslessPlusPreview,
         };
         let encoder =
             VideoEncoder::new().with_binary("this-binary-definitely-does-not-exist-ffmpeg");

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -36,13 +36,15 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde_json::Value;
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{mpsc, watch, Semaphore};
 use tokio::task::{self, JoinSet};
 
+use crate::cloud::ConfigRx;
+use crate::config::DaemonConfig;
 use crate::encoding::json_trace::JsonTraceError;
 use crate::encoding::metadata::{MetadataError, VideoMetadataAccumulator};
 use crate::encoding::video_encoder::{
-    ChunkEncodeRequest, VideoEncodeError, VideoEncoder, ENCODE_THREADS_PER_OUTPUT,
+    ChunkEncodeRequest, LossyVideoCodec, VideoEncodeError, VideoEncoder, ENCODE_THREADS_PER_OUTPUT,
 };
 use crate::pipeline::json_writer::JsonWriteHandle;
 use crate::state::TraceWriteHandle;
@@ -170,6 +172,11 @@ pub struct TraceActorContext {
     /// stall can't back-pressure the dispatcher / IPC listener (see
     /// [`crate::pipeline::json_writer`]).
     pub json_writer: JsonWriteHandle,
+    /// Live view of the effective daemon config, published by the config
+    /// watcher. The actor reads `video_codec` from here at a trace's first
+    /// chunk instead of re-parsing the profile YAML. Seeded with the default
+    /// config; production overrides it via [`TraceActorContext::with_config_rx`].
+    pub config_rx: ConfigRx,
 }
 
 impl TraceActorContext {
@@ -204,6 +211,12 @@ impl TraceActorContext {
     ) -> Self {
         // Captured before any permit is acquired, so this is the pool's total.
         let ffmpeg_permit_total = ffmpeg_permits.available_permits();
+        // Seed the config view with defaults. The sender is dropped
+        // immediately; a `watch::Receiver` still serves its last value via
+        // `borrow()` after the sender is gone, which is all the actor needs
+        // when no watcher is wired (tests / offline construction). Production
+        // replaces this via `with_config_rx`.
+        let (_seed_tx, config_rx) = watch::channel(DaemonConfig::default());
         Self {
             recordings_root: Arc::new(recordings_root.into()),
             storage_budget,
@@ -214,6 +227,7 @@ impl TraceActorContext {
             event_bus: None,
             trace_writer,
             json_writer,
+            config_rx,
         }
     }
 
@@ -222,6 +236,13 @@ impl TraceActorContext {
     /// [`TraceActorContext::with_ffmpeg_permits`].
     pub fn with_event_bus(mut self, bus: crate::state::EventBus) -> Self {
         self.event_bus = Some(bus);
+        self
+    }
+
+    /// Attach the live config view published by the config watcher. Returns
+    /// `self` so it composes with the constructors and [`Self::with_event_bus`].
+    pub fn with_config_rx(mut self, config_rx: ConfigRx) -> Self {
+        self.config_rx = config_rx;
         self
     }
 }
@@ -287,6 +308,9 @@ enum TraceWriterKind {
         width: u32,
         /// Frame height in pixels.
         height: u32,
+        /// Lossy codec for this trace, resolved once at the first chunk and
+        /// applied uniformly to every chunk encode and the finalise concat.
+        codec: LossyVideoCodec,
         /// Encodes completed so far, keyed by `chunk_index` so the finalise
         /// concat can iterate in order regardless of completion order.
         completed_chunks: BTreeMap<u32, CompletedChunk>,
@@ -587,9 +611,19 @@ impl ActorState {
         // progress. The mark happens once per trace.
         let bumped_status = matches!(self.writer, TraceWriterKind::Pending);
         if bumped_status {
+            // Resolve the lossy codec once, at the trace's first chunk, so every
+            // chunk and the finalise concat agree even if the config changes
+            // mid-recording. Read from the in-memory config the watcher keeps
+            // current (env override + active profile); the RGB-only gate lives
+            // in `LossyVideoCodec::for_trace`.
+            let codec = LossyVideoCodec::for_trace(
+                &self.identity.key.data_type,
+                context.config_rx.borrow().video_codec.as_deref(),
+            );
             self.writer = TraceWriterKind::Video {
                 width,
                 height,
+                codec,
                 completed_chunks: BTreeMap::new(),
                 pending_encodes: JoinSet::new(),
             };
@@ -623,12 +657,15 @@ impl ActorState {
         }
 
         let TraceWriterKind::Video {
-            pending_encodes, ..
+            pending_encodes,
+            codec,
+            ..
         } = &mut self.writer
         else {
             // Should be unreachable — we just allocated the writer above.
             return;
         };
+        let codec = *codec;
 
         // Spawn the encode as a background task. The actor returns to the
         // inbox immediately so a slow ffmpeg invocation cannot back-pressure
@@ -643,6 +680,7 @@ impl ActorState {
             raw_nut: raw_nut.clone(),
             lossy_out: lossy_segment.clone(),
             lossless_out: lossless_segment.clone(),
+            codec,
         };
         pending_encodes.spawn(async move {
             // Acquire a permit before relinking + encoding. Gating the relink
@@ -877,6 +915,7 @@ impl ActorState {
             TraceWriterKind::Video {
                 width,
                 height,
+                codec,
                 mut completed_chunks,
                 mut pending_encodes,
             } => {
@@ -910,6 +949,10 @@ impl ActorState {
                     return Ok(context.json_writer.finish(&self.identity.trace_id).await?);
                 }
 
+                // In lossy-only mode (nc.Codec.H264_MEDIUM) no lossless archive
+                // is produced — only lossy.mp4 is stitched and uploaded.
+                let lossy_only = codec.is_lossy_only();
+
                 let trace_dir = self.trace_directory(context);
                 let lossy_out = trace_dir.join(paths::LOSSY_VIDEO_FILENAME);
                 let lossless_out = trace_dir.join(paths::LOSSLESS_VIDEO_FILENAME);
@@ -921,10 +964,14 @@ impl ActorState {
                     .values()
                     .map(|chunk| chunk.lossy_segment.clone())
                     .collect();
-                let lossless_segments: Vec<PathBuf> = completed_chunks
-                    .values()
-                    .map(|chunk| chunk.lossless_segment.clone())
-                    .collect();
+                let lossless_segments: Vec<PathBuf> = if lossy_only {
+                    Vec::new()
+                } else {
+                    completed_chunks
+                        .values()
+                        .map(|chunk| chunk.lossless_segment.clone())
+                        .collect()
+                };
 
                 // Build the metadata accumulator in the same chunk-index
                 // order so per-frame entries appear in capture order.
@@ -952,10 +999,15 @@ impl ActorState {
                     .video_encoder
                     .concat_segments(&lossy_segments, &lossy_out)
                     .await?;
-                let lossless_outcome = context
-                    .video_encoder
-                    .concat_segments(&lossless_segments, &lossless_out)
-                    .await?;
+                let lossless_bytes = if lossy_only {
+                    0
+                } else {
+                    context
+                        .video_encoder
+                        .concat_segments(&lossless_segments, &lossless_out)
+                        .await?
+                        .bytes
+                };
                 drop(permit);
 
                 // Unlink per-chunk segments now that the final outputs are
@@ -987,7 +1039,7 @@ impl ActorState {
 
                 Ok(lossy_outcome
                     .bytes
-                    .saturating_add(lossless_outcome.bytes)
+                    .saturating_add(lossless_bytes)
                     .saturating_add(metadata_bytes))
             }
         }

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 
 import pytest
 
+from neuracore.data_daemon.config_manager.profiles import ProfileManager
+from neuracore.data_daemon.const import active_profile_name
 from neuracore.data_daemon.rust_selection import is_rust_daemon_enabled
 from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
@@ -39,6 +41,33 @@ def cleanup_profiles():
     """Remove test-created daemon profiles after each test."""
     yield
     cleanup_test_profiles()
+
+
+@pytest.fixture(autouse=True)
+def reset_video_codec():
+    """Restore the active daemon profile to its exact pre-test state.
+
+    The codec is a persistent daemon-profile setting, so a case selecting a
+    lossy codec must not leak into a later test or the developer's real profile.
+    Offline cases write an ephemeral profile (removed by ``cleanup_profiles``),
+    but online cases write the default profile. Snapshot the active profile file
+    and restore it byte-for-byte (or delete it if it did not exist), rather than
+    forcing a literal ``h264_lossless`` — which would otherwise leave a residual
+    ``video_codec`` key on a developer's default profile that had none. Only
+    writes when the test actually changed the file, so non-video tests are free.
+    """
+    profile_path = ProfileManager()._get_profile_path(active_profile_name())
+    original_bytes = profile_path.read_bytes() if profile_path.exists() else None
+    try:
+        yield
+    finally:
+        current_bytes = profile_path.read_bytes() if profile_path.exists() else None
+        if current_bytes == original_bytes:
+            return
+        if original_bytes is not None:
+            profile_path.write_bytes(original_bytes)
+        elif profile_path.exists():
+            profile_path.unlink()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -91,6 +91,15 @@ PRE_NETWORK_INTEGRITY_CASES = (
         wait=False,
         requires_rust_daemon=True,
     ),
+    DataDaemonTestCase(
+        duration_sec=10,
+        joint_count=7,
+        recording_count=1,
+        video_count=1,
+        image_height=64,
+        image_width=64,
+        video_codec="h264_medium",
+    ),
 )
 
 NETWORK_INTEGRITY_CASES = (

--- a/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
@@ -15,6 +15,7 @@ from tests.integration.platform.data_daemon.shared.db_helpers import (
 )
 from tests.integration.platform.data_daemon.shared.disk_helpers import (
     assert_disk_recording_properties,
+    assert_lossy_only_video_artifacts,
 )
 from tests.integration.platform.data_daemon.shared.runners import offline_daemon_running
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
@@ -84,6 +85,8 @@ def test_disk_db_data_integrity(
                 results = run_case_contexts(case, specs=specs)
                 wait_for_all_traces_written(results=results)
                 assert_disk_recording_properties(results)
+                if case.lossy_only:
+                    assert_lossy_only_video_artifacts()
 
         finally:
             set_case_analysis_report(

--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -601,6 +601,12 @@ def _verify_synched_episode_summary(
     ), f"Unexpected camera(s) in RGB counts: {unexpected_cameras}"
 
     # --- Camera frame codes ---
+    # Frame codes are integers painted into each frame's pixels so the decoded
+    # video can be checked for ordering/completeness. Lossy encoding
+    # (nc.Codec.H264_MEDIUM) perturbs those pixels, so the exact codes do not
+    # survive round-trip
+    if case.lossy_only:
+        return
     for camera_index, camera_name in enumerate(result.camera_names):
         _assert_synced_camera_codes_are_sane(
             actual_codes=summary["frame_codes"].get(camera_name),

--- a/tests/integration/platform/data_daemon/shared/disk_helpers.py
+++ b/tests/integration/platform/data_daemon/shared/disk_helpers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -600,3 +602,94 @@ def assert_disk_recording_properties(
         )
 
     return durations
+
+
+def _ffprobe_video_stream(video_path: Path) -> dict | None:
+    """Return the first video stream's ffprobe info, or None if unavailable.
+
+    Returns None (rather than failing) when ffprobe is not installed, so the
+    file-existence checks still run on hosts without ffprobe.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        return None
+    result = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-count_frames",
+            "-show_entries",
+            "stream=codec_name,width,height,nb_read_frames",
+            "-of",
+            "json",
+            str(video_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    streams = json.loads(result.stdout).get("streams", [])
+    return streams[0] if streams else None
+
+
+def assert_lossy_only_video_artifacts(min_trace_count: int = 1) -> None:
+    """Assert every RGB video trace on disk is a single lossy H.264 video.
+
+    For a recording made with ``nc.Codec.H264_MEDIUM`` the daemon writes only
+    ``lossy.mp4`` (libx264) and no ``lossless.mp4``. For every ``RGB_IMAGES``
+    trace directory under the recordings root this verifies:
+
+    - ``lossy.mp4`` exists and ``lossless.mp4`` does NOT,
+    - (when ffprobe is available) the video is H.264 and its frame count matches
+      the per-frame ``trace.json`` sidecar.
+
+    Works identically for the Python and Rust daemons (both write the same
+    on-disk artefact layout).
+
+    Args:
+        min_trace_count: Minimum number of RGB trace directories expected.
+    """
+    recordings_root = get_daemon_recordings_root_path()
+    assert recordings_root.exists(), f"recordings root missing: {recordings_root}"
+
+    trace_dirs = [
+        trace_dir
+        for recording_dir in sorted(recordings_root.iterdir())
+        if recording_dir.is_dir()
+        for rgb_dir in [recording_dir / "RGB_IMAGES"]
+        if rgb_dir.is_dir()
+        for trace_dir in sorted(rgb_dir.iterdir())
+        if trace_dir.is_dir()
+    ]
+    assert len(trace_dirs) >= min_trace_count, (
+        f"expected at least {min_trace_count} RGB trace dir(s), "
+        f"found {len(trace_dirs)} under {recordings_root}"
+    )
+
+    for trace_dir in trace_dirs:
+        lossy_path = trace_dir / "lossy.mp4"
+        lossless_path = trace_dir / "lossless.mp4"
+        assert lossy_path.is_file(), f"missing lossy.mp4 in {trace_dir}"
+        assert (
+            not lossless_path.exists()
+        ), f"lossy-only recording must not write lossless.mp4: {lossless_path}"
+
+        stream = _ffprobe_video_stream(lossy_path)
+        if stream is None:
+            continue
+        assert (
+            stream.get("codec_name") == "h264"
+        ), f"{lossy_path} should be H.264, got {stream.get('codec_name')!r}"
+
+        trace_json = trace_dir / TRACE_JSON_NAME
+        if trace_json.is_file():
+            expected_frames = len(json.loads(trace_json.read_text(encoding="utf-8")))
+            nb_read_frames = stream.get("nb_read_frames")
+            if nb_read_frames is not None and expected_frames > 0:
+                assert int(nb_read_frames) == expected_frames, (
+                    f"{lossy_path} has {nb_read_frames} frames, "
+                    f"trace.json expects {expected_frames}"
+                )

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -162,6 +162,11 @@ class DataDaemonTestCase:
             long-running workloads that the Python daemon cannot sustain use
             this flag so they still exercise the Rust daemon in CI without
             failing the legacy suite.
+        video_codec: When set (e.g. ``"h264_medium"``), the case selects that
+            global video codec via ``nc.set_video_encoding_options`` before
+            recording, so RGB cameras upload a single lossy CRF-23 video and the
+            lossless archive is dropped.  ``None`` keeps the default
+            lossless+lossy behaviour.
 
     Note:
         ``mode="staggered"`` and ``context_duration_mode="variable"``:
@@ -191,11 +196,17 @@ class DataDaemonTestCase:
     timestamp_mode: TimestampMode = TIMESTAMP_MODE_MANUAL
     skip: bool = False
     requires_rust_daemon: bool = False
+    video_codec: str | None = None
 
     @property
     def has_video(self) -> bool:
         """Return True when this case logs at least one camera stream."""
         return self.video_count > 0
+
+    @property
+    def lossy_only(self) -> bool:
+        """Return True when the case drops the lossless archive for RGB video."""
+        return self.video_codec == "h264_medium"
 
     @property
     def expected_joint_frames(self) -> int:
@@ -308,6 +319,8 @@ def case_id(case: DataDaemonTestCase) -> str:
         parts.append(f"{case.image_width}x{case.image_height}")
         if case.video_fps != DataDaemonTestCase.video_fps:
             parts.append(f"{case.video_fps}hz")
+        if case.video_codec is not None:
+            parts.append(case.video_codec)
     if case.producer_channels == PRODUCER_PER_THREAD:
         parts.append("threaded")
     if case.timestamp_mode == TIMESTAMP_MODE_REAL:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -971,6 +971,11 @@ def run_case_contexts(
     if specs is None:
         specs = build_context_specs(case)
 
+    if case.has_video:
+        nc.set_video_encoding_options(
+            nc.Codec(case.video_codec) if case.video_codec else nc.Codec.H264_LOSSLESS
+        )
+
     if specs:
         with Timer(MAX_TIME_TO_START_S, label="nc.create_dataset", always_log=True):
             nc.create_dataset(specs[0].dataset_name)

--- a/tests/unit/core/data/test_video_url_fallback.py
+++ b/tests/unit/core/data/test_video_url_fallback.py
@@ -1,0 +1,135 @@
+"""Tests for the lossless -> lossy video URL fallback in SynchronizedRecording."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from neuracore_types import DataType
+
+from neuracore.core.data.synced_recording import SynchronizedRecording
+
+MODULE = "neuracore.core.data.synced_recording"
+
+
+def _response(status_code: int, url: str | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"HTTP {status_code}"
+        )
+    else:
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"url": url}
+    return response
+
+
+def _call_get_video_url(
+    session: MagicMock, camera_type: DataType = DataType.RGB_IMAGES
+) -> str:
+    fake_self = SimpleNamespace(id="rec-1", dataset=SimpleNamespace(org_id="org-1"))
+    auth = MagicMock()
+    auth.get_headers = MagicMock(return_value={})
+    with (
+        patch(f"{MODULE}.thread_local_session", return_value=session),
+        patch(f"{MODULE}.get_auth", return_value=auth),
+    ):
+        return SynchronizedRecording._get_video_url(fake_self, camera_type, "cam")
+
+
+def test_falls_back_to_lossy_when_lossless_missing() -> None:
+    requested: list[str] = []
+
+    def fake_get(url, params=None, headers=None):
+        filepath = params["filepath"]
+        requested.append(filepath)
+        if filepath.endswith("lossless.mp4"):
+            return _response(404)
+        return _response(200, url="https://example.com/lossy.mp4")
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+
+    assert _call_get_video_url(session) == "https://example.com/lossy.mp4"
+    # Lossless is tried first, lossy second.
+    assert requested == [
+        "RGB_IMAGES/cam/lossless.mp4",
+        "RGB_IMAGES/cam/lossy.mp4",
+    ]
+
+
+def test_uses_lossless_when_present() -> None:
+    requested: list[str] = []
+
+    def fake_get(url, params=None, headers=None):
+        requested.append(params["filepath"])
+        return _response(200, url="https://example.com/lossless.mp4")
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+
+    assert _call_get_video_url(session) == "https://example.com/lossless.mp4"
+    # The lossless hit short-circuits — lossy is never requested.
+    assert requested == ["RGB_IMAGES/cam/lossless.mp4"]
+
+
+def test_raises_when_neither_lossless_nor_lossy_found() -> None:
+    session = MagicMock()
+    session.get.side_effect = lambda *args, **kwargs: _response(404)
+
+    with pytest.raises(requests.HTTPError):
+        _call_get_video_url(session)
+
+
+def test_non_404_on_lossless_raises_without_falling_back() -> None:
+    # A server/auth error (here 500) on the lossless request is a real failure
+    # and must propagate as-is — it must NOT be masked by trying the lossy
+    # fallback (which could otherwise silently downgrade to lossy data).
+    requested: list[str] = []
+
+    def fake_get(url, params=None, headers=None):
+        requested.append(params["filepath"])
+        return _response(500)
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+
+    with pytest.raises(requests.HTTPError):
+        _call_get_video_url(session)
+    # Only the lossless request is made; the lossy fallback is never attempted.
+    assert requested == ["RGB_IMAGES/cam/lossless.mp4"]
+
+
+def test_depth_requests_lossless_only_and_never_falls_back_to_lossy() -> None:
+    # Depth's lossy.mp4 is a visualisation, never a valid source, so a missing
+    # depth lossless must fail loudly rather than silently decode the proxy.
+    requested: list[str] = []
+
+    def fake_get(url, params=None, headers=None):
+        requested.append(params["filepath"])
+        return _response(404)
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+
+    with pytest.raises(requests.HTTPError):
+        _call_get_video_url(session, DataType.DEPTH_IMAGES)
+    assert requested == ["DEPTH_IMAGES/cam/lossless.mp4"]
+
+
+def test_non_404_on_lossy_fallback_propagates() -> None:
+    # The lossless 404 falls back to lossy; a real error (here 500) on the lossy
+    # leg must propagate, not be swallowed as "no artefact found".
+    def fake_get(url, params=None, headers=None):
+        if params["filepath"].endswith("lossless.mp4"):
+            return _response(404)
+        return _response(500)
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+
+    with pytest.raises(requests.HTTPError):
+        _call_get_video_url(session)

--- a/tests/unit/data_daemon/recording_disk_manager/test_batch_encoder_worker_video_trace_flow.py
+++ b/tests/unit/data_daemon/recording_disk_manager/test_batch_encoder_worker_video_trace_flow.py
@@ -12,6 +12,8 @@ import pytest
 import pytest_asyncio
 from neuracore_types import DataType
 
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
 from neuracore.data_daemon.models import CompleteMessage
 
 
@@ -234,6 +236,7 @@ async def make_worker(tmp_path: Path, patched_modules, fake_emitter: _FakeEmitte
         filesystem=filesystem,
         abort_trace=abort_trace,
         emitter=fake_emitter,
+        config_watcher=ConfigWatcher(initial_config=DaemonConfig()),
     )
     worker = worker_module._BatchEncoderWorker(
         filesystem=filesystem,

--- a/tests/unit/data_daemon/recording_disk_manager/test_encoder_manager_codec_gating.py
+++ b/tests/unit/data_daemon/recording_disk_manager/test_encoder_manager_codec_gating.py
@@ -1,0 +1,55 @@
+"""Tests for the RGB-only gating of the lossy video codec in _EncoderManager.
+
+Only RGB honours a lossy codec; depth always keeps its lossless storage even
+under ``h264_medium``. Tests inject a ConfigWatcher seeded with a fixed codec.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from neuracore_types import DataType
+
+from neuracore.core.video_encoding import Libx264Options
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
+from neuracore.data_daemon.recording_encoding_disk_manager.lifecycle import (
+    encoder_manager as em,
+)
+
+
+def _resolve(codec: str | None, data_type: DataType) -> Libx264Options | None:
+    """Resolve lossy-only options for `data_type` given a fixed cached codec.
+
+    The encoder path re-resolves the watcher synchronously before reading the
+    codec (so a codec set just before recording is honoured), so the injected
+    resolver returns the same fixed codec the cache is seeded with.
+    """
+    config = DaemonConfig(video_codec=codec)
+    watcher = ConfigWatcher(initial_config=config, resolver=lambda: config)
+    fake_self = SimpleNamespace(_config_watcher=watcher)
+    return em._EncoderManager._resolve_lossy_only_options(fake_self, data_type)
+
+
+def test_rgb_honours_lossy_codec() -> None:
+    assert _resolve("h264_medium", DataType.RGB_IMAGES) == {
+        "crf": "23",
+        "preset": "medium",
+    }
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    [DataType.DEPTH_IMAGES, DataType.JOINT_POSITIONS, DataType.POINT_CLOUDS],
+)
+def test_non_rgb_keeps_lossless_even_when_lossy_configured(
+    data_type: DataType,
+) -> None:
+    # Gated off before the codec matters: depth keeps its lossless storage;
+    # non-video types never carry lossy-only options.
+    assert _resolve("h264_medium", data_type) is None
+
+
+def test_rgb_default_codec_uses_default_encoders() -> None:
+    assert _resolve(None, DataType.RGB_IMAGES) is None

--- a/tests/unit/data_daemon/recording_disk_manager/test_encoding_traces.py
+++ b/tests/unit/data_daemon/recording_disk_manager/test_encoding_traces.py
@@ -84,6 +84,7 @@ def test_json_trace_preserves_unicode_when_ensure_ascii_false(tmp_path: Path) ->
 class _FakeDiskVideoEncoder:
     def __init__(self, *, filepath: Path, **kwargs: Any) -> None:
         self.filepath = filepath
+        self.codec_context_options = kwargs.get("codec_context_options")
         self.calls: list[tuple[float, tuple[int, ...]]] = []
         self._finished = False
         self.filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -151,6 +152,17 @@ def test_video_trace_accepts_metadata_list(tmp_path: Path, patched_video_trace) 
 
     frame = bytes([10, 20, 30] * (w * h))
     vt.add_payload(frame)
+    assert vt._lossless_encoder is not None
+    assert vt._lossless_encoder.codec_context_options == {
+        "crf": "0",
+        "preset": "ultrafast",
+    }
+    assert vt._lossy_encoder is not None
+    assert vt._lossy_encoder.codec_context_options == {
+        "qp": "23",
+        "preset": "ultrafast",
+    }
+
     vt.finish()
 
     assert (out_dir / "lossy.mp4").is_file()
@@ -164,6 +176,34 @@ def test_video_trace_accepts_metadata_list(tmp_path: Path, patched_video_trace) 
     assert trace[0]["height"] == h
     assert trace[0]["frame_idx"] == 0
     assert trace[1]["frame_idx"] == 1
+
+
+def test_video_trace_lossy_only_skips_lossless_and_uses_options(
+    tmp_path: Path, patched_video_trace
+) -> None:
+    pytest.importorskip("numpy")
+
+    VideoTrace = patched_video_trace.VideoTrace
+    out_dir = tmp_path / "video"
+    vt = VideoTrace(
+        output_dir=out_dir,
+        codec_option_overrides={"crf": "23", "preset": "medium"},
+    )
+
+    w, h = 4, 3
+    meta: dict[str, Any] = {"width": w, "height": h, "timestamp": 1.0}
+    vt.add_payload(json.dumps(meta).encode("utf-8"))
+    frame = bytes([10, 20, 30] * (w * h))
+    vt.add_payload(frame)
+
+    assert vt._lossless_encoder is None
+    assert vt._lossy_encoder is not None
+    assert vt._lossy_encoder.codec_context_options == {"crf": "23", "preset": "medium"}
+
+    vt.finish()
+    assert (out_dir / "lossy.mp4").is_file()
+    assert not (out_dir / "lossless.mp4").exists()
+    assert (out_dir / "trace.json").is_file()
 
 
 def test_video_trace_validates_frame_size(tmp_path: Path, patched_video_trace) -> None:

--- a/tests/unit/data_daemon/recording_disk_manager/test_recording_disk_manager.py
+++ b/tests/unit/data_daemon/recording_disk_manager/test_recording_disk_manager.py
@@ -12,6 +12,8 @@ from typing import Any
 import pytest
 from neuracore_types import DataType
 
+from neuracore.data_daemon.config_manager.config_watcher import ConfigWatcher
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
 from neuracore.data_daemon.event_emitter import Emitter
 from neuracore.data_daemon.event_loop_manager import EventLoopManager
 from neuracore.data_daemon.models import CompleteMessage
@@ -138,6 +140,7 @@ def rdm_factory(
         rdm = rdm_module.RecordingDiskManager(
             loop_manager=loop_manager,
             emitter=rdm_emitter,
+            config_watcher=ConfigWatcher(initial_config=DaemonConfig()),
             flush_bytes=flush_bytes,
             storage_limit_bytes=storage_limit,
             recordings_root=str(recordings_root),

--- a/tests/unit/data_daemon/registration_management/test_registration_manager.py
+++ b/tests/unit/data_daemon/registration_management/test_registration_manager.py
@@ -48,12 +48,14 @@ def _make_candidate(
     recording_id: str = "r1",
     data_type: DataType = DataType.JOINT_POSITIONS,
     data_type_name: str = "joints",
+    path: str | None = None,
 ) -> RegistrationCandidate:
     return RegistrationCandidate(
         trace_id=trace_id,
         recording_id=recording_id,
         data_type=data_type,
         data_type_name=data_type_name,
+        path=path,
     )
 
 
@@ -94,6 +96,26 @@ class TestGetCloudFileList:
             },
         ]
 
+    def test_rgb_lossy_only_dir_omits_lossless(self, tmp_path) -> None:
+        (tmp_path / "lossy.mp4").write_bytes(b"x")
+        files = get_cloud_file_list(DataType.RGB_IMAGES, "cam_front", str(tmp_path))
+        paths = [f["filepath"] for f in files]
+        assert paths == [
+            "RGB_IMAGES/cam_front/lossy.mp4",
+            "RGB_IMAGES/cam_front/trace.json",
+        ]
+
+    def test_rgb_with_lossless_on_disk_lists_both(self, tmp_path) -> None:
+        (tmp_path / "lossy.mp4").write_bytes(b"x")
+        (tmp_path / "lossless.mp4").write_bytes(b"x")
+        files = get_cloud_file_list(DataType.RGB_IMAGES, "cam_front", str(tmp_path))
+        paths = {f["filepath"] for f in files}
+        assert paths == {
+            "RGB_IMAGES/cam_front/lossy.mp4",
+            "RGB_IMAGES/cam_front/lossless.mp4",
+            "RGB_IMAGES/cam_front/trace.json",
+        }
+
 
 class TestBatchRegistration:
     """Tests for the batch registration HTTP call and outcome handling."""
@@ -121,6 +143,32 @@ class TestBatchRegistration:
         assert trace_entry["cloud_files"] == get_cloud_file_list(
             DataType.RGB_IMAGES, "cam"
         )
+
+    @pytest.mark.asyncio
+    async def test_lossy_only_candidate_payload_omits_lossless(
+        self, mock_auth, state_api, emitter, tmp_path
+    ) -> None:
+        (tmp_path / "lossy.mp4").write_bytes(b"x")
+        session = _mock_http_session({
+            "registered_traces": [{"trace_id": "t1", "upload_session_uris": {}}],
+            "failed_traces": [],
+        })
+        candidate = _make_candidate(
+            data_type=DataType.RGB_IMAGES, data_type_name="cam", path=str(tmp_path)
+        )
+
+        mgr = RegistrationManager(
+            client_session=session,
+            state_api=state_api,
+            emitter=emitter,
+            batch_size=10,
+        )
+        await mgr._register_data_trace_batch([candidate])
+
+        payload = session.post.call_args.kwargs["json"]
+        cloud_files = payload["traces"][0]["cloud_files"]
+        paths = [entry["filepath"] for entry in cloud_files]
+        assert paths == ["RGB_IMAGES/cam/lossy.mp4", "RGB_IMAGES/cam/trace.json"]
 
     @pytest.mark.asyncio
     async def test_session_uris_forwarded_to_state_api(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Encodes RGB cameras as a single full-resolution lossy video (libx264 CRF 23) and drops the lossless archive when `h264_medium` is selected, saving storage and bandwidth. Depth cameras keep their lossless storage. Adds a playback fallback so recordings captured lossy-only read the lossy video when no lossless archive exists.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-945](https://neuracore.atlassian.net/browse/NCP-945)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - #751 — this PR is stacked on top of it (targets `feat/live-video-codec-config`, not `main`)

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->