### PR TITLE
ci: drop free-disk-space action and report runner disk space

### DIFF
--- a/.github/workflows/integration-importer-production.yaml
+++ b/.github/workflows/integration-importer-production.yaml
@@ -38,15 +38,8 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -177,3 +170,7 @@ jobs:
             -k "not shared"
           )
           pytest "${pytest_args[@]}" tests/integration/importer/
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -38,18 +38,8 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
-      - name: Install libclang for bindgen
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -193,3 +183,7 @@ jobs:
             -v
           )
           pytest "${pytest_args[@]}" tests/integration/importer/
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -48,20 +48,11 @@ jobs:
         include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
-    # The native cargo build of the Rust daemon needs more room than the
-    # stock runner provides alongside the Python dependencies.
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
+    - name: Show disk space
+      run: df -h /
 
     - name: Install system packages
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Restore training metadata from cache
       uses: actions/cache/restore@v4
@@ -166,3 +157,7 @@ jobs:
       run: |
         Xvfb $DISPLAY -screen 0 1280x1024x24 &
         pytest -o log_cli=true --log-cli-level=INFO -v -k test_evaluate "$TEST_HARNESS_PATH"
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -53,20 +53,11 @@ jobs:
         include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
-    # The native cargo build of the Rust daemon needs more room than the
-    # stock runner provides alongside the Python dependencies.
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
+    - name: Show disk space
+      run: df -h /
 
     - name: Install system packages
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -156,3 +147,7 @@ jobs:
           training_job_id.txt
           test_harness_ref.txt
         key: training-job-${{ matrix.algorithm }}-${{ matrix.environment }}-${{ github.run_number }}
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /

--- a/.github/workflows/integration-ml-algorithm-validation-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-validation-staging.yaml
@@ -10,20 +10,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    # The native cargo build of the Rust daemon needs more room than the
-    # stock runner provides alongside the Python dependencies.
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
+    - name: Show disk space
+      run: df -h /
 
     - name: Install system packages
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout test harness
       uses: actions/checkout@v4
@@ -96,3 +87,7 @@ jobs:
         NCD_RUST_DAEMON: "1"
         NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
       run: pytest -o log_cli=true --log-cli-level=INFO -v tests/integration/ml/test_algorithm_validation.py
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /

--- a/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
@@ -51,20 +51,11 @@ jobs:
         include: ${{ fromJson(needs.discover-algorithms.outputs.matrix) }}
 
     steps:
-    # The native cargo build of the Rust daemon needs more room than the
-    # stock runner provides alongside the Python dependencies.
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
+    - name: Show disk space
+      run: df -h /
 
     - name: Install system packages
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -219,3 +210,7 @@ jobs:
           echo "waiting ${RETRY_WAIT_SECONDS}s between attempts."
         } >> "$GITHUB_STEP_SUMMARY"
         exit 1
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /

