### PR TITLE
ci: drop mujoco from daemon prod test

### DIFF
--- a/.github/workflows/integration-pf-data-daemon-production.yaml
+++ b/.github/workflows/integration-pf-data-daemon-production.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: NeuracoreAI/shared-workflows/actions/setup-neuracore-from-pypi@main
       with:
         version: ${{ steps.harness.outputs.release-tag }}
-        extras: dev,ml,examples
+        extras: dev
 
     - name: Run Data Daemon Integration Tests
       env:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Prod CI job was incorrectly using Mujoco. Python 3.14 is incompatible with Mujoco anyway.
