### PR TITLE
ci: launch importer from the installed package in integration tests, run suites in parallel

### DIFF
--- a/.github/workflows/integration-importer-production.yaml
+++ b/.github/workflows/integration-importer-production.yaml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
+        suite: [lerobot, mcap, rlds]
 
     steps:
       - name: Show disk space
@@ -146,7 +147,7 @@ jobs:
           echo "Test harness environment: production"
           echo "Test harness ref: ${{ steps.harness-ref.outputs.harness_ref }}"
           echo "Test harness commit: $(git rev-parse HEAD)"
-          echo "Test harness path: tests/integration/importer/"
+          echo "Test harness path: tests/integration/importer/test_${{ matrix.suite }}_dataset_import.py"
           python - << 'EOF'
           import neuracore
 
@@ -169,7 +170,7 @@ jobs:
             -v
             -k "not shared"
           )
-          pytest "${pytest_args[@]}" tests/integration/importer/
+          pytest "${pytest_args[@]}" "tests/integration/importer/test_${{ matrix.suite }}_dataset_import.py"
 
       - name: Show disk space after tests
         if: always()

--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
+        suite: [lerobot, mcap, rlds]
 
     steps:
       - name: Show disk space
@@ -159,7 +160,7 @@ jobs:
           echo "Test harness environment: staging"
           echo "Test harness ref: ${{ steps.harness-ref.outputs.harness_ref }}"
           echo "Test harness commit: $(git rev-parse HEAD)"
-          echo "Test harness path: tests/integration/importer/"
+          echo "Test harness path: tests/integration/importer/test_${{ matrix.suite }}_dataset_import.py"
           python - << 'EOF'
           import neuracore
 
@@ -182,7 +183,7 @@ jobs:
             --log-cli-date-format="%H:%M:%S"
             -v
           )
-          pytest "${pytest_args[@]}" tests/integration/importer/
+          pytest "${pytest_args[@]}" "tests/integration/importer/test_${{ matrix.suite }}_dataset_import.py"
 
       - name: Show disk space after tests
         if: always()

--- a/tests/integration/importer/utils.py
+++ b/tests/integration/importer/utils.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
-import sys
+import tempfile
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -86,11 +87,20 @@ def find_robot_urdf(robot_repo_dir: Path, robot_keyword: str) -> Path:
     )
 
 
+_robots_repo_dir: Path | None = None
+
+
 def clone_robots_repo(tmp_path: Path) -> Path:
-    robots_repo_dir = tmp_path / "neuracore_robots"
-    run_checked(["git", "clone", ROBOTS_REPO_URL, str(robots_repo_dir)])
-    run_checked(["git", "-C", str(robots_repo_dir), "checkout", ROBOTS_REPO_COMMIT])
-    return robots_repo_dir
+    """Clone the robots repo once per session and reuse it across tests."""
+    global _robots_repo_dir
+    if _robots_repo_dir is None:
+        robots_repo_dir = (
+            Path(tempfile.mkdtemp(prefix="importer_it_")) / "neuracore_robots"
+        )
+        run_checked(["git", "clone", ROBOTS_REPO_URL, str(robots_repo_dir)])
+        run_checked(["git", "-C", str(robots_repo_dir), "checkout", ROBOTS_REPO_COMMIT])
+        _robots_repo_dir = robots_repo_dir
+    return _robots_repo_dir
 
 
 def resolve_source_config_path(dataset_config: str) -> Path:
@@ -284,10 +294,10 @@ def build_importer_command(
     worker_count = (
         max_workers if max_workers is not None else case.get("max_workers", 1)
     )
+    neuracore_cli = shutil.which("neuracore")
+    assert neuracore_cli is not None, "neuracore CLI entry point not on PATH"
     return [
-        sys.executable,
-        "-m",
-        "neuracore.core.cli.app",
+        neuracore_cli,
         "importer",
         "import",
         "--dataset-config",


### PR DESCRIPTION
### Bugfixes
- Launch the importer from the installed `neuracore` command instead of `python -m`. The `python -m` form put the source folder on the path, which lacks the bundled rust binary, so every recording failed and the staging tests timed out.
- Clone the robot description repository once per session and reuse it, instead of per test.
- Run each dataset suite (lerobot, mcap, rlds) as its own parallel job in the staging and production workflows.
