### PR TITLE
fix: missing recording index test failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ examples/test_streaming/
 
 .data_daemon_test_state/
 
+# Local Neuracore login helper (contains credentials)
+login_neuracore.sh
+
 # Bundled rust artefacts built into the package tree by
 # `rust/scripts/build_wheel_artefacts.sh`. Both are per-machine and per-build,
 # so we never commit them; the wheel-build CI job recreates them on every run.

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -380,6 +380,7 @@ pyinstrument
 pymodule
 pyquaternion
 pytest
+pytestmark
 pyyaml
 pyzmq
 Qbcaa

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 import pytest
 
 import neuracore as nc
+from neuracore.data_daemon.rust_selection import is_rust_daemon_enabled
 from tests.integration.platform.data_daemon.shared.assertions import (
     assert_exactly_one_daemon_pid,
     assert_post_test_storage_state,
@@ -39,6 +40,11 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.skipif(
+    is_rust_daemon_enabled(),
+    reason="Shared-slot reopen applies only to the legacy Python daemon",
+)
 
 
 _CASE = DataDaemonTestCase(

--- a/tests/integration/platform/data_daemon/shared/db_helpers.py
+++ b/tests/integration/platform/data_daemon/shared/db_helpers.py
@@ -29,6 +29,7 @@ import logging
 import sqlite3
 import time
 from collections.abc import Callable, Iterable
+from contextlib import closing
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -131,13 +132,13 @@ class DaemonDbStore:
     def fetch_all_rows(self, table: str) -> list[dict[str, Any]]:
         """Return every row from the named table in the daemon state DB."""
         table_name = self._table_name(table)
-        with self.connect() as conn:
+        with closing(self.connect()) as conn:
             rows = conn.execute(f"SELECT * FROM {table_name}").fetchall()  # noqa: S608
         return [dict(row) for row in rows]
 
     def list_tables(self) -> set[str]:
         """Return the names of all user tables currently present in the daemon DB."""
-        with self.connect() as conn:
+        with closing(self.connect()) as conn:
             rows = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             ).fetchall()
@@ -173,7 +174,7 @@ class DaemonDbStore:
         ``recording_id`` (TEXT) under the legacy Python daemon.
         """
         correlation_column = _recording_correlation_column()
-        with self.connect() as conn:
+        with closing(self.connect()) as conn:
             row = conn.execute(
                 f"SELECT * FROM {RECORDINGS_TABLE} " f"WHERE {correlation_column} = ?",
                 (recording_key,),
@@ -192,7 +193,7 @@ class DaemonDbStore:
         correlate a worker's recordings to daemon-minted ``recording_index``
         values without seeing the local handle.
         """
-        with self.connect() as conn:
+        with closing(self.connect()) as conn:
             rows = conn.execute(
                 f"SELECT * FROM {RECORDINGS_TABLE} "
                 f"WHERE {COLUMN_ROBOT_ID} = ? AND {COLUMN_ROBOT_INSTANCE} = ? "
@@ -214,7 +215,7 @@ class DaemonDbStore:
         under the legacy Python daemon.
         """
         correlation_column = _recording_correlation_column()
-        with self.connect_read_only() as conn:
+        with closing(self.connect_read_only()) as conn:
             if not self.table_exists(conn, TRACES_TABLE):
                 return []
 

--- a/tests/integration/platform/data_daemon/shared/storage_assertions.py
+++ b/tests/integration/platform/data_daemon/shared/storage_assertions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from neuracore.data_daemon.helpers import (
@@ -90,23 +91,22 @@ def assert_db_empty() -> None:
     db_path = harness_db_path()
     if not db_path.exists():
         return
-    with sqlite3.connect(str(db_path)) as conn:
+    non_empty: list[str] = []
+    with closing(sqlite3.connect(str(db_path))) as conn:
         tables = {
             row[0]
             for row in conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         }
-    non_empty: list[str] = []
-    for table in sorted(tables):
-        if table in _INFRA_TABLES:
-            continue
-        with sqlite3.connect(str(db_path)) as conn:
+        for table in sorted(tables):
+            if table in _INFRA_TABLES:
+                continue
             count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[
                 0
             ]  # noqa: S608
-        if count:
-            non_empty.append(f"  {table}: {count} row(s)")
+            if count:
+                non_empty.append(f"  {table}: {count} row(s)")
     assert (
         not non_empty
     ), "Daemon DB is not empty — unexpected rows found:\n" + "\n".join(non_empty)

--- a/tests/integration/platform/data_daemon/shared/test_infrastructure.py
+++ b/tests/integration/platform/data_daemon/shared/test_infrastructure.py
@@ -20,6 +20,9 @@ import pytest
 
 import neuracore as nc
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
+from tests.integration.platform.data_daemon.shared.process_control import (
+    get_runner_pids,
+)
 from tests.integration.platform.data_daemon.shared.storage_assertions import (
     assert_post_test_storage_state,
     harness_db_path,
@@ -147,6 +150,22 @@ def apply_storage_state_action(storage_state_action: str) -> None:
     db_path = harness_db_path()
     recordings_root = harness_recordings_root()
 
+    destructive_actions = {STORAGE_STATE_EMPTY, STORAGE_STATE_DELETE}
+    if storage_state_action in destructive_actions:
+        daemon_pids = sorted(get_runner_pids())
+        if daemon_pids:
+            raise RuntimeError(
+                f"Refusing {storage_state_action!r} storage cleanup while daemon "
+                f"processes are alive: {daemon_pids}"
+            )
+
+    def checkpoint(connection: sqlite3.Connection) -> None:
+        result = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if result is None or int(result[0]) != 0:
+            raise AssertionError(
+                f"SQLite WAL checkpoint remained busy for {db_path}: {result!r}"
+            )
+
     if storage_state_action == STORAGE_STATE_EMPTY:
         if db_path.exists():
             connection = sqlite3.connect(str(db_path))
@@ -157,13 +176,19 @@ def apply_storage_state_action(storage_state_action: str) -> None:
                     except sqlite3.OperationalError:
                         pass
                 connection.commit()
-                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                checkpoint(connection)
             finally:
                 connection.close()
         if recordings_root.exists():
             shutil.rmtree(recordings_root, ignore_errors=True)
         recordings_root.mkdir(parents=True, exist_ok=True)
     elif storage_state_action == STORAGE_STATE_DELETE:
+        if db_path.exists():
+            connection = sqlite3.connect(str(db_path))
+            try:
+                checkpoint(connection)
+            finally:
+                connection.close()
         try:
             db_path.unlink(missing_ok=True)
         except OSError:
@@ -171,7 +196,7 @@ def apply_storage_state_action(storage_state_action: str) -> None:
         if recordings_root.exists():
             shutil.rmtree(recordings_root, ignore_errors=True)
 
-    if storage_state_action in {STORAGE_STATE_EMPTY, STORAGE_STATE_DELETE}:
+    if storage_state_action == STORAGE_STATE_DELETE:
         for suffix in ("-shm", "-wal"):
             try:
                 Path(str(db_path) + suffix).unlink(missing_ok=True)


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Do not manually delete the .wal and .shm files, these are owned by sqlite3 and we are letting it manage the cleanup and tear down of them which it does well, because un-linking them whilst any connection still knows about them, such as the pytest process in this case, can produce the cross test state problems we see here. 
 - Disabled rust for shared transport layer tests as they are not applicable to the rust daemon.
 - Explicitly closed the database connection as opposed to just removing files in between tests, as leaving the connection open means that sqlite can still hold the file descriptors, locks, references to wal & shm files etc.
