### PR TITLE
ci: install ffmpeg and fix integration tests to use the installed wheel

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -60,8 +60,8 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Install libclang for bindgen
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+    - name: Install system packages
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Restore training metadata from cache
       uses: actions/cache/restore@v4
@@ -164,7 +164,5 @@ jobs:
         ALGORITHM_NAME: ${{ matrix.algorithm }}
         DISPLAY: :0
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
         pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate "$TEST_HARNESS_PATH"

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -65,8 +65,8 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Install libclang for bindgen
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+    - name: Install system packages
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/integration-ml-algorithm-validation-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-staging.yaml
@@ -22,8 +22,8 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Install libclang for bindgen
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+    - name: Install system packages
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout test harness
       uses: actions/checkout@v4

--- a/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
@@ -63,8 +63,8 @@ jobs:
         large-packages: true
         swap-storage: true
 
-    - name: Install libclang for bindgen
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+    - name: Install system packages
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/integration-ml-back-to-back-training-staging.yaml
+++ b/.github/workflows/integration-ml-back-to-back-training-staging.yaml
@@ -22,8 +22,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -101,8 +101,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
+++ b/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
@@ -22,8 +22,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -101,8 +101,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
+++ b/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
@@ -20,8 +20,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -99,8 +99,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-failure-reporting-staging.yaml
+++ b/.github/workflows/integration-ml-failure-reporting-staging.yaml
@@ -22,8 +22,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -101,8 +101,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-inference-staging.yaml
+++ b/.github/workflows/integration-ml-inference-staging.yaml
@@ -22,8 +22,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -101,8 +101,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-resume-training-staging.yaml
+++ b/.github/workflows/integration-ml-resume-training-staging.yaml
@@ -22,8 +22,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -101,8 +101,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/.github/workflows/integration-ml-training-flow-staging.yaml
+++ b/.github/workflows/integration-ml-training-flow-staging.yaml
@@ -32,8 +32,8 @@ jobs:
           large-packages: true
           swap-storage: true
 
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -111,8 +111,6 @@ jobs:
           NEURACORE_ENDPOINT_TIMEOUT: 30
           DISPLAY: :0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           pytest \
             -o log_cli=true \

--- a/tests/integration/importer/conftest.py
+++ b/tests/integration/importer/conftest.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import pytest
 import yaml
 
+# Resolve neuracore from the installed wheel before repo_root joins sys.path.
+import neuracore  # noqa: F401
+
 ROBOTS_REPO_URL = "https://github.com/NeuracoreAI/neuracore_robots.git"
 ROBOTS_REPO_COMMIT = "c3d17b303296686ceb9a2fcddea06af95a88fe4f"
 

--- a/tests/integration/ml/conftest.py
+++ b/tests/integration/ml/conftest.py
@@ -6,6 +6,9 @@ from typing import Any
 import pytest
 import yaml
 
+# Resolve neuracore from the installed wheel before repo_root joins sys.path.
+import neuracore  # noqa: F401
+
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 repo_root = str(Path(__file__).resolve().parents[3])
 if repo_root not in sys.path:


### PR DESCRIPTION
### Bugfixes
 - Staging ML and importer integration tests now install ffmpeg (required by the Rust data daemon) in a single consolidated system-packages step, and their test setup imports the installed neuracore package instead of the source checkout, which previously hid the bundled Rust extension and broke daemon startup.

### Related PRs
 - #756