### PR TITLE
fix: recording reaper completion race

### DIFF
--- a/rust/data_daemon/migrations/0002_trace_completion_reported.sql
+++ b/rust/data_daemon/migrations/0002_trace_completion_reported.sql
@@ -1,0 +1,17 @@
+-- Backend-ack watermark for trace completions. Stamped by the status
+-- coordinator once the batch PUT carrying this trace's UPLOAD_COMPLETE is
+-- acknowledged; the recording reaper refuses to reclaim a recording while
+-- any of its traces is still unstamped, so a queued-but-unflushed completion
+-- can no longer be destroyed by the sweep. No dedicated index: lookups are
+-- always per-recording via `idx_traces_recording_upload`'s leading column.
+ALTER TABLE traces ADD COLUMN completion_reported_at DATETIME;
+
+-- How many times the status coordinator's reconcile pass has re-driven this
+-- trace's completion PUT. Reclaim opens once the attempts are exhausted so a
+-- permanently-rejected completion cannot pin the recording's disk forever.
+ALTER TABLE traces ADD COLUMN completion_report_attempts INTEGER NOT NULL DEFAULT 0;
+
+-- Traces that finished uploading before this upgrade already reported their
+-- completion under the old semantics; stamping them keeps recordings that
+-- straddle the upgrade reclaimable.
+UPDATE traces SET completion_reported_at = last_updated WHERE upload_status = 'uploaded';

--- a/rust/data_daemon/src/cloud/coordinators/status.rs
+++ b/rust/data_daemon/src/cloud/coordinators/status.rs
@@ -22,6 +22,7 @@ use crate::api::models::{TraceStatusUpdate, TraceStatusValue};
 use crate::api::ApiClient;
 use crate::cloud::OrgIdRx;
 use crate::lifecycle::shutdown::ShutdownSignal;
+use crate::state::store::MAX_COMPLETION_REPORT_ATTEMPTS;
 use crate::state::{RecordingRow, SqliteStateStore, StateStore};
 
 /// Maximum number of traces to coalesce before flushing.
@@ -35,6 +36,10 @@ pub const COMPLETION_MAX_WAIT: Duration = Duration::from_millis(200);
 /// larger than the `MAX_WAIT` triggers above so a perpetually-missing org
 /// doesn't spin the executor while waiting for login / org selection.
 const ORG_RESOLVE_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+/// Ignore unreported completions younger than this during a reconcile pass —
+/// a freshly-queued completion normally stamps within the flush deadline, so
+/// only traces that have sat unacknowledged for a while are re-driven.
+const COMPLETION_RECONCILE_GRACE: Duration = Duration::from_secs(10);
 
 /// Update emitted by the uploader for the status coordinator to forward to
 /// the backend.
