### PR TITLE
fix: surface version mismatch errors through the CLI

### DIFF
--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -7,7 +7,6 @@ the application.
 """
 
 import os
-import sys
 from typing import Any
 
 import requests
@@ -20,7 +19,7 @@ from neuracore.core.utils.http_session import thread_local_session
 from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
 
 from .const import API_URL
-from .exceptions import AuthenticationError
+from .exceptions import AuthenticationError, VersionMismatchError
 
 
 def _response_json_payload(response: requests.Response) -> dict[str, Any] | None:
@@ -35,36 +34,25 @@ def _response_json_payload(response: requests.Response) -> dict[str, Any] | None
     return None
 
 
-def _payload_value(payload: dict[str, Any], key: str) -> Any:
-    """Read a value from top-level or nested FastAPI detail payloads."""
-    value = payload.get(key)
-    if value is not None:
-        return value
+def _installed_neuracore_version() -> str:
+    """Return the installed neuracore package version."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
 
-    detail = payload.get("detail")
-    if isinstance(detail, dict):
-        return detail.get(key)
-    return None
+    try:
+        return pkg_version("neuracore")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
 
 
 def _format_version_validation_error(response: requests.Response) -> str:
-    """Build a user-facing version validation error message."""
+    """Build a user-facing version validation error message with mitigation steps."""
     detail = extract_error_detail(response) or "Version validation failed."
-    payload = _response_json_payload(response)
-
-    if payload is None:
-        return detail
-
-    client_version = _payload_value(payload, "client_version")
-    required_version = _payload_value(payload, "required_version")
-
-    if client_version and required_version and required_version not in detail:
-        return (
-            f"{detail}. Client version: {client_version}. "
-            f"Required version: {required_version}."
-        )
-
-    return detail
+    return (
+        f"{detail}. Installed version: {_installed_neuracore_version()}. "
+        "To resolve this, upgrade to the latest client: "
+        "pip install --upgrade neuracore"
+    )
 
 
 class Auth(metaclass=SingletonMetaclass):
@@ -196,8 +184,7 @@ class Auth(metaclass=SingletonMetaclass):
                 raise AuthenticationError(str(exc)) from exc
 
             error_message = _format_version_validation_error(response)
-            print(error_message, file=sys.stderr)
-            raise AuthenticationError(
+            raise VersionMismatchError(
                 error_message, response_payload=_response_json_payload(response)
             ) from exc
         except requests.exceptions.ConnectionError as exc:

--- a/neuracore/core/cli/generate_api_key.py
+++ b/neuracore/core/cli/generate_api_key.py
@@ -13,7 +13,11 @@ from pydantic import BaseModel, ValidationError
 
 from neuracore.core.cli.get_user_confirmation import get_user_confirmation
 from neuracore.core.config.config_manager import get_config_manager
-from neuracore.core.exceptions import AuthenticationError, InputError
+from neuracore.core.exceptions import (
+    AuthenticationError,
+    InputError,
+    VersionMismatchError,
+)
 from neuracore.core.utils.http_session import thread_local_session
 
 from ..const import API_URL, MAX_INPUT_ATTEMPTS
@@ -144,8 +148,14 @@ def run(
     ),
 ) -> None:
     """Generate a new API key for access to the neuracore platform."""
+    from neuracore.core.auth import get_auth
+
     try:
+        get_auth().validate_version()
         generate_api_key(email=email, password=password)
+    except VersionMismatchError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
     except AuthenticationError:
         typer.echo("Failed to generate API key, please try again later", err=True)
         raise typer.Exit(code=1)

--- a/neuracore/core/cli/select_current_org.py
+++ b/neuracore/core/cli/select_current_org.py
@@ -11,7 +11,12 @@ import typer
 
 from neuracore.core.auth import get_auth
 from neuracore.core.config.config_manager import get_config_manager
-from neuracore.core.exceptions import AuthenticationError, InputError, OrganizationError
+from neuracore.core.exceptions import (
+    AuthenticationError,
+    InputError,
+    OrganizationError,
+    VersionMismatchError,
+)
 from neuracore.core.organizations import Organization, list_my_orgs
 
 from ..const import MAX_INPUT_ATTEMPTS, REJECTION_INPUT