--- a/.github/workflows/integration-ml-back-to-back-training-prod.yaml
+++ b/.github/workflows/integration-ml-back-to-back-training-prod.yaml
@@ -12,15 +12,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -98,3 +91,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_back_to_back_training.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-back-to-back-training-staging.yaml
+++ b/.github/workflows/integration-ml-back-to-back-training-staging.yaml
@@ -12,18 +12,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -109,3 +102,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_back_to_back_training.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-dataset-datatype-validation-prod.yaml
+++ b/.github/workflows/integration-ml-dataset-datatype-validation-prod.yaml
@@ -12,15 +12,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -98,3 +91,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_dataset_datatype_validation.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
+++ b/.github/workflows/integration-ml-dataset-datatype-validation-staging.yaml
@@ -12,18 +12,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -109,3 +102,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_dataset_datatype_validation.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-deleted-dataset-resume-prod.yaml
+++ b/.github/workflows/integration-ml-deleted-dataset-resume-prod.yaml
@@ -10,15 +10,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -96,3 +89,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
+++ b/.github/workflows/integration-ml-deleted-dataset-resume-staging.yaml
@@ -10,18 +10,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -107,3 +100,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_deleted_dataset_on_resume_training.py::test_resume_fails_when_training_dataset_has_been_deleted
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-failure-reporting-prod.yaml
+++ b/.github/workflows/integration-ml-failure-reporting-prod.yaml
@@ -12,15 +12,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -98,3 +91,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_failure_reporting.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-failure-reporting-staging.yaml
+++ b/.github/workflows/integration-ml-failure-reporting-staging.yaml
@@ -12,18 +12,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -109,3 +102,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_failure_reporting.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-inference-prod.yaml
+++ b/.github/workflows/integration-ml-inference-prod.yaml
@@ -12,15 +12,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -98,3 +91,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_inference.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-inference-staging.yaml
+++ b/.github/workflows/integration-ml-inference-staging.yaml
@@ -12,18 +12,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -109,3 +102,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_inference.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-resume-training-prod.yaml
+++ b/.github/workflows/integration-ml-resume-training-prod.yaml
@@ -12,15 +12,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -98,3 +91,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_resume_training.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-resume-training-staging.yaml
+++ b/.github/workflows/integration-ml-resume-training-staging.yaml
@@ -12,18 +12,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -109,3 +102,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_resume_training.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-training-flow-prod.yaml
+++ b/.github/workflows/integration-ml-training-flow-prod.yaml
@@ -22,15 +22,8 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Checkout repository metadata
         uses: actions/checkout@v4
@@ -108,3 +101,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_training_flow.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-ml-training-flow-staging.yaml
+++ b/.github/workflows/integration-ml-training-flow-staging.yaml
@@ -22,18 +22,11 @@ jobs:
     #   in CommunicationsManager when calling create_producer_socket()
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+      - name: Show disk space
+        run: df -h /
 
       - name: Install system packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libxml2-utils xvfb libgl1-mesa-dev libgl1 libosmesa6-dev
 
       - name: Checkout test harness
         uses: actions/checkout@v4
@@ -119,3 +112,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S" \
             -v \
             tests/integration/ml/test_training_flow.py
+
+      - name: Show disk space after tests
+        if: always()
+        run: df -h /

--- a/.github/workflows/integration-platform-production.yaml
+++ b/.github/workflows/integration-platform-production.yaml
@@ -34,15 +34,8 @@ jobs:
         ffmpeg: [true, false]
 
     steps:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
+    - name: Show disk space
+      run: df -h /
 
     - name: Checkout repository metadata
       uses: actions/checkout@v4
@@ -138,3 +131,7 @@ jobs:
         NEURACORE_API_KEY: ${{ secrets.PROD_SERVICE_API_KEY }}
         NEURACORE_ORG_ID: ${{ vars.PROD_SERVICE_ORG_ID }}
       run: pytest -o log_cli=true --log-cli-level=INFO tests/integration/platform/data_daemon/
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /

--- a/.github/workflows/integration-platform-staging.yaml
+++ b/.github/workflows/integration-platform-staging.yaml
@@ -46,21 +46,8 @@ jobs:
             macos-deployment-target: '11.0'
 
     steps:
-    # Linux runners ship near-full; the native cargo build + ffmpeg need room.
-    # No-op on macOS (action is Ubuntu-only), so gate it to the Linux leg.
-    - name: Free Disk Space (Ubuntu)
-      if: runner.os == 'Linux'
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        swap-storage: true
-
-    - name: Install libclang for bindgen
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libclang-dev
+    - name: Show disk space
+      run: df -h /
 
     - name: Checkout repository metadata
       uses: actions/checkout@v4
@@ -195,3 +182,7 @@ jobs:
         if ! pytest -o log_cli=true --log-cli-level=INFO --import-mode=importlib tests/integration/platform/test_consume_stream.py; then
           echo "::warning::test_consume_stream.py failed, but this is non-blocking."
         fi
+
+    - name: Show disk space after tests
+      if: always()
+      run: df -h /


### PR DESCRIPTION
- `jlumbroso/free-disk-space@main` is not needed anymore. Github bumped the diskspace on runners to 150GB
- Added steps to show before and after disk space stats in workflows.