@@ -121,6 +126,12 @@ async fn run(
     // Periodic flush ticker — fires on the STATUS_FLUSH cadence regardless of inbox load.
     let mut flush_ticker = interval(crate::intervals::STATUS_FLUSH);
     flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // Reconcile ticker — re-drives completions whose backend ack never landed
+    // (dropped batch, crash between ack and stamp, failed stamp write). The
+    // reclaim gate reads `completion_reported_at`, so without this a single
+    // lost batch would retain its recording forever.
+    let mut reconcile_ticker = interval(crate::intervals::COMPLETION_RECONCILE);
+    reconcile_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             biased;
@@ -153,6 +164,13 @@ async fn run(
             _ = flush_ticker.tick() => {
                 flush_due(&store, &client, &org_rx, &mut pending, &mut background_flushes);
             }
+            _ = reconcile_ticker.tick() => {
+                reconcile_unreported_completions(
+                    &store,
+                    &mut pending,
+                    COMPLETION_RECONCILE_GRACE,
+                ).await;
+            }
             maybe_update = inbox.recv() => {
                 let Some(update) = maybe_update else { break };
                 let recording_index = update.recording_index;
@@ -172,6 +190,54 @@ async fn run(
                 }
             }
         }
+    }
+}
+
+/// Re-queue completion updates for uploaded traces whose backend ack never
+/// landed. The batch PUT is idempotent (same status body the uploader already
+/// sent), so re-driving is safe; each pass increments the trace's attempt
+/// counter and the reclaim gate opens once the attempts are exhausted, so a
+/// permanently-rejected completion cannot retain its recording forever.
+async fn reconcile_unreported_completions(
+    store: &Arc<SqliteStateStore>,
+    pending: &mut HashMap<i64, RecordingBatch>,
+    grace: Duration,
+) {
+    let stale = match store
+        .claim_unreported_completions(grace.as_secs() as i64, MAX_BATCH_SIZE as i64)
+        .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::warn!(%error, "could not list unreported completions");
+            return;
+        }
+    };
+    for trace in stale {
+        if trace.completion_report_attempts >= MAX_COMPLETION_REPORT_ATTEMPTS {
+            tracing::warn!(
+                trace_id = %trace.trace_id,
+                recording_index = trace.recording_index,
+                attempts = trace.completion_report_attempts,
+                "final re-send of unacknowledged trace completion; reclaim unblocks after this"
+            );
+        } else {
+            tracing::info!(
+                trace_id = %trace.trace_id,
+                recording_index = trace.recording_index,
+                attempts = trace.completion_report_attempts,
+                "re-sending unacknowledged trace completion"
+            );
+        }
+        let recording_index = trace.recording_index;
+        let batch = pending
+            .entry(recording_index)
+            .or_insert_with(|| RecordingBatch::new(recording_index));
+        batch.add(StatusUpdate::completed(
+            recording_index,
+            trace.trace_id,
+            trace.total_bytes,
+        ));
     }
 }
 
@@ -285,6 +351,17 @@ async fn flush_batch(
                 count = updates_payload.len(),
                 "flushed status updates"
             );
