### PR TITLE
fix: twine license-file metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -478,7 +478,9 @@ jobs:
         run: |
           ls -l dist/
           [ "$(ls dist/*.whl | wc -l)" -eq 10 ] || { echo "expected 10 wheels"; exit 1; }
-          python -m pip install --upgrade twine
+          # packaging>=24.2 is required for twine to parse maturin's
+          # Metadata-Version 2.4 License-File field; the runner ships an older one.
+          python -m pip install --upgrade twine "packaging>=24.2"
           twine upload --skip-existing dist/*.whl
 
   dry-run-summary:


### PR DESCRIPTION
## Problem

The `publish` job in the Release workflow fails at `twine upload`:

```
InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'
```

https://github.com/NeuracoreAI/neuracore/actions/runs/29241409683/job/86789561078

(seen on the 13.4.0 release run — the version bump, tag `v13.4.0`, and GitHub release all succeeded, but the wheels never reached PyPI.)

## Root cause

- maturin builds the wheels with `Metadata-Version: 2.4` and writes a `License-File` field (we have a `LICENSE` plus `license = { text = "MIT" }`).
- Modern twine (6.x) validates that metadata via `packaging.metadata`.
- The `License-File` / `License-Expression` fields are only understood by **`packaging` >= 24.2**.
- The `publish` job has no `setup-python` step, so it runs on the runner's system Python, which ships an older `packaging`. `pip install --upgrade twine` upgrades twine but leaves that stale `packaging` in place (its lower bound is already satisfied), so twine chokes on metadata it can't parse.

## Fix

Explicitly upgrade `packaging` (>= 24.2) alongside twine in the publish step.
