### PR TITLE
fix: drop stale materialize_artefacts call from integration script

### DIFF
--- a/rust/scripts/run_integration_tests.sh
+++ b/rust/scripts/run_integration_tests.sh
@@ -301,7 +301,6 @@ main() {
   check_installed_bundle
   stop_daemon
   cleanup_state
-  materialize_artefacts
 
   set +e
   run_tests


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - `rust/scripts/run_integration_tests.sh` called `materialize_artefacts` in `main()`, but no such function exists

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - #754
