### PR TITLE
test: fix importer integration auth

### DIFF
--- a/tests/integration/importer/conftest.py
+++ b/tests/integration/importer/conftest.py
@@ -1,12 +1,13 @@
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 import yaml
 
 # Resolve neuracore from the installed wheel before repo_root joins sys.path.
-import neuracore  # noqa: F401
+import neuracore as nc
 
 ROBOTS_REPO_URL = "https://github.com/NeuracoreAI/neuracore_robots.git"
 ROBOTS_REPO_COMMIT = "c3d17b303296686ceb9a2fcddea06af95a88fe4f"
@@ -19,6 +20,14 @@ CONFIG_DIR = THIS_DIR / "config"
 RLDS_CONFIGS_FILE = CONFIG_DIR / "rlds_importer_datasets.yaml"
 LEROBOT_CONFIGS_FILE = CONFIG_DIR / "lerobot_importer_datasets.yaml"
 MCAP_CONFIGS_FILE = CONFIG_DIR / "mcap_importer_datasets.yaml"
+
+
+@pytest.fixture(autouse=True)
+def login_parent_process() -> Iterator[None]:
+    """Authenticate the pytest process around each importer test."""
+    nc.login()
+    yield
+    nc.logout()
 
 
 def _load_configs(config_path: Path) -> list[dict]:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Restore authentication for the importer integration test suite . Since #782 moved `nc.login()` out of `online_daemon_running()` the importer suite lost its only login.

Test run with these changes: https://github.com/NeuracoreAI/neuracore/actions/runs/29572614590

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1138](https://neuracore.atlassian.net/browse/NCP-1138)
