### PR TITLE
feat: add dataset recording deletion

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -461,6 +461,82 @@ class Dataset:
         self.__dict__.clear()
         self.__class__ = _DeletedDataset
 
+    def delete_recording(
+        self,
+        recording_name: str | None = None,
+        recording_id: str | None = None,
+    ) -> None:
+        """Delete a recording from this dataset by its name or ID.
+
+        Args:
+            recording_name: The recording's human-readable name.
+            recording_id: The recording's unique ID.
+
+        Raises:
+            ValueError: If neither or both identifiers are supplied.
+            DatasetError: If no recording has the supplied identifier, or if the name
+                matches more than one recording.
+            requests.HTTPError: If the API request fails.
+        """
+        # The user must provide either a name or an ID, but not both.
+        if (recording_name is None) == (recording_id is None):
+            raise ValueError(
+                "Exactly one of recording_name or recording_id must be provided."
+            )
+
+        if recording_id is not None:
+            # An ID can be sent to the API without loading the dataset first.
+            resolved_recording_id = recording_id
+        else:
+            # Load all recordings so we can find the right name.
+            recordings = list(self)
+            matches = [r for r in recordings if r.name == recording_name]
+            if not matches:
+                raise DatasetError(
+                    f"Recording {recording_name!r} not found in dataset {self.name!r}."
+                )
+            # Names can be the same, so use an ID when more than one name matches.
+            if len(matches) > 1:
+                raise DatasetError(
+                    f"Multiple recordings named {recording_name!r} exist in dataset "
+                    f"{self.name!r}; delete the recording by ID instead."
+                )
+            resolved_recording_id = matches[0].id
+
+        # Delete the recording from this dataset.
+        session = thread_local_session()
+        response = session.delete(
+            f"{API_URL}/org/{self.org_id}/datasets/{self.id}/recording/"
+            f"{resolved_recording_id}",
+            headers=get_auth().get_headers(),
+        )
+        if response.status_code == 404:
+            raise DatasetError(
+                f"Recording {recording_name or recording_id!r} not found in dataset "
+                f"{self.name!r}."
+            )
+        response.raise_for_status()
+
+        # Clear saved recordings so the next read gets fresh data.
+        with self._page_lock:
+            self._recordings_cache = []
+            self._start_after = None
+            self._num_recordings = None
+            self._robot_ids = None
+            self._robot_names = None
+
+        # Update fields such as size and data types after the recording is deleted.
+        try:
+            self._refresh_dataset_metadata()
+        except Exception as e:
+            # The delete worked, so do not report it as failed if this update fails.
+            logger.warning(
+                "Deleted recording %s, but failed to refresh dataset %s: %s",
+                resolved_recording_id,
+                self.id,
+                e,
+            )
+
     def _synchronize(
         self,
         frequency: int = 0,

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -463,6 +463,82 @@ class Dataset:
         self.__dict__.clear()
         self.__class__ = _DeletedDataset
 
+    def delete_recording(
+        self,
+        recording_name: str | None = None,
+        recording_id: str | None = None,
+    ) -> None:
+        """Delete a recording from this dataset by its name or ID.
+
+        Args:
+            recording_name: The recording's human-readable name.
+            recording_id: The recording's unique ID.
+
+        Raises:
+            ValueError: If neither or both identifiers are supplied.
+            DatasetError: If no recording has the supplied identifier, or if the name
+                matches more than one recording.
+            requests.HTTPError: If the API request fails.
+        """
+        # The user must provide either a name or an ID, but not both.
+        if (recording_name is None) == (recording_id is None):
+            raise ValueError(
+                "Exactly one of recording_name or recording_id must be provided."
+            )
+
+        if recording_id is not None:
+            # An ID can be sent to the API without loading the dataset first.
+            resolved_recording_id = recording_id
+        else:
+            # Load all recordings so we can find the right name.
+            recordings = list(self)
+            matches = [r for r in recordings if r.name == recording_name]
+            if not matches:
+                raise DatasetError(
+                    f"Recording {recording_name!r} not found in dataset {self.name!r}."
+                )
+            # Names can be the same, so use an ID when more than one name matches.
+            if len(matches) > 1:
+                raise DatasetError(
+                    f"Multiple recordings named {recording_name!r} exist in dataset "
+                    f"{self.name!r}; delete the recording by ID instead."
+                )
+            resolved_recording_id = matches[0].id
+
+        # Delete the recording from this dataset.
+        session = thread_local_session()
+        response = session.delete(
+            f"{API_URL}/org/{self.org_id}/datasets/{self.id}/recording/"
+            f"{resolved_recording_id}",
+            headers=get_auth().get_headers(),
+        )
+        if response.status_code == 404:
+            raise DatasetError(
+                f"Recording {recording_name or recording_id!r} not found in dataset "
+                f"{self.name!r}."
+            )
+        response.raise_for_status()
+
+        # Clear saved recordings so the next read gets fresh data.
+        with self._page_lock:
+            self._recordings_cache = []
+            self._start_after = None
+            self._num_recordings = None
+            self._robot_ids = None
+            self._robot_names = None
+
+        # Update fields such as size and data types after the recording is deleted.
+        try:
+            self._refresh_dataset_metadata()
+        except Exception as e:
+            # The delete worked, so do not report it as failed if this update fails.
+            logger.warning(
+                "Deleted recording %s, but failed to refresh dataset %s: %s",
+                resolved_recording_id,
+                self.id,
+                e,
+            )
+
     def _synchronize(
         self,
         frequency: int = 0,

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -215,6 +215,27 @@ class Dataset:
             self._recordings_cache.extend(wrapped)
             return wrapped
 
+    def _find_recordings_by_name(
+        self, recording_name: str, limit: int = 2
+    ) -> list[Recording]:
+        """Return recordings whose name exactly matches."""
+        session = thread_local_session()
+        query_params: dict[str, str | int] = {
+            "limit": limit,
+            "is_shared": self.is_shared,
+            "recording_name": recording_name,
+        }
+        response = session.post(
+            f"{API_URL}/org/{self.org_id}/recording/by-dataset/{self.id}",
+            headers=get_auth().get_headers(),
+            params=query_params,
+            json=None,
+        )
+        response.raise_for_status()
+        return [
+            self._wrap_raw_recording(raw) for raw in response.json().get("data", [])
+        ]
+
     def _recordings_generator(self) -> Generator[Recording, None, None]:
         """A generator yielding Recordings for this dataset.
 
@@ -490,9 +511,10 @@ class Dataset:
             # An ID can be sent to the API without loading the dataset first.
             resolved_recording_id = recording_id
         else:
-            # Load all recordings so we can find the right name.
-            recordings = list(self)
-            matches = [r for r in recordings if r.name == recording_name]
+            # Ask the API for at most two exact matches. Two are enough to detect
+            # an ambiguous name without downloading the whole dataset.
+            assert recording_name is not None
+            matches = self._find_recordings_by_name(recording_name)
             if not matches:
                 raise DatasetError(
                     f"Recording {recording_name!r} not found in dataset {self.name!r}."
@@ -512,7 +534,7 @@ class Dataset:
             f"{resolved_recording_id}",
             headers=get_auth().get_headers(),
         )
-        if response.status_code == 404:
+        if response.status_code in (400, 404):
             raise DatasetError(
                 f"Recording {recording_name or recording_id!r} not found in dataset "
                 f"{self.name!r}."

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -806,6 +806,120 @@ class TestDatasetIndexingAndSlicing:
         dataset = Dataset(**dataset_dict, recordings=recordings_list)
         assert len(dataset) == 2
 
+    def test_delete_recording_by_id(
+        self, dataset_dict, dataset_response, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict)
+        endpoint = (
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1"
+        )
+        mock_data_requests.delete(endpoint, status_code=204)
+        dataset_response.id = dataset.id
+        dataset_response.size_bytes = 512
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            json=dataset_response.model_dump(mode="json"),
+        )
+
+        dataset.delete_recording(recording_id="rec1")
+
+        assert mock_data_requests.request_history[0].url == endpoint
+        assert not any(
+            request.method == "POST"
+            and "/recording/by-dataset/" in request.url
+            for request in mock_data_requests.request_history
+        )
+        assert dataset.size_bytes == 512
+        assert dataset._recordings_cache == []
+
+    def test_delete_recording_by_name(
+        self, dataset_dict, recordings_list, mock_data_requests
+    ):
+        recordings_list[0]["metadata"]["name"] = "first episode"
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        endpoint = (
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1"
+        )
+        mock_data_requests.delete(endpoint, status_code=204)
+        dataset_response = DatasetModel(
+            id=dataset.id,
+            name=dataset.name,
+            created_at=0.0,
+            modified_at=0.0,
+            size_bytes=512,
+            tags=dataset.tags,
+            is_shared=dataset.is_shared,
+            num_demonstrations=1,
+        )
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            json=dataset_response.model_dump(mode="json"),
+        )
+
+        dataset.delete_recording(recording_name="first episode")
+
+        assert any(
+            request.url == endpoint
+            for request in mock_data_requests.request_history
+        )
+
+    def test_delete_recording_rejects_unknown_recording(
+        self, dataset_dict, recordings_list, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/missing",
+            status_code=404,
+        )
+
+        with pytest.raises(DatasetError, match="Recording 'missing' not found"):
+            dataset.delete_recording(recording_id="missing")
+
+    def test_delete_recording_succeeds_when_metadata_refresh_fails(
+        self, dataset_dict, recordings_list, mock_data_requests, caplog
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1",
+            status_code=204,
+        )
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            status_code=500,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            dataset.delete_recording(recording_id="rec1")
+
+        assert "failed to refresh dataset" in caplog.text
+        assert dataset._recordings_cache == []
+        assert dataset._num_recordings is None
+
+    def test_delete_recording_rejects_ambiguous_name(
+        self, dataset_dict, recordings_list
+    ):
+        for recording in recordings_list:
+            recording["metadata"]["name"] = "duplicate"
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+
+        with pytest.raises(DatasetError, match="Multiple recordings named 'duplicate'"):
+            dataset.delete_recording(recording_name="duplicate")
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"recording_name": "episode", "recording_id": "rec1"},
+        ],
+    )
+    def test_delete_recording_requires_exactly_one_identifier(
+        self, dataset_dict, recordings_list, kwargs
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+
+        with pytest.raises(ValueError, match="Exactly one"):
+            dataset.delete_recording(**kwargs)
+
     def test_getitem_single_index(
         self, dataset_dict, recordings_list, mock_data_requests, mocked_org_id
     ):

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -831,8 +831,7 @@ class TestDatasetIndexingAndSlicing:
 
         assert mock_data_requests.request_history[0].url == endpoint
         assert not any(
-            request.method == "POST"
-            and "/recording/by-dataset/" in request.url
+            request.method == "POST" and "/recording/by-dataset/" in request.url
             for request in mock_data_requests.request_history
         )
         assert dataset.size_bytes == 512
@@ -847,6 +846,11 @@ class TestDatasetIndexingAndSlicing:
             f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1"
         )
         mock_data_requests.delete(endpoint, status_code=204)
+        mock_data_requests.post(
+            f"{API_URL}/org/{dataset.org_id}/recording/by-dataset/{dataset.id}",
+            json={"data": [recordings_list[0]], "total": 1},
+            status_code=200,
+        )
         dataset_response = DatasetModel(
             id=dataset.id,
             name=dataset.name,
@@ -864,10 +868,13 @@ class TestDatasetIndexingAndSlicing:
 
         dataset.delete_recording(recording_name="first episode")
 
-        assert any(
-            request.url == endpoint
-            for request in mock_data_requests.request_history
-        )
+        lookup_request = mock_data_requests.request_history[0]
+        assert lookup_request.qs == {
+            "limit": ["2"],
+            "is_shared": ["false"],
+            "recording_name": ["first episode"],
+        }
+        assert mock_data_requests.request_history[1].url == endpoint
 
     def test_delete_recording_rejects_unknown_recording(
         self, dataset_dict, recordings_list, mock_data_requests
@@ -880,6 +887,18 @@ class TestDatasetIndexingAndSlicing:
 
         with pytest.raises(DatasetError, match="Recording 'missing' not found"):
             dataset.delete_recording(recording_id="missing")
+
+    def test_delete_recording_maps_not_in_dataset_to_dataset_error(
+        self, dataset_dict, recordings_list, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1",
+            status_code=400,
+        )
+
+        with pytest.raises(DatasetError, match="Recording 'rec1' not found"):
+            dataset.delete_recording(recording_id="rec1")
 
     def test_delete_recording_succeeds_when_metadata_refresh_fails(
         self, dataset_dict, recordings_list, mock_data_requests, caplog
@@ -902,14 +921,44 @@ class TestDatasetIndexingAndSlicing:
         assert dataset._num_recordings is None
 
     def test_delete_recording_rejects_ambiguous_name(
-        self, dataset_dict, recordings_list
+        self, dataset_dict, recordings_list, mock_data_requests
     ):
         for recording in recordings_list:
             recording["metadata"]["name"] = "duplicate"
         dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.post(
+            f"{API_URL}/org/{dataset.org_id}/recording/by-dataset/{dataset.id}",
+            json={"data": recordings_list, "total": 2},
+            status_code=200,
+        )
 
         with pytest.raises(DatasetError, match="Multiple recordings named 'duplicate'"):
             dataset.delete_recording(recording_name="duplicate")
+
+    def test_iteration_loads_fresh_recordings_after_deletion(
+        self, dataset_dict, recordings_list, dataset_response, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        remaining_recordings = [recordings_list[1]]
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1",
+            status_code=204,
+        )
+        dataset_response.id = dataset.id
+        dataset_response.num_demonstrations = 1
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            json=dataset_response.model_dump(mode="json"),
+        )
+        mock_data_requests.post(
+            f"{API_URL}/org/{dataset.org_id}/recording/by-dataset/{dataset.id}",
+            json={"data": remaining_recordings, "total": 1},
+            status_code=200,
+        )
+
+        dataset.delete_recording(recording_id="rec1")
+
+        assert [recording.id for recording in dataset] == ["rec2"]
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -812,6 +812,120 @@ class TestDatasetIndexingAndSlicing:
         dataset = Dataset(**dataset_dict, recordings=recordings_list)
         assert len(dataset) == 2
 
+    def test_delete_recording_by_id(
+        self, dataset_dict, dataset_response, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict)
+        endpoint = (
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1"
+        )
+        mock_data_requests.delete(endpoint, status_code=204)
+        dataset_response.id = dataset.id
+        dataset_response.size_bytes = 512
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            json=dataset_response.model_dump(mode="json"),
+        )
+
+        dataset.delete_recording(recording_id="rec1")
+
+        assert mock_data_requests.request_history[0].url == endpoint
+        assert not any(
+            request.method == "POST"
+            and "/recording/by-dataset/" in request.url
+            for request in mock_data_requests.request_history
+        )
+        assert dataset.size_bytes == 512
+        assert dataset._recordings_cache == []
+
+    def test_delete_recording_by_name(
+        self, dataset_dict, recordings_list, mock_data_requests
+    ):
+        recordings_list[0]["metadata"]["name"] = "first episode"
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        endpoint = (
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1"
+        )
+        mock_data_requests.delete(endpoint, status_code=204)
+        dataset_response = DatasetModel(
+            id=dataset.id,
+            name=dataset.name,
+            created_at=0.0,
+            modified_at=0.0,
+            size_bytes=512,
+            tags=dataset.tags,
+            is_shared=dataset.is_shared,
+            num_demonstrations=1,
+        )
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            json=dataset_response.model_dump(mode="json"),
+        )
+
+        dataset.delete_recording(recording_name="first episode")
+
+        assert any(
+            request.url == endpoint
+            for request in mock_data_requests.request_history
+        )
+
+    def test_delete_recording_rejects_unknown_recording(
+        self, dataset_dict, recordings_list, mock_data_requests
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/missing",
+            status_code=404,
+        )
+
+        with pytest.raises(DatasetError, match="Recording 'missing' not found"):
+            dataset.delete_recording(recording_id="missing")
+
+    def test_delete_recording_succeeds_when_metadata_refresh_fails(
+        self, dataset_dict, recordings_list, mock_data_requests, caplog
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        mock_data_requests.delete(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}/recording/rec1",
+            status_code=204,
+        )
+        mock_data_requests.get(
+            f"{API_URL}/org/{dataset.org_id}/datasets/{dataset.id}",
+            status_code=500,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            dataset.delete_recording(recording_id="rec1")
+
+        assert "failed to refresh dataset" in caplog.text
+        assert dataset._recordings_cache == []
+        assert dataset._num_recordings is None
+
+    def test_delete_recording_rejects_ambiguous_name(
+        self, dataset_dict, recordings_list
+    ):
+        for recording in recordings_list:
+            recording["metadata"]["name"] = "duplicate"
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+
+        with pytest.raises(DatasetError, match="Multiple recordings named 'duplicate'"):
+            dataset.delete_recording(recording_name="duplicate")
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"recording_name": "episode", "recording_id": "rec1"},
+        ],
+    )
+    def test_delete_recording_requires_exactly_one_identifier(
+        self, dataset_dict, recordings_list, kwargs
+    ):
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+
+        with pytest.raises(ValueError, match="Exactly one"):
+            dataset.delete_recording(**kwargs)
+
     def test_getitem_single_index(
         self, dataset_dict, recordings_list, mock_data_requests, mocked_org_id
     ):


### PR DESCRIPTION
## Summary

- add `Dataset.delete_recording()` with separate `recording_name` and `recording_id` arguments
- support direct deletion by ID and name lookup with duplicate-name checks
- clear recording and robot caches after deletion and refresh dataset metadata
- add unit coverage for successful deletion and failure cases

## Why

This section of code has been hacked together in multiple places, including integration tests, separate scripts, and tools. Since deleting recordings is a common operation outside the SDK, this PR formally adds the function to `Dataset`.

Please Check in detail for the Page Lock as im not 100% sure on this. 