### PR TITLE
perf: parallelise PNG compression and scale daemon encode threads

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -298,6 +298,8 @@ Multihead
 multinode
 multirun
 muxer
+muxes
+muxing
 nans
 nbconvert
 nbformat

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -48,7 +48,8 @@ pub const DEFAULT_FFMPEG_BINARY: &str = "ffmpeg";
 /// foreground logging threads while ffmpeg still consumes otherwise-idle CPU.
 const ENCODER_NICENESS: libc::c_int = 10;
 
-/// libx264 frame-thread cap applied to *each* encode output stream.
+/// Floor for the libx264 frame-thread count applied to *each* encode output —
+/// the value used when the transcode fleet is fully loaded.
 ///
 /// libx264 defaults to roughly one frame-thread per core. With the transcode
 /// concurrency permit pool also scaling with the core count, the two multiply:
@@ -61,7 +62,12 @@ const ENCODER_NICENESS: libc::c_int = 10;
 /// per output beat the uncapped default on both aggregate throughput and
 /// logging-thread jitter, so [`default_ffmpeg_concurrency`] divides by this.
 ///
+/// A *floor*, not a hard cap: [`adaptive_encode_threads`] gives each encode more
+/// threads (`cores / active`) when fewer are running, filling the idle cores
+/// while keeping the full-load thread total unchanged.
+///
 /// [`default_ffmpeg_concurrency`]: crate::pipeline::trace_actor::default_ffmpeg_concurrency
+/// [`adaptive_encode_threads`]: crate::pipeline::trace_actor::adaptive_encode_threads
 pub const ENCODE_THREADS_PER_OUTPUT: usize = 2;
 
 /// Height (in lines) the lossy *preview* proxy is downscaled to.
