### PR TITLE
feat: rust daemon on by default

### DIFF
--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -105,7 +105,6 @@ jobs:
         env:
           NEURACORE_API_URL: https://staging.api.neuracore.com/api
           NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
-          NCD_RUST_DAEMON: "1"
           NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
           NEURACORE_ENDPOINT_TIMEOUT: 30
         run: |

--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-staging.yaml
@@ -117,7 +117,6 @@ jobs:
       env:
         NEURACORE_API_URL: https://staging.api.neuracore.com/api
         NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
-        NCD_RUST_DAEMON: "1"
         NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
         NEURACORE_ENDPOINT_TIMEOUT: 30
         ALGORITHM_NAME: ${{ matrix.algorithm }}

--- a/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-staging.yaml
@@ -98,7 +98,6 @@ jobs:
       env:
         NEURACORE_API_URL: https://staging.api.neuracore.com/api
         NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
-        NCD_RUST_DAEMON: "1"
         NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
         ALGORITHM_NAME: ${{ matrix.algorithm }}
       run: pytest -o log_cli=true --log-cli-level=INFO -v -k test_start_training "$TEST_HARNESS_PATH"

--- a/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-staging.yaml
@@ -95,7 +95,6 @@ jobs:
       env:
         NEURACORE_API_URL: https://staging.api.neuracore.com/api
         NEURACORE_API_KEY: ${{ secrets.STAGING_SERVICE_API_KEY }}
-        NCD_RUST_DAEMON: "1"
         NEURACORE_ORG_ID: ${{ vars.STAGING_SERVICE_ORG_ID }}
         TEST_CASE: ${{ matrix.algorithm }}_${{ matrix.gpu_type }}
         MAX_ATTEMPTS: "5"

--- a/.github/workflows/integration-pf-data-daemon-production.yaml
+++ b/.github/workflows/integration-pf-data-daemon-production.yaml
@@ -25,16 +25,15 @@ jobs:
 
   test:
     needs: pre-commit
-    # Use the Rust data daemon for the production integration suite.
-    runs-on: ubuntu-24.04
-    env:
-      NCD_RUST_DAEMON: "1"
+    # Exercise the released wheel's bundled Rust daemon on each shipped OS
+    # (Linux x86_64, macOS arm64) across the Python support range.
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
-        python-version: ['3.11']
-        ffmpeg: [true, false]
+        python-version: ['3.10', '3.14']
+        os: [ubuntu-24.04, macos-26]
 
     steps:
     - name: Show disk space
@@ -66,7 +65,16 @@ jobs:
         NEURACORE_API_KEY: ${{ secrets.PROD_SERVICE_API_KEY }}
         NEURACORE_ORG_ID: ${{ vars.PROD_SERVICE_ORG_ID }}
         NEURACORE_PROVIDE_LIVE_DATA: false
-      run: pytest -o log_cli=true --log-cli-level=INFO tests/integration/platform/data_daemon/
+
+      # --import-mode=importlib keeps the repo root off sys.path. Without it
+      # pytest prepends it (tests/ is a package up to the root) and `import
+      # neuracore` resolves to the checked-out source instead of the installed
+      # wheel — where the bundled daemon binary is gitignored, so the Rust
+      # daemon is unreachable and the suite falls back to Python.
+      run: >-
+        pytest -o log_cli=true --log-cli-level=INFO
+        --import-mode=importlib
+        tests/integration/platform/data_daemon/
 
     - name: Show disk space after tests
       run: df -h /

--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -29,8 +29,6 @@ jobs:
     # bundled native artefacts on each shipped OS (Linux x86_64, macOS arm64)
     # across the Python support range.
     runs-on: ${{ matrix.os }}
-    env:
-      NCD_RUST_DAEMON: "1"
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/integration-pf-streaming-staging.yaml
+++ b/.github/workflows/integration-pf-streaming-staging.yaml
@@ -26,8 +26,6 @@ jobs:
   test:
     needs: pre-commit
     runs-on: ${{ matrix.os }}
-    env:
-      NCD_RUST_DAEMON: "1"
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,10 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+The Rust data daemon is now the default. Installs that ship the bundled
+`data-daemon` binary — the published Linux x86_64 and Apple-Silicon macOS
+wheels — use it without any opt-in; `NCD_RUST_DAEMON=1` is no longer needed.
+Set `NCD_RUST_DAEMON=0` to pin a process back to the legacy Python daemon.
+Where the bundled binary is absent (a source checkout that has not run
+`rust/scripts/build_wheel_artefacts.sh`, or a platform with no published
+wheel), the Python daemon is still used automatically.

--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -33,7 +33,7 @@ pip install -e .
 ```
 
 Recommended for video recording, and **required** when running the Rust daemon
-(`NCD_RUST_DAEMON=1`):
+(the default):
 
 ```bash
 sudo apt-get update && sudo apt-get install -y ffmpeg
