### PR TITLE
fix: disable timer coalescing for mac

### DIFF
--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -62,6 +62,10 @@ jobs:
         path: "."
         extras: dev
 
+    - name: Disable timer coalescing (macOS)
+      if: runner.os == 'macOS'
+      run: sudo sysctl -w kern.timer.coalescing_enabled=0
+
     - name: Run Data Daemon Integration Tests
       env:
         NEURACORE_API_URL: https://staging.api.neuracore.com/api


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Mac scheduler batches software timers that are milliseconds apart. Disable this so that time.sleep values are properly respected for stochastic test cases. 
