### PR TITLE
fix: lossy video pts collapse

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "clap",
  "crc32c",
  "dashmap",
+ "data_daemon_bridge",
  "data_daemon_shared",
  "dirs",
  "iceoryx2",

--- a/rust/data_daemon/Cargo.toml
+++ b/rust/data_daemon/Cargo.toml
@@ -39,6 +39,7 @@ url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+data_daemon_bridge = { path = "../data_daemon_bridge" }
 tempfile = "3"
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -32,6 +32,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use data_daemon_shared::service_name::VIDEO_SPOOL_TICKS_PER_SECOND;
+
 use tokio::process::Command;
 
 /// Default ffmpeg binary name. Tests override via [`VideoEncoder::with_binary`]
@@ -342,15 +344,26 @@ impl VideoEncoder {
         // bytes) fed via the rawvideo demuxer on stdin — no lavfi/input-file
         // dependency, so the probe works even on a minimal build. ffmpeg parses
         // (and would reject) the options before reading stdin, so an unsupported
-        // `-vsync passthrough` or `libx264rgb` encode fails immediately rather
-        // than on a healthy input. The two `-map 0:v -c:v …` blocks exercise the
-        // same codec and pixel formats as `encode_chunk` (the build-dependent
-        // parts); the real lossy encode adds options the probe omits (e.g.
-        // `-qp 23` / `+genpts`), so the full option set is not identical.
+        // `-vsync passthrough`, `-enc_time_base` or `libx264rgb` encode fails
+        // immediately rather than on a healthy input. The two `-map 0:v -c:v …`
+        // blocks exercise the same codec, pixel formats and timestamp pinning
+        // as `encode_chunk` (the build-dependent parts); the real lossy encode
+        // adds options the probe omits (e.g. `-qp 23` / `+genpts`), so the full
+        // option set is not identical.
+        //
+        // `-video_track_timescale` is a mov-muxer private option and the null
+        // muxer silently ignores unknown muxer options, so probing it demands a
+        // real mp4 output: the first block writes a one-frame mp4 to a temp
+        // path (removed afterwards) while the second keeps the null muxer.
         const PROBE_FRAME_LEN: usize = 16 * 16 * 3 / 2;
         let frame = vec![128u8; PROBE_FRAME_LEN];
+        let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
+        let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
+        let mp4_probe_out =
+            std::env::temp_dir().join(format!("ncd_ffmpeg_preflight_{}.mp4", std::process::id()));
 
-        let mut child = std::process::Command::new(&self.binary)
+        let child = std::process::Command::new(&self.binary)
+            .arg("-y")
             .arg("-hide_banner")
             .arg("-loglevel")
             .arg("error")
@@ -362,26 +375,32 @@ impl VideoEncoder {
             .arg("16x16")
             .arg("-i")
             .arg("-")
-            // Lossy pass (matches encode_chunk's first output).
+            // Lossy pass (matches encode_chunk's first output), written
+            // through the real mp4 muxer so the timescale pin is genuinely
+            // validated.
             .arg("-map")
             .arg("0:v")
             .arg("-vsync")
             .arg("passthrough")
+            .arg("-enc_time_base")
+            .arg(&enc_time_base)
             .arg("-c:v")
             .arg("libx264")
             .arg("-pix_fmt")
             .arg("yuv420p")
             .arg("-preset")
             .arg("ultrafast")
-            .arg("-f")
-            .arg("null")
-            .arg("-")
+            .arg("-video_track_timescale")
+            .arg(&track_timescale)
+            .arg(&mp4_probe_out)
             // Lossless pass (matches encode_chunk's second output) — the
             // build-dependent `libx264rgb` rgb24 capability the encoder relies on.
             .arg("-map")
             .arg("0:v")
             .arg("-vsync")
             .arg("passthrough")
+            .arg("-enc_time_base")
+            .arg(&enc_time_base)
             .arg("-c:v")
             .arg("libx264rgb")
             .arg("-pix_fmt")
@@ -400,7 +419,14 @@ impl VideoEncoder {
             .map_err(|source| FfmpegPreflightError::NotFound {
                 binary: self.binary.clone(),
                 source,
-            })?;
+            });
+        let mut child = match child {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = std::fs::remove_file(&mp4_probe_out);
+                return Err(error);
+            }
+        };
 
         // The frame is far smaller than a pipe buffer, so writing then dropping
         // stdin cannot deadlock against ffmpeg's reads.
