### PR TITLE
fix: preserve recording duration during dataset imports

### DIFF
--- a/neuracore/importer/lerobot_importer.py
+++ b/neuracore/importer/lerobot_importer.py
@@ -150,6 +150,7 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
         if self.frequency is None:
             raise ImportError("Frequency is required for importing episodes.")
         base_time = time.time()
+        recording_stop_timestamp = base_time
         worker_label = (
             f"worker {self._worker_id}" if self._worker_id is not None else "worker 0"
         )
@@ -164,6 +165,7 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
             nc.start_recording(
                 robot_name=self.robot_name,
                 instance=self.robot_instance(self._worker_id),
+                timestamp=base_time,
             )
         step_iter, total_steps = self._iter_episode_steps(self._dataset, episode_id)
         self._emit_progress(
@@ -172,6 +174,7 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
         for step_idx, step_data in enumerate(step_iter, start=1):
             self._reset_step_state()
             timestamp = base_time + (step_idx / self.frequency)
+            recording_stop_timestamp = timestamp + (1.0 / self.frequency)
             try:
                 self._record_step(step_data, timestamp)
             except Exception as exc:  # noqa: BLE001
@@ -201,6 +204,7 @@ class LeRobotDatasetImporter(NeuracoreDatasetImporter):
                 robot_name=self.robot_name,
                 instance=self.robot_instance(self._worker_id),
                 wait=True,
+                timestamp=recording_stop_timestamp,
             )
         self.logger.info("[%s] Completed episode %s", worker_label, episode_id)
 

--- a/neuracore/importer/mcap/mcap_importer.py
+++ b/neuracore/importer/mcap/mcap_importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -133,18 +134,29 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
             f"Importing MCAP file {label} ({item.index + 1}/{len(self.mcap_files)})"
         )
 
+        recording_start_timestamp = time.time()
+        recording_stop_timestamp = recording_start_timestamp
+
         if not self.dry_run:
-            nc.start_recording(robot_name=self.robot_name, instance=instance)
+            nc.start_recording(
+                robot_name=self.robot_name,
+                instance=instance,
+                timestamp=recording_start_timestamp,
+            )
         try:
-            message_count = self._stream_episode_file(
+            message_count, recording_stop_timestamp = self._stream_episode_file(
                 episode_file_path=file_path,
                 item=item,
                 label=label,
+                recording_start_timestamp=recording_start_timestamp,
             )
         finally:
             if not self.dry_run:
                 nc.stop_recording(
-                    robot_name=self.robot_name, instance=instance, wait=True
+                    robot_name=self.robot_name,
+                    instance=instance,
+                    wait=True,
+                    timestamp=recording_stop_timestamp,
                 )
 
         self.logger.info(f"Completed MCAP file {label} | messages={message_count}")
@@ -168,12 +180,17 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
                 )
 
     def _stream_episode_file(
-        self, episode_file_path: Path, item: ImportItem, label: str
-    ) -> int:
+        self,
+        episode_file_path: Path,
+        item: ImportItem,
+        label: str,
+        recording_start_timestamp: float,
+    ) -> tuple[int, float]:
         """Stream messages from one MCAP episode file."""
         topics = get_mcap_topics(topic_map=self.topic_map)
         factories = list(self._decoder_factories or [])
-        base_timestamp: float | None = None
+        source_start_timestamp: float | None = None
+        recording_stop_timestamp = recording_start_timestamp
         message_count = 0
 
         with episode_file_path.open("rb") as stream:
@@ -195,9 +212,16 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
                 reader=reader,
                 topics=topics,
             ):
-                if base_timestamp is None:
-                    base_timestamp = decoded_message.timestamp_seconds
-                timestamp = max(0.0, decoded_message.timestamp_seconds - base_timestamp)
+                if source_start_timestamp is None:
+                    source_start_timestamp = decoded_message.timestamp_seconds
+
+                relative_timestamp = max(
+                    0.0,
+                    decoded_message.timestamp_seconds - source_start_timestamp,
+                )
+                timestamp = recording_start_timestamp + relative_timestamp
+                recording_stop_timestamp = max(recording_stop_timestamp, timestamp)
+
                 decoded_data = convert_decoded_mcap_data(
                     decoded_data=decoded_message.data
                 )
@@ -220,7 +244,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
             total_steps=total,
             episode_label=label,
         )
