### PR TITLE
feat: enforce monotonic log timestamps

### DIFF
--- a/neuracore/core/streaming/data_stream.py
+++ b/neuracore/core/streaming/data_stream.py
@@ -73,6 +73,7 @@ class DataStream(ABC):
         self._stream_name = stream_name
         self._producer_channel: ProducerChannel | None = None
         self._use_data_bridge = is_rust_daemon_enabled()
+        self._last_logged_timestamp: float | None = None
 
     @property
     def data_type(self) -> DataType:
@@ -96,6 +97,7 @@ class DataStream(ABC):
                 stop_cutoff_sequence_number=stop_cutoff_sequence_number,
             )
         self._recording = True
+        self._last_logged_timestamp = None
         self._context = context
         self._handle_ensure_producer_channel(context)
 
@@ -200,6 +202,33 @@ class DataStream(ABC):
         """Return the active recording context for this stream, if present."""
         return self._context
 
+    def _enforce_monotonic_timestamp(self, timestamp: float) -> None:
+        """Reject a timestamp that does not strictly increase within a recording.
+
+        Tracked per stream and only while recording; the previous value is
+        cleared when a recording starts (see :meth:`start_recording`) so each
+        recording is an independent, strictly increasing timeline. A no-op when
+        the stream is not recording.
+
+        Args:
+            timestamp: Capture timestamp, in seconds, of the sample being logged.
+
+        Raises:
+            ValueError: If ``timestamp`` is not strictly greater than the last
+                timestamp logged to this stream during the current recording.
+        """
+        if not self._recording:
+            return
+        last_logged_timestamp = self._last_logged_timestamp
+        if last_logged_timestamp is not None and timestamp <= last_logged_timestamp:
+            raise ValueError(
+                f"Non-monotonic timestamp for '{self._stream_name}' "
+                f"({self._data_type.value}): {timestamp} is not greater than the "
+                f"previous timestamp {last_logged_timestamp}. Logged timestamps "
+                "must be strictly increasing within a recording."
+            )
+        self._last_logged_timestamp = timestamp
+
     def _send_to_daemon(self, data: bytes) -> None:
         """Send data to the daemon via the legacy producer channel.
 
@@ -268,6 +297,7 @@ class JsonDataStream(DataStream):
             data: Data object implementing NCData interface
             send_to_daemon: Whether to forward the serialized payload to the daemon
         """
+        self._enforce_monotonic_timestamp(data.timestamp)
         self._latest_data = data
         if not self.is_recording() or not send_to_daemon:
             return
@@ -313,6 +343,7 @@ class JointDataStream(JsonDataStream):
         atomically), but it never raises and never returns a partially
         constructed ``JointData``.
         """
+        self._enforce_monotonic_timestamp(timestamp)
         self._pending_timestamp = timestamp
         self._pending_value = value
         self._has_pending_latest = True
@@ -350,6 +381,7 @@ class PointCloudDataStream(DataStream):
         Args:
             data: Point cloud data to log
         """
+        self._enforce_monotonic_timestamp(data.timestamp)
         self._latest_data = data
         if not self.is_recording():
             return
