### PR TITLE
fix: retry connection resets

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,7 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+The requests-based HTTP session now retries requests that fail because the
+connection was dropped before a response arrived (TCP resets, stale keep-alive
+reuse), matching the retry behaviour of the aiohttp stack.

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -409,6 +409,7 @@ respawns
 restartability
 resumably
 RETRYABLE
+REUSEADDR
 rgba
 rgbd
 rgbs

--- a/neuracore/core/utils/http_session.py
+++ b/neuracore/core/utils/http_session.py
@@ -27,13 +27,50 @@ from aiohttp import (
 )
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+from urllib3.exceptions import ProtocolError
 
 logger = logging.getLogger(__name__)
 
-_RETRY = Retry(
+_DROPPED_CONNECTION_ERRORS = (
+    ConnectionResetError,
+    ConnectionAbortedError,
+    BrokenPipeError,
+)
+
+
+def _is_dropped_connection(error: Exception) -> bool:
+    """Whether the error means the connection died without delivering a response.
+
+    Covers stale keep-alive reuse, TCP resets from proxies/NAT (including during
+    the TLS handshake) and ``RemoteDisconnected`` (a ``ConnectionResetError``
+    subclass). Errors where response bytes did arrive, such as a garbled status
+    line, are excluded.
+    """
+    return isinstance(error, ProtocolError) and any(
+        isinstance(arg, _DROPPED_CONNECTION_ERRORS) for arg in error.args
+    )
+
+
+class _DroppedConnectionRetry(Retry):
+    """Retry policy that treats dropped connections as connection errors.
+
+    urllib3 classifies a ``ProtocolError`` on an established connection as a
+    read error, which this policy disables. A dropped connection never
+    delivered a response, so it is safe to retry under the ``connect`` budget,
+    mirroring ``retry_connection_failures`` on the aiohttp stack.
+    """
+
+    def _is_connection_error(self, err: Exception) -> bool:
+        return super()._is_connection_error(err) or _is_dropped_connection(err)
+
+    def _is_read_error(self, err: Exception) -> bool:
+        return super()._is_read_error(err) and not _is_dropped_connection(err)
+
+
+_RETRY = _DroppedConnectionRetry(
     total=3,  # cap total retry attempts across all categories
-    connect=3,  # retry conn establishment failures (stale keep-alive reuse lands here)
-    read=0,  # never retry after bytes left the wire
+    connect=3,  # conn establishment failures and dropped connections land here
+    read=0,  # never retry once response bytes have arrived
     status=0,  # no status-code retries; let 5xx raise immediately
     backoff_factor=0.1,  # 0.1s, 0.2s, 0.4s between retries (~0.7s worst case)
     allowed_methods=False,  # type: ignore[arg-type]  # False = retry all methods

--- a/tests/unit/core/utils/test_http_session.py
+++ b/tests/unit/core/utils/test_http_session.py
@@ -1,3 +1,5 @@
+import socket
+import struct
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -9,6 +11,7 @@ import requests_mock
 from aiohttp import ClientSession, ServerDisconnectedError, web
 from aiohttp.test_utils import TestServer
 from requests.adapters import HTTPAdapter
+from urllib3.exceptions import MaxRetryError, ProtocolError
 
 from neuracore.core.utils import http_session
 from neuracore.core.utils.http_session import (
@@ -313,4 +316,106 @@ class TestTransientRetryBehaviour:
             response = thread_local_session().get(server.url)
         assert response.status_code == 503
         assert server.call_count == 1
+        _reset_thread_local()
+
+
+class _ScriptedSocketServer:
+    """Raw socket server replaying one scripted action per connection.
+
+    Actions: ``rst`` aborts with a TCP reset after reading the request,
+    ``fin`` closes cleanly without responding, ``garbled`` answers with a
+    malformed status line and ``ok`` serves a minimal HTTP 200. The final
+    action repeats for any additional connections.
+    """
+
+    def __init__(self, actions: list[str]) -> None:
+        self.actions = actions
+        self.connections = 0
+        self._listener = socket.socket()
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind(("127.0.0.1", 0))
+        self._listener.listen(8)
+        self.url = f"http://127.0.0.1:{self._listener.getsockname()[1]}/resource"
+
+    def __enter__(self) -> "_ScriptedSocketServer":
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._listener.close()
+        self._thread.join(timeout=5)
+
+    def _serve(self) -> None:
+        while True:
+            try:
+                connection, _ = self._listener.accept()
+            except OSError:
+                return
+            action = self.actions[min(self.connections, len(self.actions) - 1)]
+            self.connections += 1
+            connection.recv(65536)
+            if action == "rst":
+                connection.setsockopt(
+                    socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                )
+            elif action == "garbled":
+                connection.sendall(b"banana\r\n\r\n")
+            elif action == "ok":
+                connection.sendall(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Length: 4\r\nConnection: close\r\n\r\nbody"
+                )
+            connection.close()
+
+
+class TestDroppedConnectionRetry:
+    def test_reset_counts_against_connect_budget(self):
+        reset_error = ProtocolError(
+            "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+        )
+        updated = http_session._RETRY.increment("POST", "/resource", error=reset_error)
+        assert updated.connect == http_session._RETRY.connect - 1
+
+    def test_garbled_response_exhausts_immediately(self):
+        from http.client import BadStatusLine
+
+        garbled_error = ProtocolError("Connection aborted.", BadStatusLine("banana"))
+        with pytest.raises(MaxRetryError):
+            http_session._RETRY.increment("GET", "/resource", error=garbled_error)
+
+    def test_recovers_from_connection_reset(self):
+        _reset_thread_local()
+        with _ScriptedSocketServer(["rst", "ok"]) as server:
+            response = thread_local_session().get(server.url)
+        assert response.status_code == 200
+        assert server.connections == 2
+
+    def test_recovers_from_server_disconnect(self):
+        _reset_thread_local()
+        with _ScriptedSocketServer(["fin", "ok"]) as server:
+            response = thread_local_session().get(server.url)
+        assert response.status_code == 200
+        assert server.connections == 2
+
+    def test_retries_resets_on_post(self):
+        _reset_thread_local()
+        with _ScriptedSocketServer(["rst", "ok"]) as server:
+            response = thread_local_session().post(server.url, json={"a": 1})
+        assert response.status_code == 200
+        assert server.connections == 2
+
+    def test_gives_up_when_resets_persist(self):
+        _reset_thread_local()
+        with _ScriptedSocketServer(["rst"]) as server:
+            with pytest.raises(requests.exceptions.ConnectionError):
+                thread_local_session().get(server.url)
+        assert server.connections == 4  # first attempt + three retries
+
+    def test_garbled_response_is_not_retried(self):
+        _reset_thread_local()
+        with _ScriptedSocketServer(["garbled"]) as server:
+            with pytest.raises(requests.exceptions.ConnectionError):
+                thread_local_session().get(server.url)
+        assert server.connections == 1
         _reset_thread_local()


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Requests that fail because the connection died before any response arrived (TCP reset, stale keep-alive reuse, abrupt proxy/NAT close) are now retried under the existing `connect` budget. 
 - Added unit tests covering recovery from injected RSTs and clean disconnects on GET and POST, retry-budget exhaustion, and the no-retry guarantee for garbled responses.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1172](https://neuracore.atlassian.net/browse/NCP-1172)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore_backend/pull/476

### Verification

Reproduced the CI failure locally by running the real backend under the production gunicorn config behind a proxy adding 25ms latency, driving it with this session module at the keep-alive deadline:

| Scenario | Before | After |
|---|---|---|
| Reuse race at server keep-alive deadline | 9 failures / 51 requests, 0 retries | 0 failures / 51, 15 resets absorbed |
| Injected RST on a fresh connection | instant `Max retries exceeded` | success after retry |