### PR TITLE
fix: use NEURACORE_ORG_ID as the single org id source for the daemon

### DIFF
--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -261,7 +261,13 @@ Supported environment variables:
 | `keep_wakelock_while_upload` | `NCD_KEEP_WAKELOCK_WHILE_UPLOAD` |
 | `offline` | `NCD_OFFLINE` |
 | `api_key` | `NCD_API_KEY` |
-| `current_org_id` | `NCD_CURRENT_ORG_ID` |
+| `current_org_id` | `NEURACORE_ORG_ID` (shared with the SDK) |
+
+Note on `NEURACORE_ORG_ID`: the daemon uses it only as a fallback while
+`~/.neuracore/config.json` has no organization set. The config file is watched
+live, so an org selected with `neuracore select-org` mid-run always takes
+precedence. This differs from the SDK, where `NEURACORE_ORG_ID` overrides the
+config file.
 
 Boolean values treat these as true:
 - `1`

--- a/docs/environment_variable.md
+++ b/docs/environment_variable.md
@@ -9,5 +9,5 @@ Configure Neuracore behavior with environment variables (case insensitive, prefi
 | `NEURACORE_CONSUME_LIVE_DATA`                | Enable live data consumption for inference             | `true`/`false` | `true`                                                                  |
 | `NEURACORE_API_URL`                          | Base URL for Neuracore platform                        | URL string     | `https://api.neuracore.com/api`                                         |
 | `NEURACORE_API_KEY`                          | An override to the api-key to access the neuracore     | `nrc_XXXX`     | Configured with the [`neuracore login`](./commandline.md#configure-once) command |
-| `NEURACORE_ORG_ID`                           | An override to select the organization to use.         | A valid UUID   | Configured with the [`neuracore select-org`](./commandline.md#configure-once) command |
+| `NEURACORE_ORG_ID`                           | An override to select the organization to use (also read by the data daemon). | A valid UUID   | Configured with the [`neuracore select-org`](./commandline.md#configure-once) command |
 | `TMPDIR`                                     | Specifies a directory used for storing temporary files | Filepath       | An appropriate folder for your system                                   |

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -272,6 +272,9 @@ class RecordingStateManager(BaseSSEConsumer):
         if current_recording != recording_id:
             return
         self.recording_robot_instances.pop(instance_key, None)
+        # Data-bridge stop is driven by the recording context or expiry timer —
+        # not here — so the daemon gets exactly one StopRecording with the
+        # correct data-clock boundary.
         if recording_id is not None:
             self._cancel_recording_timers(recording_id)
 

--- a/neuracore/data_daemon/config_manager/config.py
+++ b/neuracore/data_daemon/config_manager/config.py
@@ -18,7 +18,7 @@ _ENV_MAP: dict[str, str] = {
     "keep_wakelock_while_upload": "NCD_KEEP_WAKELOCK_WHILE_UPLOAD",
     "offline": "NCD_OFFLINE",
     "api_key": "NCD_API_KEY",
-    "current_org_id": "NCD_CURRENT_ORG_ID",
+    "current_org_id": "NEURACORE_ORG_ID",
 }
 
 YES_CONFIRMATION = {"1", "true", "yes", "y"}

--- a/neuracore/data_daemon/helpers.py
+++ b/neuracore/data_daemon/helpers.py
@@ -66,20 +66,6 @@ def get_daemon_recordings_root_path() -> Path:
     )
 
 
-def bridge_sdk_org_id_env() -> None:
-    """Mirror the SDK's ``NEURACORE_ORG_ID`` into ``NCD_CURRENT_ORG_ID``.
-
-    The daemon resolves its org from ``~/.neuracore/config.json`` or
-    ``NCD_CURRENT_ORG_ID`` — it never reads the SDK's ``NEURACORE_ORG_ID``,
-    and an env-only org is never persisted to config.json, so without this
-    bridge the daemon has no org and uploads stall with traces pending
-    forever. An explicit ``NCD_CURRENT_ORG_ID`` always wins.
-    """
-    sdk_org_id = os.environ.get("NEURACORE_ORG_ID")
-    if sdk_org_id:
-        os.environ.setdefault("NCD_CURRENT_ORG_ID", sdk_org_id)
-
-
 def is_debug_mode() -> bool:
     """Return True if the daemon is running in debug mode."""
     return os.environ.get("NDD_DEBUG", "false").lower() == "true"

--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -18,11 +18,7 @@ from neuracore.data_daemon.const import (
     DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS,
     SOCKET_PATH,
 )
-from neuracore.data_daemon.helpers import (
-    bridge_sdk_org_id_env,
-    get_daemon_db_path,
-    get_daemon_pid_path,
-)
+from neuracore.data_daemon.helpers import get_daemon_db_path, get_daemon_pid_path
 from neuracore.data_daemon.lifecycle.auth_preflight import ensure_daemon_auth_ready
 from neuracore.data_daemon.rust_selection import (
     is_rust_daemon_enabled,
@@ -378,7 +374,6 @@ def launch_new_daemon_subprocess(
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_file_lock = str(pid_path) + ".lock"
 
-    bridge_sdk_org_id_env()
     ensure_daemon_auth_ready(env_overrides)
 
     with filelock.FileLock(pid_file_lock):
@@ -414,7 +409,6 @@ def ensure_daemon_running(
 
     os.environ.setdefault("NEURACORE_DAEMON_PID_PATH", str(pid_path))
     os.environ.setdefault("NEURACORE_DAEMON_DB_PATH", str(db_path))
-    bridge_sdk_org_id_env()
 
     with filelock.FileLock(pid_file_lock):
         existing_pid = read_pid_from_file(pid_path)

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -333,7 +333,7 @@ fn run_daemon(
                 IpcTransport::bring_up().context("failed to bring up iceoryx2 transport")?;
 
             // Resolve the initial org_id from the local SDK-managed config,
-            // falling back to the daemon profile (NCD_CURRENT_ORG_ID or the
+            // falling back to the daemon profile (NEURACORE_ORG_ID or the
             // YAML profile override). This is only the seed value: the cloud
             // coordinators spawn a watcher over `config_path` and read the
             // *current* org live, so an org selected after launch is picked up

--- a/rust/data_daemon/src/cloud/mod.rs
+++ b/rust/data_daemon/src/cloud/mod.rs
@@ -45,7 +45,7 @@ use serde::Deserialize;
 ///
 /// Used for the one-shot resolutions at launch/spawn. Returns `None` when the
 /// file is missing, malformed, or the field is unset. The daemon falls back to
-/// `NCD_CURRENT_ORG_ID` (via the `DaemonConfig` resolved at launch) when this
+/// `NEURACORE_ORG_ID` (via the `DaemonConfig` resolved at launch) when this
 /// returns `None`.
 pub fn read_org_id_from_config(path: &Path) -> Option<String> {
     match std::fs::read(path) {

--- a/rust/data_daemon/src/cloud/watchers/org_watcher.rs
+++ b/rust/data_daemon/src/cloud/watchers/org_watcher.rs
@@ -38,7 +38,7 @@ impl OrgWatcherHandle {
 /// Spawn the config-file watcher.
 ///
 /// Returns a [`OrgIdRx`] seeded with the org resolved at spawn time and the
-/// task handle. `fallback` is the daemon-profile override (`NCD_CURRENT_ORG_ID`
+/// task handle. `fallback` is the daemon-profile override (`NEURACORE_ORG_ID`
 /// / YAML profile) used whenever the config file has no `current_org_id`,
 /// matching the launch-time resolution order.
 pub fn spawn_org_watcher(

--- a/rust/data_daemon_shared/src/config/env.rs
+++ b/rust/data_daemon_shared/src/config/env.rs
@@ -91,7 +91,7 @@ where
 /// read through this helper treats an empty value as unset (so a shell that
 /// exports an unset variable as the empty string falls through to the
 /// configured profile value rather than clobbering it). This is most important
-/// for the secret-bearing `NCD_API_KEY` / `NCD_CURRENT_ORG_ID`, but it applies
+/// for the secret-bearing `NCD_API_KEY` / `NEURACORE_ORG_ID`, but it applies
 /// uniformly to the boolean and numeric overrides too — unlike Python's
 /// `config.py`, which honours an empty string as a real override.
 fn env_var(name: &str) -> Option<String> {
@@ -142,7 +142,7 @@ pub fn env_config_overrides() -> DaemonConfig {
     if let Some(value) = env_var("NCD_API_KEY") {
         config.api_key = Some(value);
     }
-    if let Some(value) = env_var("NCD_CURRENT_ORG_ID") {
+    if let Some(value) = env_var("NEURACORE_ORG_ID") {
         config.current_org_id = Some(value);
     }
 
@@ -295,7 +295,7 @@ mod tests {
         "NCD_KEEP_WAKELOCK_WHILE_UPLOAD",
         "NCD_OFFLINE",
         "NCD_API_KEY",
-        "NCD_CURRENT_ORG_ID",
+        "NEURACORE_ORG_ID",
         "NEURACORE_DAEMON_PROFILE",
     ];
 
@@ -318,7 +318,7 @@ mod tests {
         std::env::set_var("NCD_KEEP_WAKELOCK_WHILE_UPLOAD", "yes");
         std::env::set_var("NCD_OFFLINE", "1");
         std::env::set_var("NCD_API_KEY", "secret-key");
-        std::env::set_var("NCD_CURRENT_ORG_ID", "org-42");
+        std::env::set_var("NEURACORE_ORG_ID", "org-42");
         std::env::set_var("NEURACORE_DAEMON_PROFILE", "lab");
 
         let config = env_config_overrides();

--- a/rust/scripts/run_integration_tests.sh
+++ b/rust/scripts/run_integration_tests.sh
@@ -301,6 +301,7 @@ main() {
   check_installed_bundle
   stop_daemon
   cleanup_state
+  materialize_artefacts
 
   set +e
   run_tests

--- a/tests/unit/data_daemon/config_manager/test_config.py
+++ b/tests/unit/data_daemon/config_manager/test_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from neuracore.data_daemon.config_manager.config import ConfigManager
+from neuracore.data_daemon.config_manager.daemon_config import DaemonConfig
+
+
+class _StubProfileManager:
+    def __init__(self, profile_config: DaemonConfig) -> None:
+        self._profile_config = profile_config
+
+    def get_profile(self, profile: str | None) -> DaemonConfig:
+        return self._profile_config
+
+
+def test_env_org_id_read_from_neuracore_org_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-env")
+
+    manager = ConfigManager(_StubProfileManager(DaemonConfig()))
+    config = manager.resolve_effective_config()
+
+    assert config.current_org_id == "org-from-env"
+
+
+def test_env_org_id_overrides_profile_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-env")
+
+    manager = ConfigManager(
+        _StubProfileManager(DaemonConfig(current_org_id="org-from-profile"))
+    )
+    config = manager.resolve_effective_config()
+
+    assert config.current_org_id == "org-from-env"
+
+
+def test_org_id_unset_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEURACORE_ORG_ID", raising=False)
+
+    manager = ConfigManager(_StubProfileManager(DaemonConfig()))
+    config = manager.resolve_effective_config()
+
+    assert config.current_org_id is None

--- a/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
+++ b/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
@@ -8,7 +8,6 @@ from typing import IO, cast
 import pytest
 
 import neuracore.data_daemon.lifecycle.daemon_os_control as daemon_os_control
-from neuracore.data_daemon.helpers import bridge_sdk_org_id_env
 from neuracore.data_daemon.lifecycle.daemon_os_control import (
     DaemonLifecycleError,
     acquire_pid_file,
@@ -102,86 +101,6 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
     assert env["NEURACORE_DAEMON_DB_PATH"] == str(db_path)
     assert env["NEURACORE_DAEMON_MANAGE_PID"] == "0"
     assert pid_path.read_text(encoding="utf-8").strip() == "54321"
-
-
-def test_bridge_sdk_org_id_env_bridges_to_daemon_var(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-sdk-env")
-    monkeypatch.delenv("NCD_CURRENT_ORG_ID", raising=False)
-
-    bridge_sdk_org_id_env()
-
-    assert os.environ["NCD_CURRENT_ORG_ID"] == "org-from-sdk-env"
-
-
-def test_bridge_sdk_org_id_env_keeps_explicit_daemon_var(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-sdk-env")
-    monkeypatch.setenv("NCD_CURRENT_ORG_ID", "org-explicit")
-
-    bridge_sdk_org_id_env()
-
-    assert os.environ["NCD_CURRENT_ORG_ID"] == "org-explicit"
-
-
-def test_bridge_sdk_org_id_env_noop_without_sdk_var(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("NEURACORE_ORG_ID", raising=False)
-    monkeypatch.delenv("NCD_CURRENT_ORG_ID", raising=False)
-
-    bridge_sdk_org_id_env()
-
-    assert "NCD_CURRENT_ORG_ID" not in os.environ
-
-
-def _stub_daemon_launch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Stub out process/auth side effects so entry points run hermetically."""
-    monkeypatch.setattr(
-        daemon_os_control, "get_daemon_pid_path", lambda: tmp_path / "daemon.pid"
-    )
-    monkeypatch.setattr(
-        daemon_os_control, "get_daemon_db_path", lambda: tmp_path / "state.db"
-    )
-    monkeypatch.setattr(
-        daemon_os_control, "cleanup_stale_client_state", lambda **_: None
-    )
-    monkeypatch.setattr(daemon_os_control, "ensure_daemon_auth_ready", lambda *_: None)
-    monkeypatch.setattr(
-        daemon_os_control,
-        "launch_daemon_subprocess",
-        lambda **_: _FakePopen(pid=54321),
-    )
-
-
-def test_ensure_daemon_running_bridges_sdk_org_id(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-sdk-env")
-    monkeypatch.delenv("NCD_CURRENT_ORG_ID", raising=False)
-    _stub_daemon_launch(monkeypatch, tmp_path)
-
-    daemon_os_control.ensure_daemon_running()
-
-    assert os.environ["NCD_CURRENT_ORG_ID"] == "org-from-sdk-env"
-
-
-def test_launch_new_daemon_subprocess_bridges_sdk_org_id(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setenv("NEURACORE_ORG_ID", "org-from-sdk-env")
-    monkeypatch.delenv("NCD_CURRENT_ORG_ID", raising=False)
-    _stub_daemon_launch(monkeypatch, tmp_path)
-
-    daemon_os_control.launch_new_daemon_subprocess(
-        pid_path=tmp_path / "daemon.pid",
-        db_path=tmp_path / "state.db",
-        background=True,
-    )
-
-    assert os.environ["NCD_CURRENT_ORG_ID"] == "org-from-sdk-env"
 
 
 def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Rust daemon was not picking up NEURACORE_ORG_ID 

