### PR TITLE
fix: cancel daemon retry timers on shutdown and deflake daemon tests

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,5 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+The data daemon now cancels pending upload retry timers when it shuts down, so a retry can no longer fire after the daemon has stopped.

--- a/neuracore/data_daemon/services.py
+++ b/neuracore/data_daemon/services.py
@@ -150,6 +150,12 @@ class DaemonServices:
             logger.exception("Error shutting down TraceStatusUpdater")
 
         try:
+            await self.state_manager.shutdown()
+            logger.debug("StateManager shutdown")
+        except Exception:
+            logger.exception("Error shutting down StateManager")
+
+        try:
             await self.state_store.reset_retrying_to_written()
             await self.state_store.close()
             logger.debug("SqliteStateStore closed")

--- a/neuracore/data_daemon/state_management/state_manager.py
+++ b/neuracore/data_daemon/state_management/state_manager.py
@@ -78,6 +78,27 @@ class StateManager:
             Emitter.SET_EXPECTED_TRACE_COUNT, self._handle_set_expected_trace_count
         )
 
+        self._retry_timer_handles: dict[str, asyncio.TimerHandle] = {}
+
+    async def shutdown(self) -> None:
+        """Cancel all pending retry timers."""
+        for handle in self._retry_timer_handles.values():
+            handle.cancel()
+        self._retry_timer_handles.clear()
+
+    def _schedule_retry_emit(self, trace_id: str, delay: float) -> None:
+        """Arm a retry timer for the trace, replacing any existing one."""
+        existing = self._retry_timer_handles.pop(trace_id, None)
+        if existing is not None:
+            existing.cancel()
+
+        def _fire() -> None:
+            self._retry_timer_handles.pop(trace_id, None)
+            asyncio.create_task(self._retry_emit(trace_id))
+
+        loop = asyncio.get_running_loop()
+        self._retry_timer_handles[trace_id] = loop.call_later(delay, _fire)
+
     async def _handle_start_trace(
         self,
         trace_id: str,
@@ -714,11 +735,7 @@ class StateManager:
             error_message=error_message,
         )
 
-        loop = asyncio.get_running_loop()
-        loop.call_later(
-            float(backoff),
-            lambda: asyncio.create_task(self._retry_emit(trace_id)),
-        )
+        self._schedule_retry_emit(trace_id, float(backoff))
 
     async def _retry_emit(self, trace_id: str) -> None:
         """Emit READY_FOR_UPLOAD when a trace is due for retry."""
@@ -731,11 +748,7 @@ class StateManager:
             now = datetime.now(timezone.utc).replace(tzinfo=None)
             if trace.next_retry_at > now:
                 delay = (trace.next_retry_at - now).total_seconds()
-                loop = asyncio.get_running_loop()
-                loop.call_later(
-                    float(delay),
-                    lambda: asyncio.create_task(self._retry_emit(trace_id)),
-                )
+                self._schedule_retry_emit(trace_id, float(delay))
                 return
         await self._emit_ready_for_upload_from_trace(trace)
 

--- a/tests/unit/data_daemon/event_loop_manager/test_event_loop_manager.py
+++ b/tests/unit/data_daemon/event_loop_manager/test_event_loop_manager.py
@@ -72,8 +72,8 @@ def test_stop_terminates_loops(running_loop_manager: EventLoopManager):
     assert not running_loop_manager.is_running()
     assert not running_loop_manager._started
 
-    time.sleep(0.1)
     if running_loop_manager._general_thread:
+        running_loop_manager._general_thread.join(timeout=2.0)
         assert not running_loop_manager._general_thread.is_alive()
 
 