@@ -124,16 +124,17 @@ neuracore data-daemon launch
 ```
 
 the CLI launches the daemon as a separate background process. There are two
-daemon implementations and the launcher picks one based on the `NCD_RUST_DAEMON`
-flag (see [rust_data_daemon_development.md](rust_data_daemon_development.md)):
+daemon implementations and the launcher picks one (see
+[rust_data_daemon_development.md](rust_data_daemon_development.md)):
 
-- **Rust daemon** — when `NCD_RUST_DAEMON` is truthy,
-  the launcher `exec`s the native binary bundled in the `neuracore` wheel
-  (Linux x86_64 and Apple-Silicon macOS) at
+- **Rust daemon (default)** — the launcher `exec`s the native binary bundled in
+  the `neuracore` wheel (Linux x86_64 and Apple-Silicon macOS) at
   `neuracore/data_daemon/bin/data-daemon`. This is the implementation described
   throughout this guide.
-- **Legacy Python daemon (default)** — when `NCD_RUST_DAEMON` is unset or not
-  truthy, the launcher runs the Python implementation instead.
+- **Legacy Python daemon** — used when `NCD_RUST_DAEMON` is set to a falsy value
+  (`0`, `false`, `no`, `n`), or when the bundled binary is not present at all —
+  a source install that never ran `rust/scripts/build_wheel_artefacts.sh`, or a
+  platform with no published wheel.
 
 Either daemon process:
 - boots the internal components it needs
@@ -548,11 +549,11 @@ neuracore data-daemon launch
 
 Both daemons encode video with `ffmpeg`, but they handle a missing or broken
 `ffmpeg` differently:
-- **Rust daemon** (`NCD_RUST_DAEMON=1`) — verifies `ffmpeg` at startup. If the
+- **Rust daemon** (default) — verifies `ffmpeg` at startup. If the
   binary is missing from `PATH`, or the local build cannot run the encode the
   daemon needs, the preflight fails and the daemon refuses to start (rather than
   starting and silently dropping every video recording).
-- **Legacy Python daemon** (default) — uses the `ffmpeg` CLI when it is on
+- **Legacy Python daemon** — uses the `ffmpeg` CLI when it is on
   `PATH` and falls back to PyAV when `ffmpeg` is unavailable or fails to
   initialise.
 

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -218,14 +218,16 @@ maturin develop
 python -c "import neuracore.data_daemon._data_bridge as p; print(p)"
 ```
 
-To route the Python SDK through the data bridge instead of the legacy zmq one, set the rollout flag:
+The SDK routes through the data bridge by default. To pin a run to the legacy zmq producer and the Python daemon instead, set the rollout flag falsy:
 
 ```bash
-export NCD_RUST_DAEMON=1
+export NCD_RUST_DAEMON=0
 python your_script.py
 ```
 
 Selection logic lives in [neuracore/data_daemon/rust_selection.py](../neuracore/data_daemon/rust_selection.py); both the daemon binary handoff and the SDK's `DataStream` construction read it. A small shim bridges the data bridge to the Python `ProducerChannel` contract.
+
+With the flag unset, the default is gated on the daemon binary actually being present. This matters during development because `maturin develop` builds only the `_data_bridge` extension — the binary comes from `rust/scripts/build_wheel_artefacts.sh`. Without that gate, a bridge-only build would put the SDK on the Rust producer while the *Python* daemon consumed the other end. Run the artefacts script (or set `NCD_RUST_DAEMON=1` deliberately) when you want the Rust daemon in a source checkout.
 
 ---
 

--- a/neuracore/data_daemon/__main__.py
+++ b/neuracore/data_daemon/__main__.py
@@ -1,9 +1,8 @@
 """Entry point for ``python -m neuracore.data_daemon``.
 
-By default this runs the Python data daemon CLI. When the
-``NCD_RUST_DAEMON`` environment variable is truthy and the bundled Rust
-data-daemon binary is present, execution is handed off to it instead. The
-flag keeps the Python daemon available throughout the rollout window.
+By default this hands off to the bundled Rust data-daemon binary, falling back
+to the Python data daemon CLI when that binary is absent or unusable. Setting
+``NCD_RUST_DAEMON`` to a falsy value pins the process to the Python daemon.
 """
 
 from __future__ import annotations
@@ -43,9 +42,8 @@ def main() -> None:
                 # executable, ENOEXEC); fall back to the Python daemon rather
                 # than crashing the rollout.
                 print(
-                    f"NCD_RUST_DAEMON is set but the bundled Rust data-daemon "
-                    f"binary could not be executed ({error}); falling back to "
-                    "the Python daemon.",
+                    "The bundled Rust data-daemon binary could not be "
+                    f"executed ({error}); falling back to the Python daemon.",
                     file=sys.stderr,
                 )
 

