### PR TITLE
fix: Preserve indexed embodiment metadata

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -77,16 +77,16 @@ def _resolve_recording_cache_dir(cfg: DictConfig) -> Path:
 
 def _serialize_cross_embodiment_description(
     cross_embodiment_description: CrossEmbodimentDescription,
-) -> dict[str, dict[str, list[str]]]:
-    """Convert a cross-embodiment description to JSON-serializable name lists."""
-    serializable: dict[str, dict[str, list[str]]] = {}
+) -> dict[str, dict[str, dict[int, str]]]:
+    """Convert a cross-embodiment description to data type name keys."""
+    serializable: dict[str, dict[str, dict[int, str]]] = {}
     for robot_id, data_types in cross_embodiment_description.items():
         serializable[robot_id] = {}
         for data_type, indexed_names in data_types.items():
             key = data_type.name if hasattr(data_type, "name") else str(data_type)
-            serializable[robot_id][key] = [
-                indexed_names[index] for index in sorted(indexed_names)
-            ]
+            serializable[robot_id][key] = {
+                index: indexed_names[index] for index in sorted(indexed_names)
+            }
     return serializable
 
 

--- a/neuracore/ml/utils/nc_archive.py
+++ b/neuracore/ml/utils/nc_archive.py
@@ -23,6 +23,7 @@ from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.json_serialization import to_json_serializable
 from neuracore.ml.utils.preprocessing import resolve_preprocessing_config
+from neuracore.ml.utils.training_config import normalize_cross_embodiment_description
 
 logger = logging.getLogger(__name__)
 
