### PR TITLE
fix: guard empty train/val split

### DIFF
--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -397,6 +397,24 @@ def run_training(
         train_split = 1 - cfg.validation_split
         train_size = int(train_split * dataset_size)
         val_size = dataset_size - train_size
+        if train_size == 0 and val_size == 0:
+            raise ValueError(
+                "The training and validation sets are both empty. "
+                "Try adding more recordings to the dataset, "
+                "or changing the validation split."
+            )
+        if train_size == 0:
+            raise ValueError(
+                "The training set is empty. "
+                "Try adding more recordings to the dataset, "
+                "or changing the validation split."
+            )
+        if val_size == 0:
+            raise ValueError(
+                "The validation set is empty. "
+                "Try adding more recordings to the dataset, "
+                "or changing the validation split."
+            )
 
         # Use random split with fixed seed for deterministic behavior
         generator = torch.Generator().manual_seed(cfg.seed)

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -1958,6 +1958,44 @@ class TestRunTraining:
             20,
         ]  # train_size=80, val_size=20 for 100 samples with 0.2 split
 
+    @pytest.mark.parametrize(
+        ("dataset_size", "validation_split", "expected_message"),
+        [
+            (0, 0.2, "training and validation sets are both empty"),
+            (1, 0.2, "training set is empty"),
+            (3, 0.0, "validation set is empty"),
+        ],
+    )
+    def test_run_training_raises_when_train_or_val_split_is_empty(
+        self,
+        mock_cfg_training,
+        mock_dataset,
+        model_init_description,
+        mock_model_class,
+        monkeypatch,
+        dataset_size,
+        validation_split,
+        expected_message,
+    ):
+        mock_cfg_training.validation_split = validation_split
+        mock_dataset.__len__ = Mock(return_value=dataset_size)
+
+        setup = RunTrainingTestSetup(
+            monkeypatch,
+            model_init_description,
+            mock_model_class,
+        )
+        setup.setup_mocks()
+
+        mock_random_split = Mock()
+        monkeypatch.setattr("neuracore.ml.train.random_split", mock_random_split)
+
+        with pytest.raises(ValueError, match=expected_message):
+            setup.call_run_training(mock_cfg_training, mock_dataset)
+
+        mock_random_split.assert_not_called()
+        setup.mock_trainer_class.assert_not_called()
+
     def test_autotune_and_training_use_same_dataloader_worker_counts(
         self,
         mock_cfg_training,


### PR DESCRIPTION
### Bugfixes
- train.py computes train_size and val_size from len(dataset) and validation_split, then builds loaders unconditionally. Small datasets can produce train_size == 0 or val_size == 0, causing confusing late failures or bogus metrics. Add an explicit validation error before random_split

### Items
 - [NCRL-705](https://neuracore.atlassian.net/browse/NCRL-705)
