### PR TITLE
feat: estimate minimum disk size for training

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -14,6 +14,7 @@ from neuracore_types import (
     GPUType,
     SynchronizationDetails,
     TrainingJobRequest,
+    estimate_min_disk_size_gb,
 )
 
 from neuracore.core.config.get_current_org import get_current_org
@@ -156,13 +157,19 @@ def start_training_run(
         )
     )
 
-    # Validate that the machine size is large enough for the dataset.
-    dataset_size_gb = dataset.size_bytes / 1_000_000_000
-    if disk_size_gb <= dataset_size_gb:
+    # Validate that the machine disk is large enough for training workloads.
+    min_disk_size_gb = estimate_min_disk_size_gb(
+        size_bytes=dataset.size_bytes,
+        num_demonstrations=len(dataset),
+        hydra_arg_name=algorithm_name,
+        input_cross_embodiment_description=input_cross_embodiment_description,
+        output_cross_embodiment_description=output_cross_embodiment_description,
+    )
+    if disk_size_gb < min_disk_size_gb:
         raise ValueError(
-            f"Dataset {dataset_name} is {dataset_size_gb:.2f} GB, "
-            f"but selected VM disk is {disk_size_gb} GB. "
-            "Please increase disk_size_gb."
+            f"Estimated minimum disk for this training job is "
+            f"{min_disk_size_gb} GB, but selected VM disk is "
+            f"{disk_size_gb} GB. Please increase disk_size_gb."
         )
 
     validate_training_params(

--- a/tests/unit/api/test_training.py
+++ b/tests/unit/api/test_training.py
@@ -904,7 +904,7 @@ def test_start_training_run_raises_when_disk_size_too_small(
     algorithm_list_response,
     mocked_org_id,
 ):
-    """start_training_run rejects disks that cannot fit the dataset."""
+    """start_training_run rejects disks below the estimated minimum."""
     nc.login("test_api_key")
     dataset_id = "dataset123"
     dataset_response = Dataset(
@@ -936,14 +936,20 @@ def test_start_training_run_raises_when_disk_size_too_small(
         status_code=200,
     )
     mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/recording/by-dataset/{dataset_id}",
+        json={"data": [], "total": 20, "limit": 1, "start_after": None},
+        status_code=200,
+    )
+    mock_auth_requests.post(
         f"{API_URL}/org/{mocked_org_id}/training/jobs",
         json={"id": "should_not_create"},
         status_code=200,
     )
 
     expected_message = (
-        "Dataset test_dataset is 2.00 GB, but selected VM disk is 1 GB. "
-        "Please increase disk_size_gb."
+        "Estimated minimum disk for this training job is "
+        r"\d+ GB, but selected VM disk is 1 GB\. "
+        "Please increase disk_size_gb\\."
     )
     with pytest.raises(ValueError, match=expected_message):
         nc.start_training_run(


### PR DESCRIPTION
### Features
- Use estimated minimum disk size for training instead of just the dataset size

### Items
 - [NCRL-732](https://neuracore.atlassian.net/browse/NCRL-732)

### Related PRs
- https://github.com/NeuracoreAI/neuracore_types/pull/104