--- a/tests/unit/data_daemon/state_management/test_state_manager_integration.py
+++ b/tests/unit/data_daemon/state_management/test_state_manager_integration.py
@@ -41,6 +41,7 @@ async def manager_store(
     try:
         yield manager, store
     finally:
+        await manager.shutdown()
         await store.close()
 
 
@@ -1208,3 +1209,82 @@ async def test_retry_emit_does_not_emit_before_next_retry_at(
         assert scheduled[0] >= 30.0
     finally:
         emitter.remove_listener(Emitter.READY_FOR_UPLOAD, ready_handler)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_pending_retry_timers(
+    manager_store, emitter: Emitter
+) -> None:
+    manager, store = manager_store
+    await manager._handle_start_trace(
+        "trace-shutdown",
+        "rec-shutdown",
+        DataType.CUSTOM_1D,
+        "custom",
+        1,
+        None,
+        None,
+        None,
+        None,
+        path="/tmp/trace-shutdown.bin",
+    )
+    await manager._store.update_write_status(
+        "trace-shutdown", TraceWriteStatus.INITIALIZING
+    )
+    await manager._store.update_write_status("trace-shutdown", TraceWriteStatus.WRITTEN)
+    await manager._store.update_upload_status(
+        "trace-shutdown", TraceUploadStatus.UPLOADING
+    )
+
+    await manager.handle_upload_failed(
+        "trace-shutdown", 0, TraceErrorCode.NETWORK_ERROR, "net"
+    )
+
+    assert "trace-shutdown" in manager._retry_timer_handles
+    handle = manager._retry_timer_handles["trace-shutdown"]
+
+    await manager.shutdown()
+
+    assert manager._retry_timer_handles == {}
+    assert handle.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_rearmed_retry_timer_replaces_existing_handle(
+    manager_store, emitter: Emitter
+) -> None:
+    manager, store = manager_store
+    await manager._handle_start_trace(
+        "trace-rearm",
+        "rec-rearm",
+        DataType.CUSTOM_1D,
+        "custom",
+        1,
+        None,
+        None,
+        None,
+        None,
+        path="/tmp/trace-rearm.bin",
+    )
+    await manager._store.update_write_status(
+        "trace-rearm", TraceWriteStatus.INITIALIZING
+    )
+    await manager._store.update_write_status("trace-rearm", TraceWriteStatus.WRITTEN)
+    await manager._store.update_upload_status(
+        "trace-rearm", TraceUploadStatus.UPLOADING
+    )
+
+    await manager.handle_upload_failed(
+        "trace-rearm", 0, TraceErrorCode.NETWORK_ERROR, "net"
+    )
+    first_handle = manager._retry_timer_handles["trace-rearm"]
+
+    await manager._store.update_upload_status(
+        "trace-rearm", TraceUploadStatus.UPLOADING
+    )
+    await manager.handle_upload_failed(
+        "trace-rearm", 0, TraceErrorCode.NETWORK_ERROR, "net again"
+    )
+
+    assert first_handle.cancelled()
+    assert manager._retry_timer_handles["trace-rearm"] is not first_handle

--- a/tests/unit/data_daemon/upload_management/test_trace_status_updater.py
+++ b/tests/unit/data_daemon/upload_management/test_trace_status_updater.py
@@ -10,6 +10,8 @@ from neuracore.data_daemon.upload_management.trace_status_updater import (
     TraceStatusUpdater,
 )
 
+HANG_GUARD_S = 2.0
+
 # --- Fixtures ---
 
 
@@ -171,13 +173,13 @@ async def test_update_trace_completed_waits(
         trace_status_updater.update_trace_completed("rec-1", "trace-1", 500)
     )
 
-    await asyncio.wait_for(put_called.wait(), timeout=0.1)
+    await asyncio.wait_for(put_called.wait(), timeout=HANG_GUARD_S)
     await asyncio.sleep(0.1)
     assert not task.done(), "update should not be done before request is completed"
     put_response.set_result(AsyncMock(spec=aiohttp.ClientResponse, status=200))
     # Assert
 
-    await asyncio.wait_for(task, timeout=0.1)
+    await asyncio.wait_for(task, timeout=HANG_GUARD_S)
     assert task.result() is True
     mock_client_session.put.assert_called_once()
     json_data = mock_client_session.put.call_args.kwargs["json"]
@@ -206,7 +208,7 @@ async def test_auth_refresh_on_401(
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 10, wait_for_completion=True
         ),
-        timeout=0.1,
+        timeout=HANG_GUARD_S,
     )
 
     # Assert
@@ -232,7 +234,7 @@ async def test_failed_request_returns_false(trace_status_updater, mock_client_se
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 10, wait_for_completion=True
         ),
-        timeout=0.1,
+        timeout=HANG_GUARD_S,
     )
     # Assert
     assert success is False
@@ -253,7 +255,7 @@ async def test_error_request_returns_false(trace_status_updater, mock_client_ses
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 10, wait_for_completion=True
         ),
-        timeout=0.1,
+        timeout=HANG_GUARD_S,
     )
     # Assert
     assert success is False
@@ -271,20 +273,20 @@ async def test_stacking_updates_on_same_trace(
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 100, wait_for_completion=False
         ),
-        timeout=0.01,
+        timeout=HANG_GUARD_S,
     )
     await asyncio.wait_for(
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 200, wait_for_completion=False
         ),
-        timeout=0.01,
+        timeout=HANG_GUARD_S,
     )
     # Manually trigger batch processing or use a wait_for_completion call
     await asyncio.wait_for(
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 300, wait_for_completion=True
         ),
-        timeout=0.1,
+        timeout=HANG_GUARD_S,
     )
 
     json_data = mock_client_session.put.call_args.kwargs["json"]
@@ -323,9 +325,9 @@ async def test_completed_update_is_sent_earlier_than_in_progress(
         trace_status_updater.update_trace_completed(
             "rec-1", "trace-2", 200, wait_for_completion=True
         ),
-        timeout=0.1,
+        timeout=HANG_GUARD_S,
     )
-    await asyncio.wait_for(progress_update_task, timeout=0.1)
+    await asyncio.wait_for(progress_update_task, timeout=HANG_GUARD_S)
 
     # Assert: request already sent (did NOT wait 1s)
     assert mock_client_session.put.call_count == 1
@@ -342,7 +344,7 @@ async def test_shutdown_cancels_pending_batch_tasks(
         trace_status_updater.update_trace_progress(
             "rec-1", "trace-1", 100, wait_for_completion=False
         ),
-        timeout=0.01,
+        timeout=HANG_GUARD_S,
     )
 
     assert len(trace_status_updater._batch_update_tasks) == 1


### PR DESCRIPTION
- Fixes the flaky test-non-ml issues on PR CI 
- Reproduction of the Issue: https://github.com/NeuracoreAI/neuracore/actions/runs/28786578848/job/85355091450?pr=762