### PR TITLE
fix: datatype-validation-test

### DIFF
--- a/neuracore/data_daemon/lifecycle/daemon_os_control.py
+++ b/neuracore/data_daemon/lifecycle/daemon_os_control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import signal
 import subprocess
@@ -10,7 +11,7 @@ import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import FrameType
-from typing import IO, cast
+from typing import IO, Any, cast
 
 import filelock
 
@@ -48,6 +49,25 @@ def read_pid_from_file(pid_path: Path) -> int | None:
         return None
 
     return pid_value if pid_value > 0 else None
+
+
+def _rust_daemon_ready(pid_path: Path, *, timeout_s: float = 0.0) -> bool:
+    """Return True once the Rust daemon answers an IPC health probe."""
+    pid_value = read_pid_from_file(pid_path)
+    if pid_value is None or not pid_is_running(pid_value):
+        return False
+    try:
+        data_bridge = cast(
+            Any, importlib.import_module("neuracore.data_daemon._data_bridge")
+        )
+    except (ImportError, OSError):
+        return False
+
+    try:
+        ready_pid = data_bridge.wait_until_ready(timeout_s)
+    except (AttributeError, RuntimeError):
+        return False
+    return ready_pid == pid_value
 
 
 def _is_zombie(pid_value: int) -> bool:
