### PR TITLE
fix: reduce request timeout

### DIFF
--- a/neuracore/core/utils/backend_utils.py
+++ b/neuracore/core/utils/backend_utils.py
@@ -66,7 +66,7 @@ def is_recording_upload_complete(recording_id: str) -> bool:
     response = session.get(
         f"{API_URL}/org/{org_id}/recording/{recording_id}/traces/complete",
         headers=get_auth().get_headers(),
-        timeout=10,
+        timeout=3,
     )
     response.raise_for_status()
 

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -282,7 +282,7 @@ def test_is_recording_upload_complete_returns_backend_state(
     session.get.assert_called_once_with(
         (f"{API_URL}/org/org-123/recording/" "recording-123/traces/complete"),
         headers={"Authorization": "Bearer test-token"},
-        timeout=10,
+        timeout=3,
     )
     response.raise_for_status.assert_called_once_with()
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Reduced the timeout to 3s as a 10s timeout was excessive and caused the test to fail a less than 10s stop recording assertion.