@@ -408,12 +434,12 @@ impl VideoEncoder {
             let _ = stdin.write_all(&frame);
         }
 
-        let output = child
-            .wait_with_output()
-            .map_err(|source| FfmpegPreflightError::NotFound {
-                binary: self.binary.clone(),
-                source,
-            })?;
+        let output = child.wait_with_output();
+        let _ = std::fs::remove_file(&mp4_probe_out);
+        let output = output.map_err(|source| FfmpegPreflightError::NotFound {
+            binary: self.binary.clone(),
+            source,
+        })?;
 
         if output.status.success() {
             Ok(())
@@ -480,10 +506,27 @@ impl VideoEncoder {
         // on both (only deprecated, not removed, on 5.1+). The default branch
         // emits two `-map 0:v -c:v ...` output blocks from a single demux pass;
         // lossy-only emits a single block (no preview/archive split).
+        //
+        // Every output also pins its timing to the NUT's microsecond clock
+        // ([`VIDEO_SPOOL_TICKS_PER_SECOND`], shared with the producer's NUT
+        // writer): `-enc_time_base` fixes the encoder time base and
+        // `-video_track_timescale` fixes the mp4 track timescale.
+        // Without both, ffmpeg derives them from a per-chunk *guessed* frame
+        // rate, and the guess is unstable across chunks of one recording
+        // (near-constant capture deltas keep the microsecond base while
+        // jittery ones normalise to e.g. 59.94 fps → a 1/60000 track). The
+        // final stream-copy concat mishandles mixed-timescale segments and
+        // emits whole chunks crammed onto consecutive single ticks with
+        // backwards decoded PTS — the "Video missing logged frames" rejection
+        // — from perfectly clean input. Pinning both bases keeps every
+        // segment's PTS equal to its capture timestamps (microsecond-exact,
+        // matching the trace sidecar) and makes the concat timescale-uniform.
         // Bound each output's libx264 thread pool to the caller-sized value
         // (see `adaptive_encode_threads`) so the transcode fleet fills idle
         // cores at low concurrency without oversubscribing at high concurrency.
         let encode_threads = encode_threads.to_string();
+        let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
+        let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let lossy_only = request.codec.is_lossy_only();
         let mut command = Command::new(&self.binary);
         command
@@ -505,6 +548,8 @@ impl VideoEncoder {
             // `-preset medium`. No preview downscale and no lossless pass — this
             // is the canonical (and only) upload for the trace.
             command
+                .arg("-enc_time_base")
+                .arg(&enc_time_base)
                 .arg("-c:v")
                 .arg("libx264")
                 .arg("-threads")
@@ -515,6 +560,8 @@ impl VideoEncoder {
                 .arg("medium")
                 .arg("-crf")
                 .arg("23")
+                .arg("-video_track_timescale")
+                .arg(&track_timescale)
                 .arg(&request.lossy_out);
         } else {
             // Downscale the lossy preview proxy (only) to keep this dominant
@@ -527,6 +574,8 @@ impl VideoEncoder {
                 // output and the per-frame timestamp sidecar.
                 .arg("-vf")
                 .arg(&preview_filter)
+                .arg("-enc_time_base")
+                .arg(&enc_time_base)
                 .arg("-c:v")
                 .arg("libx264")
                 .arg("-threads")
@@ -537,11 +586,15 @@ impl VideoEncoder {
                 .arg("ultrafast")
                 .arg("-qp")
                 .arg("23")
+                .arg("-video_track_timescale")
+                .arg(&track_timescale)
                 .arg(&request.lossy_out)
                 .arg("-map")
                 .arg("0:v")
                 .arg("-vsync")
                 .arg("passthrough")
+                .arg("-enc_time_base")
+                .arg(&enc_time_base)
                 // libx264rgb encodes the rgb24 frames directly: bit-exact to the
                 // captured pixels, ~2.5× faster than a yuv444p10le pass, and the
                 // format the Python reference encoder writes.
@@ -555,6 +608,8 @@ impl VideoEncoder {
                 .arg("ultrafast")
                 .arg("-qp")
                 .arg("0")
+                .arg("-video_track_timescale")
+                .arg(&track_timescale)
                 .arg(&request.lossless_out);
         }
         command
@@ -1237,6 +1292,177 @@ mod tests {
         assert_eq!(frames, 6, "all source frames must be encoded");
     }
 
+    #[tokio::test]
+    async fn encode_chunk_pins_the_microsecond_track_timescale() {
+        // Without the pinned `-enc_time_base` / `-video_track_timescale`,
+        // ffmpeg derives each segment's timescale from a per-chunk guessed
+        // frame rate. The guess differs between chunks of one recording
+        // (near-constant capture deltas keep the microsecond base, jittery
+        // ones normalise to a standard rate), and the stream-copy concat of
+        // mixed-timescale segments crams whole chunks onto consecutive
+        // single ticks with backwards decoded PTS — the backend's "Video
+        // missing logged frames" rejection — from perfectly clean input.
+        // Every output must therefore carry the NUT's 1/1000000 clock.
+        let ffmpeg = match locate_binary("ffmpeg") {
+            Some(path) => path,
+            None => {
+                eprintln!("ffmpeg not on PATH — skipping timescale test.");
+                return;
+            }
+        };
+        let ffprobe = match locate_binary("ffprobe") {
+            Some(path) => path,
+            None => {
+                eprintln!("ffprobe not on PATH — skipping timescale test.");
+                return;
+            }
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let raw = tempdir.path().join("chunk_0000.nut");
+        write_synthetic_nut(&ffmpeg, &raw, 8);
+
+        let encoder = VideoEncoder::new();
+        let split_lossy = tempdir.path().join("split_lossy.mp4");
+        let split_lossless = tempdir.path().join("split_lossless.mp4");
+        encoder
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw.clone(),
+                    lossy_out: split_lossy.clone(),
+                    lossless_out: split_lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("split transcode");
+        let single_lossy = tempdir.path().join("single_lossy.mp4");
+        encoder
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: single_lossy.clone(),
+                    lossless_out: tempdir.path().join("unused_lossless.mp4"),
+                    codec: LossyVideoCodec::H264MediumLossyOnly,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("lossy-only transcode");
+
+        for path in [&split_lossy, &split_lossless, &single_lossy] {
+            let probe = StdCommand::new(&ffprobe)
+                .args([
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=time_base",
+                    "-of",
+                    "csv=p=0",
+                ])
+                .arg(path)
+                .output()
+                .expect("spawn ffprobe");
+            assert!(probe.status.success());
+            let time_base = String::from_utf8_lossy(&probe.stdout).trim().to_string();
+            assert_eq!(
+                time_base,
+                format!("1/{VIDEO_SPOOL_TICKS_PER_SECOND}"),
+                "{} must carry the pinned microsecond timescale",
+                path.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn concat_of_mixed_cadence_chunks_keeps_monotonic_pts() {
+        // The terminal symptom this pipeline must never reproduce: chunks of
+        // one recording whose capture cadence differs in character (jittery
+        // vs metronome-constant) used to encode to segments with *different*
+        // guessed timescales, and the stream-copy concat of those crammed a
+        // whole chunk onto consecutive single ticks with backwards decoded
+        // PTS. Build exactly that fixture with the real producer NUT writer
+        // and assert the merged video stays sound.
+        let ffprobe = match locate_binary("ffprobe") {
+            Some(path) => path,
+            None => {
+                eprintln!("ffprobe not on PATH — skipping mixed-cadence test.");
+                return;
+            }
+        };
+        if locate_binary("ffmpeg").is_none() {
+            eprintln!("ffmpeg not on PATH — skipping mixed-cadence test.");
+            return;
+        }
+
+        use data_daemon_bridge::nut_writer::{NutVideoConfig, NutWriter};
+        let tempdir = TempDir::new().unwrap();
+        let frames_per_chunk: i64 = 48;
+        let rgb = vec![128u8; 16 * 16 * 3];
+        let write_chunk = |path: &Path, jittery: bool| {
+            let mut writer = NutWriter::create(
+                path,
+                NutVideoConfig {
+                    width: 16,
+                    height: 16,
+                    time_base_num: 1,
+                    time_base_den: VIDEO_SPOOL_TICKS_PER_SECOND,
+                },
+            )
+            .expect("create NUT");
+            let mut timestamp_us: i64 = 0;
+            for index in 0..frames_per_chunk {
+                // ~59.9 fps; the jittery variant wobbles ±0.5 ms like real
+                // capture, the constant variant ticks like a metronome — the
+                // exact contrast that used to flip the guessed timescale.
+                timestamp_us += if jittery {
+                    16_740 + ((index * 7_919) % 1_000) - 500
+                } else {
+                    16_683
+                };
+                writer
+                    .write_frame(timestamp_us as u64, &rgb)
+                    .expect("write frame");
+            }
+            writer.finish().expect("finish NUT");
+        };
+
+        let encoder = VideoEncoder::new();
+        let mut segments = Vec::new();
+        for (chunk_index, jittery) in [true, false, true].into_iter().enumerate() {
+            let raw = tempdir.path().join(format!("chunk_{chunk_index:04}.nut"));
+            let lossy = tempdir
+                .path()
+                .join(format!("chunk_{chunk_index:04}_lossy.mp4"));
+            write_chunk(&raw, jittery);
+            encoder
+                .encode_chunk(
+                    &ChunkEncodeRequest {
+                        raw_nut: raw,
+                        lossy_out: lossy.clone(),
+                        lossless_out: tempdir
+                            .path()
+                            .join(format!("chunk_{chunk_index:04}_lossless.mp4")),
+                        codec: LossyVideoCodec::LosslessPlusPreview,
+                    },
+                    ENCODE_THREADS_PER_OUTPUT,
+                )
+                .await
+                .expect("transcode chunk");
+            segments.push(lossy);
+        }
+
+        let final_lossy = tempdir.path().join("lossy.mp4");
+        encoder
+            .concat_segments(&segments, &final_lossy)
+            .await
+            .expect("concat");
+        assert_merged_video_is_sound(&ffprobe, &final_lossy);
+    }
+
     #[test]
     fn lossy_video_codec_resolves_from_config_str() {
         assert_eq!(
@@ -1362,6 +1588,75 @@ mod tests {
             nb_read_frames, total_frames,
             "concat output should contain all {total_frames} frames"
         );
+        assert_merged_video_is_sound(&ffprobe, &final_lossy);
+    }
+
+    /// Assert the invariants the whole per-chunk pipeline exists to protect on
+    /// a concatenated video: the merged track carries the pinned microsecond
+    /// timescale and its decoded frames present in strictly increasing PTS
+    /// order (the backend's `synchronize_video` rejects the file on the first
+    /// backwards step as "Video missing logged frames").
+    fn assert_merged_video_is_sound(ffprobe: &Path, video: &Path) {
+        let probe = StdCommand::new(ffprobe)
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=time_base",
+                "-of",
+                "csv=p=0",
+            ])
+            .arg(video)
+            .output()
+            .expect("spawn ffprobe");
+        assert!(probe.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&probe.stdout).trim(),
+            format!("1/{VIDEO_SPOOL_TICKS_PER_SECOND}"),
+            "{} must keep the pinned microsecond timescale through the concat",
+            video.display()
+        );
+
+        // Decode-order PTS, exactly as the backend guard walks them.
+        let probe = StdCommand::new(ffprobe)
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_frames",
+                "-show_entries",
+                "frame=pts,pkt_pts",
+                "-of",
+                "default=noprint_wrappers=1",
+            ])
+            .arg(video)
+            .output()
+            .expect("spawn ffprobe");
+        assert!(probe.status.success());
+        let stdout = String::from_utf8_lossy(&probe.stdout);
+        let pts_values: Vec<i64> = stdout
+            .lines()
+            .filter_map(|line| {
+                line.strip_prefix("pts=")
+                    .or_else(|| line.strip_prefix("pkt_pts="))
+            })
+            .filter_map(|value| value.parse().ok())
+            .collect();
+        assert!(
+            !pts_values.is_empty(),
+            "{} yielded no decoded PTS",
+            video.display()
+        );
+        for pair in pts_values.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "{}: decoded PTS must be strictly increasing, got {pair:?}",
+                video.display()
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/data_daemon_bridge/src/nut_writer.rs
+++ b/rust/data_daemon_bridge/src/nut_writer.rs
@@ -44,6 +44,9 @@ const MAIN_STARTCODE: u64 = 0x4E4D_7A56_1F5F_04AD;
 const STREAM_STARTCODE: u64 = 0x4E53_1140_5BF2_F9DB;
 const SYNCPOINT_STARTCODE: u64 = 0x4E4B_E4AD_EECA_4569;
 
+/// On-disk width of a startcode — the full 64 bits, written big-endian.
+const STARTCODE_BYTES: usize = size_of::<u64>();
+
 /// NUT bitstream version we emit. Version 3 is the long-stable spec; version
 /// 4 introduced extra stream-header fields we do not need.
 const NUT_VERSION: u64 = 3;
@@ -652,7 +655,7 @@ fn wrap_packet(startcode: u64, payload: &[u8]) -> Vec<u8> {
     let forward_ptr = payload.len() as u64 + 4; // +4 for the trailing checksum
     let needs_header_checksum = forward_ptr > 4096;
 
-    let mut packet = Vec::with_capacity(8 + 9 + 4 + payload.len() + 4);
+    let mut packet = Vec::with_capacity(STARTCODE_BYTES + 9 + 4 + payload.len() + 4);
     packet.extend_from_slice(&startcode.to_be_bytes());
     vencode(&mut packet, forward_ptr);
     if needs_header_checksum {
@@ -712,6 +715,50 @@ fn sencode(out: &mut Vec<u8>, value: i64) {
         magnitude.wrapping_mul(2).wrapping_sub(1)
     };
     vencode(out, encoded);
+}
+
+/// Decode every frame's PTS from a finished NUT chunk, in write order — the
+/// test-side inverse of [`NutWriter::write_frame_precompressed`]'s framing, so
+/// writer tests can assert on the exact timestamps written into a chunk.
+#[cfg(test)]
+pub(crate) fn read_frame_pts(bytes: &[u8]) -> Vec<u64> {
+    let mut pts_values = Vec::new();
+    let mut offset = FILE_ID_STRING.len();
+    while offset < bytes.len() {
+        if bytes[offset] == b'N' {
+            // Startcode-wrapped packet (headers / syncpoints): skip startcode,
+            // forward_ptr, the header checksum forward_ptr > 4096 implies, and
+            // the payload-plus-checksum span forward_ptr covers.
+            offset += STARTCODE_BYTES;
+            let (forward_ptr, consumed) = vdecode(bytes, offset);
+            offset += consumed;
+            if forward_ptr > 4096 {
+                offset += 4;
+            }
+            offset += forward_ptr as usize;
+        } else {
+            assert_eq!(
+                bytes[offset], FRAME_CODE_ALL_EXPLICIT,
+                "unexpected frame_code at offset {offset}"
+            );
+            offset += 1;
+            let (_coded_flags, consumed) = vdecode(bytes, offset);
+            offset += consumed;
+            let (_stream_id, consumed) = vdecode(bytes, offset);
+            offset += consumed;
+            let (coded_pts, consumed) = vdecode(bytes, offset);
+            offset += consumed;
+            let (data_size, consumed) = vdecode(bytes, offset);
+            offset += consumed;
+            let pts = coded_pts
+                .checked_sub(1u64 << MSB_PTS_SHIFT)
+                .expect("frame not coded in full-pts form");
+            pts_values.push(pts);
+            // Skip the frame header checksum and the payload.
+            offset += 4 + data_size as usize;
+        }
+    }
+    pts_values
 }
 
 /// Decode a NUT variable-length unsigned integer starting at `offset`.

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -46,7 +46,7 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
-use data_daemon_shared::service_name::MAX_VIDEO_CHUNK_FRAMES;
+use data_daemon_shared::service_name::{MAX_VIDEO_CHUNK_FRAMES, VIDEO_SPOOL_TICKS_PER_SECOND};
 use data_daemon_shared::Envelope;
 
 use crate::nut_writer::{NutVideoConfig, NutWriter};
@@ -99,6 +99,18 @@ const WRITER_QUEUE_MAX_BYTES: usize = CHUNK_FLUSH_BYTES as usize;
 /// estimate and release frame-admission backpressure. Also bounds how long a
 /// producer stays blocked after the daemon drains a chunk (≤ this interval).
 const SPOOL_SCAN_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Bounds on the synthesized PTS step for a frame whose capture timestamp does
+/// not advance past the previous frame's PTS (a duplicate, out-of-order or
+/// regressed capture clock). The step is the stream's last healthy inter-frame
+/// gap clamped into this range: the floor keeps a disordered stretch from
+/// collapsing into sub-millisecond spacing — a chunk crammed onto a 1 µs ramp
+/// makes the per-chunk transcode guess a microsecond frame rate, and the
+/// stream-copy concat then emits the non-monotonic PTS the backend rejects as
+/// "Video missing logged frames" — while the ceiling keeps a long capture
+/// pause from being replayed as the synthetic step.
+const SYNTH_PTS_STEP_MIN_US: u64 = 1_000;
+const SYNTH_PTS_STEP_MAX_US: u64 = 100_000;
 
 /// How long a video frame may wait for spool-backlog headroom before
 /// `log_frame` gives up and raises. The spool drains only as the *daemon*
@@ -168,6 +180,18 @@ struct VideoChunkState {
     pts_origin_us: Option<i64>,
     /// Last PTS written to any chunk for the stream; enforces monotonicity.
     last_pts_us: Option<u64>,
+    /// Most recent healthy PTS advance for the stream (µs), recorded only when
+    /// it is a plausible frame interval (≤ `SYNTH_PTS_STEP_MAX_US`, so a
+    /// forward timestamp spike never counts). Survives chunk rolls — it
+    /// describes the camera's cadence, not the chunk — and is the step used
+    /// (clamped into `SYNTH_PTS_STEP_{MIN,MAX}_US`) when a frame's capture
+    /// timestamp fails to advance past the previous frame's PTS.
+    observed_frame_gap_us: Option<u64>,
+    /// Whether the in-progress chunk has already logged a synthesized-PTS
+    /// warning. One warn per chunk surfaces every affected chunk without a
+    /// sustained disorder stretch (potentially every remaining frame of the
+    /// chunk) flooding the log.
+    pts_synth_warned: bool,
     /// Per-frame capture time in ns for the in-progress chunk — drained into
     /// the announcement so the daemon can bucket frames into a window.
     frame_timestamps_ns: Vec<i64>,
@@ -957,6 +981,8 @@ fn record_video_frame(
             frame_count: 0,
             pts_origin_us: None,
             last_pts_us: None,
+            observed_frame_gap_us: None,
+            pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }));
@@ -1058,13 +1084,53 @@ fn append_frame_locked(
     if state.nut_writer.is_none() {
         state.pts_origin_us = None;
         state.last_pts_us = None;
+        state.pts_synth_warned = false;
     }
-    let origin_us = *state.pts_origin_us.get_or_insert(timestamp_ns / 1_000);
-    let relative_us = (timestamp_ns / 1_000).saturating_sub(origin_us).max(0);
+    let timestamp_us = timestamp_ns / 1_000;
+    let origin_us = *state.pts_origin_us.get_or_insert(timestamp_us);
+    let relative_us = timestamp_us.saturating_sub(origin_us).max(0);
     let mut pts = relative_us as u64;
     if let Some(previous) = state.last_pts_us {
         if pts <= previous {
-            pts = previous.saturating_add(1);
+            // The capture timestamp failed to advance past the previous
+            // frame's PTS (duplicate, out-of-order or regressed clock — e.g.
+            // a future-stamped frame having seeded this chunk's origin).
+            // Advance by the stream's healthy frame gap and re-anchor the
+            // origin on this frame so the rest of the chunk resumes true
+            // capture spacing: one bad timestamp then costs one synthesized
+            // step instead of collapsing every remaining frame onto a 1 µs
+            // ramp (see `SYNTH_PTS_STEP_MIN_US` for the downstream failure
+            // that causes). The trade runs long by construction: every
+            // synthesized step stretches the chunk's timeline by up to one
+            // frame gap rather than ever shortening it.
+            let step = state
+                .observed_frame_gap_us
+                .unwrap_or(SYNTH_PTS_STEP_MIN_US)
+                .clamp(SYNTH_PTS_STEP_MIN_US, SYNTH_PTS_STEP_MAX_US);
+            if !state.pts_synth_warned {
+                state.pts_synth_warned = true;
+                // `behind_us` is how far this frame's capture stamp sits
+                // behind the previous frame's effective capture position —
+                // the size of the upstream disorder (µs-scale = logging
+                // jitter; seconds-scale = a recording-seam or clock event
+                // worth chasing at its source).
+                tracing::warn!(
+                    sensor_name,
+                    timestamp_us,
+                    previous_pts_us = previous,
+                    step_us = step,
+                    behind_us = origin_us + previous as i64 - timestamp_us,
+                    "video frame timestamp did not advance past the previous \
+                     frame's PTS; synthesizing step (logged once per chunk)"
+                );
+            }
+            pts = previous.saturating_add(step);
+            state.pts_origin_us = Some(timestamp_us.saturating_sub(pts as i64));
+        } else if pts - previous <= SYNTH_PTS_STEP_MAX_US {
+            // Only a plausible frame interval counts as the healthy gap: a
+            // forward spike (a future-stamped frame mid-chunk) must not become
+            // the step used to recover from the regression it causes.
+            state.observed_frame_gap_us = Some(pts - previous);
         }
     }
 
@@ -1083,7 +1149,7 @@ fn append_frame_locked(
             width: state.width,
             height: state.height,
             time_base_num: 1,
-            time_base_den: 1_000_000,
+            time_base_den: VIDEO_SPOOL_TICKS_PER_SECOND,
         };
         match NutWriter::create(&chunk_path, config) {
             Ok(writer) => state.nut_writer = Some(writer),
@@ -1290,6 +1356,8 @@ mod tests {
             frame_count: 0,
             pts_origin_us: None,
             last_pts_us: None,
+            observed_frame_gap_us: None,
+            pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }
@@ -1577,5 +1645,169 @@ mod tests {
         // Draining one frame frees headroom and admits the waiter.
         assert!(matches!(queue.pop(), WriterMsg::Frame(_)));
         assert!(pusher.join().unwrap().is_ok());
+    }
+
+    /// One frame interval at ~60 fps, in microseconds.
+    const FRAME_GAP_US: i64 = 16_683;
+
+    /// Append one frame stamped `timestamp_us` to `state`, using a geometry
+    /// large enough (4096×4096, ~48 MiB logical per frame) that a chunk rolls
+    /// after six frames — the PTS-collapse scenarios all sit at chunk
+    /// rotation, so tests need cheap rolls. The payload is a stand-in blob:
+    /// the NUT muxes it verbatim and these tests only read back PTS.
+    fn append_ts_us(state: &mut VideoChunkState, timestamp_us: i64) -> Vec<Envelope> {
+        append_frame_locked(
+            state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            4096,
+            4096,
+            &[0u8; 4],
+            timestamp_us * 1_000,
+            timestamp_us as f64 / 1e6,
+        )
+    }
+
+    /// Read back every sealed chunk's frame PTS from `spool_dir`, in chunk
+    /// open order (spool filenames embed the strictly-increasing open time).
+    fn sealed_chunk_pts(spool_dir: &std::path::Path) -> Vec<Vec<u64>> {
+        let mut chunk_names: Vec<PathBuf> = std::fs::read_dir(spool_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        chunk_names.sort();
+        chunk_names
+            .iter()
+            .map(|path| crate::nut_writer::read_frame_pts(&std::fs::read(path).unwrap()))
+            .collect()
+    }
+
+    /// The canonical PTS vector for six frames at the test cadence: one
+    /// synthesized step (equal to the learned gap) followed by re-anchored
+    /// capture-relative spacing reproduces the true capture timeline exactly.
+    fn capture_relative_pts() -> Vec<u64> {
+        (0..6).map(|index| (index * FRAME_GAP_US) as u64).collect()
+    }
+
+    #[test]
+    fn future_stamped_chunk_open_frame_does_not_collapse_the_chunk() {
+        // Regression: a single future-stamped frame arriving exactly
+        // at a chunk rotation used to seed the fresh chunk's PTS origin, pin
+        // every following frame's `relative_us` at 0, and collapse the whole
+        // chunk onto a 1 µs ramp ([0, 1, 2, 3, 4, 5] here). The per-chunk
+        // transcode then guesses a microsecond frame rate for that segment
+        // and the stream-copy concat turns it into the non-monotonic PTS the
+        // backend rejects as "Video missing logged frames" — even though the
+        // capture timestamps of all the other frames were pristine.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 4096, 4096);
+        let base: i64 = 1_753_000_000_000_000;
+
+        // Chunk 1: six clean ~60 fps frames (seals on the sixth).
+        for index in 0..6 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        // Chunk 2 opens on a frame stamped ~5 s in the future; the remaining
+        // frames continue the true capture series.
+        append_ts_us(&mut state, base + 6 * FRAME_GAP_US + 5_000_000);
+        for index in 7..12 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state);
+
+        // The poisoned frame lands at 0; the first true frame costs one
+        // synthesized step at the learned gap and re-anchors, so the rest of
+        // the chunk reproduces the capture-relative timeline exactly.
+        let chunks = sealed_chunk_pts(dir.path());
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0], capture_relative_pts());
+        assert_eq!(chunks[1], capture_relative_pts());
+    }
+
+    #[test]
+    fn mid_chunk_timestamp_regression_does_not_collapse_the_tail() {
+        // Regression, mid-chunk variant: a capture-clock rewind
+        // inside a chunk used to pin `relative_us` at 0 for the rest of the
+        // chunk, cramming every remaining frame onto the 1 µs ramp
+        // ([0, 16683, 33366, 33367, 33368, 33369] here).
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 4096, 4096);
+        let base: i64 = 1_753_000_000_000_000;
+
+        for index in 0..3 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        // The clock rewinds ~10 s mid-chunk and keeps advancing at 60 fps.
+        for index in 3..6 {
+            append_ts_us(&mut state, base - 10_000_000 + index * FRAME_GAP_US);
+        }
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state);
+
+        // The rewound frame costs one synthesized step at the learned gap and
+        // re-anchors, so the tail keeps capture-relative spacing.
+        let chunks = sealed_chunk_pts(dir.path());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], capture_relative_pts());
+    }
+
+    #[test]
+    fn forward_timestamp_spike_does_not_poison_the_healthy_gap() {
+        // A frame stamped far in the future *mid-chunk* passes the monotonic
+        // branch (the phantom freeze it leaves is the accepted, run-long
+        // trade), but its jump must not be recorded as the stream's healthy
+        // gap: the very next frame — which regresses relative to the spike —
+        // must be synthesized at the camera's learned cadence, not at the
+        // clamp ceiling.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 4096, 4096);
+        let base: i64 = 1_753_000_000_000_000;
+
+        for index in 0..3 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        // Frame 3 spikes ~5 s forward; frames 4 and 5 resume the true series.
+        append_ts_us(&mut state, base + 3 * FRAME_GAP_US + 5_000_000);
+        for index in 4..6 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state);
+
+        let spike = 5_000_000 + 3 * FRAME_GAP_US;
+        let expected: Vec<u64> = vec![
+            0,
+            FRAME_GAP_US as u64,
+            (2 * FRAME_GAP_US) as u64,
+            // The spike itself stays where it was stamped...
+            spike as u64,
+            // ...and recovery advances by the learned gap, then re-anchored
+            // capture spacing — not by `SYNTH_PTS_STEP_MAX_US`.
+            (spike + FRAME_GAP_US) as u64,
+            (spike + 2 * FRAME_GAP_US) as u64,
+        ];
+        let chunks = sealed_chunk_pts(dir.path());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], expected);
+    }
+
+    #[test]
+    fn clean_monotonic_input_keeps_chunk_relative_capture_pts() {
+        // The happy path must stay byte-identical: every chunk's PTS are the
+        // frame's capture time relative to the chunk's first frame.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 4096, 4096);
+        let base: i64 = 1_753_000_000_000_000;
+
+        for index in 0..12 {
+            append_ts_us(&mut state, base + index * FRAME_GAP_US);
+        }
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state);
+
+        let expected: Vec<u64> = (0..6).map(|index| (index * FRAME_GAP_US) as u64).collect();
+        let chunks = sealed_chunk_pts(dir.path());
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0], expected);
+        assert_eq!(chunks[1], expected);
     }
 }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -97,6 +97,16 @@ pub mod service_name {
         - VIDEO_CHUNK_HEADER_RESERVE)
         / VIDEO_CHUNK_BYTES_PER_FRAME) as u32;
 
