### PR TITLE
test: macos fix for pooled workers, surface errors and logging per context

### DIFF
--- a/.github/workflows/integration-platform-staging.yaml
+++ b/.github/workflows/integration-platform-staging.yaml
@@ -170,8 +170,14 @@ jobs:
         NEURACORE_API_URL: https://staging.api.neuracore.com/api
         NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
         NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
-      # --import-mode=importlib keeps the repo root off sys.path
-      run: pytest -o log_cli=true --log-cli-level=INFO --import-mode=importlib tests/integration/platform/data_daemon/
+      # --import-mode=importlib keeps the repo root off sys.path. log_cli_format
+      # namespaces live log lines by worker process so interleaved context output
+      # stays attributable.
+      run: >-
+        pytest -o log_cli=true --log-cli-level=INFO
+        -o "log_cli_format=%(levelname)-8s %(processName)-11s %(filename)s:%(lineno)s %(message)s"
+        --import-mode=importlib
+        tests/integration/platform/data_daemon/
 
     - name: Run Consume Stream Integration Test
       env:

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -219,6 +219,7 @@ imread
 imshow
 inertiafromgeom
 inertiagrouprange
+initargs
 inproc
 inspectable
 ipython
@@ -258,6 +259,7 @@ libglib
 libosmesa
 libx
 linalg
+lineno
 listconfig
 llava
 Llava
@@ -401,6 +403,7 @@ renice
 renicing
 reqwest
 reraises
+respawns
 restartability
 resumably
 RETRYABLE

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -43,7 +43,6 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     case_ids,
 )
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case_context import (  # noqa: E501
-    ContextSpec,
     build_context_specs,
     run_case_contexts,
 )
@@ -60,15 +59,6 @@ SIGKILL_EXIT_TIMEOUT_S = 5.0
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _run_recording_workload(case: DataDaemonTestCase, specs: list[ContextSpec]) -> None:
-    """Producer workload entry point for the SIGKILL worker child process.
-
-    Module-level so it is picklable under the ``spawn`` start method
-    (the default on macOS).
-    """
-    run_case_contexts(case, specs=specs)
 
 
 def _single_runner_pid() -> int:
@@ -403,8 +393,9 @@ def test_sigkill_mid_recording_allows_clean_restart(case: DataDaemonTestCase) ->
         # Run the producer workload in a child process so a SIGKILL at any point
         # cannot leave an uninterruptible background thread in this test process.
         worker = multiprocessing.Process(
-            target=_run_recording_workload,
-            args=(case, specs),
+            target=run_case_contexts,
+            args=(case,),
+            kwargs={"specs": specs},
             name="sigkill-recording-worker",
         )
         worker.start()

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_startup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_startup.py
@@ -7,7 +7,6 @@ These tests force online mode so startup never inherits an offline profile.
 
 import psutil
 
-import neuracore as nc
 from neuracore.data_daemon.helpers import get_daemon_pid_path
 from neuracore.data_daemon.lifecycle.daemon_os_control import pid_is_running
 from tests.integration.platform.data_daemon.shared.process_control import (
@@ -25,8 +24,6 @@ def test_ensure_single_daemon_process() -> None:
     same PID, the PID file must exist and agree with that PID, the process
     must actually be running, and there must be exactly one runner subprocess.
     """
-    nc.login()
-
     worker_count = psutil.cpu_count(logical=False) or 4
     with online_daemon_running():
         pids = collect_daemon_pids_from_parallel_startup(worker_count)

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from pathlib import Path
 
 import pytest
 
+import neuracore as nc
 from neuracore.data_daemon.config_manager.profiles import ProfileManager
 from neuracore.data_daemon.const import active_profile_name
 from neuracore.data_daemon.rust_selection import is_rust_daemon_enabled
 from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
 )
+from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import Timer
 from tests.integration.platform.data_daemon.shared.profiles import cleanup_test_profiles
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
@@ -30,10 +34,30 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 )
 
 # cspell:ignore terminalreporter exitstatus finalizer NODEIDS exitfirst unparameterized
-# cspell:ignore nodeid getfixturevalue
+# cspell:ignore nodeid getfixturevalue modifyitems callspec
+
+# Add the repo root to the path so sub workers on macos can unpickle pool tasks
+# correctly. pytest --import-mode=importlib imports tests files without touching the
+# sys.path. So this is to compensate. Repo root at the front would shadow the installed
+# neuracore wheel so the path is appended rather than prepended.
+_REPO_ROOT = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT not in sys.path:
+    sys.path.append(_REPO_ROOT)
 
 
 _BATCH_START_CLEANED_NODEIDS: set[str] = set()
+
+
+@pytest.fixture(autouse=True)
+def login_parent_process() -> Iterator[None]:
+    """Authenticate the parent pytest process for each test.
+
+    Logs in during setup and logs out during teardown, so every test
+    performs (and times) a real login against a clean environment.
+    """
+    ensure_login()
+    yield
+    nc.logout()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/platform/data_daemon/performance/test_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_network.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 import pytest
 
-import neuracore as nc
 from tests.integration.platform.data_daemon.daemon_test_cases import (
     NETWORK_PERFORMANCE_CASES,
 )
@@ -60,14 +59,13 @@ def test_cloud_upload_and_readiness_performance(
       timing budget (``case_timeout_seconds``)
     - asserts the expected number of recordings are present in the dataset
     """
-    nc.login()
     if not has_configured_org():
         pytest.skip(
             "Online performance tests require NEURACORE_ORG_ID"
             " or a saved current organization."
         )
     dataset_name = create_testing_dataset_name(case)
-    specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=False)
+    specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=True)
     results: list[ContextResult] = []
     with scoped_storage_state(case, dataset_name=dataset_name):
         try:

