### PR TITLE
ci: add integration code freeze

### DIFF
--- a/.github/workflows/code-freeze.yaml
+++ b/.github/workflows/code-freeze.yaml
@@ -1,0 +1,28 @@
+name: Code Freeze
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: code-freeze-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: false
+
+jobs:
+  code-freeze:
+    uses: NeuracoreAI/shared-workflows/.github/workflows/code-freeze-gate.yaml@main
+    permissions:
+      statuses: write
+      pull-requests: write
+    secrets:
+      actions-read-token: ${{ secrets.INTEGRATION_STATUS_READ_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,6 +137,7 @@ jobs:
                 author: pr.data.user.login,
                 url: pr.data.html_url,
                 bump_type: bumpType,
+                hotfix: labels.includes('type:hotfix'),
                 labels: labels,
                 body: pr.data.body || ''
               });
@@ -278,7 +279,7 @@ jobs:
           if (groups.breaking.length > 0) {
             changelog += `## Breaking Changes\n\n`;
             for (const pr of groups.breaking.sort((a, b) => a.number - b.number)) {
-              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}\n`;
+              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}${pr.hotfix ? ' **(hotfix)**' : ''}\n`;
             }
             changelog += '\n';
           }
@@ -286,7 +287,7 @@ jobs:
           if (groups.features.length > 0) {
             changelog += `## Features\n\n`;
             for (const pr of groups.features.sort((a, b) => a.number - b.number)) {
-              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}\n`;
+              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}${pr.hotfix ? ' **(hotfix)**' : ''}\n`;
             }
             changelog += '\n';
           }
@@ -294,7 +295,7 @@ jobs:
           if (groups.fixes.length > 0) {
             changelog += `## Bug Fixes\n\n`;
             for (const pr of groups.fixes.sort((a, b) => a.number - b.number)) {
-              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}\n`;
+              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}${pr.hotfix ? ' **(hotfix)**' : ''}\n`;
             }
             changelog += '\n';
           }
@@ -302,7 +303,7 @@ jobs:
           if (groups.other.length > 0) {
             changelog += `## Other Changes\n\n`;
             for (const pr of groups.other.sort((a, b) => a.number - b.number)) {
-              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}\n`;
+              changelog += `- **${pr.title}** ([#${pr.number}](${pr.url})) by @${pr.author}${pr.hotfix ? ' **(hotfix)**' : ''}\n`;
             }
             changelog += '\n';
           }


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Feature PRs are blocked while nightly integration tests are failing; PRs labeled `type:hotfix` are exempt and get a comment explaining the freeze
 - Release notes annotate hotfix PRs with **(hotfix)**

### Note
This workflow only reports the `code-freeze` commit status. Blocking takes effect when `code-freeze` is added to the required status checks on `main` (under branch protection)

The gate reads nightly results through the `INTEGRATION_STATUS_READ_TOKEN` organization secret: a fine-grained PAT (resource owner NeuracoreAI) with repository access to neuracore, neuracore_frontend and neuracore_backend and the Actions read-only permission, shared with this repository. Without it, pull request runs skip and sweep runs fail.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1123](https://neuracore.atlassian.net/browse/NCP-1123)

### Related PRs
 - https://github.com/NeuracoreAI/shared-workflows/pull/1
 - https://github.com/NeuracoreAI/neuracore_types/pull/103
 - https://github.com/NeuracoreAI/neuracore_backend/pull/470
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/403