@@ -146,7 +166,7 @@ def _build_daemon_launch_env(
     environment = os.environ.copy()
     environment["NEURACORE_DAEMON_PID_PATH"] = str(pid_path)
     environment["NEURACORE_DAEMON_DB_PATH"] = str(db_path)
-    if not is_rust_daemon_enabled():
+    if not (is_rust_daemon_enabled() and rust_daemon_binary_path() is not None):
         environment["NEURACORE_DAEMON_MANAGE_PID"] = "0"
     if env_overrides:
         environment.update(env_overrides)
@@ -310,13 +330,12 @@ def launch_daemon_subprocess(
     """Launch the daemon runner subprocess and poll until it is ready.
 
     Readiness signal differs by backend: the Python daemon publishes a Unix
-    socket the SDK connects to, while the Rust daemon never opens one (its IPC
-    is iceoryx2 shared memory) — so under ``NCD_RUST_DAEMON`` we instead wait
-    for the daemon to write its PID file. The Rust binary also acquires the
-    PID file itself, so the parent must not overwrite it.
+    socket the SDK connects to, while the Rust daemon answers a side-effect-free
+    iceoryx2 health query once its IPC listener and dispatcher are live. The
+    Rust binary still owns the PID file, so the parent must not overwrite it.
     """
     pid_path.parent.mkdir(parents=True, exist_ok=True)
-
+    rust_mode = is_rust_daemon_enabled() and rust_daemon_binary_path() is not None
     process, daemon_log_path = _start_daemon_subprocess(
         pid_path=pid_path,
         db_path=db_path,
@@ -327,16 +346,14 @@ def launch_daemon_subprocess(
     )
     poll_interval_s = 0.05
     daemon_startup_timeout_s = time.monotonic() + timeout_s
-    rust_mode = is_rust_daemon_enabled() and rust_daemon_binary_path() is not None
 
     def _ready() -> bool:
         if rust_mode:
-            existing = read_pid_from_file(pid_path)
-            return existing is not None and pid_is_running(existing)
+            return _rust_daemon_ready(pid_path, timeout_s=0.0)
         return SOCKET_PATH.exists()
 
     readiness_target = (
-        "pid file " + str(pid_path) if rust_mode else "socket " + str(SOCKET_PATH)
+        "Rust daemon IPC health probe" if rust_mode else "socket " + str(SOCKET_PATH)
     )
 
     while time.monotonic() < daemon_startup_timeout_s:
@@ -412,8 +429,16 @@ def ensure_daemon_running(
 
     with filelock.FileLock(pid_file_lock):
         existing_pid = read_pid_from_file(pid_path)
+        rust_mode = is_rust_daemon_enabled() and rust_daemon_binary_path() is not None
         if existing_pid is not None and pid_is_running(existing_pid):
-            return existing_pid
+            if not rust_mode:
+                return existing_pid
+            if _rust_daemon_ready(pid_path, timeout_s=timeout_s):
+                return existing_pid
+            raise DaemonLifecycleError(
+                f"Daemon process is running (pid={existing_pid}) but did not "
+                "become ready to accept IPC commands."
+            )
 
         cleanup_stale_client_state(
             pid_path=pid_path,

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -234,14 +234,6 @@ fn run_daemon(
         }
     };
 
-    // Signal readiness to the launcher *before* the main loop blocks so the
-    // user's shell prompt returns as soon as the daemon is actually up.
-    if let Some(reporter) = reporter {
-        if let Err(error) = reporter.ready(std::process::id()) {
-            tracing::warn!(%error, "failed to report readiness to launcher (continuing)");
-        }
-    }
-
     let db_path = runtime_env.db_path.clone();
     let recordings_root = runtime_env.recordings_root.clone();
     // The recordings root is shared with the data bridge, which lives in a
@@ -475,6 +467,12 @@ fn run_daemon(
             // Drain the primary handler-installed receiver so it doesn't
             // accumulate broadcasts behind our back; we no longer need it.
             drop(shutdown_rx);
+
+            if let Some(reporter) = reporter {
+                if let Err(error) = reporter.ready(std::process::id()) {
+                    tracing::warn!(%error, "failed to report readiness to launcher (continuing)");
+                }
+            }
 
             tracing::info!(?org_id, "daemon ready; awaiting shutdown signal");
             listener::run(

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -13,12 +13,14 @@
 //! backpressure on the dispatcher send propagate to iceoryx2 without keeping
 //! the subscriber locked across the await. (`Send` is not actually required
 //! here — `run` is awaited inline under `block_on`, never `tokio::spawn`'d, and
-//! the later `serve_queries` borrow is itself held across an await.)
+//! the later `serve_recording_id_queries` borrow is itself held across an await.)
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use data_daemon_shared::{Envelope, RecordingIdQuery, RecordingIdReply};
+use data_daemon_shared::{
+    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply,
+};
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::ipc;
@@ -71,7 +73,8 @@ pub async fn run(
 ) {
     tracing::info!(
         commands = data_daemon_shared::service_name::COMMANDS,
-        queries = data_daemon_shared::service_name::QUERIES,
+        recording_ids = data_daemon_shared::service_name::RECORDING_IDS,
+        health = data_daemon_shared::service_name::HEALTH,
         "ipc listener started"
     );
 
@@ -106,12 +109,18 @@ pub async fn run(
             }
         }
 
+        // -- Answer readiness probes --------------------------------------------
+        // A health reply is the SDK launcher's readiness contract: reaching this
+        // point proves the daemon has opened IPC, spawned the dispatcher, and
+        // entered the listener loop that drains commands.
+        serve_health(transport.health_server());
+
         // -- Answer recording-id queries ----------------------------------------
-        // Each request is resolved against the daemon's own store (a single
+        // Each recording-id request is resolved against the daemon's own store (a single
         // `.await`) while holding the iceoryx2 `ActiveRequest` to reply on. That
         // borrow makes this future `!Send`, which is fine: `run` is awaited
         // inline under `block_on`, never `tokio::spawn`'d.
-        serve_queries(transport.queries_server(), &store).await;
+        serve_recording_id_queries(transport.recording_id_server(), &store).await;
 
         // -- Yield / shutdown ---------------------------------------------------
         // Poll fast while data is flowing; relax once the bus has been empty
@@ -132,21 +141,60 @@ pub async fn run(
     }
 }
 
+/// Drain every pending health query, answering each with this daemon's PID.
+fn serve_health(server: &Server<ipc::Service, [u8], (), [u8], ()>) {
+    loop {
+        let active = match server.receive() {
+            Ok(Some(active)) => active,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(%error, "health server receive failed");
+                return;
+            }
+        };
+
+        let request = match HealthRequest::decode(active.payload()) {
+            Ok(request) => request,
+            Err(error) => {
+                tracing::warn!(%error, "dropping malformed health query");
+                continue;
+            }
+        };
+
+        let reply = HealthReply {
+            pid: std::process::id(),
+            nonce: request.nonce,
+        };
+        match reply.encode() {
+            Ok(bytes) => match active.loan_slice_uninit(bytes.len()) {
+                Ok(response) => {
+                    let response = response.write_from_slice(&bytes);
+                    if let Err(error) = response.send() {
+                        tracing::warn!(%error, "failed to send health reply");
+                    }
+                }
+                Err(error) => tracing::warn!(%error, "failed to loan health reply sample"),
+            },
+            Err(error) => tracing::warn!(%error, "failed to encode health reply"),
+        }
+    }
+}
+
 /// Drain every pending recording-id query, answering each from the daemon's
 /// own store.
 ///
 /// The SDK resolves a recording's cloud id by asking the daemon over the
-/// `queries` request-response service instead of reading the daemon's private
+/// `recording_ids` request-response service instead of reading the daemon's private
 /// SQLite DB directly. Requests are cheap and infrequent (one per
 /// `get_recording_id` poll), so a malformed request or store error is logged
 /// and the next request is served rather than aborting the loop.
 ///
-/// The per-tick request volume is bounded rather than unbounded: each query
+/// The per-tick request volume is bounded rather than unbounded: each recording-id
 /// client keeps at most one request in flight (it awaits the reply before
 /// sending the next), so a single drain serves at most one request per
-/// connected client (≤ `MAX_QUERY_CLIENTS_PER_SERVICE`) before `receive`
+/// connected request-response client (≤ `MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE`) before `receive`
 /// returns `None` and the loop hands the next tick back to the commands drain.
-async fn serve_queries(
+async fn serve_recording_id_queries(
     server: &Server<ipc::Service, [u8], (), [u8], ()>,
     store: &Arc<SqliteStateStore>,
 ) {
@@ -155,7 +203,7 @@ async fn serve_queries(
             Ok(Some(active)) => active,
             Ok(None) => return,
             Err(error) => {
-                tracing::warn!(%error, "queries server receive failed");
+                tracing::warn!(%error, "recording-id server receive failed");
                 return;
             }
         };

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -11,9 +11,10 @@
 //! [`Envelope::VideoChunkReady`]: data_daemon_shared::Envelope::VideoChunkReady
 
 use data_daemon_shared::service_name::{
-    COMMANDS, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
-    MAX_QUERY_CLIENTS_PER_SERVICE, MAX_QUERY_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE,
-    QUERIES, QUERIES_MAX_PAYLOAD_BYTES,
+    COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
+    MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
+    MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
+    RECORDING_ID_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
 use iceoryx2::port::server::Server;
@@ -90,11 +91,16 @@ pub struct IpcTransport {
     /// Service handle held alongside the subscriber so port discovery doesn't
     /// race the service handle going out of scope.
     _commands_service: PortFactory<ipc::Service, [u8], ()>,
-    /// Request-response server on `neuracore/data_daemon/queries` that answers
+    /// Request-response server on `neuracore/data_daemon/recording_ids` that answers
     /// SDK recording-id lookups.
-    queries_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    recording_id_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the server, as for the commands service.
-    _queries_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    _recording_id_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response server on `neuracore/data_daemon/health` that answers
+    /// side-effect-free readiness probes.
+    health_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the health server.
+    _health_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
 }
 
 impl IpcTransport {
@@ -118,14 +124,19 @@ impl IpcTransport {
         let (commands_service, commands_subscriber) =
             open_subscriber(&node, COMMANDS, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE)?;
 
-        let (queries_service, queries_server) = open_query_server(&node, QUERIES)?;
+        let (recording_id_service, recording_id_server) =
+            open_query_server(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
+        let (health_service, health_server) =
+            open_query_server(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
 
         Ok(IpcTransport {
             _node: node,
             commands_subscriber,
             _commands_service: commands_service,
-            queries_server,
-            _queries_service: queries_service,
+            recording_id_server,
+            _recording_id_service: recording_id_service,
+            health_server,
+            _health_service: health_service,
         })
     }
 
@@ -134,9 +145,14 @@ impl IpcTransport {
         &self.commands_subscriber
     }
 
-    /// Borrow the `queries` request-response server port.
-    pub fn queries_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
-        &self.queries_server
+    /// Borrow the `recording_ids` request-response server port.
+    pub fn recording_id_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.recording_id_server
+    }
+
+    /// Borrow the `health` request-response server port.
+    pub fn health_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.health_server
     }
 }
 
@@ -201,10 +217,11 @@ type ByteSliceServer = Server<ipc::Service, [u8], (), [u8], ()>;
 ///
 /// The SDK opens client ports on the same service (one per OS thread, like the
 /// `commands` publisher), so the caps mirror the publisher topology. Requests
-/// and responses are both small postcard blobs ([`QUERIES_MAX_PAYLOAD_BYTES`]).
+/// and responses are both small postcard blobs ([`RECORDING_ID_MAX_PAYLOAD_BYTES`]).
 fn open_query_server(
     node: &Node<ipc::Service>,
     name: &str,
+    max_slice_len: usize,
 ) -> Result<(ByteSliceQueryFactory, ByteSliceServer), IpcSetupError> {
     let service_name = name
         .try_into()
@@ -215,8 +232,8 @@ fn open_query_server(
     let service = node
         .service_builder(&service_name)
         .request_response::<[u8], [u8]>()
-        .max_clients(MAX_QUERY_CLIENTS_PER_SERVICE)
-        .max_servers(MAX_QUERY_SERVERS_PER_SERVICE)
+        .max_clients(MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE)
+        .max_servers(MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE)
         .max_nodes(MAX_NODES_PER_SERVICE)
         .open_or_create()
         .map_err(|error| IpcSetupError::ServiceOpen {
@@ -225,7 +242,7 @@ fn open_query_server(
         })?;
     let server = service
         .server_builder()
-        .initial_max_slice_len(QUERIES_MAX_PAYLOAD_BYTES)
+        .initial_max_slice_len(max_slice_len)
         .create()
         .map_err(|error| IpcSetupError::ServerCreate {
             name: name.to_string(),

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -53,7 +53,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 use crate::publisher::{now_ns, publish, publisher_tx, ProducerError, PublishMsg};
-use crate::query::resolve_recording_id;
+use crate::query::{resolve_recording_id, wait_until_ready as wait_until_ready_impl};
 use crate::writer::{writer_queue, FrameJob, WriterMsg};
 
 /// Announce that a recording has started for a source. Fire-and-forget: the
@@ -426,6 +426,13 @@ fn get_recording_id(
     })
 }
 
+/// Wait until the Rust daemon answers a side-effect-free IPC health probe.
+#[pyfunction]
+#[pyo3(signature = (timeout_s))]
+fn wait_until_ready(py: Python<'_>, timeout_s: f64) -> PyResult<Option<u32>> {
+    py.detach(|| -> PyResult<Option<u32>> { Ok(wait_until_ready_impl(timeout_s)?) })
+}
+
 /// Ask the running daemon to reload its profile config immediately (see
 /// [`Envelope::RefreshConfig`]). Published on the caller thread's command port
 /// so it is strictly ordered ahead of a subsequent `start_recording` from the
@@ -452,6 +459,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
+    module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;
     Ok(())
 }

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -36,9 +36,10 @@ use std::sync::{LazyLock, Mutex, Once};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use data_daemon_shared::service_name::{
-    COMMANDS, COMMANDS_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE,
-    MAX_PUBLISHERS_PER_SERVICE, MAX_QUERY_CLIENTS_PER_SERVICE, MAX_QUERY_SERVERS_PER_SERVICE,
-    MAX_SUBSCRIBERS_PER_SERVICE, QUERIES, QUERIES_MAX_PAYLOAD_BYTES,
+    COMMANDS, COMMANDS_MAX_PAYLOAD_BYTES, HEALTH, HEALTH_MAX_PAYLOAD_BYTES,
+    LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
+    MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE, MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE,
+    MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES,
 };
 use data_daemon_shared::{BatchedDataItem, Envelope};
 use iceoryx2::node::{Node, NodeBuilder};
@@ -93,12 +94,17 @@ pub(crate) struct ProducerState {
     _node: Node<ipc::Service>,
     _commands_service: PortFactory<ipc::Service, [u8], ()>,
     commands_publisher: Publisher<ipc::Service, [u8], ()>,
-    /// Service handle held alongside the query client so port discovery doesn't
+    /// Service handle held alongside the recording-id client so port discovery doesn't
     /// race the handle going out of scope.
-    _queries_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    _recording_id_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
     /// Request-response client used by `get_recording_id` to ask the daemon
     /// for a recording's cloud id.
-    pub(crate) queries_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    pub(crate) recording_id_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the health client so port discovery doesn't
+    /// race the handle going out of scope.
+    _health_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response client used by launch readiness probes.
+    pub(crate) health_client: Client<ipc::Service, [u8], (), [u8], ()>,
 }
 
 /// Work item for the publisher thread.
@@ -320,18 +326,23 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         COMMANDS_MAX_PAYLOAD_BYTES,
     )?;
 
-    let (queries_service, queries_client) = open_query_client(&node, QUERIES)?;
+    let (recording_id_service, recording_id_client) =
+        open_query_client(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
+    let (health_service, health_client) =
+        open_query_client(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
 
     Ok(ProducerState {
         _node: node,
         _commands_service: commands_service,
         commands_publisher,
-        _queries_service: queries_service,
-        queries_client,
+        _recording_id_service: recording_id_service,
+        recording_id_client,
+        _health_service: health_service,
+        health_client,
     })
 }
 
-/// Open (or attach to) the `[u8]` request-response `queries` service off `node`
+/// Open (or attach to) the `[u8]` request-response `recording_ids` service off `node`
 /// and build a client on it. Config mirrors the daemon's `open_query_server`
 /// so `open_or_create` reconciles to the same service attributes regardless of
 /// which side comes up first.
@@ -339,6 +350,7 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
 fn open_query_client(
     node: &Node<ipc::Service>,
     service_name: &str,
+    max_slice_len: usize,
 ) -> Result<
     (
         QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
@@ -352,14 +364,14 @@ fn open_query_client(
     let service = node
         .service_builder(&parsed_name)
         .request_response::<[u8], [u8]>()
-        .max_clients(MAX_QUERY_CLIENTS_PER_SERVICE)
-        .max_servers(MAX_QUERY_SERVERS_PER_SERVICE)
+        .max_clients(MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE)
+        .max_servers(MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE)
         .max_nodes(MAX_NODES_PER_SERVICE)
         .open_or_create()
         .map_err(|error| ProducerError::ServiceOpen(error.to_string()))?;
     let client = service
         .client_builder()
-        .initial_max_slice_len(QUERIES_MAX_PAYLOAD_BYTES)
+        .initial_max_slice_len(max_slice_len)
         .create()
         .map_err(|error| ProducerError::PublisherCreate(error.to_string()))?;
     Ok((service, client))

--- a/rust/data_daemon_bridge/src/query.rs
+++ b/rust/data_daemon_bridge/src/query.rs
@@ -1,4 +1,4 @@
-//! Recording-id resolution over the `queries` request-response service.
+//! Recording-id resolution over the `recording_ids` request-response service.
 //!
 //! The thin producer never mints recording identity — the daemon allocates the
 //! cloud id asynchronously after `/recording/start`. These helpers ask the
@@ -7,9 +7,9 @@
 
 use std::time::{Duration, Instant};
 
-use data_daemon_shared::RecordingIdReply;
+use data_daemon_shared::{HealthReply, HealthRequest, RecordingIdReply};
 
-use crate::publisher::{with_producer, ProducerError, ProducerState};
+use crate::publisher::{now_ns, with_producer, ProducerError, ProducerState};
 
 /// Interval between successive recording-id requests to the daemon.
 const RECORDING_ID_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -17,14 +17,14 @@ const RECORDING_ID_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const RECORDING_ID_RESPONSE_WAIT: Duration = Duration::from_millis(40);
 /// Poll cadence while waiting for a single request's reply.
 const RECORDING_ID_RECEIVE_POLL: Duration = Duration::from_millis(2);
+/// Interval between successive health probes to the daemon.
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(25);
+/// How long a single health request waits for the daemon's reply before re-asking.
+const HEALTH_RESPONSE_WAIT: Duration = Duration::from_millis(20);
+/// Poll cadence while waiting for one health reply.
+const HEALTH_RECEIVE_POLL: Duration = Duration::from_millis(2);
 
-/// Block (with the GIL released by the caller) until the daemon-owned cloud
-/// `recording_id` is available or `timeout_s` elapses, re-asking on each poll
-/// interval. Returns `None` on timeout / when no daemon is answering.
-pub(crate) fn resolve_recording_id(
-    request_bytes: &[u8],
-    timeout_s: f64,
-) -> Result<Option<String>, ProducerError> {
+fn bounded_timeout(timeout_s: f64) -> Duration {
     // Clamp before converting: `Duration::from_secs_f64` panics on a non-finite
     // or huge value, and `timeout_s` is caller-controlled across the FFI
     // boundary (e.g. `float('inf')` / `float('nan')`). `f64::clamp` propagates
@@ -35,7 +35,66 @@ pub(crate) fn resolve_recording_id(
     } else {
         timeout_s.clamp(0.0, 86_400.0)
     };
-    let deadline = Instant::now() + Duration::from_secs_f64(bounded_timeout_s);
+    Duration::from_secs_f64(bounded_timeout_s)
+}
+
+/// Block (with the GIL released by the caller) until the daemon answers a
+/// side-effect-free health probe or `timeout_s` elapses.
+pub(crate) fn wait_until_ready(timeout_s: f64) -> Result<Option<u32>, ProducerError> {
+    let nonce = now_ns() as u64;
+    let request_bytes = HealthRequest { nonce }.encode()?;
+    let deadline = Instant::now() + bounded_timeout(timeout_s);
+    loop {
+        if let Some(pid) = health_probe_once(&request_bytes, nonce)? {
+            return Ok(Some(pid));
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(HEALTH_POLL_INTERVAL);
+    }
+}
+
+fn health_probe_once(request_bytes: &[u8], nonce: u64) -> Result<Option<u32>, ProducerError> {
+    with_producer(|state| {
+        let request = state
+            .health_client
+            .loan_slice_uninit(request_bytes.len())
+            .map_err(|error| ProducerError::Loan(error.to_string()))?;
+        let request = request.write_from_slice(request_bytes);
+        let pending = request
+            .send()
+            .map_err(|error| ProducerError::Send(error.to_string()))?;
+
+        let response_deadline = Instant::now() + HEALTH_RESPONSE_WAIT;
+        loop {
+            match pending.receive() {
+                Ok(Some(response)) => {
+                    let reply = HealthReply::decode(response.payload())?;
+                    return Ok((reply.pid > 0 && reply.nonce == nonce).then_some(reply.pid));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(%error, "health receive failed; treating as no reply");
+                    return Ok(None);
+                }
+            }
+            if Instant::now() >= response_deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(HEALTH_RECEIVE_POLL);
+        }
+    })
+}
+
+/// Block (with the GIL released by the caller) until the daemon-owned cloud
+/// `recording_id` is available or `timeout_s` elapses, re-asking on each poll
+/// interval. Returns `None` on timeout / when no daemon is answering.
+pub(crate) fn resolve_recording_id(
+    request_bytes: &[u8],
+    timeout_s: f64,
+) -> Result<Option<String>, ProducerError> {
+    let deadline = Instant::now() + bounded_timeout(timeout_s);
     loop {
         let resolved = with_producer(|state| resolve_recording_id_once(state, request_bytes))?;
         if resolved.is_some() {
@@ -58,7 +117,7 @@ fn resolve_recording_id_once(
     request_bytes: &[u8],
 ) -> Result<Option<String>, ProducerError> {
     let request = state
-        .queries_client
+        .recording_id_client
         .loan_slice_uninit(request_bytes.len())
         .map_err(|error| ProducerError::Loan(error.to_string()))?;
     let request = request.write_from_slice(request_bytes);

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -172,6 +172,16 @@ pub mod service_name {
     /// the cliff entirely.
     pub const MAX_NODES_PER_SERVICE: usize = 512;
 
+    /// Request-response service the SDK uses to probe daemon readiness.
+    ///
+    /// A successful health reply proves the daemon has opened IPC and entered
+    /// the listener loop, so launchers can wait on this service instead of
+    /// treating the PID file as readiness.
+    pub const HEALTH: &str = "neuracore/data_daemon/health";
+
+    /// Maximum size of a single health-service sample.
+    pub const HEALTH_MAX_PAYLOAD_BYTES: usize = 1024;
+
     /// Request-response service the SDK uses to resolve a recording's
     /// daemon-owned cloud `recording_id`.
     ///
@@ -181,20 +191,20 @@ pub mod service_name {
     /// daemon answers authoritatively from its own state. A request carries the
     /// source + the recording's capture marker; the reply carries the id once
     /// minted (or "not yet"). See [`crate::RecordingIdQuery`] / [`crate::RecordingIdReply`].
-    pub const QUERIES: &str = "neuracore/data_daemon/queries";
+    pub const RECORDING_IDS: &str = "neuracore/data_daemon/recording_ids";
 
-    /// Maximum size of a single `queries`-service sample. Both the request and
+    /// Maximum size of a single `recording_ids` service sample. Both the request and
     /// the reply are a handful of UUID strings + integers; 4 KiB is generous.
-    pub const QUERIES_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
+    pub const RECORDING_ID_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
 
-    /// Maximum number of concurrent query clients. Mirrors
+    /// Maximum number of concurrent request-response clients. Mirrors
     /// [`MAX_PUBLISHERS_PER_SERVICE`]: the data bridge parks one client port
     /// per OS thread (iceoryx2 ports are `!Sync`), so the cap must cover the
     /// integration matrix's full thread fan-out.
-    pub const MAX_QUERY_CLIENTS_PER_SERVICE: usize = 128;
+    pub const MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE: usize = 128;
 
-    /// Maximum number of concurrent query servers. The daemon opens exactly one.
-    pub const MAX_QUERY_SERVERS_PER_SERVICE: usize = 1;
+    /// Maximum number of concurrent request-response servers. The daemon opens exactly one.
+    pub const MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE: usize = 1;
 }
 
 /// A single message exchanged between the producer and the daemon.
@@ -454,7 +464,7 @@ pub enum EnvelopeCodecError {
     Decode(#[source] postcard::Error),
 }
 
-/// Request sent by the SDK on the [`service_name::QUERIES`] service to resolve a
+/// Request sent by the SDK on the [`service_name::RECORDING_IDS`] service to resolve a
 /// recording's daemon-owned cloud `recording_id`.
 ///
 /// The recording is identified exactly the way the daemon stored it: the
@@ -481,25 +491,65 @@ pub struct RecordingIdReply {
     pub recording_id: Option<String>,
 }
 
+/// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthRequest {
+    /// Caller-generated token echoed by the reply.
+    pub nonce: u64,
+}
+
+/// Reply to a [`HealthRequest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthReply {
+    /// PID of the daemon process that answered.
+    pub pid: u32,
+    /// Echo of [`HealthRequest::nonce`].
+    pub nonce: u64,
+}
+
 impl RecordingIdQuery {
-    /// Encode as a postcard byte vector for a `queries`-service request sample.
+    /// Encode as a postcard byte vector for a `recording_ids` service request sample.
     pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
         encode_postcard(self)
     }
 
-    /// Decode from the byte slice carried in a `queries`-service request sample.
+    /// Decode from the byte slice carried in a `recording_ids` service request sample.
     pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
         decode_postcard(bytes)
     }
 }
 
 impl RecordingIdReply {
-    /// Encode as a postcard byte vector for a `queries`-service response sample.
+    /// Encode as a postcard byte vector for a `recording_ids` service response sample.
     pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
         encode_postcard(self)
     }
 
-    /// Decode from the byte slice carried in a `queries`-service response sample.
+    /// Decode from the byte slice carried in a `recording_ids` service response sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl HealthRequest {
+    /// Encode as a postcard byte vector for a health-service request sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a health-service request sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl HealthReply {
+    /// Encode as a postcard byte vector for a health-service response sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a health-service response sample.
     pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
         decode_postcard(bytes)
     }
@@ -508,6 +558,24 @@ impl RecordingIdReply {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn health_request_and_reply_round_trip() {
+        let request = HealthRequest { nonce: 42 };
+        assert_eq!(
+            HealthRequest::decode(&request.encode().unwrap()).unwrap(),
+            request
+        );
+
+        let reply = HealthReply {
+            pid: 1234,
+            nonce: 42,
+        };
+        assert_eq!(
+            HealthReply::decode(&reply.encode().unwrap()).unwrap(),
+            reply
+        );
+    }
 
     #[test]
     fn start_recording_round_trips_through_postcard() {

--- a/tests/integration/ml/test_dataset_datatype_validation.py
+++ b/tests/integration/ml/test_dataset_datatype_validation.py
@@ -83,8 +83,13 @@ CNNMLP_CONFIG = {
 
 def _record_episode(data_types: set[DataType]) -> None:
     """Record one episode logging only the given data types."""
-    t = time.time()
-    nc.start_recording(robot_name=ROBOT_NAME, instance=ROBOT_INSTANCE)
+    start_time = time.time()
+    t = start_time
+    nc.start_recording(
+        robot_name=ROBOT_NAME,
+        instance=ROBOT_INSTANCE,
+        timestamp=start_time,
+    )
     for _ in range(EPISODE_STEPS):
         t += 1.0 / FREQUENCY
         if DataType.JOINT_POSITIONS in data_types:
@@ -109,7 +114,12 @@ def _record_episode(data_types: set[DataType]) -> None:
                 instance=ROBOT_INSTANCE,
                 timestamp=t,
             )
-    nc.stop_recording(wait=True, robot_name=ROBOT_NAME, instance=ROBOT_INSTANCE)
+    nc.stop_recording(
+        wait=True,
+        robot_name=ROBOT_NAME,
+        instance=ROBOT_INSTANCE,
+        timestamp=t + 1.0 / FREQUENCY,
+    )
 
 
 def _missing_recordings_from_error(error_msg: str) -> dict[str, set[str]]:
@@ -148,8 +158,9 @@ class TestDatasetDatatypeValidation:
     all_steps_passed: bool = True
     dataset_name: str
     dataset: Dataset | None = None
-    # recording id -> data types logged for that episode in step 1
+    # recording name -> data types logged for that episode in step 1
     recording_data_types: dict[str, set[DataType]]
+    seen_recording_ids: set[str]
 
     @classmethod
     def setup_class(cls) -> None:
@@ -157,6 +168,7 @@ class TestDatasetDatatypeValidation:
         cls.dataset_name = unique_name(prefix="datatype_validation")
         cls.dataset = None
         cls.recording_data_types = {}
+        cls.seen_recording_ids = set()
         nc.login()
 
     @classmethod
@@ -198,15 +210,19 @@ class TestDatasetDatatypeValidation:
                     timeout_s=RECORDING_STOP_TIMEOUT_SECONDS,
                     poll_interval_s=RECORDING_POLL_SECONDS,
                 )
-                current_ids = {
-                    str(r.id) for r in nc.get_dataset(name=self.dataset_name)
+                recordings_by_id = {
+                    str(r.id): r for r in nc.get_dataset(name=self.dataset_name)
                 }
-                new_ids = current_ids - set(self.recording_data_types)
+                new_ids = set(recordings_by_id) - self.seen_recording_ids
                 assert len(new_ids) == 1, (
                     f"Expected exactly one new recording after episode "
                     f"{ep_idx + 1}, got {sorted(new_ids)}"
                 )
-                self.recording_data_types[new_ids.pop()] = data_types
+                recording_id = new_ids.pop()
+                self.seen_recording_ids.add(recording_id)
+                self.recording_data_types[recordings_by_id[recording_id].name] = (
+                    data_types
+                )
                 logger.info(f"Episode {ep_idx + 1} ready.")
 
         self.__class__.dataset = nc.get_dataset(name=self.dataset_name)
@@ -244,15 +260,15 @@ class TestDatasetDatatypeValidation:
         )
         expected_missing = {
             data_type.value: {
-                recording_id
-                for recording_id, logged_types in self.recording_data_types.items()
+                recording_name
+                for recording_name, logged_types in self.recording_data_types.items()
                 if data_type not in logged_types
             }
             for data_type in REQUESTED_TYPES
         }
         complete_recordings = {
-            recording_id
-            for recording_id, logged_types in self.recording_data_types.items()
+            recording_name
+            for recording_name, logged_types in self.recording_data_types.items()
             if logged_types == REQUESTED_TYPES
         }
         assert len(complete_recordings) == COMPLETE_RECORDINGS, (
@@ -289,9 +305,9 @@ class TestDatasetDatatypeValidation:
             f"Grouped error does not match the per-episode ground truth.\n"
             f"Expected: {expected_missing}\nFull message:\n{error_msg}"
         )
-        for recording_id in complete_recordings:
-            assert recording_id not in error_msg, (
-                f"Fully-typed recording {recording_id} must not appear in the "
+        for recording_name in complete_recordings:
+            assert recording_name not in error_msg, (
+                f"Fully-typed recording {recording_name} must not appear in the "
                 f"error.\nGot: {error_msg}"
             )
 

--- a/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
+++ b/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
@@ -31,6 +31,10 @@ class _FakePopen:
     def poll(self) -> int | None:
         return self._poll_value
 
+    def terminate(self) -> None:
+        self.returncode = -15
+        self._poll_value = -15
+
 
 def test_acquire_pid_file_rejects_running_pid(tmp_path: Path) -> None:
     pid_path = tmp_path / "daemon.pid"
@@ -55,6 +59,100 @@ def test_remove_pid_file_removes(tmp_path: Path) -> None:
     remove_pid_file(pid_path)
 
     assert not pid_path.exists()
+
+
+def test_rust_launch_waits_for_ipc_health_not_pid_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    fake_pid = os.getpid()
+    readiness_checks = iter([False, True])
+    captured: dict[str, object] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        captured["command"] = command
+        captured.update(kwargs)
+        pid_path.write_text(str(fake_pid), encoding="utf-8")
+        return _FakePopen(pid=fake_pid, poll_value=None)
+
+    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
+    monkeypatch.setattr(
+        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
+    )
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        daemon_os_control,
+        "_rust_daemon_ready",
+        lambda _pid_path, *, timeout_s=0.0: next(readiness_checks),
+    )
+
+    proc = launch_daemon_subprocess(
+        pid_path=pid_path,
+        db_path=db_path,
+        background=True,
+    )
+
+    assert proc.pid == fake_pid
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "NEURACORE_DAEMON_MANAGE_PID" not in env
+
+
+def test_rust_launch_times_out_when_only_pid_appears(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    fake_pid = os.getpid()
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        pid_path.write_text(str(fake_pid), encoding="utf-8")
+        return _FakePopen(pid=fake_pid, poll_value=None)
+
+    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
+    monkeypatch.setattr(
+        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
+    )
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        daemon_os_control, "_rust_daemon_ready", lambda *_args, **_kwargs: False
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        launch_daemon_subprocess(
+            pid_path=pid_path,
+            db_path=db_path,
+            background=True,
+            timeout_s=0.0,
+        )
+
+    assert "Rust daemon IPC health probe" in str(exc_info.value)
+
+
+def test_ensure_daemon_running_existing_rust_pid_waits_for_health(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+    calls: list[float] = []
+
+    def fake_ready(_pid_path: Path, *, timeout_s: float = 0.0) -> bool:
+        calls.append(timeout_s)
+        return True
+
+    monkeypatch.setattr(daemon_os_control, "get_daemon_pid_path", lambda: pid_path)
+    monkeypatch.setattr(daemon_os_control, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
+    monkeypatch.setattr(
+        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
+    )
+    monkeypatch.setattr(daemon_os_control, "_rust_daemon_ready", fake_ready)
+
+    assert daemon_os_control.ensure_daemon_running(timeout_s=2.5) == os.getpid()
+    assert calls == [2.5]
 
 
 def test_launch_daemon_subprocess_redirects_stdio_in_background(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Changed the readiness protocol to wait for readiness health check returned positive from the rust daemon process before the producer starts sending data to the daemon.
 - Ensure_online_daemon_running won't return until the daemon is ready, not just that the PID file exists. 
