### PR TITLE
fix: auth test error

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -104,7 +104,15 @@ def logout() -> None:
     Logs out from the Neuracore server and resets all global state including
     active robots, recording IDs, dataset IDs, and version validation status.
     """
-    get_auth().logout()
+    # Streaming tasks use the shared Auth instance at execution time. Stop and
+    # drain them before clearing its token so an in-flight heartbeat or track
+    # submission cannot become an unauthenticated background exception.
+    try:
+        StreamManagerOrchestrator.shutdown_global()
+    finally:
+        # Clearing local credentials must not be skipped if resource cleanup
+        # itself encounters an unexpected failure.
+        get_auth().logout()
     GlobalSingleton()._active_robot = None
     GlobalSingleton()._active_dataset_id = None
     GlobalSingleton()._active_dataset = None

--- a/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
+++ b/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
@@ -264,7 +264,7 @@ class ClientConsumerStreamManager(BaseP2PStreamManager):
 
     def _on_close(self) -> None:
         """Internal cleanup method called when streaming is disabled."""
-        for connection in self.connections.values():
+        for connection in list(self.connections.values()):
             connection.close()
 
         self.connections.clear()

--- a/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
+++ b/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
@@ -290,7 +290,9 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
 
     def _on_close(self) -> None:
         """Internal cleanup method called when streaming is disabled."""
-        for connection in self.connections.values():
+        self.background_tracker.stop_background_coroutines()
+
+        for connection in list(self.connections.values()):
             connection.close()
 
         self.connections.clear()

--- a/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
+++ b/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
@@ -6,6 +6,8 @@ integrates with the signalling server to route messages.
 """
 
 import asyncio
+import logging
+from concurrent.futures import TimeoutError as FutureTimeoutError
 
 from aiohttp import ClientSession, ClientTimeout
 from neuracore_types import RobotInstanceIdentifier
@@ -34,6 +36,10 @@ from neuracore.core.streaming.p2p.signalling_events_consumer import (
 )
 from neuracore.core.utils.http_session import retry_connection_failures
 from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