--- a/tests/integration/platform/data_daemon/shared/auth.py
+++ b/tests/integration/platform/data_daemon/shared/auth.py
@@ -1,0 +1,31 @@
+"""Client authentication helper for integration tests.
+
+Single login primitive for the suite: guarded on the in-process auth state,
+so repeat calls within a test are free. The parent process logs out between
+tests (see the autouse ``login_parent_process`` fixture), so each test
+performs exactly one real login.
+"""
+
+from __future__ import annotations
+
+import neuracore as nc
+from neuracore.core.auth import get_auth
+from tests.integration.platform.data_daemon.shared.process_control import Timer
+from tests.integration.platform.data_daemon.shared.test_case.constants import (
+    MAX_TIME_TO_START_S,
+)
+
+
+def ensure_login() -> None:
+    """Authenticate the current process from the environment if needed.
+
+    The parent pytest process is covered by an autouse conftest fixture that
+    logs in before each test and logs out after it. Pool workers on macOS
+    use the ``spawn`` start method and get a fresh Auth
+    singleton instead of the parent's in-process access token.
+    """
+
+    if get_auth().is_authenticated:
+        return
+    with Timer(MAX_TIME_TO_START_S, label="nc.login", always_log=True):
+        nc.login()

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -8,13 +8,19 @@ here without cycles.
 
 from __future__ import annotations
 
+import functools
 import logging
+import logging.handlers
 import multiprocessing
 import os
 import signal
 import subprocess
 import sys
+import threading
 import time
+import traceback
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 from neuracore.data_daemon.const import SOCKET_PATH
@@ -167,6 +173,71 @@ def assert_on_schedule(deadline: float, tolerance: float, label: str) -> None:
         f"{label} fired at wrong moment: "
         f"lateness={lateness:+.3f}s, tolerance=±{tolerance:.3f}s"
     )