+    /// The microsecond clock shared by every stage of the video path: the
+    /// producer writes spool NUT chunks with a `1/1_000_000` time base, and
+    /// the daemon pins its per-chunk encode outputs to the same clock
+    /// (`-enc_time_base` / `-video_track_timescale`). Sharing one constant
+    /// keeps the two in lockstep — if they diverge, ffmpeg falls back to a
+    /// per-chunk *guessed* frame rate, chunks of one recording land on
+    /// different timescales, and the stream-copy concat corrupts the merged
+    /// video's PTS.
+    pub const VIDEO_SPOOL_TICKS_PER_SECOND: u32 = 1_000_000;
+
     /// Subscriber buffer depth for the lifecycle service.
     ///
     /// Lossless, in-order delivery is *not* a function of this depth: the


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
Fixed the lossy video issue behind the dashboard "Video missing logged frames". This happened because ffmpeg segment's encoder time base and mp4 track timescale from a per-chunk *guessed* frame rate; the guess is unstable across the chunks of one recording whole chunks get crammed onto consecutive single ticks with backwards decoded PTS.
 
  - `encode_chunk` now pins every output to the NUT's microsecond clock so segment PTS equal the capture timestamps and the concat is uniform: no cramming, no backwards PTS, capture jitter preserved. Verified A/B: the previously-corrupting mixed-chunk concat now decodes monotonic.
  - Hardened the producer's PTS derivation as defence in depth:  Clean input is byte-identical (regression-tested).

> No data was lost due to this bug so i am migrating the existing recordings that have been uploaded

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1164](https://neuracore.atlassian.net/browse/NCP-1164)
