### PR TITLE
fix: skip stochastic cases on mac

### DIFF
--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -124,6 +124,22 @@ def skip_rust_only_cases(request: pytest.FixtureRequest) -> None:
 
 
 @pytest.fixture(autouse=True)
+def skip_other_os_cases(request: pytest.FixtureRequest) -> None:
+    """Skip cases whose ``run_on_os`` does not include the running platform.
+
+    Cases default to every OS; a case (or its batch) narrows the selection when
+    the workload cannot hold its guarantees on a given platform — e.g.
+    stochastic-timestamp cases opt out of darwin, whose scheduler cannot meet
+    their per-frame deadlines.
+    """
+    if "case" not in request.fixturenames:
+        return
+    case = request.getfixturevalue("case")
+    if not case.runs_on_current_os:
+        pytest.skip(f"case does not run on {sys.platform} (run_on_os={case.run_on_os})")
+
+
+@pytest.fixture(autouse=True)
 def apply_batch_start_storage_state(request: pytest.FixtureRequest) -> None:
     """Apply local storage cleanup once before the first case in each batch.
 

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -5,6 +5,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DURATION_MODE_FIXED,
     DURATION_MODE_VARIABLE,
     MODE_STAGGERED,
+    OS_EXCEPT_DARWIN,
     PRODUCER_PER_THREAD,
     TIMESTAMP_MODE_REAL,
     TIMESTAMP_MODE_STOCHASTIC,
@@ -88,6 +89,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         joint_fps=250,  # previously 500 but flaky due to sync
         producer_channels=PRODUCER_PER_THREAD,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
         wait=False,
         requires_rust_daemon=True,
     ),
@@ -179,6 +181,7 @@ NETWORK_INTEGRITY_CASES = (
         joint_fps=250,  # previously 500 but flaky due to sync
         producer_channels=PRODUCER_PER_THREAD,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
         wait=False,
     ),
     DataDaemonTestCase(
@@ -272,6 +275,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         video_fps=15,
         joint_fps=15,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -397,6 +401,7 @@ NETWORK_PERFORMANCE_CASES = (
         video_fps=15,
         joint_fps=15,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
     ),
     DataDaemonTestCase(
         duration_sec=300,
@@ -410,6 +415,7 @@ NETWORK_PERFORMANCE_CASES = (
         video_fps=15,
         joint_fps=15,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
         wait=True,
     ),
     DataDaemonTestCase(
@@ -445,6 +451,7 @@ NETWORK_PERFORMANCE_CASES = (
         joint_fps=250,
         producer_channels=PRODUCER_PER_THREAD,
         timestamp_mode=TIMESTAMP_MODE_STOCHASTIC,
+        run_on_os=OS_EXCEPT_DARWIN,
         wait=False,
     ),
 )

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING
@@ -40,6 +41,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     TIMESTAMP_MODE_STOCHASTIC,
     StopMethod,
     StorageStateAction,
+    TestOs,
     TimestampMode,
 )
 
@@ -162,6 +164,12 @@ class DataDaemonTestCase:
             long-running workloads that the Python daemon cannot sustain use
             this flag so they still exercise the Rust daemon in CI without
             failing the legacy suite.
+        run_on_os: Operating systems the case runs on, as ``sys.platform``
+            values (see ``OS_ALL`` / ``OS_EXCEPT_DARWIN``).  ``None`` (default)
+            means every OS; set a tuple to opt out of the platforms it omits, and
+            the case is skipped at collection time elsewhere.  A batch-level
+            ``run_on_os`` only fills in cases that leave this ``None``, so a
+            per-case selection always wins over the batch's.
         video_codec: When set (e.g. ``"h264_medium"``), the case selects that
             global video codec via ``nc.set_video_encoding_options`` before
             recording, so RGB cameras upload a single lossy CRF-23 video and the
@@ -196,7 +204,13 @@ class DataDaemonTestCase:
     timestamp_mode: TimestampMode = TIMESTAMP_MODE_MANUAL
     skip: bool = False
     requires_rust_daemon: bool = False
+    run_on_os: tuple[TestOs, ...] | None = None
     video_codec: str | None = None
+
+    @property
+    def runs_on_current_os(self) -> bool:
+        """Return True when this case is selected for the running platform."""
+        return self.run_on_os is None or sys.platform in self.run_on_os
 
     @property
     def has_video(self) -> bool:
@@ -257,6 +271,11 @@ class DataDaemonTestBatch:
             against the Rust data daemon and is skipped on the legacy Python
             daemon.  When ``False`` (default), each case keeps its own per-case
             ``requires_rust_daemon`` value.
+        run_on_os: Default OS selection for cases that do not specify one; see
+            ``DataDaemonTestCase.run_on_os``.  Unlike the infrastructure params
+            above this does *not* override the cases: any case with its own
+            ``run_on_os`` keeps it.  ``None`` (default) leaves every case
+            running on all platforms.
     """
 
     cases: tuple[DataDaemonTestCase, ...]
@@ -267,6 +286,7 @@ class DataDaemonTestBatch:
     timestamp_mode: TimestampMode | None = None
     skip: bool = False
     requires_rust_daemon: bool = False
+    run_on_os: tuple[TestOs, ...] | None = None
 
     def as_cases(self) -> list[DataDaemonTestCase]:
         """Return cases with batch-level infrastructure params applied."""
@@ -290,6 +310,13 @@ class DataDaemonTestBatch:
                     if f.name not in _BATCH_PARAMS
                 },
                 **batch_overrides,
+                # Batch OS selection is a default, not an override: a case that
+                # names its own platforms keeps them.
+                **(
+                    {"run_on_os": self.run_on_os}
+                    if self.run_on_os is not None and c.run_on_os is None
+                    else {}
+                ),
             })
             for c in self.cases
         ]

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -51,6 +51,11 @@ DURATION_MODE_VARIABLE = "variable"
 DURATION_VARIABLE_MIN_FACTOR = 0.75
 DURATION_VARIABLE_MAX_FACTOR = 1.25
 
+# run_on_os (values match ``sys.platform``)
+OS_LINUX = "linux"
+OS_DARWIN = "darwin"
+OS_WINDOWS = "win32"
+
 # timestamp_mode
 TIMESTAMP_MODE_MANUAL = "manual"
 TIMESTAMP_MODE_REAL = "real"
@@ -89,6 +94,9 @@ TIMESTAMP_MODES = (
     TIMESTAMP_MODE_REAL,
     TIMESTAMP_MODE_STOCHASTIC,
 )
+OS_ALL = (OS_LINUX, OS_DARWIN, OS_WINDOWS)
+# The macOS scheduler cannot hold the per-frame deadlines stochastic cases assert.
+OS_EXCEPT_DARWIN = (OS_LINUX, OS_WINDOWS)
 
 # ---------------------------------------------------------------------------
 # Type aliases (for type hints)
@@ -97,6 +105,7 @@ TIMESTAMP_MODES = (
 StopMethod = Literal["cli", "sigterm", "sigkill"]
 StorageStateAction = Literal["delete", "preserve", "empty"]
 TimestampMode = Literal["manual", "real", "stochastic"]
+TestOs = Literal["linux", "darwin", "win32"]
 
 MAX_TIME_TO_START_S = 20.0
 STOP_RECORDING_OVERHEAD_PER_SEC = 0.5


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Stochastic Cases don't play nice with the MacOs CI Runner so turn them off
