### PR TITLE
fix: wait for explicit recording upload completion

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -32,6 +32,9 @@ from .globals import GlobalSingleton
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_STOP_RECORDING_WAIT_TIMEOUT_S = 60 * 15
+_RECORDING_UPLOAD_POLL_INTERVAL_S = 0.2
+
 
 def _get_robot(robot_name: str | None, instance: int) -> Robot:
     """Get a robot by name and instance.
@@ -305,6 +308,7 @@ def stop_recording(
     instance: int = 0,
     wait: bool = False,
     timestamp: float | None = None,
+    wait_timeout_s: float = _DEFAULT_STOP_RECORDING_WAIT_TIMEOUT_S,
 ) -> None:
     """Stop recording data for a specific robot.
 
@@ -320,6 +324,8 @@ def stop_recording(
         timestamp: Optional capture time (Unix seconds) for the recording's
             stop, matching the ``log_*`` methods. When omitted, the current
             time is captured.
+        wait_timeout_s: Maximum number of seconds to wait for recording uploads
+            to complete when ``wait=True``.
 
     Raises:
         RobotError: If no robot is active and no robot_name is provided.
@@ -334,6 +340,11 @@ def stop_recording(
     recording_id = robot.get_current_recording_id()
     if not recording_id:
         raise ValueError("Recording_id is None, no current recording")
+
+    if wait_timeout_s < 0:
+        raise ValueError("wait_timeout_s must be non-negative")
+
+    wait_deadline = time.monotonic() + wait_timeout_s if wait else None
     if is_rust_daemon_enabled():
         cloud_recording_id = robot.get_cloud_recording_id() if wait else None
         robot.stop_recording(
@@ -349,15 +360,18 @@ def stop_recording(
         if not wait:
             return
 
-    # TODO: We need to instead check that the specific recording is complete
-    is_traces_registered = False
-    while True:
-        data_traces = backend_utils.get_active_data_traces(recording_id)
-        if len(data_traces) > 0:
-            is_traces_registered = True
-        elif len(data_traces) == 0 and is_traces_registered:
-            break
-        time.sleep(0.2)
+    assert wait_deadline is not None
+
+    while time.monotonic() < wait_deadline:
+        if backend_utils.is_recording_upload_complete(recording_id):
+            return
+
+        time.sleep(_RECORDING_UPLOAD_POLL_INTERVAL_S)
+
+    raise TimeoutError(
+        "Timed out waiting for recording uploads to complete "
+        f"for recording '{recording_id}'"
+    )
 
 
 def get_cloud_recording_id(

--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -31,18 +31,50 @@ def get_active_data_traces(recording_id: str) -> list[RecordingDataTrace]:
         requests.HTTPError: If the API request fails.
         ValueError: If the response has an unexpected format.
         ConfigError: If there is an error trying to get the current org.
+        requests.RequestException: If the API request fails or times out.
     """
     org_id = get_current_org()
     session = thread_local_session()
     response = session.get(
         f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/active",
         headers=get_auth().get_headers(),
+        timeout=10,
     )
     if response.status_code == 404:
         return []
     response.raise_for_status()
     data = response.json() or []
     return [RecordingDataTrace.model_validate(item) for item in data]
+
+
+def is_recording_upload_complete(recording_id: str) -> bool:
+    """Check whether all expected traces for a recording are uploaded.
+
+    Args:
+        recording_id: Unique identifier of the recording to check.
+
+    Returns:
+        True when all expected traces are uploaded, otherwise False.
+
+    Raises:
+        requests.HTTPError: If the API returns an unsuccessful response.
+        requests.RequestException: If the request fails or times out.
+        TypeError: If the response is not a boolean.
+    """
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.get(
+        f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/complete",
+        headers=get_auth().get_headers(),
+        timeout=10,
+    )
+    response.raise_for_status()
+
+    data = response.json()
+    if not isinstance(data, bool):
+        raise TypeError("Expected a boolean recording upload-completion response")
+
+    return data
 
 
 def synced_dataset_key(sync_freq: int, data_types: list[DataType]) -> str:

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock
 
 import pytest
 import requests
@@ -206,9 +207,120 @@ def test_update_robot_name_forwards_arguments(monkeypatch):
     assert robot_id == "robot_id_123"
 
 
+def test_get_active_data_traces_uses_request_timeout(monkeypatch) -> None:
+    response = Mock(status_code=200)
+    response.json.return_value = []
+
+    session = Mock()
+    session.get.return_value = response
+
+    auth = Mock()
+    auth.get_headers.return_value = {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "thread_local_session",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_current_org",
+        lambda: "org-123",
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_auth",
+        lambda: auth,
+    )
+
+    result = api_core.backend_utils.get_active_data_traces("recording-123")
+
+    assert result == []
+    session.get.assert_called_once()
+
+    request_kwargs = session.get.call_args.kwargs
+    assert request_kwargs.get("timeout") == 10
+
+
+@pytest.mark.parametrize("complete", [True, False])
+def test_is_recording_upload_complete_returns_backend_state(
+    monkeypatch,
+    complete: bool,
+) -> None:
+    response = Mock()
+    response.json.return_value = complete
+
+    session = Mock()
+    session.get.return_value = response
+
+    auth = Mock()
+    auth.get_headers.return_value = {"Authorization": "Bearer test-token"}
+
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "thread_local_session",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_current_org",
+        lambda: "org-123",
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_auth",
+        lambda: auth,
+    )
+
+    result = api_core.backend_utils.is_recording_upload_complete("recording-123")
+
+    assert result is complete
+    session.get.assert_called_once_with(
+        (f"{API_URL}/org/org-123/recording/" "recording-123/traces/complete"),
+        headers={"Authorization": "Bearer test-token"},
+        timeout=10,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_is_recording_upload_complete_rejects_invalid_response(
+    monkeypatch,
+) -> None:
+    response = Mock()
+    response.json.return_value = {"complete": True}
+
+    session = Mock()
+    session.get.return_value = response
+
+    auth = Mock()
+    auth.get_headers.return_value = {}
+
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "thread_local_session",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_current_org",
+        lambda: "org-123",
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "get_auth",
+        lambda: auth,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="Expected a boolean recording upload-completion response",
+    ):
+        api_core.backend_utils.is_recording_upload_complete("recording-123")
+
+
 def test_stop_recording_forwards_wait_flag_to_robot(monkeypatch) -> None:
     calls: list[tuple[str, bool]] = []
-    active_trace_rows = iter(([{"id": "trace-1"}], []))
+    completion_checks: list[str] = []
 
     class _FakeRobot:
         def is_recording(self) -> bool:
@@ -226,13 +338,24 @@ def test_stop_recording_forwards_wait_flag_to_robot(monkeypatch) -> None:
         ) -> None:
             calls.append((recording_id, wait_for_producer_drain))
 
+    def is_upload_complete(recording_id: str) -> bool:
+        completion_checks.append(recording_id)
+        return True
+
     monkeypatch.setattr(
-        api_core, "_get_robot", lambda robot_name, instance: _FakeRobot()
+        api_core,
+        "_get_robot",
+        lambda robot_name, instance: _FakeRobot(),
+    )
+    monkeypatch.setattr(
+        api_core,
+        "is_rust_daemon_enabled",
+        lambda: False,
     )
     monkeypatch.setattr(
         api_core.backend_utils,
-        "get_active_data_traces",
-        lambda recording_id: next(active_trace_rows),
+        "is_recording_upload_complete",
+        is_upload_complete,
     )
 
     nc.stop_recording(wait=False)
@@ -242,3 +365,73 @@ def test_stop_recording_forwards_wait_flag_to_robot(monkeypatch) -> None:
         ("rec-123", False),
         ("rec-123", True),
     ]
+    assert completion_checks == ["rec-123"]
+
+
+def test_stop_recording_wait_times_out_when_upload_never_completes(
+    monkeypatch,
+) -> None:
+    poll_count = 0
+
+    class _FakeRobot:
+        def is_recording(self) -> bool:
+            return True
+
+        def get_current_recording_id(self) -> str:
+            return "rec-123"
+
+        def stop_recording(
+            self,
+            recording_id: str,
+            *,
+            wait_for_producer_drain: bool = True,
+            timestamp: float | None = None,
+        ) -> None:
+            pass
+
+    def upload_never_completes(recording_id: str) -> bool:
+        nonlocal poll_count
+        poll_count += 1
+        return False
+
+    # First call creates the deadline:
+    #     0.0 + 1.0 = 1.0
+    # Second call allows one poll:
+    #     0.0 < 1.0
+    # Third call passes the deadline:
+    #     2.0 > 1.0
+    clock = iter((0.0, 0.0, 2.0))
+
+    monkeypatch.setattr(
+        api_core,
+        "_get_robot",
+        lambda robot_name, instance: _FakeRobot(),
+    )
+    monkeypatch.setattr(
+        api_core,
+        "is_rust_daemon_enabled",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        api_core.backend_utils,
+        "is_recording_upload_complete",
+        upload_never_completes,
+    )
+    monkeypatch.setattr(
+        api_core.time,
+        "monotonic",
+        lambda: next(clock),
+    )
+    monkeypatch.setattr(
+        api_core.time,
+        "sleep",
+        lambda _seconds: None,
+    )
+
+    with pytest.raises(
+        TimeoutError,
+        match="Timed out waiting for recording uploads to complete",
+    ):
+        nc.stop_recording(wait=True, wait_timeout_s=1.0)
+
+    assert poll_count == 1


### PR DESCRIPTION
### Bugfixes
- Fix the Data Daemon network wait performance test hanging until GitHub Actions cancels the job.
- Fix stop_recording(wait=True) hanging when traces complete before the SDK observes them as active. The previous loop required seeing a non-empty active-trace response before accepting an empty response as completion.
- Poll the backend’s explicit upload-completion endpoint and add request and overall polling timeouts.
- Staging logs showed thousands of successful 101-byte /traces/active responses, consistent with repeated empty lists, while trace registration and status updates succeeded—confirming a completion-state race rather than a persistent network failure.

### Related PRs
- https://github.com/NeuracoreAI/neuracore_backend/pull/478

successful run - https://github.com/NeuracoreAI/neuracore/actions/runs/30270506004/job/89992090436 