@@ -303,11 +304,15 @@ def load_cross_embodiment_descriptions_from_nc_archive(
         with open(
             _archive_path(extracted_files, "input_cross_embodiment_description")
         ) as f:
-            input_cross_embodiment_description = json.load(f)
+            input_cross_embodiment_description = normalize_cross_embodiment_description(
+                json.load(f)
+            )
         with open(
             _archive_path(extracted_files, "output_cross_embodiment_description")
         ) as f:
-            output_cross_embodiment_description = json.load(f)
+            output_cross_embodiment_description = (
+                normalize_cross_embodiment_description(json.load(f))
+            )
         return input_cross_embodiment_description, output_cross_embodiment_description
     finally:
         if use_temp_dir and temp_dir_context:
@@ -378,13 +383,17 @@ def load_model_from_nc_archive(
             with open(
                 _archive_path(extracted_files, "input_cross_embodiment_description")
             ) as f:
-                input_cross_embodiment_description = json.load(f)
+                input_cross_embodiment_description = (
+                    normalize_cross_embodiment_description(json.load(f))
+                )
         output_cross_embodiment_description = {}
         if "output_cross_embodiment_description" in extracted_files:
             with open(
                 _archive_path(extracted_files, "output_cross_embodiment_description")
             ) as f:
-                output_cross_embodiment_description = json.load(f)
+                output_cross_embodiment_description = (
+                    normalize_cross_embodiment_description(json.load(f))
+                )
         input_preprocessing_config: PreprocessingConfiguration = (
             PreprocessingConfiguration()
         )

--- a/neuracore/ml/utils/training_config.py
+++ b/neuracore/ml/utils/training_config.py
@@ -367,10 +367,10 @@ def build_cross_embodiment_description_from_data_types(
     return cross_embodiment_description
 
 
-def _normalize_cross_embodiment_description(
+def normalize_cross_embodiment_description(
     cross_embodiment_cfg: Any,
 ) -> CrossEmbodimentDescription:
-    """Convert config data type keys to DataType enums."""
+    """Convert config data type keys and item indexes to runtime types."""
     result: CrossEmbodimentDescription = {}
     for embodiment, embodiment_values in cross_embodiment_cfg.items():
         result[embodiment] = {}
@@ -386,7 +386,9 @@ def _normalize_cross_embodiment_description(
                     f"Invalid data type '{data_type}' for robot '{embodiment}'. "
                     f"Expected one of {[item.value for item in DataType]}."
                 )
-            result[embodiment][data_type_enum] = dict(item_names)
+            result[embodiment][data_type_enum] = {
+                int(index): name for index, name in item_names.items()
+            }
     return result
 
 
@@ -398,7 +400,7 @@ def _resolve_cross_embodiment_description(
 ) -> CrossEmbodimentDescription:
     """Resolve an explicit cross-embodiment config or build one from data types."""
     if _is_provided(cross_embodiment_description_cfg):
-        return _normalize_cross_embodiment_description(cross_embodiment_description_cfg)
+        return normalize_cross_embodiment_description(cross_embodiment_description_cfg)
     if not _is_provided(data_types_cfg):
         raise ValueError(f"Either '{field_name}' or data types must be provided.")
     return build_cross_embodiment_description_from_data_types(

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -36,6 +36,7 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 )
 from neuracore.ml.train import (
     _resolve_recording_cache_dir,
+    _serialize_cross_embodiment_description,
     assert_valid_batch_size,
     determine_optimal_batch_size,
     get_model_and_algorithm_config,
@@ -898,6 +899,27 @@ class TestResolveRecordingCacheDir:
         custom_dir = tmp_path / "recordings"
         cfg = OmegaConf.create({"recording_cache_dir": str(custom_dir)})
         assert _resolve_recording_cache_dir(cfg) == custom_dir
+
+
+class TestSerializeCrossEmbodimentDescription:
+    def test_preserves_indexed_name_mappings(self):
+        result = _serialize_cross_embodiment_description({
+            "robot-id-1": {
+                DataType.JOINT_POSITIONS: {
+                    1: "joint_2",
+                    0: "joint_1",
+                },
+            },
+        })
+
+        assert result == {
+            "robot-id-1": {
+                "JOINT_POSITIONS": {
+                    0: "joint_1",
+                    1: "joint_2",
+                },
+            },
+        }
 
 
 class TestResolveCrossEmbodimentDescription:

--- a/tests/unit/ml/utils/test_nc_archive.py
+++ b/tests/unit/ml/utils/test_nc_archive.py
@@ -1,9 +1,13 @@
 import json
+import zipfile
 
 from neuracore_types import DataType
 from omegaconf import OmegaConf
 
 from neuracore.ml.utils.json_serialization import to_json_serializable
+from neuracore.ml.utils.nc_archive import (
+    load_cross_embodiment_descriptions_from_nc_archive,
+)
 
 
 class ModelDumpWithOmegaConf:
@@ -47,3 +51,39 @@ def test_to_json_serializable_recurses_after_model_dump():
 
     json.dumps(result)
     assert result == {"model_init": {"hidden_dim": 128}}
+
+
+def test_load_cross_embodiment_descriptions_normalizes_json_index_keys(tmp_path):
+    archive_path = tmp_path / "model.nc.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(
+            "input_cross_embodiment_description.json",
+            json.dumps({
+                "robot_id": {
+                    "JOINT_POSITIONS": {
+                        "0": "joint_positions_0",
+                        "1": "joint_positions_1",
+                    }
+                }
+            }),
+        )
+        archive.writestr(
+            "output_cross_embodiment_description.json",
+            json.dumps({"robot_id": {"JOINT_TARGET_POSITIONS": {"0": "target_0"}}}),
+        )
+
+    input_description, output_description = (
+        load_cross_embodiment_descriptions_from_nc_archive(archive_path)
+    )
+
+    assert input_description == {
+        "robot_id": {
+            DataType.JOINT_POSITIONS: {
+                0: "joint_positions_0",
+                1: "joint_positions_1",
+            }
+        }
+    }
+    assert output_description == {
+        "robot_id": {DataType.JOINT_TARGET_POSITIONS: {0: "target_0"}}
+    }


### PR DESCRIPTION
## Summary

Preserve indexed cross-embodiment metadata when serializing local training metadata instead of collapsing each data type mapping into a positional list.

when loading a JSON it convertes stringed keys back into ints. to be compatible with CrossEmbodiments Types 

Based on error raised by @dennisthevara 