### PR TITLE
fix: recording loss from stop/start inversion

### DIFF
--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -544,10 +544,17 @@ impl Dispatcher {
         // A well-behaved producer stops before starting; if a live window is
         // somehow still open, retire it to `closing` bounded at the new start's
         // publish time so it stops catching data published after this point.
+        // This also happens under an inverted start/stop pair (a slow stop
+        // reaching the daemon after the next start), so persist the retired
+        // recording's stop here — using the new start's publish time as the
+        // exclusive upper bound of its membership range — rather than leaving
+        // its row open. A later stolen stop refines the exact boundary.
+        let mut retired: Option<i64> = None;
         if let Some(mut previous) = entry.live.take() {
             if previous.stopped_at_ns.is_none() {
                 previous.stopped_at_ns = Some(publish_timestamp_ns);
                 previous.stop_recv_at = Some(recv_at);
+                retired = Some(previous.recording_index);
             }
             entry.closing.push(previous);
         }
@@ -558,6 +565,23 @@ impl Dispatcher {
             stop_recv_at: None,
             traces: HashMap::new(),
         });
+
+        if let Some(retired_index) = retired {
+            tracing::warn!(
+                recording_index = retired_index,
+                successor_index = recording_index,
+                "start arrived with prior recording still live; closing it"
+            );
+            // Persist the retired recording's stop so it reaches a terminal,
+            // notifiable state even if its own (late) stop never arrives.
+            if let Err(error) = self
+                .store
+                .mark_recording_stopped(retired_index, publish_timestamp_ns)
+                .await
+            {
+                tracing::warn!(%error, recording_index = retired_index, "failed to mark superseded recording stopped");
+            }
+        }
 
         if let Some(bus) = self.context.event_bus.as_ref() {
             bus.publish(DaemonEvent::RecordingStarted { recording_index });
@@ -576,34 +600,97 @@ impl Dispatcher {
             return;
         };
         entry.last_seen = Some(recv_at);
-        let Some(mut window) = entry.live.take() else {
+
+        // A stop whose publish time falls inside the live window closes the live
+        // recording normally. A stop that predates the live window is a delayed
+        // stop for a recording `handle_start` already retired (an inverted
+        // start/stop pair) — it is matched against the closing windows instead.
+        // Both paths converge on the shared post-persist tail below, so a
+        // retired recording also becomes notifiable (fires `RecordingStopped`).
+        let recording_index = if entry
+            .live
+            .as_ref()
+            .is_some_and(|window| window.contains(publish_timestamp_ns))
+        {
+            let mut window = entry
+                .live
+                .take()
+                .expect("live window was checked immediately above");
+            // The window closes on the publish clock; the row's
+            // `stop_timestamp_ns` (→ backend `end_time`) is the caller's capture
+            // time.
+            window.stopped_at_ns = Some(publish_timestamp_ns);
+            window.stop_recv_at = Some(recv_at);
+            let recording_index = window.recording_index;
+            entry.closing.push(window);
+            // Persist `stopped_at` before publishing the event: the cloud
+            // stop-notifier reads this row on `RecordingStopped`, so the
+            // timestamp must be on disk first.
+            if let Err(error) = self
+                .store
+                .mark_recording_stopped(recording_index, timestamp_ns)
+                .await
+            {
+                tracing::warn!(%error, recording_index, "failed to mark recording stopped");
+                return;
+            }
+            recording_index
+        } else if let Some(position) = entry
+            .closing
+            .iter()
+            .rposition(|window| window.contains(publish_timestamp_ns))
+        {
+            let window = &mut entry.closing[position];
+            let recording_index = window.recording_index;
+            // Deliberately DO NOT narrow the window's in-memory `stopped_at_ns`
+            // to this true (earlier) stop. `handle_start` set it to the
+            // successor recording's start time so the two consecutive windows
+            // tile the publish-clock line with no gap. Rewinding it to the real
+            // stop would re-open a no-window interval `(true stop, successor
+            // start)`; a tail video chunk whose NUT open time lands in that gap
+            // — the writer is mid-flush at exactly that moment — would then find
+            // no window and be dropped as an orphan. Only the retired
+            // recording's own producer can stamp data in that interval, so
+            // keeping the boundary at the successor start mis-routes nothing.
+            //
+            // Refresh the closing-retention deadline so the extra late tail data
+            // this delayed stop implies still has a window to land in.
+            window.stop_recv_at = Some(recv_at);
+            tracing::warn!(
+                robot_id = source.0,
+                recording_index,
+                "stop arrived after a later recording started; refining the retired recording's stop"
+            );
+            // Refine the row's `stop_timestamp_ns` (→ backend `end_time`) to
+            // this true capture stop. `handle_start` already marked the row with
+            // the successor start's time, and `mark_recording_stopped` is
+            // COALESCE-idempotent, so a plain re-mark would no-op — a forced
+            // overwrite is required, and correct because `stop < successor
+            // start`.
+            if let Err(error) = self
+                .store
+                .refine_recording_stop(recording_index, timestamp_ns)
+                .await
+            {
+                tracing::warn!(%error, recording_index, "failed to refine retired recording stop");
+                return;
+            }
+            recording_index
+        } else {
             tracing::debug!(
                 robot_id = source.0,
-                "stop with no active recording; ignoring"
+                publish_timestamp_ns,
+                "stop does not belong to any retained recording window; ignoring"
             );
             return;
         };
-        // The window closes on the publish clock; the row's `stop_timestamp_ns`
-        // (→ backend `end_time`) is the caller's capture time.
-        window.stopped_at_ns = Some(publish_timestamp_ns);
-        window.stop_recv_at = Some(recv_at);
-        let recording_index = window.recording_index;
-        entry.closing.push(window);
 
-        // Persist `stopped_at` before publishing the event: the cloud
-        // stop-notifier reads this row on `RecordingStopped`, so the timestamp
-        // must be on disk first.
-        if let Err(error) = self
-            .store
-            .mark_recording_stopped(recording_index, timestamp_ns)
-            .await
-        {
-            tracing::warn!(%error, recording_index, "failed to mark recording stopped");
-        } else {
-            tracing::info!(recording_index, "recording stopped");
-            if let Some(bus) = self.context.event_bus.as_ref() {
-                bus.publish(DaemonEvent::RecordingStopped { recording_index });
-            }
+        // Shared post-persist tail. A retired recording never fired
+        // `RecordingStopped` at retire time (only its row was marked), so this
+        // is where it — like a normally-closed recording — becomes notifiable.
+        tracing::info!(recording_index, "recording stopped");
+        if let Some(bus) = self.context.event_bus.as_ref() {
+            bus.publish(DaemonEvent::RecordingStopped { recording_index });
         }
     }
 
@@ -1316,6 +1403,125 @@ mod tests {
         let a: serde_json::Value =
             serde_json::from_slice(&std::fs::read(a_dir.join("trace.json")).unwrap()).unwrap();
         assert_eq!(a, serde_json::json!([{"i": 1}]));
+    }
+
+    #[tokio::test]
+    async fn inverted_stop_after_next_start_preserves_both_recordings() {
+        // A slow stop can reach the daemon after the next recording's start
+        // (start/stop inversion). Listener order here is:
+        //   start(A, t1=100) -> data(A) -> start(B, t3=200)
+        //   -> stop(t2=150) -> data(B) -> stop(t4=300)
+        // with t1 < t2 < t3 < t4. The dispatcher must: close A (stopped_at set,
+        // refined to the true stop 150) with its data; keep B alive through
+        // t2's stolen stop, closing it only at t4 (300) with its data; drop
+        // nothing as an orphan (both traces exist); and fire RecordingStopped
+        // for BOTH recordings (the retired one must still become notifiable).
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let bus = crate::state::EventBus::new();
+        let mut sub = bus.subscribe();
+        let dispatcher_context = DispatcherContext {
+            event_bus: Some(bus.clone()),
+            config_refresh_tx: None,
+        };
+        let (tx, handle) = spawn_with_context(
+            store.clone(),
+            context.clone(),
+            dispatcher_context,
+            shutdown_rx,
+        );
+
+        tx.send(start("robot-1", 100)).await.unwrap();
+        tx.send(datum("robot-1", 110, 1)).await.unwrap();
+        tx.send(start("robot-1", 200)).await.unwrap();
+        // The stolen stop: its publish time (150) predates B's open (200).
+        tx.send(stop("robot-1", 150)).await.unwrap();
+        tx.send(datum("robot-1", 210, 2)).await.unwrap();
+        tx.send(stop("robot-1", 300)).await.unwrap();
+
+        drop(tx);
+        timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 2);
+        let recording_a = &recordings[0];
+        let recording_b = &recordings[1];
+
+        assert!(
+            recording_a.stopped_at.is_some(),
+            "recording A must be closed when the next start supersedes it"
+        );
+        assert_eq!(
+            recording_a.stop_timestamp_ns,
+            Some(150),
+            "recording A's stop must be refined to the true (earlier) stop"
+        );
+        assert!(
+            recording_b.stopped_at.is_some(),
+            "recording B must be closed by its own stop"
+        );
+        assert_eq!(
+            recording_b.stop_timestamp_ns,
+            Some(300),
+            "the stolen stop at 150 must not close B; only t4 does"
+        );
+
+        let a_traces = store
+            .list_traces_for_recording(recording_a.recording_index)
+            .await
+            .unwrap();
+        let b_traces = store
+            .list_traces_for_recording(recording_b.recording_index)
+            .await
+            .unwrap();
+        assert_eq!(a_traces.len(), 1, "A keeps its datum (ts=110)");
+        assert_eq!(
+            b_traces.len(),
+            1,
+            "B keeps its datum (ts=210), not orphaned"
+        );
+
+        let a_dir = TracePath::new(
+            recording_a.recording_index.to_string(),
+            "joints",
+            a_traces[0].trace_id.clone(),
+        )
+        .directory(context.recordings_root.as_path());
+        let a: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(a_dir.join("trace.json")).unwrap()).unwrap();
+        assert_eq!(a, serde_json::json!([{"i": 1}]));
+
+        let b_dir = TracePath::new(
+            recording_b.recording_index.to_string(),
+            "joints",
+            b_traces[0].trace_id.clone(),
+        )
+        .directory(context.recordings_root.as_path());
+        let b: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(b_dir.join("trace.json")).unwrap()).unwrap();
+        assert_eq!(b, serde_json::json!([{"i": 2}]));
+
+        // Both recordings must fire RecordingStopped — the retired recording A
+        // (via the delayed-stop fall-through) as well as the normally-closed B —
+        // so the cloud stop-notifier fires for each.
+        let mut stopped: Vec<i64> = Vec::new();
+        while let Ok(event) = sub.try_recv() {
+            if let DaemonEvent::RecordingStopped { recording_index } = event {
+                stopped.push(recording_index);
+            }
+        }
+        assert!(
+            stopped.contains(&recording_a.recording_index),
+            "RecordingStopped must fire for the retired recording A"
+        );
+        assert!(
+            stopped.contains(&recording_b.recording_index),
+            "RecordingStopped must fire for the normally-closed recording B"
+        );
     }
 
     /// Announce a finished video chunk whose open time is `publish_ts`. The

