### PR TITLE
fix: bump actions/setup-python from v4 to v6

### DIFF
--- a/.github/workflows/integration-importer-production.yaml
+++ b/.github/workflows/integration-importer-production.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
@@ -52,7 +52,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
@@ -120,7 +120,7 @@ jobs:
         fi
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -87,7 +87,7 @@ jobs:
       run: git lfs pull
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       id: setup-python
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
@@ -91,7 +91,7 @@ jobs:
         fi
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -67,7 +67,7 @@ jobs:
       run: git lfs pull
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       id: setup-python
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
@@ -86,7 +86,7 @@ jobs:
         fi
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
@@ -65,7 +65,7 @@ jobs:
       run: git lfs pull
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       id: setup-python
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration-pf-data-daemon-production.yaml
+++ b/.github/workflows/integration-pf-data-daemon-production.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - uses: pre-commit/action@v3.0.1
@@ -46,7 +46,7 @@ jobs:
         ref: ${{ inputs.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - uses: pre-commit/action@v3.0.1
@@ -50,7 +50,7 @@ jobs:
         ref: ${{ inputs.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/integration-pf-streaming-production.yaml
+++ b/.github/workflows/integration-pf-streaming-production.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - uses: pre-commit/action@v3.0.1
@@ -45,7 +45,7 @@ jobs:
         ref: ${{ inputs.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/integration-pf-streaming-staging.yaml
+++ b/.github/workflows/integration-pf-streaming-staging.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - uses: pre-commit/action@v3.0.1
@@ -48,7 +48,7 @@ jobs:
         ref: ${{ inputs.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'


### PR DESCRIPTION
### Features
 - None

### Bugfixes
 - `actions/setup-python@v4` fails on the `macos-26-arm64` GitHub Actions runner image with `##[error]candidates is not iterable`, aborting the job before any tests run (e.g. https://github.com/NeuracoreAI/neuracore/actions/runs/29709392383/job/88251261720). v4 predates support for the newer runner image's version manifest format. Bumped all remaining `actions/setup-python@v4` references to `@v6`, matching the version already used in `rust-data-daemon.yaml`, `build-wheels.yaml`, and `pr-pre-commit-and-test.yaml`.

### Items
 - [NCP-1151](https://neuracore.atlassian.net/browse/NCP-1151)

### Related PRs
 - None