### PR TITLE
fix: retry transient recording completion checks

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -366,7 +366,11 @@ def stop_recording(
         if backend_utils.is_recording_upload_complete(recording_id):
             return
 
-        time.sleep(_RECORDING_UPLOAD_POLL_INTERVAL_S)
+        remaining_s = wait_deadline - time.monotonic()
+        if remaining_s <= 0:
+            break
+
+        time.sleep(min(_RECORDING_UPLOAD_POLL_INTERVAL_S, remaining_s))
 
     raise TimeoutError(
         "Timed out waiting for recording uploads to complete "

--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -62,7 +62,7 @@ def is_recording_upload_complete(recording_id: str) -> bool:
         TypeError: If the response is not a boolean.
     """
     org_id = get_current_org()
-    session = thread_local_session()
+    session = thread_local_session(retry_read_timeout=True)
     response = session.get(
         f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/complete",
         headers=get_auth().get_headers(),

--- a/neuracore/core/utils/http_session.py
+++ b/neuracore/core/utils/http_session.py
@@ -84,15 +84,30 @@ _TRANSIENT_RETRY = _RETRY.new(
     raise_on_status=False,  # return the final response rather than raising
 )
 
+_READ_TIMEOUT_RETRY = _RETRY.new(
+    read=2,
+    allowed_methods=frozenset({"GET", "HEAD"}),
+)
+
+_TRANSIENT_READ_TIMEOUT_RETRY = _TRANSIENT_RETRY.new(
+    read=2,
+    allowed_methods=frozenset({"GET", "HEAD"}),
+)
+
 _thread_local = threading.local()
 
 
-def thread_local_session(retry_transient: bool = False) -> requests.Session:
+def thread_local_session(
+    retry_transient: bool = False,
+    retry_read_timeout: bool = False,
+) -> requests.Session:
     """Return a retry-enabled Session cached per thread and process.
 
     Args:
-        retry_transient: Retry transient backend statuses with exponential
-            backoff, returning the final response when attempts are exhausted.
+        retry_transient: Retry transient backend status codes with exponential
+            backoff.
+        retry_read_timeout: Retry idempotent GET and HEAD requests that time out
+            while waiting for a response.
 
     Returns:
         The cached Session for this thread, process and retry policy.
@@ -103,18 +118,26 @@ def thread_local_session(retry_transient: bool = False) -> requests.Session:
         _thread_local.sessions = {}
         _thread_local.pid = pid
 
-    session = _thread_local.sessions.get(retry_transient)
+    session_key = (retry_transient, retry_read_timeout)
+    session = _thread_local.sessions.get(session_key)
 
     if session is None:
         session = requests.Session()
 
-        adapter = HTTPAdapter(
-            max_retries=_TRANSIENT_RETRY if retry_transient else _RETRY
-        )
+        if retry_transient and retry_read_timeout:
+            retry_policy = _TRANSIENT_READ_TIMEOUT_RETRY
+        elif retry_read_timeout:
+            retry_policy = _READ_TIMEOUT_RETRY
+        elif retry_transient:
+            retry_policy = _TRANSIENT_RETRY
+        else:
+            retry_policy = _RETRY
+
+        adapter = HTTPAdapter(max_retries=retry_policy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)
 
-        _thread_local.sessions[retry_transient] = session
+        _thread_local.sessions[session_key] = session
 
     return session
 

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -256,10 +256,12 @@ def test_is_recording_upload_complete_returns_backend_state(
     auth = Mock()
     auth.get_headers.return_value = {"Authorization": "Bearer test-token"}
 
+    session_factory = Mock(return_value=session)
+
     monkeypatch.setattr(
         api_core.backend_utils,
         "thread_local_session",
-        lambda: session,
+        session_factory,
     )
     monkeypatch.setattr(
         api_core.backend_utils,
@@ -273,6 +275,8 @@ def test_is_recording_upload_complete_returns_backend_state(
     )
 
     result = api_core.backend_utils.is_recording_upload_complete("recording-123")
+
+    session_factory.assert_called_once_with(retry_read_timeout=True)
 
     assert result is complete
     session.get.assert_called_once_with(
@@ -295,10 +299,12 @@ def test_is_recording_upload_complete_rejects_invalid_response(
     auth = Mock()
     auth.get_headers.return_value = {}
 
+    session_factory = Mock(return_value=session)
+
     monkeypatch.setattr(
         api_core.backend_utils,
         "thread_local_session",
-        lambda: session,
+        session_factory,
     )
     monkeypatch.setattr(
         api_core.backend_utils,
@@ -316,6 +322,8 @@ def test_is_recording_upload_complete_rejects_invalid_response(
         match="Expected a boolean recording upload-completion response",
     ):
         api_core.backend_utils.is_recording_upload_complete("recording-123")
+
+    session_factory.assert_called_once_with(retry_read_timeout=True)
 
 
 def test_stop_recording_forwards_wait_flag_to_robot(monkeypatch) -> None:

--- a/tests/unit/core/utils/test_http_session.py
+++ b/tests/unit/core/utils/test_http_session.py
@@ -11,7 +11,7 @@ import requests_mock
 from aiohttp import ClientSession, ServerDisconnectedError, web
 from aiohttp.test_utils import TestServer
 from requests.adapters import HTTPAdapter
-from urllib3.exceptions import MaxRetryError, ProtocolError
+from urllib3.exceptions import MaxRetryError, ProtocolError, ReadTimeoutError
 
 from neuracore.core.utils import http_session
 from neuracore.core.utils.http_session import (
@@ -419,3 +419,65 @@ class TestDroppedConnectionRetry:
                 thread_local_session().get(server.url)
         assert server.connections == 1
         _reset_thread_local()
+
+
+class TestReadTimeoutRetrySession:
+    def test_read_timeout_session_is_cached_separately(self):
+        _reset_thread_local()
+
+        plain = thread_local_session()
+        read_retry = thread_local_session(retry_read_timeout=True)
+
+        assert read_retry is not plain
+        assert thread_local_session(retry_read_timeout=True) is read_retry
+
+    def test_read_timeout_retry_config(self):
+        _reset_thread_local()
+
+        retry = (
+            thread_local_session(retry_read_timeout=True).get_adapter(_URL).max_retries
+        )
+
+        assert retry.total == 3
+        assert retry.connect == 3
+        assert retry.read == 2
+        assert retry.status == 0
+        assert retry.allowed_methods == frozenset({"GET", "HEAD"})
+
+    def test_combined_retry_config(self):
+        _reset_thread_local()
+
+        retry = (
+            thread_local_session(
+                retry_transient=True,
+                retry_read_timeout=True,
+            )
+            .get_adapter(_URL)
+            .max_retries
+        )
+
+        assert retry.read == 2
+        assert retry.status == 2
+        assert retry.allowed_methods == frozenset({"GET", "HEAD"})
+
+    def test_get_read_timeout_consumes_read_retry_budget(self):
+        error = ReadTimeoutError(None, "/resource", "Read timed out")
+
+        updated = http_session._READ_TIMEOUT_RETRY.increment(
+            method="GET",
+            url="/resource",
+            error=error,
+        )
+
+        assert updated.total == 2
+        assert updated.read == 1
+
+    def test_post_read_timeout_is_not_retried(self):
+        error = ReadTimeoutError(None, "/resource", "Read timed out")
+
+        with pytest.raises(ReadTimeoutError):
+            http_session._READ_TIMEOUT_RETRY.increment(
+                method="POST",
+                url="/resource",
+                error=error,
+            )


### PR DESCRIPTION
### Bugfixes

- Retry transient connection errors and read timeouts while polling recording upload completion, preventing `stop_recording(wait=True)` from failing during temporary backend capacity or connection disruption.
- Validated with the previously affected large staging integration case: transient failures were retried successfully and the test passed.

Successful staging run: https://github.com/NeuracoreAI/neuracore/actions/runs/30354571394/job/90260030430