### PR TITLE
fix: process objects not pickled correctly

### DIFF
--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -43,6 +43,7 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     case_ids,
 )
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case_context import (  # noqa: E501
+    ContextSpec,
     build_context_specs,
     run_case_contexts,
 )
@@ -59,6 +60,15 @@ SIGKILL_EXIT_TIMEOUT_S = 5.0
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _run_recording_workload(case: DataDaemonTestCase, specs: list[ContextSpec]) -> None:
+    """Producer workload entry point for the SIGKILL worker child process.
+
+    Module-level so it is picklable under the ``spawn`` start method
+    (the default on macOS).
+    """
+    run_case_contexts(case, specs=specs)
 
 
 def _single_runner_pid() -> int:
@@ -390,12 +400,13 @@ def test_sigkill_mid_recording_allows_clean_restart(case: DataDaemonTestCase) ->
         pid_first = assert_exactly_one_daemon_pid()
         specs = build_context_specs(case=case)
 
-        def _run() -> None:
-            run_case_contexts(case, specs=specs)
-
         # Run the producer workload in a child process so a SIGKILL at any point
         # cannot leave an uninterruptible background thread in this test process.
-        worker = multiprocessing.Process(target=_run, name="sigkill-recording-worker")
+        worker = multiprocessing.Process(
+            target=_run_recording_workload,
+            args=(case, specs),
+            name="sigkill-recording-worker",
+        )
         worker.start()
         # The point of this test is restartability after an unclean daemon death;
         # the kill may land during setup, active logging, or stop cleanup.

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -298,6 +298,18 @@ def stop_daemon(
         _remove_ipc_artefacts()
 
 
+def _parallel_startup_worker(
+    barrier: object, results: dict[int, int], index: int
+) -> None:
+    """Wait on the barrier then record the daemon PID for one parallel caller.
+
+    Module-level so it is picklable under the ``spawn`` start method
+    (the default on macOS).
+    """
+    barrier.wait()
+    results[index] = ensure_daemon_running()
+
+
 def collect_daemon_pids_from_parallel_startup(worker_count: int) -> list[int]:
     """Start ``worker_count`` daemon instances in parallel and collect their PIDs.
 
@@ -308,17 +320,15 @@ def collect_daemon_pids_from_parallel_startup(worker_count: int) -> list[int]:
         A list of the PID returned by each worker.
     """
 
-    def worker(barrier: object, results: dict[int, int], index: int) -> None:
-        barrier.wait()
-        results[index] = ensure_daemon_running()
-
     barrier = multiprocessing.Barrier(worker_count)
     manager = multiprocessing.Manager()
     results = manager.dict()
     processes = []
 
     for index in range(worker_count):
-        process = multiprocessing.Process(target=worker, args=(barrier, results, index))
+        process = multiprocessing.Process(
+            target=_parallel_startup_worker, args=(barrier, results, index)
+        )
         process.start()
         processes.append(process)
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - MacOs uses spawn which pickles process targets by reference rather than ubuntu that does no pickling at all. Hoist nested functions to be straight references so proper pickling can occur and assertions can be completed.