+            // Watermark the acknowledged completions so the recording reaper
+            // knows they durably reached the backend; without the stamp a
+            // sweep can destroy a recording whose completion is still queued.
+            let completed: Vec<String> = updates_payload
+                .iter()
+                .filter(|(_, update)| update.status == Some(TraceStatusValue::UploadComplete))
+                .map(|(trace_id, _)| trace_id.clone())
+                .collect();
+            if let Err(error) = store.mark_traces_completion_reported(&completed).await {
+                tracing::warn!(%error, recording_index, "could not stamp completion_reported_at");
+            }
         }
         Err(error) => {
             tracing::warn!(%error, recording_index, recording_id, count = updates_payload.len(), "status batch update failed");
@@ -498,6 +575,132 @@ mod tests {
         )
         .await;
         assert!(result.is_none(), "a sent batch is not re-queued");
+    }
+
+    #[tokio::test]
+    async fn flush_batch_stamps_acked_completions() {
+        // The reaper's reclaim gate reads `completion_reported_at`; an acked
+        // batch must stamp exactly the traces whose UPLOAD_COMPLETE it
+        // carried, and only those.
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (store, _dir) = open_store().await;
+        let index = seed_recording(&store, "rec-1").await;
+        store
+            .create_trace(index, "t1", Some("J"), None)
+            .await
+            .unwrap();
+        store
+            .create_trace(index, "t2", Some("J"), None)
+            .await
+            .unwrap();
+        let mut batch = RecordingBatch::new(index);
+        batch.add(StatusUpdate::in_progress(index, "t1".to_string(), 10));
+        batch.add(StatusUpdate::completed(index, "t2".to_string(), 200));
+
+        flush_batch(
+            Arc::new(store.clone()),
+            client(&server),
+            org_rx(Some("org-1")),
+            batch,
+        )
+        .await;
+
+        let traces = store.list_traces_for_recording(index).await.unwrap();
+        let stamped_at = |id: &str| {
+            traces
+                .iter()
+                .find(|trace| trace.trace_id == id)
+                .unwrap()
+                .completion_reported_at
+        };
+        assert!(
+            stamped_at("t2").is_some(),
+            "the acked completion is watermarked"
+        );
+        assert!(
+            stamped_at("t1").is_none(),
+            "an in-progress update is not watermarked"
+        );
+    }
+
+    /// The dropped-batch recovery path: an uploaded trace whose completion
+    /// batch was lost (PUT failure, crash before stamp) is re-driven by the
+    /// reconcile pass, stamped once the re-sent batch is acked, and the
+    /// recording becomes reclaimable.
+    #[tokio::test]
+    async fn reconcile_re_sends_dropped_completion_until_reclaimable() {
+        use crate::state::{
+            ProgressReportStatus, TraceUpdate, TraceUploadStatus, TraceWriteStatus,
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (store, _dir) = open_store().await;
+        let store = Arc::new(store);
+        // Fully-settled recording with one uploaded trace, but its completion
+        // was never acked (the batch carrying it was dropped).
+        let index = seed_recording(&store, "rec-1").await;
+        store
+            .create_trace(index, "t1", Some("J"), None)
+            .await
+            .unwrap();
+        store
+            .update_trace(
+                "t1",
+                TraceUpdate {
+                    write_status: Some(TraceWriteStatus::Written),
+                    upload_status: Some(TraceUploadStatus::Uploaded),
+                    total_bytes: Some(200),
+                    ..TraceUpdate::default()
+                },
+            )
+            .await
+            .unwrap();
+        store.mark_recording_stopped(index, 1).await.unwrap();
+        store.mark_recording_stop_notified(index).await.unwrap();
+        store.set_expected_trace_count(index, 1).await.unwrap();
+        store
+            .set_progress_report_status(
+                index,
+                ProgressReportStatus::Pending,
+                ProgressReportStatus::Reported,
+            )
+            .await
+            .unwrap();
+        assert!(
+            store.recordings_pending_reclaim().await.unwrap().is_empty(),
+            "the dropped completion blocks reclaim"
+        );
+
+        // Reconcile pass picks the trace up and queues a fresh completion.
+        let mut pending: HashMap<i64, RecordingBatch> = HashMap::new();
+        reconcile_unreported_completions(&store, &mut pending, Duration::ZERO).await;
+        let batch = pending.remove(&index).expect("reconcile queues a batch");
+        assert!(batch.has_completion, "the re-driven update is a completion");
+
+        // Flushing the re-driven batch stamps the trace and unblocks reclaim.
+        flush_batch(
+            Arc::clone(&store),
+            client(&server),
+            org_rx(Some("org-1")),
+            batch,
+        )
+        .await;
+        let traces = store.list_traces_for_recording(index).await.unwrap();
+        assert!(traces[0].completion_reported_at.is_some());
+        let reclaimable = store.recordings_pending_reclaim().await.unwrap();
+        assert_eq!(reclaimable.len(), 1, "the recording reclaims after re-send");
     }
 
     #[tokio::test]

--- a/rust/data_daemon/src/cloud/watchers/recording_reaper.rs
+++ b/rust/data_daemon/src/cloud/watchers/recording_reaper.rs
@@ -169,6 +169,17 @@ mod tests {
     /// Drive a stopped recording with one fully-uploaded trace through every
     /// notify + progress gate so the server-side reclaim filter reports it.
     async fn seed_reclaimable_stopped(store: &SqliteStateStore, instance: i64) -> i64 {
+        let index = seed_stopped_unreported(store, instance).await;
+        store
+            .mark_traces_completion_reported(&[format!("t-{instance}")])
+            .await
+            .unwrap();
+        index
+    }
+
+    /// Same as [`seed_reclaimable_stopped`] but the trace's `UPLOAD_COMPLETE`
+    /// has not yet been acknowledged by the backend.
+    async fn seed_stopped_unreported(store: &SqliteStateStore, instance: i64) -> i64 {
         let index = store
             .create_recording(new_recording(instance))
             .await
@@ -206,6 +217,36 @@ mod tests {
             .await
             .unwrap();
         index
+    }
+
+    /// The `bbe50b98` incident shape: everything settled locally, but the
+    /// status coordinator has not yet flushed the trace's `UPLOAD_COMPLETE`
+    /// to the backend. The sweep must leave the recording alone.
+    #[tokio::test]
+    async fn sweep_spares_a_recording_with_an_unacknowledged_completion() {
+        let (store, _db_dir) = open_store().await;
+        let root_dir = TempDir::new().unwrap();
+        let root = Arc::new(root_dir.path().to_path_buf());
+        let index = seed_stopped_unreported(&store, 0).await;
+
+        let dir = recording_dir(&root, index);
+        std::fs::create_dir_all(&dir).unwrap();
+        touch(&dir.join("trace.json"));
+
+        sweep_once(&Arc::new(store.clone()), &root).await;
+
+        assert!(dir.exists(), "files survive until the completion is acked");
+        assert!(
+            store.get_recording(index).await.unwrap().is_some(),
+            "the recording row survives until the completion is acked"
+        );
+
+        store
+            .mark_traces_completion_reported(&["t-0".to_string()])
+            .await
+            .unwrap();
+        sweep_once(&Arc::new(store.clone()), &root).await;
+        assert!(!dir.exists(), "acked completion unblocks the reclaim");
     }
 
     /// A cancelled recording whose backend cancel has been notified — the

--- a/rust/data_daemon/src/intervals.rs
+++ b/rust/data_daemon/src/intervals.rs
@@ -49,5 +49,11 @@ pub const UPLOAD_RESCAN: Duration = Duration::from_secs(5);
 /// the cloud, so a relaxed cadence keeps the scan off the hot path.
 pub const RECORDING_RECLAIM: Duration = Duration::from_secs(60);
 
+/// Completion-report reconcile: re-drives `UPLOAD_COMPLETE` status updates
+/// whose backend acknowledgement never landed (dropped batch, crash between
+/// ack and stamp). The PUT is idempotent, so the relaxed cadence only bounds
+/// how quickly a stuck recording becomes reclaimable again.
+pub const COMPLETION_RECONCILE: Duration = Duration::from_secs(30);
+
 /// Connection health probe — matches the Python `connection_manager.py` cadence.
 pub const CONNECTION_HEALTH_CHECK: Duration = Duration::from_secs(10);

--- a/rust/data_daemon/src/state/schema.rs
+++ b/rust/data_daemon/src/state/schema.rs
@@ -252,6 +252,17 @@ pub struct TraceRecord {
     /// registration coordinator. The uploader reads this back on
     /// `ReadyForUpload` and dispatches one resumable upload per entry.
     pub upload_session_uris: Option<String>,
+    /// When the status coordinator's `UPLOAD_COMPLETE` PUT for this trace
+    /// was acknowledged by the backend. `NULL` until then; the reaper only
+    /// reclaims recordings whose traces are all stamped (or have exhausted
+    /// [`completion_report_attempts`](Self::completion_report_attempts)).
+    /// Note: failed traces emit a terminal status through the same path, so
+    /// a stamp means "final status acked", NOT "uploaded successfully" —
+    /// `upload_status` stays the authority on upload success.
+    pub completion_reported_at: Option<NaiveDateTime>,
+    /// How many times the reconcile pass has re-driven this trace's
+    /// completion PUT; reclaim opens once the attempts are exhausted.
+    pub completion_report_attempts: i64,
     /// First-seen timestamp.
     pub created_at: NaiveDateTime,
     /// Last write timestamp; bumped on every row mutation.
@@ -286,6 +297,8 @@ impl TraceRecord {
             error_code,
             error_message: row.try_get("error_message")?,
             upload_session_uris: row.try_get("upload_session_uris")?,
+            completion_reported_at: row.try_get("completion_reported_at")?,
+            completion_report_attempts: row.try_get("completion_report_attempts")?,
             created_at: row.try_get("created_at")?,
             last_updated: row.try_get("last_updated")?,
         })

--- a/rust/data_daemon/src/state/store.rs
+++ b/rust/data_daemon/src/state/store.rs
@@ -33,6 +33,12 @@ const BUSY_TIMEOUT_MS: u32 = 5000;
 /// lives on its own single-connection pool and never competes for these.
 const READ_POOL_CONNECTIONS: u32 = 4;
 
+/// How many reconcile re-sends a trace's completion PUT gets before the
+/// recording reaper is allowed to reclaim the recording anyway. At the
+/// reconcile cadence this bounds a persistently-rejected completion to
+/// roughly ten minutes of retention, instead of pinning the disk forever.
+pub const MAX_COMPLETION_REPORT_ATTEMPTS: i64 = 20;
+
 /// Errors surfaced by [`StateStore`] operations.
 #[derive(Debug, Error)]
 pub enum StateStoreError {
@@ -273,6 +279,29 @@ pub trait StateStore: Send + Sync {
     /// a recording stuck on a permanently-failed upload on every 60 s sweep.
     /// Returned in `created_at` order.
     async fn recordings_pending_reclaim(&self) -> Result<Vec<RecordingRow>, StateStoreError>;
+
+    /// Stamp `completion_reported_at = now` on the given traces after the
+    /// status coordinator's batch PUT carrying their `UPLOAD_COMPLETE` was
+    /// acknowledged by the backend. Idempotent: already-stamped traces keep
+    /// their original timestamp.
+    async fn mark_traces_completion_reported(
+        &self,
+        trace_ids: &[String],
+    ) -> Result<(), StateStoreError>;
+
+    /// Claim uploaded traces whose completion was never acknowledged
+    /// (`completion_reported_at IS NULL`) so the status coordinator's
+    /// reconcile pass can re-send them. Only traces untouched for
+    /// `older_than_secs` are eligible (a freshly-queued completion stamps
+    /// within the flush deadline), and each claim increments
+    /// `completion_report_attempts`; traces at
+    /// [`MAX_COMPLETION_REPORT_ATTEMPTS`] are never claimed again — at that
+    /// point the reclaim gate opens instead.
+    async fn claim_unreported_completions(
+        &self,
+        older_than_secs: i64,
+        limit: i64,
+    ) -> Result<Vec<TraceRecord>, StateStoreError>;
 
     /// Resolve the cloud `recording_id` for the recording identified by
     /// `(robot_id, robot_instance, start_timestamp_ns)`.
@@ -1199,15 +1228,90 @@ impl StateStore for SqliteStateStore {
                          (SELECT 1 FROM traces t \
                            WHERE t.recording_index = r.recording_index \
                              AND t.upload_status != 'uploaded') \
+                     AND NOT EXISTS \
+                         (SELECT 1 FROM traces t \
+                           WHERE t.recording_index = r.recording_index \
+                             AND t.completion_reported_at IS NULL \
+                             AND t.completion_report_attempts < ?1) \
                  ) \
            ORDER BY r.created_at ASC",
         )
+        .bind(MAX_COMPLETION_REPORT_ATTEMPTS)
         .fetch_all(&self.read_pool)
         .await?;
         rows.iter()
             .map(RecordingRow::from_row)
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
+    }
+
+    async fn mark_traces_completion_reported(
+        &self,
+        trace_ids: &[String],
+    ) -> Result<(), StateStoreError> {
+        if trace_ids.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.write_pool.begin().await?;
+        let now = Utc::now().naive_utc();
+        for trace_id in trace_ids {
+            sqlx::query(
+                "UPDATE traces \
+                    SET completion_reported_at = COALESCE(completion_reported_at, ?2), \
+                        last_updated = ?2 \
+                  WHERE trace_id = ?1",
+            )
+            .bind(trace_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn claim_unreported_completions(
+        &self,
+        older_than_secs: i64,
+        limit: i64,
+    ) -> Result<Vec<TraceRecord>, StateStoreError> {
+        let mut tx = self.write_pool.begin().await?;
+        let now = Utc::now().naive_utc();
+        let cutoff = now - chrono::Duration::seconds(older_than_secs);
+        let rows = sqlx::query(
+            "SELECT * FROM traces \
+              WHERE upload_status = 'uploaded' \
+                AND completion_reported_at IS NULL \
+                AND completion_report_attempts < ?1 \
+                AND last_updated <= ?2 \
+              ORDER BY last_updated ASC \
+              LIMIT ?3",
+        )
+        .bind(MAX_COMPLETION_REPORT_ATTEMPTS)
+        .bind(cutoff)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await?;
+        let mut claimed = rows
+            .iter()
+            .map(TraceRecord::from_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        for trace in &mut claimed {
+            sqlx::query(
+                "UPDATE traces \
+                    SET completion_report_attempts = completion_report_attempts + 1, \
+                        last_updated = ?2 \
+                  WHERE trace_id = ?1",
+            )
+            .bind(&trace.trace_id)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            trace.completion_report_attempts += 1;
+            trace.last_updated = now;
+        }
+        tx.commit().await?;
+        Ok(claimed)
     }
 
     async fn resolve_recording_id_for_marker(
@@ -2232,57 +2336,65 @@ mod tests {
         );
     }
 
+    // Helper: drive a stopped recording with one trace at `upload` status
+    // through the full notify/progress gates.
+    async fn stopped_with_trace(
+        store: &SqliteStateStore,
+        instance: i64,
+        trace_id: &str,
+        upload: TraceUploadStatus,
+    ) -> i64 {
+        let index = seed_recording(store, instance).await;
+        store
+            .mark_recording_start_notified(index, &format!("cloud-{instance}"))
+            .await
+            .unwrap();
+        store
+            .create_trace(index, trace_id, Some("J"), None)
+            .await
+            .unwrap();
+        store
+            .update_trace(
+                trace_id,
+                TraceUpdate {
+                    write_status: Some(TraceWriteStatus::Written),
+                    upload_status: Some(upload),
+                    ..TraceUpdate::default()
+                },
+            )
+            .await
+            .unwrap();
+        store.mark_recording_stopped(index, 1).await.unwrap();
+        store.mark_recording_stop_notified(index).await.unwrap();
+        store.set_expected_trace_count(index, 1).await.unwrap();
+        store
+            .set_progress_report_status(
+                index,
+                ProgressReportStatus::Pending,
+                ProgressReportStatus::Reported,
+            )
+            .await
+            .unwrap();
+        index
+    }
+
     #[tokio::test]
     async fn recordings_pending_reclaim_only_returns_settled_recordings() {
         let (store, _tempdir) = open_store().await;
 
-        // Helper: drive a stopped recording with one trace at `upload` status
-        // through the full notify/progress gates.
-        async fn stopped_with_trace(
-            store: &SqliteStateStore,
-            instance: i64,
-            trace_id: &str,
-            upload: TraceUploadStatus,
-        ) -> i64 {
-            let index = seed_recording(store, instance).await;
-            store
-                .mark_recording_start_notified(index, &format!("cloud-{instance}"))
-                .await
-                .unwrap();
-            store
-                .create_trace(index, trace_id, Some("J"), None)
-                .await
-                .unwrap();
-            store
-                .update_trace(
-                    trace_id,
-                    TraceUpdate {
-                        write_status: Some(TraceWriteStatus::Written),
-                        upload_status: Some(upload),
-                        ..TraceUpdate::default()
-                    },
-                )
-                .await
-                .unwrap();
-            store.mark_recording_stopped(index, 1).await.unwrap();
-            store.mark_recording_stop_notified(index).await.unwrap();
-            store.set_expected_trace_count(index, 1).await.unwrap();
-            store
-                .set_progress_report_status(
-                    index,
-                    ProgressReportStatus::Pending,
-                    ProgressReportStatus::Reported,
-                )
-                .await
-                .unwrap();
-            index
-        }
-
-        // A: stopped + fully uploaded → reclaimable.
+        // A: stopped + fully uploaded + completion acked → reclaimable.
         let uploaded = stopped_with_trace(&store, 0, "a1", TraceUploadStatus::Uploaded).await;
+        store
+            .mark_traces_completion_reported(&["a1".to_string()])
+            .await
+            .unwrap();
         // B: stopped, settled at the recording level, but one trace failed to
         // upload → must NOT be reclaimable (and must not be re-scanned forever).
         let failed = stopped_with_trace(&store, 1, "b1", TraceUploadStatus::Failed).await;
+        // E: fully uploaded locally but the completion PUT has not been acked
+        // → must NOT be reclaimable (the reaper would destroy the queued
+        // completion before the status coordinator flushes it).
+        let unreported = stopped_with_trace(&store, 4, "e1", TraceUploadStatus::Uploaded).await;
         // C: cancelled + backend notified → reclaimable with no trace scan.
         let cancelled = seed_recording(&store, 2).await;
         store
@@ -2319,6 +2431,51 @@ mod tests {
         assert!(
             !reclaimable.contains(&live),
             "a live recording never reclaims"
+        );
+        assert!(
+            !reclaimable.contains(&unreported),
+            "an unacknowledged completion blocks reclaim until the status PUT lands"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_unreported_completions_bounds_attempts_and_unblocks_reclaim() {
+        let (store, _tempdir) = open_store().await;
+        let index = stopped_with_trace(&store, 0, "t1", TraceUploadStatus::Uploaded).await;
+
+        // A fresh row is inside the grace window: nothing to claim yet.
+        assert!(store
+            .claim_unreported_completions(3600, 10)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Each pass past the grace window claims the trace once and
+        // increments its attempt counter.
+        for expected_attempts in 1..=MAX_COMPLETION_REPORT_ATTEMPTS {
+            let claimed = store.claim_unreported_completions(0, 10).await.unwrap();
+            assert_eq!(claimed.len(), 1);
+            assert_eq!(claimed[0].trace_id, "t1");
+            assert_eq!(claimed[0].completion_report_attempts, expected_attempts);
+        }
+
+        // Attempts exhausted: never claimed again, and the reclaim gate opens
+        // so the recording cannot be retained forever.
+        assert!(store
+            .claim_unreported_completions(0, 10)
+            .await
+            .unwrap()
+            .is_empty());
+        let reclaimable: Vec<i64> = store
+            .recordings_pending_reclaim()
+            .await
+            .unwrap()
+            .iter()
+            .map(|row| row.recording_index)
+            .collect();
+        assert!(
+            reclaimable.contains(&index),
+            "exhausted completion-report attempts unblock reclaim"
         );
     }
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - The recording reaper can no longer destroy a recording whose `UPLOAD_COMPLETE` status is still queued in the status coordinator. 
 - A reconcile pass in the status coordinator re-drives completions whose acknowledgement never landed, so the recording is not stuck.

### Evidence
Without the guard, reclaim raced the status coordinator's 200 ms completion batch: in the observed incident the reaper deleted the recording row ~2 ms before the batch flush read it, `flush_batch` treated the missing row as not-created-yet and deferred forever, and the backend never received the final trace completion — the recording stayed 16/17 complete server-side and CI hung draining it (recording `bbe50b98`, staging, 2026-07-21 23:00Z; request logs confirmed the PUT never arrived).

Tests (fail-before verified for the gate): `sweep_spares_a_recording_with_an_unacknowledged_completion` (the incident shape), the extended reclaim-filter store test, `flush_batch_stamps_acked_completions` (stamp exactness), `claim_unreported_completions_bounds_attempts_and_unblocks_reclaim` (grace window, attempt bounding, gate opens on exhaustion), and `reconcile_re_sends_dropped_completion_until_reclaimable` (dropped batch → re-send → stamp → reclaim).


### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1162](https://neuracore.atlassian.net/browse/NCP-1162)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - Stacked on #804 