--- a/neuracore/data_daemon/communications_management/shared_transport/recording_context.py
+++ b/neuracore/data_daemon/communications_management/shared_transport/recording_context.py
@@ -19,7 +19,7 @@ _DATA_BRIDGE_IMPORT_HINT = (
     "neuracore.data_daemon._data_bridge is not available. The Rust extension "
     "is bundled in the neuracore wheel (prebuilt for Linux x86_64 and "
     "Apple-Silicon macOS); reinstall with `pip install neuracore` on one of "
-    "those platforms, or unset NCD_RUST_DAEMON to fall back to the legacy "
+    "those platforms, or set NCD_RUST_DAEMON=0 to fall back to the legacy "
     "Python data daemon."
 )
 

--- a/neuracore/data_daemon/rust_selection.py
+++ b/neuracore/data_daemon/rust_selection.py
@@ -1,8 +1,8 @@
-"""Runtime selection between the legacy Python daemon and the Rust rewrite.
+"""Runtime selection between the Rust data daemon and the legacy Python one.
 
-Centralises the ``NCD_RUST_DAEMON`` environment-variable check used by both
-the CLI entry point ([__main__.py](neuracore/data_daemon/__main__.py)) and
-SDK-side producer routing in
+Centralises the daemon choice used by both the CLI entry point
+([__main__.py](neuracore/data_daemon/__main__.py)) and SDK-side producer
+routing in
 [neuracore/core/streaming/data_stream.py](neuracore/core/streaming/data_stream.py)
 so both surfaces agree on which daemon is in play for a given process.
 
@@ -13,15 +13,40 @@ heavyweight runtime modules.
 from __future__ import annotations
 
 import os
+from functools import lru_cache
 from importlib.resources import files
 from pathlib import Path
 
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "y"})
+_FALSY_VALUES = frozenset({"0", "false", "no", "n"})
 
 
 def is_rust_daemon_enabled() -> bool:
-    """Return True when ``NCD_RUST_DAEMON`` selects the Rust data daemon."""
-    return os.environ.get("NCD_RUST_DAEMON", "").strip().lower() in _TRUTHY_VALUES
+    """Return True when the Rust data daemon should handle this process.
+
+    The Rust daemon is the default. ``NCD_RUST_DAEMON`` overrides in both
+    directions: a falsy value pins the process to the legacy Python daemon, and
+    a truthy value demands Rust even where the bundled binary is missing (the
+    launcher reports its own fallback in that case).
+    """
+    raw = os.environ.get("NCD_RUST_DAEMON", "").strip().lower()
+    if raw in _FALSY_VALUES:
+        return False
+    if raw in _TRUTHY_VALUES:
+        return True
+    return _bundled_binary_available()
+
+
+@lru_cache(maxsize=1)
+def _bundled_binary_available() -> bool:
+    """Return True when the daemon binary ships in this install, cached.
+
+    Whether the binary is on disk cannot change within a process, while
+    ``is_rust_daemon_enabled`` sits on per-frame paths such as
+    [log_camera_data](neuracore/api/logging.py) — so the resource traversal in
+    ``rust_daemon_binary_path`` must not run once per logged sample.
+    """
+    return rust_daemon_binary_path() is not None
 
 
 def rust_daemon_binary_path() -> Path | None:

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_shared_slot_reopen.py
@@ -41,10 +41,12 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.skipif(
-    is_rust_daemon_enabled(),
-    reason="Shared-slot reopen applies only to the legacy Python daemon",
-)
+
+@pytest.fixture(autouse=True)
+def skip_on_rust_daemon() -> None:
+    """Skip this Python-only test when the Rust daemon is the active backend."""
+    if is_rust_daemon_enabled():
+        pytest.skip("Shared-slot reopen applies only to the legacy Python daemon")
 
 
 _CASE = DataDaemonTestCase(

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -160,7 +160,8 @@ class DataDaemonTestCase:
             this per-case value.
         requires_rust_daemon: When ``True``, the case only runs against the
             Rust data daemon and is skipped when the legacy Python daemon is
-            active (``NCD_RUST_DAEMON`` unset).  High-contention, high-rate, and
+            active (``NCD_RUST_DAEMON`` falsy, or no bundled binary to run).
+            High-contention, high-rate, and
             long-running workloads that the Python daemon cannot sustain use
             this flag so they still exercise the Rust daemon in CI without
             failing the legacy suite.

--- a/tests/unit/core/test_data_stream.py
+++ b/tests/unit/core/test_data_stream.py
@@ -148,6 +148,20 @@ def _context(recording_id: str = "rec-1") -> DataRecordingContext:
     )
 
 
