### PR TITLE
fix: multi process retries

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -189,7 +189,7 @@ class Robot:
             )
 
         try:
-            session = thread_local_session()
+            session = thread_local_session(retry_transient=True)
             response = session.post(
                 f"{API_URL}/org/{self.org_id}/robots?is_shared={self.shared}",
                 json={

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
@@ -65,6 +65,7 @@ def _same_source_producer(
     producer_index: int,
     robot_name: str,
     dataset_name: str,
+    robot_connection_lock: Any,
     ready_barrier: Any,
     logged_barrier: Any,
     recording_started: Any,
@@ -79,7 +80,11 @@ def _same_source_producer(
     try:
         ensure_login()
         nc.get_dataset(dataset_name)
-        robot = nc.connect_robot(robot_name, instance=0, overwrite=False)
+        # Robot registration is setup rather than the multiprocess behavior under test.
+        # THe lock is stop the robot from being registered by more
+        # than on process. at the same time.
+        with robot_connection_lock:
+            robot = nc.connect_robot(robot_name, instance=0, overwrite=False)
         ready_barrier.wait(timeout=_PROCESS_TIMEOUT_S)
 
         recording_index: int | None = None
@@ -219,6 +224,7 @@ def test_three_processes_log_to_one_sse_started_recording() -> None:
     )
 
     process_context = multiprocessing.get_context("spawn")
+    robot_connection_lock = process_context.Lock()
     ready_barrier = process_context.Barrier(_PRODUCER_COUNT)
     logged_barrier = process_context.Barrier(_PRODUCER_COUNT)
     recording_started = process_context.Event()
@@ -243,6 +249,7 @@ def test_three_processes_log_to_one_sse_started_recording() -> None:
                         producer_index,
                         robot_name,
                         dataset_name,
+                        robot_connection_lock,
                         ready_barrier,
                         logged_barrier,
                         recording_started,

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -7,6 +7,7 @@ import requests_mock
 
 import neuracore as nc
 from neuracore.api import core as api_core
+from neuracore.core import robot as core_robot
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError
@@ -148,9 +149,16 @@ def test_login_version_check_connection_error_surfaces_cleanly(
 
 
 def test_connect_robot(
-    temp_config_dir, mock_auth_requests, reset_neuracore, mock_urdf, mocked_org_id
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mock_urdf,
+    mocked_org_id,
+    monkeypatch,
 ):
     """Test robot connection."""
+    session_factory = Mock(wraps=core_robot.thread_local_session)
+    monkeypatch.setattr(core_robot, "thread_local_session", session_factory)
     # Ensure login first
     nc.login("test_api_key")
 
@@ -167,6 +175,7 @@ def test_connect_robot(
     # Verify robot connection
     assert robot is not None
     assert robot.name == "test_robot"
+    session_factory.assert_called_once_with(retry_transient=True)
 
 
 def test_update_robot_name_calls_underlying_and_returns_robot_id(monkeypatch):


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- Added retires to robot init requests as 500 error from one failed node can cause the recording to fail under high congestion. 
- Added lock around connect robot in multi process tests.