@@ -119,13 +124,14 @@ def run(
         config_manager.config.current_org_id = organization.id
         config_manager.save_config()
 
+    except VersionMismatchError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
     except AuthenticationError as exc:
-        error_message = str(exc)
-        if exc.required_version is None:
-            typer.echo(
-                error_message or "Failed to Authenticate, please try again",
-                err=True,
-            )
+        typer.echo(
+            str(exc) or "Failed to Authenticate, please try again",
+            err=True,
+        )
         raise typer.Exit(code=1)
     except OrganizationError:
         typer.echo("Failed to select organization, please try again", err=True)

--- a/neuracore/core/exceptions.py
+++ b/neuracore/core/exceptions.py
@@ -40,6 +40,10 @@ class AuthenticationError(Exception):
         return None
 
 
+class VersionMismatchError(AuthenticationError):
+    """Raised when the client version is incompatible with the server."""
+
+
 class ValidationError(Exception):
     """Raised when input validation fails."""
 

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -107,35 +107,24 @@ def test_login_logout(temp_config_dir, mock_auth_requests, reset_neuracore):
     assert not auth.is_authenticated
 
 
-def test_login_version_mismatch_surfaces_backend_versions(
-    temp_config_dir, monkeypatch, reset_neuracore, capsys
+def test_login_version_mismatch_surfaces_installed_version(
+    temp_config_dir, reset_neuracore
 ):
-    """Test version validation shows the backend-provided mismatch details."""
-    expected_message = (
-        "Neuracore client version mismatch, client version: 1.2.3, "
-        "required version: 2.0.0"
-    )
-
+    """Test version validation surfaces the installed version and mitigation steps."""
     with requests_mock.Mocker() as m:
         m.get(
             f"{API_URL}/auth/verify-version",
-            json={
-                "detail": expected_message,
-                "client_version": "1.2.3",
-                "required_version": "2.0.0",
-            },
+            json={"detail": {"error": "Neuracore client version mismatch"}},
             status_code=400,
         )
 
         with pytest.raises(AuthenticationError) as exc_info:
             nc.login("test_api_key")
 
-    captured = capsys.readouterr()
-
-    assert str(exc_info.value) == expected_message
-    assert exc_info.value.required_version == "2.0.0"
-    assert exc_info.value.response_payload["required_version"] == "2.0.0"
-    assert expected_message in captured.err
+    message = str(exc_info.value)
+    assert "Neuracore client version mismatch" in message
+    assert f"Installed version: {nc.__version__}" in message
+    assert "pip install --upgrade neuracore" in message
 
 
 def test_login_version_check_connection_error_surfaces_cleanly(

--- a/tests/unit/core/cli/test_cli_app.py
+++ b/tests/unit/core/cli/test_cli_app.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 from neuracore import __version__
 from neuracore.core.cli.app import app
 from neuracore.core.cli.cache_commands import _directory_size
-from neuracore.core.exceptions import AuthenticationError
+from neuracore.core.exceptions import AuthenticationError, VersionMismatchError
 from neuracore.core.organizations import Organization
 
 runner = CliRunner()
@@ -268,7 +268,12 @@ def test_neuracore_login_works_regardless_of_torch(
 ) -> None:
     """Test that login works with or without torch available."""
 
+    class DummyAuth:
+        def validate_version(self):
+            pass
+
     # Setup mocks for auth
+    monkeypatch.setattr("neuracore.core.auth.get_auth", lambda: DummyAuth())
     monkeypatch.setattr(
         "neuracore.core.cli.generate_api_key.generate_api_key",
         lambda email=None, password=None: "test_api_key",
@@ -320,14 +325,16 @@ def test_neuracore_select_org_works_regardless_of_torch(
     assert result.exit_code == 0
 
 
-def test_select_org_auth_version_mismatch_uses_required_version(monkeypatch) -> None:
+def test_select_org_version_mismatch_is_echoed(monkeypatch) -> None:
     class DummyAuth:
         is_authenticated = False
 
         def login(self, api_key=None):
-            raise AuthenticationError(
-                "Please upgrade the client",
-                response_payload={"required_version": "2.0.0"},
+            raise VersionMismatchError(
+                "Neuracore client version mismatch",
+                response_payload={
+                    "detail": {"error": "Neuracore client version mismatch"}
+                },
             )
 
     monkeypatch.setattr(
@@ -342,34 +349,25 @@ def test_select_org_auth_version_mismatch_uses_required_version(monkeypatch) -> 
     )
 
     assert result.exit_code == 1
-    assert "Please upgrade the client" not in result.output
+    assert "Neuracore client version mismatch" in result.stderr
 
 
-def test_select_org_auth_version_mismatch_uses_nested_required_version(
-    monkeypatch,
-) -> None:
+def test_login_version_mismatch_fails(monkeypatch) -> None:
     class DummyAuth:
-        is_authenticated = False
+        def validate_version(self):
+            raise VersionMismatchError("Neuracore client version mismatch")
 
-        def login(self, api_key=None):
-            raise AuthenticationError(
-                "Please upgrade the client",
-                response_payload={"detail": {"required_version": "2.0.0"}},
-            )
-
-    monkeypatch.setattr(
-        "neuracore.core.cli.select_current_org.get_auth", lambda: DummyAuth()
-    )
+    monkeypatch.setattr("neuracore.core.auth.get_auth", lambda: DummyAuth())
 
     result = runner.invoke(
         app,
-        ["select-org"],
+        ["login", "--email", "user@example.com", "--password", "pw"],
         color=False,
         env={"TERM": "dumb", "NO_COLOR": "1", "RICH_DISABLE": "1"},
     )
 
     assert result.exit_code == 1
-    assert "Please upgrade the client" not in result.output
+    assert "Neuracore client version mismatch" in result.stderr
 
 
 def test_select_org_auth_error_without_required_version_is_echoed(monkeypatch) -> None:


### PR DESCRIPTION
### Features
 - None

### Bugfixes
 - When the installed client is too old for the backend, CLI commands now show a clear error instead of failing with a generic authentication message. The error includes the short summary from the backend, the version you have installed, and the exact command to fix it (pip install --upgrade neuracore).
  ```
 Neuracore client version mismatch. Installed version: 13.3.0. To resolve this, upgrade to the latest client: pip install --upgrade neuracore
 ```
 - Added a dedicated VersionMismatchError exception so the login and select-org commands can tell a version problem apart from a real authentication failure.
 - The login command now checks the client version before asking for credentials, so users find out about an outdated client right away.
 - Removed a duplicate print of the version error to stderr; the message is now shown once through the CLI.


### Items
 - [NCRL-710](https://neuracore.atlassian.net/jira/software/projects/NCRL/boards/67?selectedIssue=NCRL-710)

### Related PRs
 - None