### PR TITLE
test: resolve cloud recording id in shared slot reopen

### DIFF
--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
@@ -134,7 +134,7 @@ def test_shared_slot_reopen_after_stalled_descriptor_uploads_next_recording(
                     MAX_TIME_TO_START_S, label="nc.start_recording", always_log=True
                 ):
                     nc.start_recording(robot_name=robot_name)
-                resumed_recording_id = robot.get_current_recording_id()
+                resumed_recording_id = robot.get_cloud_recording_id()
                 assert resumed_recording_id is not None
 
                 log_frames(spec, recording_index=0, marker_name="marker_reopen")


### PR DESCRIPTION
### Bugfixes
 - `test_shared_slot_reopen` used the `robot.get_current_recording_id()`, which under the Rust daemon returns a client-side local correlation handle Switched to `robot.get_cloud_recording_id()` (matching `test_cancel_recording.py`). 

### Items
 - [NCP-1152](https://neuracore.atlassian.net/browse/NCP-1152)