@@ -395,6 +427,7 @@ class VideoDataStream(DataStream):
             metadata: Camera metadata including timestamp and calibration
             frame: Video frame as numpy array
         """
+        self._enforce_monotonic_timestamp(metadata.timestamp)
         metadata.frame = frame
         self._latest_data = metadata
         if not self.is_recording():

--- a/tests/unit/core/test_data_stream.py
+++ b/tests/unit/core/test_data_stream.py
@@ -4,9 +4,14 @@ import json
 import struct
 
 import numpy as np
-from neuracore_types import DataType
+import pytest
+from neuracore_types import DataType, JointData
 
-from neuracore.core.streaming.data_stream import DataRecordingContext, RGBDataStream
+from neuracore.core.streaming.data_stream import (
+    DataRecordingContext,
+    JointDataStream,
+    RGBDataStream,
+)
 from neuracore.data_daemon.communications_management.producer.producer_channel import (
     producer_transport_args_for_data_type,
 )
@@ -255,3 +260,90 @@ def test_rgb_stream_owns_no_channel_under_rust_daemon(monkeypatch) -> None:
     stream.stop_recording(stop_cutoff_sequence_number=0)
     assert stream.is_recording() is False
     assert stream.get_recording_context() is None
+
+
+def _use_rust_daemon(monkeypatch) -> None:
+    """Route streams through the rust daemon so log() needs no legacy channel."""
+    monkeypatch.setattr(
+        "neuracore.core.streaming.data_stream.is_rust_daemon_enabled",
+        lambda: True,
+    )
+
+
+def test_video_stream_rejects_non_increasing_timestamp(monkeypatch) -> None:
+    _use_rust_daemon(monkeypatch)
+    stream = RGBDataStream("front_camera", width=4, height=3)
+    stream.start_recording(_context())
+    frame = np.zeros((3, 4, 3), dtype=np.uint8)
+
+    stream.log(_DummyCameraData(timestamp=1.0), frame)
+    stream.log(_DummyCameraData(timestamp=2.0), frame)
+
+    with pytest.raises(ValueError, match="Non-monotonic timestamp"):
+        stream.log(_DummyCameraData(timestamp=2.0), frame)
+    with pytest.raises(ValueError, match="Non-monotonic timestamp"):
+        stream.log(_DummyCameraData(timestamp=1.5), frame)
+
+
+def test_joint_stream_record_scalar_rejects_non_increasing_timestamp(
+    monkeypatch,
+) -> None:
+    _use_rust_daemon(monkeypatch)
+    stream = JointDataStream(data_type=DataType.JOINT_POSITIONS, data_type_name="j1")
+    stream.start_recording(_context())
+
+    stream.record_scalar(1.0, 0.5)
+    stream.record_scalar(2.0, 0.6)
+
+    with pytest.raises(ValueError, match="Non-monotonic timestamp"):
+        stream.record_scalar(2.0, 0.7)
+
+
+def test_joint_stream_log_rejects_non_increasing_timestamp(monkeypatch) -> None:
+    _use_rust_daemon(monkeypatch)
+    stream = JointDataStream(data_type=DataType.JOINT_POSITIONS, data_type_name="j1")
+    stream.start_recording(_context())
+
+    stream.log(JointData(timestamp=1.0, value=0.5))
+
+    with pytest.raises(ValueError, match="Non-monotonic timestamp"):
+        stream.log(JointData(timestamp=0.9, value=0.6))
+
+
+def test_monotonic_check_is_per_stream(monkeypatch) -> None:
+    """Each stream keeps its own timeline — sharing a timestamp is fine."""
+    _use_rust_daemon(monkeypatch)
+    frame = np.zeros((3, 4, 3), dtype=np.uint8)
+    front = RGBDataStream("front_camera", width=4, height=3)
+    wrist = RGBDataStream("wrist_camera", width=4, height=3)
+    front.start_recording(_context())
+    wrist.start_recording(_context())
+
+    front.log(_DummyCameraData(timestamp=1.0), frame)
+    wrist.log(_DummyCameraData(timestamp=1.0), frame)
+    front.log(_DummyCameraData(timestamp=2.0), frame)
+    wrist.log(_DummyCameraData(timestamp=2.0), frame)
+
+
+def test_monotonic_check_skipped_when_not_recording(monkeypatch) -> None:
+    """Outside a recording there is no timeline to enforce."""
+    _use_rust_daemon(monkeypatch)
+    stream = RGBDataStream("front_camera", width=4, height=3)
+    frame = np.zeros((3, 4, 3), dtype=np.uint8)
+
+    stream.log(_DummyCameraData(timestamp=5.0), frame)
+    stream.log(_DummyCameraData(timestamp=1.0), frame)
+
+
+def test_start_recording_resets_monotonic_timeline(monkeypatch) -> None:
+    """A new recording is an independent timeline that may restart lower."""
+    _use_rust_daemon(monkeypatch)
+    stream = RGBDataStream("front_camera", width=4, height=3)
+    frame = np.zeros((3, 4, 3), dtype=np.uint8)
+
+    stream.start_recording(_context("rec-1"))
+    stream.log(_DummyCameraData(timestamp=5.0), frame)
+    stream.stop_recording(stop_cutoff_sequence_number=0)
+
+    stream.start_recording(_context("rec-2"))
+    stream.log(_DummyCameraData(timestamp=1.0), frame)


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - The `log_*` functions now enforce that timestamps are strictly increasing per sensor stream within a recording. 

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1121](https://neuracore.atlassian.net/browse/NCP-1121)