+
+logger = logging.getLogger(__name__)
+
+_SHUTDOWN_TIMEOUT_S = 5.0
 
 
 class StreamManagerOrchestrator(
@@ -77,10 +83,15 @@ class StreamManagerOrchestrator(
         self.org_id = org_id or get_current_org()
         self.auth = auth or get_auth()
         self.loop = loop or get_running_loop()
-        self.client_session = client_session or ClientSession(
-            timeout=ClientTimeout(sock_read=None, total=None),
-            loop=self.loop,
-            middlewares=(retry_connection_failures,),
+        self._owns_client_session = client_session is None
+        self.client_session = (
+            client_session
+            if client_session is not None
+            else ClientSession(
+                timeout=ClientTimeout(sock_read=None, total=None),
+                loop=self.loop,
+                middlewares=(retry_connection_failures,),
+            )
         )
 
         self.signalling_consumer = SignallingEventsConsumer(
@@ -94,6 +105,73 @@ class StreamManagerOrchestrator(
                 get_consume_live_data_enabled_manager(),
             ),
         )
+
+    def _close_streaming_resources(self) -> None:
+        """Stop signalling and every manager before authentication is removed."""
+        self.signalling_consumer.close()
+
+        # Manager disable listeners remove themselves from these dictionaries.
+        # Clear the dictionaries first so those callbacks do not recursively
+        # call close() on the manager that is already being disabled.
+        consumer_managers = list(self.consumer_managers.values())
+        provider_managers = list(self.provider_managers.values())
+        self.consumer_managers.clear()
+        self.provider_managers.clear()
+
+        for consumer_manager in consumer_managers:
+            consumer_manager.close()
+        for provider_manager in provider_managers:
+            provider_manager.close()
+
+    async def _finish_shutdown(self) -> None:
+        """Drain cancellation callbacks and close the owned HTTP session."""
+        # Let task-cancellation callbacks run before the authenticated session
+        # is closed and, subsequently, the caller clears authentication.
+        await asyncio.sleep(0)
+        if self._owns_client_session and not self.client_session.closed:
+            await self.client_session.close()
+
+    def shutdown(self) -> None:
+        """Synchronously stop streaming so logout can safely clear credentials."""
+        # Do this before scheduling anything on the loop. Even if the loop is
+        # blocked, trackers immediately reject new work while cancellation is
+        # queued for tasks already running there.
+        self._close_streaming_resources()
+
+        if self.loop.is_closed():
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is self.loop:
+            # A synchronous API cannot wait on its own event loop. Resource
+            # disabling and task cancellation are synchronous; only aiohttp
+            # session closure needs to be scheduled for the next loop turn.
+            self.loop.create_task(self._finish_shutdown())
+            return
+
+        future = asyncio.run_coroutine_threadsafe(self._finish_shutdown(), self.loop)
+        try:
+            future.result(timeout=_SHUTDOWN_TIMEOUT_S)
+        except FutureTimeoutError:
+            future.cancel()
+            logger.warning(
+                "Timed out waiting for streaming resources to shut down cleanly"
+            )
+
+    @classmethod
+    def shutdown_global(cls) -> None:
+        """Shut down and forget the singleton, allowing a later fresh session."""
+        instance = SingletonMetaclass._instances.get(cls)
+        if instance is None:
+            return
+        try:
+            instance.shutdown()
+        finally:
+            SingletonMetaclass._instances.pop(cls, None)
 
     def get_manager(
         self, type: ManagerType, robot_id: str, robot_instance: int

--- a/neuracore/core/utils/background_coroutine_tracker.py
+++ b/neuracore/core/utils/background_coroutine_tracker.py
@@ -26,6 +26,7 @@ class BackgroundCoroutineTracker:
         """
         self.background_tasks: list[asyncio.Task] = []
         self.loop = loop or get_running_loop()
+        self._stopped = False
 
     def _task_done(self, task: asyncio.Task) -> None:
         """Cleanup after task completion.
@@ -57,11 +58,18 @@ class BackgroundCoroutineTracker:
         Args:
             coroutine: the coroutine to be run at another time.
         """
+        if self._stopped:
+            coroutine.close()
+            return
         if self.loop.is_closed():
+            coroutine.close()
             logger.warning("Cannot submit coroutine; event loop is closed.")
             return
 
         def _submit_coroutine(coroutine: Coroutine) -> None:
+            if self._stopped:
+                coroutine.close()
+                return
             task = self.loop.create_task(coroutine)
             self.background_tasks.append(task)
             task.add_done_callback(self._task_done)
@@ -73,6 +81,23 @@ class BackgroundCoroutineTracker:
 
         cancels all running background coroutines
         """
-        for task in self.background_tasks:
-            task.cancel()
-        self.background_tasks.clear()
+        self._stopped = True
+
+        def _cancel_tasks() -> None:
+            for task in self.background_tasks:
+                task.cancel()
+            self.background_tasks.clear()
+
+        if self.loop.is_closed():
+            self.background_tasks.clear()
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is self.loop:
+            _cancel_tasks()
+        else:
+            self.loop.call_soon_threadsafe(_cancel_tasks)

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -10,6 +10,9 @@ from neuracore.api import core as api_core
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError
+from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
+    StreamManagerOrchestrator,
+)
 
 
 def test_login_with_api_key(temp_config_dir, monkeypatch):
@@ -59,6 +62,46 @@ def test_logout(temp_config_dir, monkeypatch):
         config = json.load(f)
         assert config["api_key"] is None
         assert config["current_org_id"] is None
+
+
+def test_logout_shuts_down_streaming_before_clearing_auth(monkeypatch):
+    """Auth must remain valid until every streaming task has been stopped."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        StreamManagerOrchestrator,
+        "shutdown_global",
+        lambda: calls.append("streaming_shutdown"),
+    )
+    monkeypatch.setattr(
+        api_core.get_auth(),
+        "logout",
+        lambda: calls.append("auth_logout"),
+    )
+
+    nc.logout()
+
+    assert calls == ["streaming_shutdown", "auth_logout"]
+
+
+def test_logout_still_clears_auth_when_streaming_shutdown_fails(monkeypatch):
+    """A cleanup failure must not leave credentials active."""
+    auth_logout = Mock()
+
+    def fail_shutdown() -> None:
+        raise RuntimeError("streaming cleanup failed")
+
+    monkeypatch.setattr(
+        StreamManagerOrchestrator,
+        "shutdown_global",
+        fail_shutdown,
+    )
+    monkeypatch.setattr(api_core.get_auth(), "logout", auth_logout)
+
+    with pytest.raises(RuntimeError, match="streaming cleanup failed"):
+        nc.logout()
+
+    auth_logout.assert_called_once_with()
 
 
 def test_auth_instance_singleton():

--- a/tests/unit/core/p2p/test_background_coroutine_tracker.py
+++ b/tests/unit/core/p2p/test_background_coroutine_tracker.py
@@ -68,3 +68,22 @@ async def test_handles_closed_event_loop(caplog):
 
     # Ensure no task was added
     assert len(tracker.background_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_prevents_queued_coroutine_from_starting():
+    """Stopping must reject submissions already queued on the event loop."""
+    started = False
+
+    async def queued_coroutine():
+        nonlocal started
+        started = True
+
+    tracker = BackgroundCoroutineTracker(loop=asyncio.get_running_loop())
+    tracker.submit_background_coroutine(queued_coroutine())
+    tracker.stop_background_coroutines()
+
+    await asyncio.sleep(0)
+
+    assert started is False
+    assert tracker.background_tasks == []

--- a/tests/unit/core/p2p/test_stream_manager_orchestrator.py
+++ b/tests/unit/core/p2p/test_stream_manager_orchestrator.py
@@ -1,0 +1,86 @@
+"""Tests for the global P2P stream orchestrator lifecycle."""
+
+import asyncio
+import threading
+from unittest.mock import Mock, patch
+
+from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
+    StreamManagerOrchestrator,
+)
+from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
+
+
+def test_close_streaming_resources_closes_and_forgets_all_managers():
+    """Shutdown closes signalling and every manager exactly once."""
+    orchestrator = object.__new__(StreamManagerOrchestrator)
+    orchestrator.signalling_consumer = Mock()
+    consumer_manager = Mock()
+    provider_manager = Mock()
+    orchestrator.consumer_managers = {"consumer": consumer_manager}
+    orchestrator.provider_managers = {"provider": provider_manager}
+
+    orchestrator._close_streaming_resources()
+
+    orchestrator.signalling_consumer.close.assert_called_once_with()
+    consumer_manager.close.assert_called_once_with()
+    provider_manager.close.assert_called_once_with()
+    assert orchestrator.consumer_managers == {}
+    assert orchestrator.provider_managers == {}
+
+
+def test_shutdown_global_forgets_singleton_so_it_can_be_recreated():
+    """A later login/connect must not receive the closed orchestrator."""
+    previous_instance = SingletonMetaclass._instances.pop(
+        StreamManagerOrchestrator, None
+    )
+    try:
+        with patch.object(StreamManagerOrchestrator, "__init__", return_value=None):
+            first = StreamManagerOrchestrator()
+            first.shutdown = Mock()
+
+            StreamManagerOrchestrator.shutdown_global()
+            second = StreamManagerOrchestrator()
+
+        first.shutdown.assert_called_once_with()
+        assert second is not first
+    finally:
+        SingletonMetaclass._instances.pop(StreamManagerOrchestrator, None)
+        if previous_instance is not None:
+            SingletonMetaclass._instances[StreamManagerOrchestrator] = previous_instance
+
+
+def test_shutdown_waits_for_owned_client_session_to_close():
+    """Synchronous shutdown drains loop cleanup before returning to logout."""
+    loop = asyncio.new_event_loop()
+    loop_started = threading.Event()
+
+    def run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop_started.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=run_loop, daemon=True)
+    loop_thread.start()
+    loop_started.wait(timeout=1.0)
+
+    class ClientSessionStub:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    orchestrator = object.__new__(StreamManagerOrchestrator)
+    orchestrator.loop = loop
+    orchestrator._owns_client_session = True
+    orchestrator.client_session = ClientSessionStub()
+    orchestrator.signalling_consumer = Mock()
+    orchestrator.consumer_managers = {}
+    orchestrator.provider_managers = {}
+
+    try:
+        orchestrator.shutdown()
+        assert orchestrator.client_session.closed is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=1.0)
+        loop.close()


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- Race condition in the tests between logout and teardown exposed hanging peer to peer connections which could send a heartbeat and cause an auth error. Logout who now owns stream Orchastrater tear down.
