### PR TITLE
ci: increase max parallelisation of per wheel testing for staging daemon tests

### DIFF
--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       # Dispatch inputs narrow the axes; the literals are the fallback for
       # scheduled runs, where the `inputs` context is empty and dispatch input
       # defaults do not apply.


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Increase max parallelisation of per wheel testing for data daemon staging from 2 to 4. 

### Why
 - Data Daemon tests are taking too long
- We need ensure our staging can handle suitable workload

### How
- Increase the rate of tests hitting our staging backend to diagnose performance