### PR TITLE
fix: endpoint name

### DIFF
--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -7,6 +7,7 @@ including deployment, status monitoring, and deletion operations.
 
 import logging
 
+import requests
 from neuracore_types import (
     DeploymentConfig,
     DeploymentRequest,
@@ -32,6 +33,7 @@ from neuracore.core.get_latest_sync_point import (
 from neuracore.core.utils.embodiment_description_utils import (
     resolve_embodiment_descriptions_with_override,
 )
+from neuracore.core.utils.http_errors import extract_error_detail
 from neuracore.core.utils.http_session import thread_local_session
 
 logger = logging.getLogger(__name__)
@@ -284,8 +286,16 @@ def deploy_model(
         )
         response.raise_for_status()
         return response.json()
+    except requests.exceptions.HTTPError as e:
+        detail = None
+        if e.response is not None:
+            detail = extract_error_detail(e.response)
+            if e.response.status_code == 409:
+                detail = detail or f"Endpoint with name {name} already exists"
+                raise ValueError(f"Error deploying model: {detail}") from e
+        raise ValueError(f"Error deploying model: {detail or e}") from e
     except Exception as e:
-        raise ValueError(f"Error deploying model: {e}")
+        raise ValueError(f"Error deploying model: {e}") from e
 
 
 def get_endpoint_status(endpoint_id: str) -> str:

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -779,6 +779,38 @@ def test_deploy_model_failure(
         )
 
 
+def test_deploy_model_endpoint_name_conflict_shows_backend_detail(
+    temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
+):
+    """Deployment name conflicts should surface a clear terminal error."""
+    nc.login(TEST_API_KEY)
+
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/models/deploy",
+        status_code=409,
+        json={
+            "detail": {
+                "error": "Endpoint with name test_endpoint already exists",
+            }
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Error deploying model: Endpoint with name test_endpoint already exists",
+    ):
+        nc.deploy_model(
+            job_id="job_123",
+            name="test_endpoint",
+            input_embodiment_description={
+                DataType.RGB_IMAGES: _indexed_names(["top_camera"]),
+            },
+            output_embodiment_description={
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names(["joint1"]),
+            },
+        )
+
+
 def test_deploy_model_loads_embodiments_from_job_metadata_for_robot_id(
     temp_config_dir, mock_auth_requests, reset_neuracore, mocked_org_id
 ):


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - User can no longer create an endpoint with the same name as an existing endpoint.
 - The error message is displayed to the users' terminal upon receiving the relevant 409 error from the backend.