@@ -354,13 +360,21 @@ impl VideoEncoder {
 
     /// Transcode one NUT chunk into the configured per-chunk mp4 outputs.
     ///
+    /// `encode_threads` bounds each output's libx264 frame-thread pool; the
+    /// caller sizes it to the live transcode concurrency (see
+    /// [`adaptive_encode_threads`]) so a few-camera workload uses the otherwise
+    /// idle cores.
+    ///
     /// The source `raw.nut` is left in place — the caller is responsible for
     /// unlinking it after verifying both outputs landed (the per-trace actor
     /// drops the source as part of its envelope handling so a partial encode
     /// can be retried via the recovery sweep without needing to re-spool).
+    ///
+    /// [`adaptive_encode_threads`]: crate::pipeline::trace_actor::adaptive_encode_threads
     pub async fn encode_chunk(
         &self,
         request: &ChunkEncodeRequest,
+        encode_threads: usize,
     ) -> Result<ChunkEncodeOutcome, VideoEncodeError> {
         ensure_parent_dirs(&request.lossy_out)?;
         ensure_parent_dirs(&request.lossless_out)?;
@@ -393,10 +407,10 @@ impl VideoEncoder {
         // the encode with "Unrecognized option 'fps_mode'". `-vsync` is accepted
         // on both (only deprecated, not removed, on 5.1+). Two `-map 0:v -c:v ...`
         // blocks emit both outputs from a single demux pass.
-        // Bound each output's libx264 thread pool (see
-        // `ENCODE_THREADS_PER_OUTPUT`) so the transcode fleet doesn't
-        // oversubscribe the cores the logging threads need.
-        let encode_threads = ENCODE_THREADS_PER_OUTPUT.to_string();
+        // Bound each output's libx264 thread pool to the caller-sized value
+        // (see `adaptive_encode_threads`) so the transcode fleet fills idle
+        // cores at low concurrency without oversubscribing at high concurrency.
+        let encode_threads = encode_threads.to_string();
         // Downscale the lossy preview proxy (only) to keep the dominant pass
         // cheap at high resolution. The lossless output stays native.
         let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
@@ -925,7 +939,10 @@ mod tests {
             lossy_out: lossy.clone(),
             lossless_out: lossless.clone(),
         };
-        let outcome = encoder.encode_chunk(&request).await.expect("transcode");
+        let outcome = encoder
+            .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
+            .await
+            .expect("transcode");
 
         assert!(outcome.lossy_bytes > 0);
         assert!(outcome.lossless_bytes > 0);
@@ -981,11 +998,14 @@ mod tests {
 
         let encoder = VideoEncoder::new();
         encoder
-            .encode_chunk(&ChunkEncodeRequest {
-                raw_nut: raw,
-                lossy_out: lossy.clone(),
-                lossless_out: lossless.clone(),
-            })
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
             .await
             .expect("transcode");
 
@@ -1076,11 +1096,14 @@ mod tests {
                 .join(format!("chunk_{chunk_index:04}_lossless.mp4"));
             write_synthetic_nut(&ffmpeg, &raw, 4);
             encoder
-                .encode_chunk(&ChunkEncodeRequest {
-                    raw_nut: raw,
-                    lossy_out: lossy.clone(),
-                    lossless_out: lossless,
-                })
+                .encode_chunk(
+                    &ChunkEncodeRequest {
+                        raw_nut: raw,
+                        lossy_out: lossy.clone(),
+                        lossless_out: lossless,
+                    },
+                    ENCODE_THREADS_PER_OUTPUT,
+                )
                 .await
                 .expect("transcode chunk");
             segments.push(lossy);
@@ -1137,7 +1160,7 @@ mod tests {
         };
         let encoder = VideoEncoder::new();
         let error = encoder
-            .encode_chunk(&request)
+            .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
             .await
             .expect_err("ffmpeg should fail");
         assert!(
@@ -1159,7 +1182,7 @@ mod tests {
         let encoder =
             VideoEncoder::new().with_binary("this-binary-definitely-does-not-exist-ffmpeg");
         let error = encoder
-            .encode_chunk(&request)
+            .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
             .await
             .expect_err("spawn should fail");
         match error {

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -100,9 +100,29 @@ const BYTES_WRITTEN_DEBOUNCE_FRAMES: u64 = 32;
 ///
 /// Floor at 2 so single-core hosts still get a useful permit pool.
 pub(crate) fn default_ffmpeg_concurrency() -> usize {
+    (encode_host_cores() / ENCODE_THREADS_PER_OUTPUT).max(2)
+}
+
+/// Host parallelism (logical cores), floored at 1. Cached-cheap syscall; read
+/// once when the actor context is built.
+pub(crate) fn encode_host_cores() -> usize {
     std::thread::available_parallelism()
-        .map(|n| (n.get() / ENCODE_THREADS_PER_OUTPUT).max(2))
-        .unwrap_or(2)
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// libx264 threads for each output of an encode, given the host core count and
+/// how many transcodes are running right now. The permit pool caps concurrency
+/// at `cores / ENCODE_THREADS_PER_OUTPUT`; when fewer than that run (a few-camera
+/// load on a many-core host) the rest of the box is idle. `cores / active` keeps
+/// total encoder threads ≈ `2 × cores` at any concurrency — it collapses to
+/// [`ENCODE_THREADS_PER_OUTPUT`] at full load (the original fixed cap) and fills
+/// the idle cores otherwise.
+pub(crate) fn adaptive_encode_threads(cores: usize, active_encodes: usize) -> usize {
+    let cores = cores.max(1);
+    let active = active_encodes.max(1);
+    let ceiling = cores.max(ENCODE_THREADS_PER_OUTPUT);
+    (cores / active).clamp(ENCODE_THREADS_PER_OUTPUT, ceiling)
 }
 
 /// Shared context passed to every per-trace actor.
@@ -126,6 +146,14 @@ pub struct TraceActorContext {
     /// integration matrix's parallel encode storms don't fork-bomb the
     /// transcoder.
     pub ffmpeg_permits: Arc<Semaphore>,
+    /// Total permits in [`ffmpeg_permits`](Self::ffmpeg_permits), captured at
+    /// construction (before any are held). Subtracting the live
+    /// `available_permits()` yields how many transcodes are running right now,
+    /// which sizes each encode's thread pool (see [`adaptive_encode_threads`]).
+    pub ffmpeg_permit_total: usize,
+    /// Host parallelism, paired with the live permit count to scale each
+    /// encode's libx264 thread pool to the idle cores.
+    pub encode_cores: usize,
     /// Optional daemon event bus. When present, the trace actor publishes a
     /// [`crate::state::DaemonEvent::TraceWritten`] on finalise so the
     /// registration coordinator can wake immediately. Optional so unit tests
@@ -174,11 +202,15 @@ impl TraceActorContext {
         trace_writer: TraceWriteHandle,
         json_writer: JsonWriteHandle,
     ) -> Self {
+        // Captured before any permit is acquired, so this is the pool's total.
+        let ffmpeg_permit_total = ffmpeg_permits.available_permits();
         Self {
             recordings_root: Arc::new(recordings_root.into()),
             storage_budget,
             video_encoder,
             ffmpeg_permits,
+            ffmpeg_permit_total,
+            encode_cores: encode_host_cores(),
             event_bus: None,
             trace_writer,
             json_writer,
@@ -602,6 +634,8 @@ impl ActorState {
         // inbox immediately so a slow ffmpeg invocation cannot back-pressure
         // unrelated joint / scalar publishers sharing the commands service.
         let permits = context.ffmpeg_permits.clone();
+        let permit_total = context.ffmpeg_permit_total;
+        let encode_cores = context.encode_cores;
         let encoder = context.video_encoder.clone();
         let trace_id = self.identity.trace_id.clone();
         let chunks_dir_for_task = chunks_dir.clone();
@@ -611,9 +645,17 @@ impl ActorState {
             lossless_out: lossless_segment.clone(),
         };
         pending_encodes.spawn(async move {
-            // Acquire a permit, then encode. The permit lives only inside
-            // the task — dropping it releases the slot, even on panic.
-            let permit = match permits.acquire_owned().await {
+            // Acquire a permit before relinking + encoding. Gating the relink
+            // (which frees the producer's on-disk spool) on a permit is
+            // deliberate: it makes the fixed spool cap the backstop that bounds
+            // the un-encoded backlog. When the encoder can't keep up, chunks stay
+            // in the spool until a permit frees, the spool fills, and the
+            // *producer* back-pressures — rather than the daemon-side chunks dir
+            // growing without bound. Adaptive threading (below) keeps the encoder
+            // fast enough that this backstop rarely engages. Clone the `Arc` for
+            // the (consuming) acquire so `permits` stays live for the
+            // `available_permits()` read below.
+            let permit = match permits.clone().acquire_owned().await {
                 Ok(permit) => permit,
                 Err(_) => {
                     return ChunkEncodeJobResult {
@@ -659,7 +701,14 @@ impl ActorState {
                     };
                 }
             }
-            let outcome = encoder.encode_chunk(&request).await;
+            // Size this encode's thread pool to the cores the rest of the fleet
+            // isn't using: with the permit held, `available_permits()` is the
+            // idle capacity, so `total - available` is how many encodes (incl.
+            // this one) are running now. Read after acquiring so we count
+            // ourselves.
+            let active_encodes = permit_total.saturating_sub(permits.available_permits());
+            let encode_threads = adaptive_encode_threads(encode_cores, active_encodes);
+            let outcome = encoder.encode_chunk(&request, encode_threads).await;
             drop(permit);
             match outcome {
                 Ok(encode) => {
@@ -1111,6 +1160,36 @@ mod tests {
     fn scalar_fallback_entry_wraps_non_json_payload() {
         let entry = crate::pipeline::json_writer::scalar_fallback_entry(123, &[0xFF, 0xFE]);
         assert_eq!(entry, json!({"timestamp_ns": 123, "payload_len": 2}));
+    }
+
+    #[test]
+    fn adaptive_threads_fill_idle_cores_and_collapse_at_full_load() {
+        let cores = 14;
+        // Pool full (cores / 2 encodes running): each collapses to the floor,
+        // so total encoder threads stay ~= 2 * cores — the original behaviour.
+        let full = default_ffmpeg_concurrency_for(cores);
+        assert_eq!(
+            adaptive_encode_threads(cores, full),
+            ENCODE_THREADS_PER_OUTPUT
+        );
+        // One encode on an otherwise-idle host takes the whole box; two split it
+        // — total encoder threads still ~= 2 * cores at any concurrency.
+        assert_eq!(adaptive_encode_threads(cores, 1), cores);
+        assert_eq!(adaptive_encode_threads(cores, 2), cores / 2);
+        // Never below the floor even if the count is somehow over-subscribed,
+        // and degenerate inputs don't panic or divide by zero.
+        assert_eq!(
+            adaptive_encode_threads(cores, cores * 4),
+            ENCODE_THREADS_PER_OUTPUT
+        );
+        assert_eq!(adaptive_encode_threads(0, 0), ENCODE_THREADS_PER_OUTPUT);
+    }
+
+    /// Mirror of [`default_ffmpeg_concurrency`] for an explicit core count, so
+    /// the adaptive-threads test can assert the full-load boundary without
+    /// depending on the host's real parallelism.
+    fn default_ffmpeg_concurrency_for(cores: usize) -> usize {
+        (cores / ENCODE_THREADS_PER_OUTPUT).max(2)
     }
 
     #[tokio::test]

--- a/rust/data_daemon_bridge/src/nut_writer.rs
+++ b/rust/data_daemon_bridge/src/nut_writer.rs
@@ -23,6 +23,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 // Only the Linux `sync_file_range` writeback hint needs the raw fd; gated to
 // avoid an unused-import warning on platforms without that syscall (e.g. macOS).
+use std::cell::RefCell;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -194,9 +195,6 @@ pub struct NutWriter {
     /// File offset up to which an async writeback hint has been issued. The
     /// next hint covers `[last_writeback_hint, bytes_written)`.
     last_writeback_hint: u64,
-    /// Reused PNG-encode scratch space (buffers + compressor); see
-    /// [`PngScratch`].
-    png: PngScratch,
 }
 
 /// Emit a new syncpoint when the bytes-since-last-syncpoint would exceed
@@ -286,7 +284,6 @@ impl NutWriter {
             logical_bytes: 0,
             last_syncpoint_offset: 0,
             last_writeback_hint: 0,
-            png: PngScratch::new(),
         };
         writer.write_headers()?;
         Ok(writer)
@@ -316,6 +313,12 @@ impl NutWriter {
     /// Append one frame at the supplied PTS (frame index in time-base ticks).
     /// The frame is supplied as packed RGB24 — exactly `width * height * 3`
     /// bytes — and stored as a per-frame lossless PNG.
+    ///
+    /// Compresses on the calling thread. The hot producer path instead
+    /// compresses on a worker pool and calls
+    /// [`write_frame_precompressed`](Self::write_frame_precompressed); this
+    /// wrapper is retained for the round-trip tests, which drive raw RGB
+    /// straight through.
     pub fn write_frame(&mut self, pts: u64, rgb_bytes: &[u8]) -> Result<(), NutError> {
         if rgb_bytes.len() != self.expected_frame_bytes {
             return Err(NutError::FrameSize {
@@ -323,14 +326,17 @@ impl NutWriter {
                 actual: rgb_bytes.len(),
             });
         }
+        let png = encode_png_frame(self.config.width, self.config.height, rgb_bytes);
+        self.write_frame_precompressed(pts, &png)
+    }
 
-        // The caller always supplies packed RGB24; we compress it to a per-frame
-        // PNG here, into the writer's reused scratch. `payload_len` is the length
-        // of the assembled PNG now sitting in `self.png.output` — the bytes that
-        // land in the NUT frame packet below.
-        let payload_len = self
-            .png
-            .encode(self.config.width, self.config.height, rgb_bytes);
+    /// Append one already-PNG-compressed frame (as produced by
+    /// [`encode_png_frame`]) at the supplied PTS. The writer thread's half of
+    /// the split: it only muxes the payload into the NUT chunk — the expensive
+    /// compression has already run on a pool worker — so the single writer keeps
+    /// up with multi-camera capture.
+    pub fn write_frame_precompressed(&mut self, pts: u64, png: &[u8]) -> Result<(), NutError> {
+        let payload_len = png.len();
 
         // Emit a periodic syncpoint before appending the frame so the gap
         // between consecutive syncpoints stays within the demuxer's reach.
@@ -385,7 +391,7 @@ impl NutWriter {
         header.extend_from_slice(&checksum.to_be_bytes());
 
         self.write_all(&header)?;
-        self.write_png_payload(payload_len)?;
+        self.write_all(png)?;
 
         // Track decoded-equivalent volume so chunk rolls track frame count, not
         // the (much smaller, content-dependent) compressed PNG size.
@@ -515,21 +521,6 @@ impl NutWriter {
                 source,
             })?;
         self.bytes_written = self.bytes_written.saturating_add(bytes.len() as u64);
-        Ok(())
-    }
-
-    /// Write the first `len` bytes of the reused `png.output` (the assembled PNG
-    /// payload). A dedicated method rather than `write_all(&self.png.output)` so
-    /// the borrow stays a disjoint `&mut self.writer` + `&self.png.output` rather
-    /// than the whole-`self` borrow a method argument would force.
-    fn write_png_payload(&mut self, len: usize) -> Result<(), NutError> {
-        self.writer
-            .write_all(&self.png.output[..len])
-            .map_err(|source| NutError::Write {
-                path: self.path.clone(),
-                source,
-            })?;
-        self.bytes_written = self.bytes_written.saturating_add(len as u64);
         Ok(())
     }
 
@@ -885,6 +876,27 @@ impl PngScratch {
         write_png_chunk(&mut self.output, b"IEND", &[]);
         self.output.len()
     }
+}
+
+thread_local! {
+    /// Per-thread PNG-encode scratch. Reused across calls on the same thread so
+    /// the compression workers don't reallocate their filter/compressor buffers
+    /// each frame. Thread-local (not a shared pool) because [`encode_png_frame`]
+    /// runs on multiple compression worker threads concurrently.
+    static ENCODE_SCRATCH: RefCell<PngScratch> = RefCell::new(PngScratch::new());
+}
+
+/// Compress one packed RGB24 frame to a standalone per-frame PNG, returning the
+/// owned bitstream. This is the CPU-heavy half of the old inline `write_frame`;
+/// running it on a pool worker rather than the single writer thread is what lets
+/// the producer keep up with multi-camera high-detail capture. The result is
+/// handed to [`NutWriter::write_frame_precompressed`], which only muxes it.
+pub fn encode_png_frame(width: u32, height: u32, rgb: &[u8]) -> Vec<u8> {
+    ENCODE_SCRATCH.with(|cell| {
+        let mut scratch = cell.borrow_mut();
+        let len = scratch.encode(width, height, rgb);
+        scratch.output[..len].to_vec()
+    })
 }
 
 /// Compress `input` as a zlib stream into `output`, reusing both `compressor`

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -517,8 +517,12 @@ fn writer_queue_global() -> Arc<FrameQueue> {
     let worker_queue = queue.clone();
     match std::thread::Builder::new()
         .name("nc-video-writer".to_string())
-        .spawn(move || writer_loop(&worker_queue))
-    {
+        .spawn(move || {
+            // The compression pool lives on (and is owned by) the writer thread,
+            // so a forked child rebuilds both together through the heal path.
+            let pool = CompressPool::new(compress_pool_size());
+            writer_loop(&worker_queue, &pool);
+        }) {
         Ok(_handle) => {
             reg.owner_pid = pid;
             reg.queue = Some(queue.clone());
@@ -561,9 +565,211 @@ extern "C" fn clear_queue_cache() {
     });
 }
 
+/// Cap on frames whose compression may be in flight on the pool ahead of the
+/// writer's in-order muxing. Bounds the pipeline's extra memory and, because the
+/// writer stops draining the queue once this many are outstanding, preserves the
+/// queue's admission backpressure (the writer never outruns the pool).
+const MAX_FRAMES_IN_FLIGHT: usize = 8;
+
+/// PNG-compression worker threads feeding the writer. Compression (~24 ms for a
+/// detailed 720p frame) — not the NUT muxing — is the pipeline's dominant cost,
+/// so a single thread can't keep up with two 30 fps cameras; a small pool can,
+/// while the writer thread still owns all chunk state and ordering. Capped so it
+/// doesn't oversubscribe a small host against the daemon's transcode fleet.
+fn compress_pool_size() -> usize {
+    std::thread::available_parallelism()
+        .map(|cores| (cores.get() / 2).clamp(2, 4))
+        .unwrap_or(2)
+}
+
+/// One-shot slot a pool worker fills with a frame's compressed PNG and the
+/// writer thread collects, in submission order. Hand-rolled (Mutex + Condvar)
+/// rather than a channel so the writer can both block on the next frame and poll
+/// whether it is ready yet.
+struct FrameResult {
+    png: Mutex<Option<Vec<u8>>>,
+    ready: Condvar,
+}
+
+impl FrameResult {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            png: Mutex::new(None),
+            ready: Condvar::new(),
+        })
+    }
+
+    /// Store the compressed frame and wake a writer blocked in [`wait`](Self::wait).
+    fn set(&self, png: Vec<u8>) {
+        *self.png.lock().unwrap_or_else(|p| p.into_inner()) = Some(png);
+        self.ready.notify_one();
+    }
+
+    /// Take the compressed frame if the worker has finished, without blocking.
+    fn try_take(&self) -> Option<Vec<u8>> {
+        self.png.lock().unwrap_or_else(|p| p.into_inner()).take()
+    }
+
+    /// Block until the worker has compressed the frame, then take it.
+    fn wait(&self) -> Vec<u8> {
+        let mut guard = self.png.lock().unwrap_or_else(|p| p.into_inner());
+        loop {
+            if let Some(png) = guard.take() {
+                return png;
+            }
+            guard = self.ready.wait(guard).unwrap_or_else(|p| p.into_inner());
+        }
+    }
+}
+
+/// One frame submitted to the compression pool.
+struct CompressJob {
+    width: u32,
+    height: u32,
+    rgb: Vec<u8>,
+    result: Arc<FrameResult>,
+}
+
+/// Fixed pool of PNG-compression worker threads shared by the writer loop.
+struct CompressPool {
+    work: Arc<(Mutex<VecDeque<CompressJob>>, Condvar)>,
+}
+
+impl CompressPool {
+    /// Spawn `workers` compression threads. They live for the process (like the
+    /// writer thread); a forked child re-creates the pool via the writer heal
+    /// path, so the parent's detached workers are never inherited.
+    fn new(workers: usize) -> Self {
+        let work = Arc::new((Mutex::new(VecDeque::new()), Condvar::new()));
+        for index in 0..workers {
+            let work = work.clone();
+            if let Err(error) = std::thread::Builder::new()
+                .name(format!("nc-png-compress-{index}"))
+                .spawn(move || compress_worker(&work))
+            {
+                tracing::warn!(%error, "failed to spawn PNG compression worker");
+            }
+        }
+        Self { work }
+    }
+
+    /// Queue a frame for compression and wake one idle worker.
+    fn submit(&self, job: CompressJob) {
+        let (lock, cond) = &*self.work;
+        lock.lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push_back(job);
+        cond.notify_one();
+    }
+}
+
+/// Compression worker: pull frames FIFO and compress each to PNG, publishing the
+/// result into its one-shot slot. Compression is stateless per frame, so any
+/// worker can take any frame — the writer restores per-stream order on collect.
+fn compress_worker(work: &(Mutex<VecDeque<CompressJob>>, Condvar)) {
+    let (lock, cond) = work;
+    loop {
+        let job = {
+            let mut queue = lock.lock().unwrap_or_else(|p| p.into_inner());
+            loop {
+                if let Some(job) = queue.pop_front() {
+                    break job;
+                }
+                queue = cond.wait(queue).unwrap_or_else(|p| p.into_inner());
+            }
+        };
+        let png = crate::nut_writer::encode_png_frame(job.width, job.height, &job.rgb);
+        job.result.set(png);
+    }
+}
+
+/// A frame whose compression is in flight, awaiting in-order muxing by the
+/// writer thread. Carries the routing metadata the write phase needs (its raw
+/// pixels already moved into the pool job) plus the slot the pool fills.
+struct PendingFrame {
+    job: FrameJob,
+    result: Arc<FrameResult>,
+}
+
+/// Validate one frame and submit it to the compression pool, recording it in the
+/// in-order pipeline. A frame whose byte length disagrees with its geometry is
+/// dropped here (the pre-split inline encode rejected it the same way) rather
+/// than handed to a worker.
+fn submit_frame(pool: &CompressPool, in_flight: &mut VecDeque<PendingFrame>, mut job: FrameJob) {
+    let expected = (job.width as usize)
+        .checked_mul(job.height as usize)
+        .and_then(|pixels| pixels.checked_mul(3));
+    if expected != Some(job.data.len()) {
+        tracing::warn!(
+            sensor_name = job.sensor_name,
+            ?expected,
+            actual = job.data.len(),
+            "video frame size disagrees with geometry; dropping frame"
+        );
+        return;
+    }
+    let result = FrameResult::new();
+    // Move the raw pixels into the compression job; the pending frame keeps only
+    // the routing metadata (its `data` is now empty and never read again).
+    let rgb = std::mem::take(&mut job.data);
+    pool.submit(CompressJob {
+        width: job.width,
+        height: job.height,
+        rgb,
+        result: result.clone(),
+    });
+    in_flight.push_back(PendingFrame { job, result });
+}
+
+/// Mux one already-compressed pending frame into its chunk (writer thread).
+fn write_pending_frame(pending: PendingFrame, png: Vec<u8>) {
+    if let Err(error) = record_video_frame(
+        &pending.job.robot_id,
+        pending.job.robot_instance,
+        &pending.job.data_type,
+        &pending.job.sensor_name,
+        pending.job.width,
+        pending.job.height,
+        &png,
+        pending.job.timestamp_ns,
+        pending.job.timestamp_s,
+    ) {
+        tracing::warn!(%error, sensor_name = pending.job.sensor_name, "failed to spool video frame");
+    }
+}
+
+/// Mux every frame whose compression has already finished, front to back,
+/// stopping at the first still-compressing frame so per-stream order is kept.
+fn drain_ready(in_flight: &mut VecDeque<PendingFrame>) {
+    while let Some(front) = in_flight.front() {
+        match front.result.try_take() {
+            Some(png) => {
+                let pending = in_flight.pop_front().expect("front just observed");
+                write_pending_frame(pending, png);
+            }
+            None => break,
+        }
+    }
+}
+
+/// Block until the front frame is compressed, then mux it — used to make room
+/// when the pipeline is full and to drain it fully at a stop/cancel barrier.
+fn write_front(in_flight: &mut VecDeque<PendingFrame>) {
+    if let Some(pending) = in_flight.pop_front() {
+        let png = pending.result.wait();
+        write_pending_frame(pending, png);
+    }
+}
+
 /// The writer thread's run loop. Sole accessor of the in-progress chunk state
 /// and sole publisher of video chunk + stop/cancel envelopes for this process.
-fn writer_loop(queue: &FrameQueue) {
+///
+/// Frame compression is offloaded to `pool`; this thread submits each frame then
+/// muxes the results back into their chunks in strict submission order (which is
+/// per-stream FIFO). It only ever muxes — the expensive PNG encode runs on the
+/// pool — so it keeps up with multi-camera capture the single-thread inline
+/// encode could not.
+fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
     // With the spool cap disabled there is nothing to scan, so block on each
     // message indefinitely rather than waking on a timer.
     let bounded = queue.spool_max > 0;
@@ -571,6 +777,7 @@ fn writer_loop(queue: &FrameQueue) {
         // Prime the backlog estimate so the first frames see a real spool size.
         refresh_spool_backlog(queue);
     }
+    let mut in_flight: VecDeque<PendingFrame> = VecDeque::new();
     let mut last_scan = Instant::now();
     loop {
         let next = if bounded {
@@ -580,18 +787,12 @@ fn writer_loop(queue: &FrameQueue) {
         };
         match next {
             Some(WriterMsg::Frame(job)) => {
-                if let Err(error) = record_video_frame(
-                    &job.robot_id,
-                    job.robot_instance,
-                    &job.data_type,
-                    &job.sensor_name,
-                    job.width,
-                    job.height,
-                    &job.data,
-                    job.timestamp_ns,
-                    job.timestamp_s,
-                ) {
-                    tracing::warn!(%error, sensor_name = job.sensor_name, "failed to spool video frame");
+                submit_frame(pool, &mut in_flight, job);
+                // Cap outstanding compressions: block-mux the oldest until the
+                // pipeline has room. This doubles as the queue's backpressure —
+                // the writer stops popping while it waits here.
+                while in_flight.len() >= MAX_FRAMES_IN_FLIGHT {
+                    write_front(&mut in_flight);
                 }
             }
             Some(WriterMsg::FlushSource {
@@ -599,6 +800,12 @@ fn writer_loop(queue: &FrameQueue) {
                 robot_instance,
                 ack,
             }) => {
+                // The stop barrier must seal chunks that include every frame
+                // submitted before it, so finish all outstanding compressions and
+                // mux them before flushing the tail.
+                while !in_flight.is_empty() {
+                    write_front(&mut in_flight);
+                }
                 if let Err(error) = flush_source_chunks(&robot_id, robot_instance) {
                     tracing::warn!(%error, "failed to flush tail video chunks on stop");
                 }
@@ -609,6 +816,12 @@ fn writer_loop(queue: &FrameQueue) {
                 robot_instance,
                 ack,
             }) => {
+                // Mux outstanding frames before dropping so the pool never holds a
+                // slot for a stream we are about to remove; the dropped chunks are
+                // reclaimed by the daemon's cancel + recovery sweep regardless.
+                while !in_flight.is_empty() {
+                    write_front(&mut in_flight);
+                }
                 let prefix = source_prefix(&robot_id, robot_instance);
                 with_video_chunks(|streams| {
                     streams.retain(|key, _| !key.starts_with(&prefix));
@@ -618,6 +831,9 @@ fn writer_loop(queue: &FrameQueue) {
             // pop_timeout elapsed with no message: fall through to the rescan.
             None => {}
         }
+        // Mux whatever finished compressing, keeping spooling latency low without
+        // ever blocking on a slow frame.
+        drain_ready(&mut in_flight);
         // Refresh the backlog estimate on a coarse cadence so frame-admission
         // backpressure tracks the daemon draining the spool inbox.
         if bounded && last_scan.elapsed() >= SPOOL_SCAN_INTERVAL {
@@ -698,6 +914,9 @@ fn should_flush_chunk(logical_chunk_bytes: u64, frame_count: u32) -> bool {
 /// crosses [`CHUNK_FLUSH_BYTES`] or [`MAX_VIDEO_CHUNK_FRAMES`]. Best-effort:
 /// NUT-write errors are logged and the frame dropped, never propagated to
 /// Python.
+///
+/// `png_payload` is the frame already compressed to a per-frame PNG by a pool
+/// worker (see [`submit_frame`]); this only muxes it into the chunk.
 #[allow(clippy::too_many_arguments)]
 fn record_video_frame(
     robot_id: &str,
@@ -706,7 +925,7 @@ fn record_video_frame(
     sensor_name: &str,
     width: u32,
     height: u32,
-    payload: &[u8],
+    png_payload: &[u8],
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Result<(), ProducerError> {
@@ -763,7 +982,7 @@ fn record_video_frame(
             sensor_name,
             width,
             height,
-            payload,
+            png_payload,
             timestamp_ns,
             timestamp_s,
         )
@@ -784,6 +1003,9 @@ fn record_video_frame(
 /// IPC — the caller publishes the returned envelopes outside the lock — which
 /// also makes the open/seal/roll logic unit-testable without a live daemon.
 /// Best-effort: a NUT open/write error logs and drops the frame.
+///
+/// `png_payload` is the frame already compressed to a per-frame PNG; this muxes
+/// it straight into the chunk.
 #[allow(clippy::too_many_arguments)]
 fn append_frame_locked(
     state: &mut VideoChunkState,
@@ -793,7 +1015,7 @@ fn append_frame_locked(
     sensor_name: &str,
     width: u32,
     height: u32,
-    payload: &[u8],
+    png_payload: &[u8],
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Vec<Envelope> {
@@ -876,7 +1098,7 @@ fn append_frame_locked(
     // [`should_flush_chunk`] for why.
     let logical_bytes_after_write = {
         let writer = state.nut_writer.as_mut().expect("opened immediately above");
-        if let Err(error) = writer.write_frame(pts, payload) {
+        if let Err(error) = writer.write_frame_precompressed(pts, png_payload) {
             tracing::warn!(
                 %error,
                 sensor_name,
@@ -1014,6 +1236,32 @@ mod tests {
             CHUNK_FLUSH_BYTES - 1,
             MAX_VIDEO_CHUNK_FRAMES - 1
         ));
+    }
+
+    #[test]
+    fn frame_result_is_ready_only_after_set_and_taken_once() {
+        let result = FrameResult::new();
+        assert!(result.try_take().is_none(), "empty slot must not be ready");
+        result.set(vec![1, 2, 3]);
+        assert_eq!(result.try_take(), Some(vec![1, 2, 3]));
+        assert!(
+            result.try_take().is_none(),
+            "the compressed frame is collected exactly once"
+        );
+    }
+
+    #[test]
+    fn frame_result_wait_wakes_on_a_late_set() {
+        // The writer thread blocks in `wait` until a pool worker publishes the
+        // compressed frame — the ordering guarantee the pipeline relies on.
+        let result = FrameResult::new();
+        let worker = result.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            worker.set(vec![7, 7, 7]);
+        });
+        assert_eq!(result.wait(), vec![7, 7, 7]);
+        handle.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
Two independent video-encoding throughput improvements, so the pipeline keeps up with high-detail / multi-camera capture instead of back-pressuring the producer:

 - **Producer — parallel PNG compression.** The single background writer thread used to PNG-compress every camera's frames inline, so high-detail multi-camera capture bottlenecked on one thread (a detailed 720p frame is ~24 ms of miniz work; one thread tops out below two 30 fps cameras). Compression is now offloaded to a small worker pool feeding the writer in submission order — the writer only muxes the NUT chunk. `nc.log_rgb` stays ~1 ms (it still just enqueues the raw frame) and per-stream FIFO ordering is preserved. (`data_daemon_bridge/src/writer.rs`, `nut_writer.rs`)
 - **Daemon — adaptive encode threads.** Each ffmpeg transcode used a fixed 2 libx264 threads per output, tuned for the many-camera 8-context case; with few cameras on a many-core host most cores sat idle. Each encode now gets `cores / active_encodes` threads, so total encoder threads stay ≈ `2 × cores` at any concurrency — it collapses to the original 2 at full load (8-context unchanged) and fills the idle cores otherwise (~2.4× faster per-chunk lossless encode for a few-camera 1080p load). Lossless output is bit-exact regardless of thread count. (`data_daemon/src/pipeline/trace_actor.rs`, `encoding/video_encoder.rs`)

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1099](https://neuracore.atlassian.net/browse/NCP-1099)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None