+
+
+def surface_worker_errors(fn):
+    """Wrap a subprocess worker entry point so failures survive pickling.
+
+    Exceptions raised in a ``multiprocessing.Pool`` worker are pickled back to
+    the parent, which drops the traceback and ``__cause__`` chain and fails
+    outright for exceptions that are not picklable. Re-raise as a plain
+    ``RuntimeError`` whose message embeds the worker's full formatted
+    traceback (chained causes included) so the parent's failure report shows
+    the real error. The message names the worker process to match the
+    ``processName`` column of the relayed live-log lines, so a failure can
+    be joined against the worker's log output.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            raise RuntimeError(
+                f"Worker {fn.__name__} "
+                f"({multiprocessing.current_process().name}, pid {os.getpid()}) "
+                f"failed with the traceback below\n{traceback.format_exc()}"
+            ) from None
+
+    return wrapper
+
+
+def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
+    """Route a pool worker's log records to the parent process.
+
+    Pool initializer. Spawned workers (macOS) start with no logging
+    configuration, so their INFO records — Timer lines included — are
+    silently dropped; forked workers (Linux) inherit pytest's handlers and
+    write into its captured streams from another process. Replacing the
+    root handlers with a ``QueueHandler`` ships every record to the parent
+    instead, where :func:`relayed_worker_logs` replays them through the
+    parent's handlers so worker Timer lines appear in the live log exactly
+    like single-context runs.
+    """
+    root = logging.getLogger()
+    root.handlers[:] = [logging.handlers.QueueHandler(log_queue)]
+    root.setLevel(level)
+
+
+@contextmanager
+def relayed_worker_logs() -> Generator[multiprocessing.Queue]:
+    """Replay pool-worker log records through this process's handlers."""
+    log_queue: multiprocessing.Queue = multiprocessing.Queue()
+
+    def _relay() -> None:
+        while True:
+            record = log_queue.get()
+            if record is None:
+                return
+            logging.getLogger(record.name).handle(record)
+
+    thread = threading.Thread(target=_relay, name="worker-log-relay", daemon=True)
+    thread.start()
+    try:
+        yield log_queue
+    finally:
+        log_queue.put(None)
+        thread.join(timeout=5.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/platform/data_daemon/shared/runners.py
+++ b/tests/integration/platform/data_daemon/shared/runners.py
@@ -12,22 +12,17 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 
-import neuracore as nc
 from neuracore.data_daemon.const import DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS
 from neuracore.data_daemon.lifecycle.daemon_os_control import ensure_daemon_running
 from tests.integration.platform.data_daemon.shared.assertions import (
     assert_daemon_cleanup,
 )
-from tests.integration.platform.data_daemon.shared.process_control import (
-    Timer,
-    stop_daemon,
-)
+from tests.integration.platform.data_daemon.shared.process_control import stop_daemon
 from tests.integration.platform.data_daemon.shared.profiles import (
     scoped_offline_profile,
     scoped_online_mode,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
-    MAX_TIME_TO_START_S,
     OFFLINE_DB_PATH,
     OFFLINE_RECORDINGS_ROOT,
 )
@@ -78,8 +73,6 @@ def offline_daemon_running() -> Generator[None]:
             stop_daemon()
             assert_daemon_cleanup()
             ensure_daemon_running(timeout_s=DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS)
-            with Timer(MAX_TIME_TO_START_S, label="nc.login", always_log=True):
-                nc.login()
             yield
         finally:
             stop_daemon()
@@ -105,9 +98,6 @@ def online_daemon_running() -> Generator[None]:
             stop_daemon()
             assert_daemon_cleanup()
             ensure_daemon_running(timeout_s=DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS)
-
-            with Timer(MAX_TIME_TO_START_S, label="nc.login", always_log=True):
-                nc.login()
             yield
         finally:
             stop_daemon()

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -443,15 +443,6 @@ def log_run_analysis(
 ) -> str:
     """Log a detailed analysis of a test run for diagnostics."""
 
-    def _format_recording_ids(recording_ids: list[str], *, max_items: int = 6) -> str:
-        cleaned = [recording_id for recording_id in recording_ids if recording_id]
-        if not cleaned:
-            return "[none]"
-        if len(cleaned) <= max_items:
-            return ", ".join(cleaned)
-        shown = ", ".join(cleaned[:max_items])
-        return f"{shown}, ... (+{len(cleaned) - max_items} more)"
-
     display_case_id = (
         f"{label_prefix}-{case_id(case)}" if label_prefix else case_id(case)
     )
@@ -497,9 +488,6 @@ def log_run_analysis(
             lines.append(
                 f"    ctx[{result.context_index}]: {wall_s:.1f}s total,"
                 f" {avg_per_recording:.1f}s avg per recording"
-            )
-            lines.append(
-                "      recordings: " f"{_format_recording_ids(result.recording_ids)}"
             )
     else:
         lines.append(
@@ -558,5 +546,5 @@ def log_run_analysis(
 
     lines.append(separator)
     report = "\n".join(lines)
-    logger.info(report)
+    logger.info("\n%s", report)
     return report

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -20,10 +20,14 @@ import numpy as np
 
 import neuracore as nc
 from tests.integration.platform.data_daemon.shared.assertions import assert_context_mode
+from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import (
     MAX_TIME_TO_LOG_S,
     Timer,
     assert_on_schedule,
+    init_worker_logging,
+    relayed_worker_logs,
+    surface_worker_errors,
 )
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
@@ -716,24 +720,36 @@ def log_frames(
     return [marker_name]
 
 
-def _bind_worker_dataset(*, dataset_name: str) -> None:
-    """Poll until the worker pool-shared dataset is visible to this worker."""
+def _bind_worker_dataset(spec: ContextSpec) -> None:
+    """Poll until the worker pool-shared dataset is visible to this worker.
+
+    The timeout RuntimeError is raised inside the Timer block on purpose:
+    ``Timer.__exit__`` skips its deadline assertion when an exception is in
+    flight, so the real ``nc.get_dataset`` error (chained via ``last_error``)
+    propagates instead of being masked by the Timer's own AssertionError.
+    """
     last_error: Exception | None = None
     deadline = time.time() + MAX_TIME_TO_START_S
-    with Timer(MAX_TIME_TO_START_S, label="nc.get_dataset", always_log=True):
+    with Timer(
+        MAX_TIME_TO_START_S,
+        label="nc.get_dataset",
+        always_log=True,
+        assert_deadline=spec.assert_deadline,
+    ):
         while time.time() < deadline:
             try:
-                nc.get_dataset(dataset_name)
+                nc.get_dataset(spec.dataset_name)
                 return
             except Exception as exc:  # noqa: BLE001
                 last_error = exc
                 time.sleep(DATASET_POLL_INTERVAL_S)
 
-    raise RuntimeError(
-        f"Timed out waiting for shared dataset '{dataset_name}' to exist"
-    ) from last_error
+        raise RuntimeError(
+            f"Timed out waiting for shared dataset '{spec.dataset_name}' to exist"
+        ) from last_error
 
 
+@surface_worker_errors
 def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     """Subprocess wrapper for context_worker used by multiprocessing.Pool.
 
@@ -742,10 +758,14 @@ def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     timers and the parent's pre-fork timers (e.g. nc.login) are not
     double-counted when stats are merged back. The stochastic-timestamp RNG
     is reseeded per-context so parallel workers produce independent jitter
-    sequences instead of replaying the parent's seed.
+    sequences instead of replaying the parent's seed. Spawned workers
+    (macOS) additionally re-authenticate, as they do not inherit the
+    parent's in-process auth state.
     """
+    multiprocessing.current_process().name = f"ctx-{spec.context_index}"
     Timer._stats.clear()
     STOCHASTIC_TIMESTAMP_RANDOM.seed(1 + spec.context_index)
+    ensure_login()
     return context_worker(spec)
 
 
@@ -773,8 +793,13 @@ def context_worker(spec: ContextSpec) -> ContextResult:
     wall_stopped_at: float = 0.0
 
     try:
-        _bind_worker_dataset(dataset_name=spec.dataset_name)
-        with Timer(MAX_TIME_TO_START_S, label="nc.connect_robot", always_log=True):
+        _bind_worker_dataset(spec)
+        with Timer(
+            MAX_TIME_TO_START_S,
+            label="nc.connect_robot",
+            always_log=True,
+            assert_deadline=spec.assert_deadline,
+        ):
             robot = nc.connect_robot(spec.robot_name, overwrite=False)
 
         source: tuple[str, int] = (str(robot.id), int(robot.instance))
@@ -968,6 +993,8 @@ def run_case_contexts(
     Returns:
         List of result dicts from each context worker, one per spec.
     """
+    ensure_login()
+
     if specs is None:
         specs = build_context_specs(case)
 
@@ -983,10 +1010,15 @@ def run_case_contexts(
     if case.parallel_contexts == 1:
         results = [context_worker(specs[0])]
     else:
-        with multiprocessing.Pool(case.parallel_contexts) as pool:
-            results = list(  # type: ignore[return-value]
-                pool.map(_subprocess_context_worker, specs)
-            )
+        with relayed_worker_logs() as log_queue:
+            with multiprocessing.Pool(
+                case.parallel_contexts,
+                initializer=init_worker_logging,
+                initargs=(log_queue, logging.getLogger().getEffectiveLevel()),
+            ) as pool:
+                results = list(  # type: ignore[return-value]
+                    pool.map(_subprocess_context_worker, specs)
+                )
         for result in results:
             Timer.merge_stats(result.timer_stats)
 

--- a/tests/integration/platform/data_daemon/shared/test_infrastructure.py
+++ b/tests/integration/platform/data_daemon/shared/test_infrastructure.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import neuracore as nc
+from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.storage_assertions import (
     assert_post_test_storage_state,
     harness_db_path,
@@ -185,7 +186,7 @@ def delete_cloud_dataset(dataset_name: str) -> None:
         dataset_name: Name of the cloud dataset to delete.
     """
     try:
-        nc.login()
+        ensure_login()
         nc.get_dataset(dataset_name).delete()
         logger.info(
             "Deleted cloud dataset %r (storage_state_action=delete)", dataset_name


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Logging per context with namespace scoped logging per context
 - Per test logout for better test scoping

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - MacOS uses spawn rather than fork, so init auth per worker
 - Append the repo root to the path so each worker with it's own interpreter can see the code
 - Performance network tests should assert deadlines