-        return message_count
+        return message_count, recording_stop_timestamp
 
     def _log_transformed_data(
         self,

--- a/neuracore/importer/rlds_tfds_importer.py
+++ b/neuracore/importer/rlds_tfds_importer.py
@@ -220,10 +220,12 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
             raise ImportError("Frequency is required for importing episodes.")
         total_steps = self._infer_total_steps(steps)
         base_time = time.time()
+        recording_stop_timestamp = base_time
         if not self.dry_run:
             nc.start_recording(
                 robot_name=self.robot_name,
                 instance=self.robot_instance(self._worker_id),
+                timestamp=base_time,
             )
         episode_label = (
             f"{item.split or 'episode'} #{item.index}"
@@ -247,6 +249,7 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
         for idx, step in enumerate(steps, start=1):
             self._reset_step_state()
             timestamp = base_time + (idx / self.frequency)
+            recording_stop_timestamp = timestamp + (1.0 / self.frequency)
             try:
                 self._record_step(step, timestamp)
             except Exception as exc:  # importer-specific policy hook
@@ -264,6 +267,7 @@ class RLDSAndTFDSDatasetImporterBase(NeuracoreDatasetImporter):
                 robot_name=self.robot_name,
                 instance=self.robot_instance(self._worker_id),
                 wait=True,
+                timestamp=recording_stop_timestamp,
             )
         self.logger.info("[%s] Completed %s", worker_label, episode_label)
 

--- a/tests/unit/importer/test_lerobot_importer_behavior.py
+++ b/tests/unit/importer/test_lerobot_importer_behavior.py
@@ -118,7 +118,13 @@ def test_lerobot_import_item_step_mode_skips_failing_steps():
     importer._record_step = MagicMock(side_effect=[ValueError("bad step"), None])
 
     with (
-        patch("neuracore.importer.lerobot_importer.nc.start_recording"),
+        patch(
+            "neuracore.importer.lerobot_importer.time.time",
+            return_value=100.0,
+        ),
+        patch(
+            "neuracore.importer.lerobot_importer.nc.start_recording"
+        ) as start_recording,
         patch(
             "neuracore.importer.lerobot_importer.nc.stop_recording"
         ) as stop_recording,
@@ -139,9 +145,19 @@ def test_lerobot_import_item_step_mode_skips_failing_steps():
         call(0, step=0, total_steps=2, episode_label="123"),
         call(0, step=2, total_steps=2, episode_label="123"),
     ])
-    stop_recording.assert_called_once_with(
-        robot_name="test_robot", instance=2, wait=True
+
+    start_recording.assert_called_once_with(
+        robot_name="test_robot",
+        instance=2,
+        timestamp=100.0,
     )
+
+    stop_recording.assert_called_once()
+    stop_kwargs = stop_recording.call_args.kwargs
+    assert stop_kwargs["robot_name"] == "test_robot"
+    assert stop_kwargs["instance"] == 2
+    assert stop_kwargs["wait"] is True
+    assert stop_kwargs["timestamp"] == pytest.approx(100.3)
 
 
 def test_lerobot_import_item_non_step_mode_re_raises():

--- a/tests/unit/importer/test_mcap_importer.py
+++ b/tests/unit/importer/test_mcap_importer.py
@@ -230,23 +230,32 @@ def test_mcap_importer_build_work_items(monkeypatch, tmp_path: Path):
 def test_mcap_importer_import_item_starts_and_stops_recording(
     monkeypatch, tmp_path: Path
 ):
-    calls: list[str] = []
+    calls: list[tuple[str, float]] = []
 
     monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.time.time",
+        lambda: 100.0,
+    )
+    monkeypatch.setattr(
         "neuracore.importer.mcap.mcap_importer.nc.start_recording",
-        lambda robot_name, instance: calls.append("start"),
+        lambda robot_name, instance, timestamp: calls.append(("start", timestamp)),
     )
     monkeypatch.setattr(
         "neuracore.importer.mcap.mcap_importer.nc.stop_recording",
-        lambda robot_name, instance, wait: calls.append("stop"),
+        lambda robot_name, instance, wait, timestamp: calls.append(("stop", timestamp)),
     )
 
     importer = _make_importer(monkeypatch, tmp_path)
-    monkeypatch.setattr(importer, "_stream_episode_file", lambda *_args, **_kwargs: 3)
+
+    def _stream_episode_file(*_args, **kwargs):
+        assert kwargs["recording_start_timestamp"] == 100.0
+        return 3, 105.0
+
+    monkeypatch.setattr(importer, "_stream_episode_file", _stream_episode_file)
 
     importer.import_item(importer.build_work_items()[0])
 
-    assert calls == ["start", "stop"]
+    assert calls == [("start", 100.0), ("stop", 105.0)]
 
 
 def test_mcap_importer_dry_run_skips_recording(monkeypatch, tmp_path: Path):
@@ -261,7 +270,11 @@ def test_mcap_importer_dry_run_skips_recording(monkeypatch, tmp_path: Path):
     )
 
     importer = _make_importer(monkeypatch, tmp_path, dry_run=True)
-    monkeypatch.setattr(importer, "_stream_episode_file", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        importer,
+        "_stream_episode_file",
+        lambda *_args, **_kwargs: (0, 100.0),
+    )
 
     importer.import_item(importer.build_work_items()[0])
 


### PR DESCRIPTION
### Bugfixes
 - Preserve the correct duration of imported MCAP, LeRobot, and RLDS/TFDS recordings by passing explicit capture timestamps to start_recording() and stop_recording(). Fixed-frequency datasets use their existing step timeline, while MCAP timestamps are rebased onto a single Unix-time anchor. This ensures duration reflects the source episode data rather than how quickly the importer executes.

### Items
 - [NC-982](https://neuracore.atlassian.net/browse/NCP-982)