+@pytest.fixture(autouse=True)
+def use_python_daemon(monkeypatch) -> None:
+    """Pin the module to the legacy zmq producer channel.
+
+    The rust daemon is the default at runtime, so without this the file's
+    coverage would swing with whether a daemon binary happens to be installed.
+    Cases that want the rust path call ``_use_rust_daemon`` to re-patch.
+    """
+    monkeypatch.setattr(
+        "neuracore.core.streaming.data_stream.is_rust_daemon_enabled",
+        lambda: False,
+    )
+
+
 def test_rgb_stream_uses_video_specific_producer_settings(monkeypatch) -> None:
     _FakeProducerChannel.instances.clear()
     monkeypatch.setattr(

--- a/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
+++ b/tests/unit/data_daemon/lifecycle/test_daemon_os_control.py
@@ -1,8 +1,18 @@
+"""OS control coverage for the default (Rust) daemon backend.
+
+Behaviour the legacy Python runner does differently — unix-socket readiness,
+parent-owned PID file, its own argv — lives in
+[test_python_daemon_os_control.py](test_python_daemon_os_control.py).
+"""
+
 from __future__ import annotations
 
 import os
 import signal
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import IO, cast
 
 import pytest
@@ -14,7 +24,10 @@ from neuracore.data_daemon.lifecycle.daemon_os_control import (
     install_signal_handlers,
     launch_daemon_subprocess,
     remove_pid_file,
+    reset_daemon_state,
 )
+
+DEAD_PID = 999999
 
 
 class _FakePopen:
@@ -36,6 +49,22 @@ class _FakePopen:
         self._poll_value = -15
 
 
+@pytest.fixture(autouse=True)
+def rust_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Pin the module to the Rust daemon and return the fake binary path.
+
+    Both the flag and the binary lookup are pinned so these tests do not depend
+    on whether a bundled ``data-daemon`` binary happens to be installed on the
+    machine running the suite.
+    """
+    binary_path = tmp_path / "data-daemon"
+    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
+    monkeypatch.setattr(
+        daemon_os_control, "rust_daemon_binary_path", lambda: binary_path
+    )
+    return binary_path
+
+
 def test_acquire_pid_file_rejects_running_pid(tmp_path: Path) -> None:
     pid_path = tmp_path / "daemon.pid"
     pid_path.write_text(str(os.getpid()), encoding="utf-8")
@@ -46,7 +75,7 @@ def test_acquire_pid_file_rejects_running_pid(tmp_path: Path) -> None:
 
 def test_acquire_pid_file_clears_stale_pid(tmp_path: Path) -> None:
     pid_path = tmp_path / "daemon.pid"
-    pid_path.write_text("999999", encoding="utf-8")
+    pid_path.write_text(str(DEAD_PID), encoding="utf-8")
 
     assert acquire_pid_file(pid_path) is True
     assert pid_path.read_text(encoding="utf-8").strip() == str(os.getpid())
@@ -76,10 +105,6 @@ def test_rust_launch_waits_for_ipc_health_not_pid_only(
         pid_path.write_text(str(fake_pid), encoding="utf-8")
         return _FakePopen(pid=fake_pid, poll_value=None)
 
-    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
-    monkeypatch.setattr(
-        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
-    )
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
     monkeypatch.setattr(
@@ -111,10 +136,6 @@ def test_rust_launch_times_out_when_only_pid_appears(
         pid_path.write_text(str(fake_pid), encoding="utf-8")
         return _FakePopen(pid=fake_pid, poll_value=None)
 
-    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
-    monkeypatch.setattr(
-        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
-    )
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(
         daemon_os_control, "_rust_daemon_ready", lambda *_args, **_kwargs: False
@@ -145,23 +166,37 @@ def test_ensure_daemon_running_existing_rust_pid_waits_for_health(
 
     monkeypatch.setattr(daemon_os_control, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(daemon_os_control, "get_daemon_db_path", lambda: db_path)
-    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: True)
-    monkeypatch.setattr(
-        daemon_os_control, "rust_daemon_binary_path", lambda: tmp_path / "data-daemon"
-    )
     monkeypatch.setattr(daemon_os_control, "_rust_daemon_ready", fake_ready)
 
     assert daemon_os_control.ensure_daemon_running(timeout_s=2.5) == os.getpid()
     assert calls == [2.5]
 
 
-def test_launch_daemon_subprocess_redirects_stdio_in_background(
+def test_ensure_daemon_running_rejects_running_but_never_ready_daemon(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A live PID with a dead IPC listener must fail rather than look healthy."""
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    monkeypatch.setattr(daemon_os_control, "get_daemon_pid_path", lambda: pid_path)
+    monkeypatch.setattr(daemon_os_control, "get_daemon_db_path", lambda: db_path)
+    monkeypatch.setattr(
+        daemon_os_control, "_rust_daemon_ready", lambda *_args, **_kwargs: False
+    )
+
+    with pytest.raises(DaemonLifecycleError) as exc_info:
+        daemon_os_control.ensure_daemon_running(timeout_s=0.0)
+
+    assert "did not become ready" in str(exc_info.value)
+
+
+def test_launch_daemon_subprocess_runs_bundled_binary_and_redirects_stdio(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, rust_mode: Path
 ) -> None:
     pid_path = tmp_path / "daemon.pid"
     db_path = tmp_path / "state.db"
-    fake_socket_path = tmp_path / "management.sock"
-    fake_socket_path.touch()
     captured: dict[str, object] = {}
 
     def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
@@ -171,7 +206,7 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
 
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
-    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", fake_socket_path)
+    monkeypatch.setattr(daemon_os_control, "_rust_daemon_ready", lambda *_, **__: True)
 
     proc = launch_daemon_subprocess(
         pid_path=pid_path,
@@ -180,6 +215,7 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
     )
 
     assert proc.pid == 54321
+    assert captured["command"] == [str(rust_mode), "launch"]
     assert captured["start_new_session"] is True
     assert captured["stdin"] is daemon_os_control.subprocess.DEVNULL
     assert captured["stdout"] is daemon_os_control.subprocess.DEVNULL
@@ -197,8 +233,10 @@ def test_launch_daemon_subprocess_redirects_stdio_in_background(
     assert isinstance(env, dict)
     assert env["NEURACORE_DAEMON_PID_PATH"] == str(pid_path)
     assert env["NEURACORE_DAEMON_DB_PATH"] == str(db_path)
-    assert env["NEURACORE_DAEMON_MANAGE_PID"] == "0"
-    assert pid_path.read_text(encoding="utf-8").strip() == "54321"
+    # The Rust binary owns its PID file, so the parent must neither claim it via
+    # NEURACORE_DAEMON_MANAGE_PID=0 nor write it itself.
+    assert "NEURACORE_DAEMON_MANAGE_PID" not in env
+    assert not pid_path.exists()
 
 
 def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
@@ -206,8 +244,6 @@ def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
 ) -> None:
     pid_path = tmp_path / "daemon.pid"
     db_path = tmp_path / "state.db"
-    fake_socket_path = tmp_path / "management.sock"
-    fake_socket_path.touch()
     captured: dict[str, object] = {}
 
     def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
@@ -217,7 +253,7 @@ def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
 
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
-    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", fake_socket_path)
+    monkeypatch.setattr(daemon_os_control, "_rust_daemon_ready", lambda *_, **__: True)
 
     proc = launch_daemon_subprocess(
         pid_path=pid_path,
@@ -235,7 +271,8 @@ def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
     env = captured["env"]
     assert isinstance(env, dict)
     assert env["NEURACORE_DAEMON_PROFILE"] == "demo"
-    assert pid_path.read_text(encoding="utf-8").strip() == "65432"
+    assert "NEURACORE_DAEMON_MANAGE_PID" not in env
+    assert not pid_path.exists()
 
 
 def test_launch_daemon_subprocess_premature_exit_includes_stderr(
@@ -243,25 +280,173 @@ def test_launch_daemon_subprocess_premature_exit_includes_stderr(
 ) -> None:
     pid_path = tmp_path / "daemon.pid"
     db_path = tmp_path / "state.db"
-    fake_socket_path = tmp_path / "management.sock"
 
     def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
         # The real daemon writes its failure to the stderr target before it
         # exits; emulate that so the parent can read it back from the log file.
         stderr_target = cast(IO[bytes], kwargs["stderr"])
-        stderr_target.write(b"ImportError: No module named 'foo'")
+        stderr_target.write(b"failed to open iceoryx2 service")
         return _FakePopen(pid=99999, poll_value=1)
 
     monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
-    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", fake_socket_path)
 
     with pytest.raises(RuntimeError) as exc_info:
         launch_daemon_subprocess(pid_path=pid_path, db_path=db_path, background=True)
 
     message = str(exc_info.value)
     assert "exit code 1" in message
-    assert "ImportError: No module named 'foo'" in message
+    assert "failed to open iceoryx2 service" in message
+
+
+def _install_fake_bridge(
+    monkeypatch: pytest.MonkeyPatch, wait_until_ready: object
+) -> None:
+    """Expose a stand-in ``_data_bridge`` module to the health probe.
+
+    ``importlib.import_module`` returns an existing ``sys.modules`` entry, so
+    seeding one lets these tests drive the probe without a built extension.
+    """
+    monkeypatch.setitem(
+        sys.modules,
+        "neuracore.data_daemon._data_bridge",
+        SimpleNamespace(wait_until_ready=wait_until_ready),
+    )
+
+
+def test_rust_daemon_ready_returns_false_without_pid_file(tmp_path: Path) -> None:
+    assert daemon_os_control._rust_daemon_ready(tmp_path / "missing.pid") is False
+
+
+def test_rust_daemon_ready_returns_false_for_dead_pid(tmp_path: Path) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(DEAD_PID), encoding="utf-8")
+
+    assert daemon_os_control._rust_daemon_ready(pid_path) is False
+
+
+def test_rust_daemon_ready_returns_false_when_bridge_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A source install without the built extension must not report readiness."""
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    def raise_import_error(_name: str) -> object:
+        raise ImportError("no module named _data_bridge")
+
+    monkeypatch.setattr(
+        daemon_os_control,
+        "importlib",
+        SimpleNamespace(import_module=raise_import_error),
+    )
+
+    assert daemon_os_control._rust_daemon_ready(pid_path) is False
+
+
+@pytest.mark.parametrize(
+    "error", [RuntimeError("probe failed"), AttributeError("gone")]
+)
+def test_rust_daemon_ready_returns_false_when_probe_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, error: Exception
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    def raise_error(_timeout_s: float) -> int:
+        raise error
+
+    _install_fake_bridge(monkeypatch, raise_error)
+
+    assert daemon_os_control._rust_daemon_ready(pid_path) is False
+
+
+def test_rust_daemon_ready_returns_false_when_probe_answers_other_pid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stale PID file must not be validated by a different live daemon."""
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    _install_fake_bridge(monkeypatch, lambda _timeout_s: os.getpid() + 1)
+
+    assert daemon_os_control._rust_daemon_ready(pid_path) is False
+
+
+def test_rust_daemon_ready_returns_true_when_probe_answers_same_pid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+    timeouts: list[float] = []
+
+    def fake_wait_until_ready(timeout_s: float) -> int:
+        timeouts.append(timeout_s)
+        return os.getpid()
+
+    _install_fake_bridge(monkeypatch, fake_wait_until_ready)
+
+    assert daemon_os_control._rust_daemon_ready(pid_path, timeout_s=1.5) is True
+    assert timeouts == [1.5]
+
+
+def test_reset_daemon_state_delegates_to_bundled_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, rust_mode: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    captured: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        captured["command"] = command
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 3)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "run", fake_run)
+
+    exit_code = reset_daemon_state(pid_path=pid_path, db_path=db_path, assume_yes=True)
+
+    assert exit_code == 3
+    assert captured["command"] == [str(rust_mode), "reset", "--yes"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["NEURACORE_DAEMON_PID_PATH"] == str(pid_path)
+    assert env["NEURACORE_DAEMON_DB_PATH"] == str(db_path)
+
+
+def test_reset_daemon_state_without_assume_yes_keeps_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, rust_mode: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "run", fake_run)
+
+    assert (
+        reset_daemon_state(
+            pid_path=tmp_path / "daemon.pid",
+            db_path=tmp_path / "state.db",
+            assume_yes=False,
+        )
+        == 0
+    )
+    assert captured["command"] == [str(rust_mode), "reset"]
+
+
+def test_reset_daemon_state_requires_bundled_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(daemon_os_control, "rust_daemon_binary_path", lambda: None)
+
+    with pytest.raises(DaemonLifecycleError):
+        reset_daemon_state(
+            pid_path=tmp_path / "daemon.pid",
+            db_path=tmp_path / "state.db",
+            assume_yes=True,
+        )
 
 
 def test_install_signal_handlers_invokes_shutdown() -> None:

--- a/tests/unit/data_daemon/lifecycle/test_python_daemon_os_control.py
+++ b/tests/unit/data_daemon/lifecycle/test_python_daemon_os_control.py
@@ -1,0 +1,244 @@
+"""OS control coverage for the legacy Python daemon backend.
+
+Every test here runs with the daemon pinned to the Python runner, including the
+mode-agnostic ones (PID file, signal handlers, premature exit) that
+[test_daemon_os_control.py](test_daemon_os_control.py) also runs against the
+default Rust backend — so neither backend can regress them alone. What is unique
+to this file is the Python runner's own launch contract: unix-socket readiness,
+a parent-owned PID file, and its own argv.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import IO, cast
+
+import pytest
+
+import neuracore.data_daemon.lifecycle.daemon_os_control as daemon_os_control
+from neuracore.data_daemon.lifecycle.daemon_os_control import (
+    DaemonLifecycleError,
+    acquire_pid_file,
+    install_signal_handlers,
+    launch_daemon_subprocess,
+    remove_pid_file,
+)
+
+DEAD_PID = 999999
+
+
+class _FakePopen:
+    def __init__(
+        self,
+        pid: int = 12345,
+        poll_value: int | None = None,
+    ) -> None:
+        self.pid = pid
+        self._poll_value = poll_value
+        self.returncode = poll_value
+        self.stderr = None
+
+    def poll(self) -> int | None:
+        return self._poll_value
+
+    def terminate(self) -> None:
+        self.returncode = -15
+        self._poll_value = -15
+
+
+@pytest.fixture(autouse=True)
+def python_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Pin the module to the Python daemon and return its readiness socket path.
+
+    The socket is not created — a test signals readiness by touching it — and the
+    flag is pinned so these tests stay on the legacy path regardless of whether a
+    bundled ``data-daemon`` binary is installed on the machine running the suite.
+    """
+    socket_path = tmp_path / "management.sock"
+    monkeypatch.setattr(daemon_os_control, "is_rust_daemon_enabled", lambda: False)
+    monkeypatch.setattr(daemon_os_control, "SOCKET_PATH", socket_path)
+    return socket_path
+
+
+def test_acquire_pid_file_rejects_running_pid(tmp_path: Path) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    with pytest.raises(DaemonLifecycleError):
+        acquire_pid_file(pid_path)
+
+
+def test_acquire_pid_file_clears_stale_pid(tmp_path: Path) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(DEAD_PID), encoding="utf-8")
+
+    assert acquire_pid_file(pid_path) is True
+    assert pid_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_remove_pid_file_removes(tmp_path: Path) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text("123", encoding="utf-8")
+
+    remove_pid_file(pid_path)
+
+    assert not pid_path.exists()
+
+
+def test_launch_daemon_subprocess_runs_python_runner_and_redirects_stdio(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, python_mode: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    python_mode.touch()
+    captured: dict[str, object] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        captured["command"] = command
+        captured.update(kwargs)
+        return _FakePopen(pid=54321, poll_value=None)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+
+    proc = launch_daemon_subprocess(
+        pid_path=pid_path,
+        db_path=db_path,
+        background=True,
+    )
+
+    assert proc.pid == 54321
+    assert captured["command"] == [
+        sys.executable,
+        "-m",
+        "neuracore.data_daemon.runner_entry",
+    ]
+    assert captured["start_new_session"] is True
+    assert captured["stdin"] is daemon_os_control.subprocess.DEVNULL
+    assert captured["stdout"] is daemon_os_control.subprocess.DEVNULL
+    # Background stderr is routed to a sibling log file (not an undrained PIPE
+    # that would deadlock the daemon, nor DEVNULL that would hide failures).
+    stderr_target = captured["stderr"]
+    assert stderr_target is not daemon_os_control.subprocess.PIPE
+    assert stderr_target is not daemon_os_control.subprocess.DEVNULL
+    assert Path(stderr_target.name) == db_path.parent / "daemon.log"
+    assert (db_path.parent / "daemon.log").exists()
+    assert captured["close_fds"] is True
+    assert captured["cwd"] == str(Path.cwd())
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["NEURACORE_DAEMON_PID_PATH"] == str(pid_path)
+    assert env["NEURACORE_DAEMON_DB_PATH"] == str(db_path)
+    # The Python runner relies on the parent for the PID file, both for the
+    # hand-off flag and for the write itself.
+    assert env["NEURACORE_DAEMON_MANAGE_PID"] == "0"
+    assert pid_path.read_text(encoding="utf-8").strip() == "54321"
+
+
+def test_launch_daemon_subprocess_keeps_foreground_stdio_attached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, python_mode: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+    python_mode.touch()
+    captured: dict[str, object] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        captured["command"] = command
+        captured.update(kwargs)
+        return _FakePopen(pid=65432, poll_value=None)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+
+    proc = launch_daemon_subprocess(
+        pid_path=pid_path,
+        db_path=db_path,
+        background=False,
+        env_overrides={"NEURACORE_DAEMON_PROFILE": "demo"},
+    )
+
+    assert proc.pid == 65432
+    assert captured["start_new_session"] is False
+    assert not captured.get("stdin")
+    assert not captured.get("stdout")
+    assert not captured.get("stderr")
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["NEURACORE_DAEMON_PROFILE"] == "demo"
+    assert env["NEURACORE_DAEMON_MANAGE_PID"] == "0"
+    assert pid_path.read_text(encoding="utf-8").strip() == "65432"
+
+
+def test_launch_daemon_subprocess_times_out_when_socket_never_appears(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, python_mode: Path
+) -> None:
+    """The Python counterpart of the Rust IPC-probe timeout names the socket."""
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        return _FakePopen(pid=54321, poll_value=None)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        launch_daemon_subprocess(
+            pid_path=pid_path,
+            db_path=db_path,
+            background=True,
+            timeout_s=0.0,
+        )
+
+    assert f"socket {python_mode}" in str(exc_info.value)
+    assert not pid_path.exists()
+
+
+def test_launch_daemon_subprocess_premature_exit_includes_stderr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid_path = tmp_path / "daemon.pid"
+    db_path = tmp_path / "state.db"
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        # The real daemon writes its failure to the stderr target before it
+        # exits; emulate that so the parent can read it back from the log file.
+        stderr_target = cast(IO[bytes], kwargs["stderr"])
+        stderr_target.write(b"ImportError: No module named 'foo'")
+        return _FakePopen(pid=99999, poll_value=1)
+
+    monkeypatch.setattr(daemon_os_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_os_control.time, "sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        launch_daemon_subprocess(pid_path=pid_path, db_path=db_path, background=True)
+
+    message = str(exc_info.value)
+    assert "exit code 1" in message
+    assert "ImportError: No module named 'foo'" in message
+
+
+def test_install_signal_handlers_invokes_shutdown() -> None:
+    called: list[int] = []
+
+    def on_shutdown(signum: int) -> None:
+        called.append(signum)
+
+    orig_term = signal.getsignal(signal.SIGTERM)
+    orig_int = signal.getsignal(signal.SIGINT)
+    try:
+        install_signal_handlers(on_shutdown=on_shutdown)
+        handler = signal.getsignal(signal.SIGTERM)
+        assert handler is not None
+        with pytest.raises(KeyboardInterrupt):
+            handler(signal.SIGTERM, None)
+        assert called == [signal.SIGTERM]
+    finally:
+        signal.signal(signal.SIGTERM, orig_term)
+        signal.signal(signal.SIGINT, orig_int)

--- a/tests/unit/data_daemon/test_rust_selection.py
+++ b/tests/unit/data_daemon/test_rust_selection.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+import neuracore.data_daemon.rust_selection as rust_selection
+from neuracore.data_daemon.rust_selection import is_rust_daemon_enabled
+
+
+@pytest.fixture(autouse=True)
+def clear_availability_cache() -> None:
+    """Drop the cached binary lookup so each test controls availability itself."""
+    rust_selection._bundled_binary_available.cache_clear()
+    yield
+    rust_selection._bundled_binary_available.cache_clear()
+
+
+@pytest.fixture
+def binary_available(monkeypatch: pytest.MonkeyPatch):
+    """Return a setter for whether the bundled daemon binary appears present."""
+
+    def _set(present: bool) -> None:
+        monkeypatch.setattr(
+            rust_selection,
+            "rust_daemon_binary_path",
+            lambda: object() if present else None,
+        )
+        rust_selection._bundled_binary_available.cache_clear()
+
+    return _set
+
+
+def test_defaults_to_rust_when_binary_is_bundled(
+    monkeypatch: pytest.MonkeyPatch, binary_available
+) -> None:
+    monkeypatch.delenv("NCD_RUST_DAEMON", raising=False)
+    binary_available(True)
+    assert is_rust_daemon_enabled() is True
+
+
+def test_defaults_to_python_when_binary_is_missing(
+    monkeypatch: pytest.MonkeyPatch, binary_available
+) -> None:
+    """A bridge-only source install must not split across the two daemons."""
+    monkeypatch.delenv("NCD_RUST_DAEMON", raising=False)
+    binary_available(False)
+    assert is_rust_daemon_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "n", " 0 "])
+def test_falsy_flag_pins_to_python_even_with_binary(
+    monkeypatch: pytest.MonkeyPatch, binary_available, value: str
+) -> None:
+    monkeypatch.setenv("NCD_RUST_DAEMON", value)
+    binary_available(True)
+    assert is_rust_daemon_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "y", " 1 "])
+def test_truthy_flag_forces_rust_without_binary(
+    monkeypatch: pytest.MonkeyPatch, binary_available, value: str
+) -> None:
+    """An explicit opt-in still wins so CI can demand Rust and fail loudly."""
+    monkeypatch.setenv("NCD_RUST_DAEMON", value)
+    binary_available(False)
+    assert is_rust_daemon_enabled() is True
+
+
+def test_unrecognised_value_falls_through_to_availability(
+    monkeypatch: pytest.MonkeyPatch, binary_available
+) -> None:
+    monkeypatch.setenv("NCD_RUST_DAEMON", "maybe")
+    binary_available(True)
+    assert is_rust_daemon_enabled() is True
+    binary_available(False)
+    assert is_rust_daemon_enabled() is False
+
+
+def test_availability_lookup_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The check sits on per-frame logging paths, so it must not re-stat."""
+    monkeypatch.delenv("NCD_RUST_DAEMON", raising=False)
+    calls = 0
+
+    def _counting_path():
+        nonlocal calls
+        calls += 1
+        return object()
+
+    monkeypatch.setattr(rust_selection, "rust_daemon_binary_path", _counting_path)
+    rust_selection._bundled_binary_available.cache_clear()
+
+    for _ in range(5):
+        assert is_rust_daemon_enabled() is True
+
+    assert calls == 1


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Turn the rust daemon on by default - fallback to the python daemon if the value is false or the binary is not available
 - Separate os control tests specific to legacy python daemon

### Bug Fixes
 - Prod CI was using incorrect pytest collection methodology for running tests, `import-mode=importlib`. Bring it up to parity with staging.