--- a/rust/data_daemon/src/state/store.rs
+++ b/rust/data_daemon/src/state/store.rs
@@ -175,6 +175,18 @@ pub trait StateStore: Send + Sync {
         stop_timestamp_ns: i64,
     ) -> Result<RecordingRow, StateStoreError>;
 
+    /// Refine a retired recording's `stop_timestamp_ns` to the true stop that
+    /// arrived after a later recording had already started (an inverted
+    /// start/stop pair). Unlike [`mark_recording_stopped`](Self::mark_recording_stopped)
+    /// this overwrites `stop_timestamp_ns` even when already set, because the
+    /// stop that superseded it was the *earlier*, accurate one; `stopped_at`
+    /// (wall clock, already set when the recording was retired) is preserved.
+    async fn refine_recording_stop(
+        &self,
+        recording_index: i64,
+        stop_timestamp_ns: i64,
+    ) -> Result<RecordingRow, StateStoreError>;
+
     /// Stamp `backend_stop_notified_at = now` after the recording-stop
     /// notifier successfully POSTed `/recording/stop`. Idempotent: a second
     /// call leaves the existing timestamp untouched.
@@ -1065,6 +1077,35 @@ impl StateStore for SqliteStateStore {
             "UPDATE recordings \
                 SET stopped_at = COALESCE(stopped_at, ?2), \
                     stop_timestamp_ns = COALESCE(stop_timestamp_ns, ?3), \
+                    last_updated = ?2 \
+              WHERE recording_index = ?1",
+        )
+        .bind(recording_index)
+        .bind(now)
+        .bind(stop_timestamp_ns)
+        .execute(&mut *tx)
+        .await?;
+
+        let record = Self::fetch_recording_locked(&mut tx, recording_index)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
+
+        tx.commit().await?;
+        Ok(record)
+    }
+
+    async fn refine_recording_stop(
+        &self,
+        recording_index: i64,
+        stop_timestamp_ns: i64,
+    ) -> Result<RecordingRow, StateStoreError> {
+        let mut tx = self.write_pool.begin().await?;
+
+        let now = Utc::now().naive_utc();
+        sqlx::query(
+            "UPDATE recordings \
+                SET stop_timestamp_ns = ?3, \
+                    stopped_at = COALESCE(stopped_at, ?2), \
                     last_updated = ?2 \
               WHERE recording_index = ?1",
         )

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -291,18 +291,24 @@ fn log_json(
     Ok(())
 }
 
-/// Flush any tail video chunks for the source, then publish one
-/// `StopRecording`. The flush happens before the stop publish so the in-order
-/// delivery contract on this thread's publisher delivers the chunk first.
+/// Publish one `StopRecording`, then flush any tail video chunks for the
+/// source before returning. The stop is published BEFORE the flush barrier:
+/// it shares the calling thread's publisher with `StartRecording`, so sending
+/// it first guarantees the daemon sees this stop ahead of the next recording's
+/// start. Stamping the boundary early but sending only after a slow flush
+/// (~19 ms observed) let the stop reach the wire after the following start —
+/// the daemon then retired the wrong window and dropped both recordings' data.
+/// Late tail chunks (announced on the writer's port after this stop) route
+/// into the just-closed window by the daemon's holdback + closing-window
+/// retention, so chunk-before-stop ordering is not required.
 ///
 /// The producer stamps the window's upper bound on the publish clock here
-/// (`publish_timestamp_ns`, always wall-clock now), so the whole publish clock
-/// is owned by the producer (consistent with the data envelopes). Every video
-/// chunk routes by its *open* time, which is strictly inside the recording, so
-/// the exact value of this boundary no longer has to be reconciled with a tail
-/// chunk. The recording's *capture* stop time (`timestamp_ns` when supplied,
-/// else the publish time) is separate — it is stored as `stop_timestamp_ns` and
-/// POSTed as the backend `end_time`, never used for window membership.
+/// (`publish_timestamp_ns`, always wall-clock now at the send), so the whole
+/// publish clock is owned by the producer (consistent with the data
+/// envelopes). The recording's *capture* stop time (`timestamp_ns` when
+/// supplied, else the publish time) is separate — it is stored as
+/// `stop_timestamp_ns` and POSTed as the backend `end_time`, never used for
+/// window membership.
 #[pyfunction]
 #[pyo3(signature = (robot_id, robot_instance, timestamp_ns = None))]
 fn stop_recording(
@@ -320,31 +326,34 @@ fn stop_recording(
         // Caller-supplied capture time, mirroring the `log_*` timestamp default
         // (publish clock when omitted). Decoupled from the window boundary.
         let capture_timestamp_ns = timestamp_ns.unwrap_or(publish_timestamp_ns);
-        // Barrier on the writer: it drains every frame still queued for this
-        // source (FIFO), seals the tail chunks and announces them, then acks.
-        // Blocking here means the stop never returns until those chunks are
-        // durably spooled + announced, so a process exit right after
-        // `stop_recording` can't lose them.
-        let (ack_tx, ack_rx) = std::sync::mpsc::channel();
-        // Control messages bypass the frame caps, so this never blocks or stalls.
-        let _ = writer_queue().push(WriterMsg::FlushSource {
-            robot_id: robot_id.clone(),
-            robot_instance,
-            ack: ack_tx,
-        });
-        let _ = ack_rx.recv();
-        // Publish `StopRecording` from THIS (the calling) thread's publisher —
-        // the same port as `StartRecording` — so consecutive recordings' start
-        // and stop boundaries stay strictly ordered for the daemon. The tail
-        // chunks were announced on the writer's port just above; the daemon's
-        // holdback + closing-window retention route them into this window even
-        // though they ride a different port.
+        // Publish `StopRecording` FIRST, from THIS (the calling) thread's
+        // publisher — the same port as `StartRecording` — stamping the window's
+        // upper bound at the actual send. Publishing before the (possibly slow)
+        // flush barrier keeps consecutive recordings' start/stop boundaries
+        // strictly ordered: the stop can never be reordered behind the next
+        // recording's `StartRecording` on this thread.
         publish(&Envelope::StopRecording {
-            robot_id,
+            robot_id: robot_id.clone(),
             robot_instance,
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // Then barrier on the writer: it drains every frame still queued for
+        // this source (FIFO), seals the tail chunks and announces them, then
+        // acks. Blocking here means `stop_recording` still returns only once
+        // those chunks are durably spooled + announced, so a process exit right
+        // after the call can't lose them. The tail chunks ride the writer's
+        // port and land after this stop; the daemon's holdback + closing-window
+        // retention route them into the just-closed window by their in-window
+        // open timestamp.
+        let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+        // Control messages bypass the frame caps, so this never blocks or stalls.
+        let _ = writer_queue().push(WriterMsg::FlushSource {
+            robot_id,
+            robot_instance,
+            ack: ack_tx,
+        });
+        let _ = ack_rx.recv();
         Ok(())
     })
 }

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -18,13 +18,18 @@
 //! `StopRecording` published from the writer's port instead, it could be
 //! reordered against the next recording's `StartRecording` on the main port —
 //! the daemon then sees a start while the prior window is still live and drops
-//! the overlapping window's data.) The stop/cancel paths only *barrier* on the
-//! writer — seal + announce (or drop) the source's tail chunks, ack — and then
-//! publish the lifecycle envelope themselves. Chunk-before-stop ordering is not
-//! a same-port guarantee here but is safe anyway: the daemon holds every
-//! `VideoChunkReady` back (`NCD_HOLDBACK_MS`, default 500 ms) and retains a
-//! just-closed window, so a tail chunk announced just before the stop still
-//! routes into the (closing) window by its in-window open timestamp.
+//! the overlapping window's data.) `stop_recording` publishes its
+//! `StopRecording` *before* it waits on the writer flush barrier, so a slow
+//! flush can never hold the stop behind the next recording's `StartRecording`;
+//! the tail chunks are sealed + announced during the barrier and land just
+//! after the stop. `cancel_recording` keeps the opposite order — it waits on
+//! the writer barrier to drop the source's in-progress chunks *before*
+//! publishing `CancelRecording`, so no tail chunk is ever announced after the
+//! daemon tears the window down. Chunk-before-stop ordering is not a same-port
+//! guarantee here but is safe anyway: the daemon holds every `VideoChunkReady`
+//! back (`NCD_HOLDBACK_MS`, default 500 ms) and retains a just-closed window,
+//! so a tail chunk announced just after the stop still routes into the
+//! (closing) window by its in-window open timestamp.
 //!
 //! ## Fork safety
 //!


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Fixed a recording-loss race on the ipc lifecycle path: the bridge's `stop_recording` published `StopRecording` only **after** blocking on the video-writer flush barrier, so under a slow flush (~19 ms observed in CI traces) the stop reached the wire **after** the next recording's `StartRecording`.
   - Bridge: `stop_recording` now publishes `StopRecording` **before** the flush barrier,
   - Dispatcher `handle_start` persists the retired window's stop when a start finds a live window, and `handle_stop` no longer lets a stale stop
   - New dispatcher test `inverted_stop_after_next_start_preserves_both_recordings` replays the exact inverted sequence from the CI trace capture

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1160](https://neuracore.atlassian.net/browse/NCP-1160)


### Validation (trace-level CI runs stacked on this commit)

Retry-loop validation on `ci/cougar-tracing-run` (runs 29916355272 / 29916353564, cancelled mid-loop after conclusive streaks): **macOS 6/6, ubuntu 4/4, importer-rlds 18/18 iterations passed — zero orphan drops (`dropped datum outside any recording window`) on every leg.** Pre-fix, the same macOS harness failed 8 of 9 iterations.

 - **Root fix proven:** macOS stop publish→receive latency median fell **3.31 ms → 0.95 ms** (now start-like) — the direct signature of publishing `StopRecording` before the flush barrier; 80/80 same-source boundaries were received stop-before-next-start.
 - **Defense layer proven necessary:** ubuntu logged zero inversion warns (the reorder alone sufficed), but macOS logged 2 residual dispatcher-side inversions under the 8-context per-thread burst case (exactly its two highest-latency stops, 38.9 ms / 20.0 ms) — both absorbed losslessly by the new `handle_start`/`handle_stop` guards (`start arrived with prior recording still live` + `stop arrived after a later recording started; refining`). With per-thread producer channels, stop and next-start can ride different ports, so the dispatcher guards are load-bearing, not just belt-and-braces.
 - **DB integrity:** every completed iteration shows full trace counts (6×32 reduced case, 16×26 burst case), zero unstopped/cancelled/zero-trace recordings.
 - Importer leg: 540 expected-trace-count reports, all full (no short counts) — 18 clean shared imports where the (separate, backend-side) save-promotion race previously struck ~1-in-5–7 iterations; suggestive but not proof that earlier stop publication narrows that race window.
