### PR TITLE
fix: prevent stale notifications truncating recording windows

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -10,6 +10,7 @@ import io
 import logging
 import os
 import tempfile
+import time
 import uuid
 import xml.etree.ElementTree as ET
 import zipfile
@@ -282,6 +283,11 @@ class Robot:
             raise RobotError("Robot not initialized. Call init() first.")
 
         local_handle = str(uuid.uuid4())
+        # The recording window's lower bound, on the same clock the backend
+        # reports for it. Without an explicit timestamp the producer stamps
+        # wall-clock now, which is at or after this value, so notifications stay
+        # orderable against it.
+        start_time = timestamp if timestamp is not None else time.time()
         self._get_daemon_recording_context().start_recording(
             robot_id=self.id,
             robot_instance=self.instance,
@@ -291,7 +297,10 @@ class Robot:
             timestamp=timestamp,
         )
         get_recording_state_manager().recording_started(
-            robot_id=self.id, instance=self.instance, recording_id=local_handle
+            robot_id=self.id,
+            instance=self.instance,
+            recording_id=local_handle,
+            start_time=start_time,
         )
         return local_handle
 

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -12,6 +12,7 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
+from typing import NamedTuple
 
 from aiohttp import ClientSession
 from neuracore_types import (
@@ -36,6 +37,29 @@ from neuracore.data_daemon import bridge as _recording_context
 from neuracore.data_daemon.daemon_control import ensure_daemon_running
 
 logger = logging.getLogger(__name__)
+
+# The producer stamps a recording's start as `int(start_time * 1e9)`, so the
+# value echoed back in a notification can sit a nanosecond below the one held
+# locally. Staleness comparisons allow this much slack — far above that
+# truncation, far below any real gap between two recordings of one instance.
+STALE_START_TOLERANCE_S = 1e-3
+
+
+class TrackedRecording(NamedTuple):
+    """The recording currently tracked for one robot instance.
+
+    Attributes:
+        recording_id: The local correlation handle minted by
+            ``Robot.start_recording``, replaced by the backend's cloud recording
+            id once a START notification for the same recording arrives.
+        start_time: The recording window's lower bound, on the same clock the
+            backend reports in ``RecordingStartPayload.start_time``. Orders
+            notifications against each other: one describing a recording that
+            began earlier than this belongs to an already-finished recording.
+    """
+
+    recording_id: str
+    start_time: float
 
 
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
@@ -107,7 +131,18 @@ class RecordingStateManager(BaseSSEConsumer):
         self.auth = auth if auth is not None else get_auth()
 
         self._connected_robot_id: str | None = None
-        self.recording_robot_instances: dict[RobotInstanceIdentifier, str] = dict()
+        # Guards the read-modify-write sequences over `recording_robot_instances`.
+        # Local `nc.start_recording` / `nc.stop_recording` run on the caller's
+        # thread while notifications are applied on the event loop thread, and
+        # both decide what to do from the map's current contents. Reentrant
+        # because `updated_recording_state` holds it across `recording_stopped`.
+        #
+        # Not taken by `get_current_recording_id` / `is_recording`: those sit on
+        # the `log_*` hot path and a single dict lookup is already atomic.
+        self._state_lock = threading.RLock()
+        self.recording_robot_instances: dict[
+            RobotInstanceIdentifier, TrackedRecording
+        ] = dict()
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
@@ -126,7 +161,8 @@ class RecordingStateManager(BaseSSEConsumer):
         instance_key = RobotInstanceIdentifier(
             robot_id=robot_id, robot_instance=instance
         )
-        return self.recording_robot_instances.get(instance_key, None)
+        tracked = self.recording_robot_instances.get(instance_key, None)
+        return tracked.recording_id if tracked is not None else None
 
     def is_recording(self, robot_id: str, instance: int) -> bool:
         """Check if a robot instance is currently recording.
@@ -155,7 +191,7 @@ class RecordingStateManager(BaseSSEConsumer):
         return recording_id in self._expired_recording_ids
 
     def recording_started(
-        self, robot_id: str, instance: int, recording_id: str
+        self, robot_id: str, instance: int, recording_id: str, start_time: float
     ) -> None:
         """Handle recording start for a robot instance.
 
@@ -165,26 +201,63 @@ class RecordingStateManager(BaseSSEConsumer):
         are retired — the instance is never transiently cleared, so a concurrent
         ``log_*`` cannot observe a ``None`` recording id and drop a frame.
 
+        Publishes the tracked state under :attr:`_state_lock` before starting the
+        daemon. Notifications are resolved against this map on another thread, so
+        an instance missing from it can have a notification for a different
+        recording adopted in its place.
+
         Args:
             robot_id: Robot ID
             instance: Instance number of the robot
             recording_id: Unique identifier for the recording session
+            start_time: The recording's window lower bound — see
+                :class:`TrackedRecording`. Callers reacting to a notification
+                must pass the value the backend reported, so subsequent
+                notifications can be ordered against it.
         """
-        instance_key = RobotInstanceIdentifier(
-            robot_id=robot_id, robot_instance=instance
-        )
-        previous_recording_id = self.recording_robot_instances.get(instance_key, None)
+        with self._state_lock:
+            self._track_recording_started(
+                robot_id=robot_id,
+                instance=instance,
+                recording_id=recording_id,
+                start_time=start_time,
+            )
+        # After the state is visible, and outside the lock: this takes a few
+        # milliseconds of filesystem work, which is long enough for a
+        # notification to arrive and be resolved against the tracked recording.
+        self._ensure_daemon_for_recording()
 
-        if previous_recording_id == recording_id:
-            return
+    def _ensure_daemon_for_recording(self) -> None:
+        """Start the data daemon if it is not already running.
 
+        Never raises: the recording proceeds either way, since abandoning it here
+        would silently turn every subsequent ``log_*`` into a no-op.
+        """
         try:
             ensure_daemon_running()
         except Exception:
             logger.exception("Failed to ensure data daemon is running")
+
+    def _track_recording_started(
+        self, robot_id: str, instance: int, recording_id: str, start_time: float
+    ) -> None:
+        """Make ``recording_id`` this instance's tracked recording.
+
+        Pure state transition plus timer bookkeeping — no blocking work, so it is
+        safe to call with :attr:`_state_lock` held. The caller must hold it.
+        """
+        instance_key = RobotInstanceIdentifier(
+            robot_id=robot_id, robot_instance=instance
+        )
+        previous = self.recording_robot_instances.get(instance_key, None)
+        previous_recording_id = previous.recording_id if previous is not None else None
+
+        if previous_recording_id == recording_id:
             return
 
-        self.recording_robot_instances[instance_key] = recording_id
+        self.recording_robot_instances[instance_key] = TrackedRecording(
+            recording_id=recording_id, start_time=start_time
+        )
         if previous_recording_id is not None:
             self._cancel_recording_timers(previous_recording_id)
         self._schedule_recording_timers(
@@ -264,10 +337,11 @@ class RecordingStateManager(BaseSSEConsumer):
         instance_key = RobotInstanceIdentifier(
             robot_id=robot_id, robot_instance=instance
         )
-        current_recording = self.recording_robot_instances.get(instance_key, None)
-        if current_recording != recording_id:
-            return
-        self.recording_robot_instances.pop(instance_key, None)
+        with self._state_lock:
+            current = self.recording_robot_instances.get(instance_key, None)
+            if current is None or current.recording_id != recording_id:
+                return
+            self.recording_robot_instances.pop(instance_key, None)
         # Data-bridge stop is driven by the recording context or expiry timer —
         # not here — so the daemon gets exactly one StopRecording with the
         # correct data-clock boundary.
@@ -282,18 +356,32 @@ class RecordingStateManager(BaseSSEConsumer):
         Processes recording state changes from remote notifications and calls
         appropriate start/stop methods if the state actually changed.
 
+        Runs under :attr:`_state_lock` so each decision and the state change it
+        implies are atomic against a concurrent local start or stop. Blocking
+        work is done before the lock is taken.
+
         Args:
             is_recording: Whether the robot should be recording
             details: Recording details including robot ID, instance, and recording ID
         """
+        if is_recording and details.robot_id == self._connected_robot_id:
+            self._ensure_daemon_for_recording()
+        with self._state_lock:
+            self._apply_recording_notification(is_recording, details)
+
+    def _apply_recording_notification(
+        self, is_recording: bool, details: BaseRecodingUpdatePayload
+    ) -> None:
+        """Apply one notification. Caller must hold :attr:`_state_lock`."""
         robot_id = details.robot_id
         instance = details.instance
         recording_id = details.recording_id
 
-        previous_recording_id = self.recording_robot_instances.get(
+        previous = self.recording_robot_instances.get(
             RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance),
             None,
         )
+        previous_recording_id = previous.recording_id if previous is not None else None
         was_recording = previous_recording_id is not None
 
         if was_recording == is_recording and previous_recording_id == recording_id:
@@ -309,6 +397,26 @@ class RecordingStateManager(BaseSSEConsumer):
             if robot_id != self._connected_robot_id:
                 return
 
+            # A START describing a recording that began before the tracked one
+            # is a late notification for an already-finished recording: the
+            # org-wide stream can lag a fast stop-then-start cycle by a whole
+            # recording. Adopting it would hand this instance a finished
+            # recording, whose STOP would then drain the live one.
+            if (
+                previous is not None
+                and details.start_time < previous.start_time - STALE_START_TOLERANCE_S
+            ):
+                logger.debug(
+                    "ignoring stale recording start notification: "
+                    "recording_id=%s start_time=%s is older than tracked "
+                    "recording_id=%s start_time=%s",
+                    recording_id,
+                    details.start_time,
+                    previous.recording_id,
+                    previous.start_time,
+                )
+                return
+
             assert (
                 len(details.dataset_ids) == 1
             ), "Recording can only be started in one dataset"
@@ -322,10 +430,12 @@ class RecordingStateManager(BaseSSEConsumer):
                 dataset_id,
                 recording_id,
             )
-            self.recording_started(
+            # Daemon already ensured above; this is the state transition only.
+            self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
                 recording_id=recording_id,
+                start_time=details.start_time,
             )
         else:
             instance_key = RobotInstanceIdentifier(

--- a/rust/data_daemon/src/api/client.rs
+++ b/rust/data_daemon/src/api/client.rs
@@ -84,9 +84,9 @@ impl ApiClientError {
     ///
     /// The recording notifiers use this to treat "the recording is already not
     /// open on the backend" as the desired post-condition rather than a
-    /// failure: a cancel/stop POST that 404s means another path already closed
-    /// the recording (a benign race between the cancel-notifier sweep and the
-    /// start-notifier's `resolve_prior_pending`), so there is nothing left to do.
+    /// failure: a cancel/stop POST that 404s means the recording was already
+    /// closed, or that the backend reaped it as an abandoned pending recording,
+    /// so there is nothing left to do.
     pub fn is_not_found(&self) -> bool {
         matches!(self, ApiClientError::Status { status, .. } if *status == StatusCode::NOT_FOUND)
     }
@@ -325,13 +325,11 @@ impl ApiClient {
 
     /// `POST /org/{org}/recording/cancel` with a JSON body carrying
     /// `recording_id` and `end_time` (the cancel time, Unix seconds) — the same
-    /// body shape the backend now requires for `/recording/stop`.
+    /// body shape the backend requires for `/recording/stop`.
     ///
-    /// Cancels the recording server-side, which also clears it as the robot
-    /// instance's *pending* recording so the next `/recording/start` mints a
-    /// fresh id instead of reusing this one. The daemon's cancel notifier makes
-    /// this call best-effort once it knows the cloud `recording_id`; the SDK
-    /// no longer calls it inline.
+    /// Cancels the recording server-side, discarding its data. The daemon's
+    /// cancel notifier owns this call, making it best-effort once the cloud
+    /// `recording_id` is known.
     pub async fn recording_cancel(
         &self,
         org_id: &str,

--- a/rust/data_daemon/src/cloud/notifiers/notifier.rs
+++ b/rust/data_daemon/src/cloud/notifiers/notifier.rs
@@ -206,9 +206,10 @@ impl LifecycleKind {
 /// Run the shared stop/cancel backend-notify flow for one recording.
 ///
 /// Idempotent and self-logging (the spawn loop never inspects the result): a
-/// 404 is treated as success (the start notifier's prior-pending resolution
-/// already closed the recording server-side), and a persist failure after a
-/// successful POST is left for the next sweep since the POST is idempotent.
+/// 404 is treated as success (the recording is already closed server-side, or
+/// the backend reaped it as an abandoned pending recording), and a persist
+/// failure after a successful POST is left for the next sweep since the POST is
+/// idempotent.
 pub async fn notify_recording_lifecycle(
     kind: LifecycleKind,
     store: &Arc<SqliteStateStore>,
@@ -287,9 +288,9 @@ pub async fn notify_recording_lifecycle(
 
     let mark_result = match &post_result {
         Ok(()) => mark_notified(kind, store, recording_index).await,
-        // 404 means the backend no longer has this recording open — the
-        // start-notifier's `resolve_prior_pending` already closed it. That is
-        // the post-condition we wanted, so record it rather than re-sweeping.
+        // 404 means the backend does not have this recording open — already
+        // closed, or reaped as an abandoned pending recording. That is the
+        // post-condition we wanted, so record it rather than re-sweeping.
         Err(error) if error.is_not_found() => mark_notified(kind, store, recording_index).await,
         Err(error) => {
             tracing::warn!(%error, recording_index, recording_id, "failed to notify backend of recording {action}");

--- a/rust/data_daemon/src/cloud/notifiers/recording_cancel_notifier.rs
+++ b/rust/data_daemon/src/cloud/notifiers/recording_cancel_notifier.rs
@@ -249,8 +249,8 @@ mod tests {
 
     #[tokio::test]
     async fn treats_backend_404_as_already_cancelled() {
-        // The start-notifier's `resolve_prior_pending` may have closed this
-        // recording on the backend first (cancel-then-start with no gap), so a
+        // The recording may already be closed on the backend — an earlier POST
+        // whose response was lost, or the backend reaping it as abandoned — so a
         // 404 here is the desired post-condition, not a failure: the row must
         // still be marked notified so the sweep stops re-posting.
         let server = MockServer::start().await;

--- a/rust/data_daemon/src/cloud/notifiers/recording_start_notifier.rs
+++ b/rust/data_daemon/src/cloud/notifiers/recording_start_notifier.rs
@@ -10,11 +10,15 @@
 //!
 //! The shared loop/sweep/lag semantics live in
 //! [`notifier`](super::notifier); see there for how events are processed. What
-//! is start-specific: the cloud `recording_id` is minted and persisted here,
-//! and any prior pending recording is closed before the next start. Every
-//! downstream coordinator (registration, progress, upload) waits for this id,
-//! so an offline recording simply stays pending until the daemon is online and
-//! `/recording/start` lands.
+//! is start-specific: the cloud `recording_id` is minted and persisted here.
+//! Every downstream coordinator (registration, progress, upload) waits for this
+//! id, so an offline recording simply stays pending until the daemon is online
+//! and `/recording/start` lands.
+//!
+//! Every POST opens a distinct backend recording — the backend never reuses a
+//! pending one for the source — so recordings that follow each other with no
+//! gap stay separate no matter what order their stop and start notifications
+//! land in.
 
 use std::sync::Arc;
 
@@ -32,9 +36,7 @@ use crate::state::{
 /// Notifier that POSTs `/recording/start` and persists the cloud `recording_id`
 /// the backend mints. The cloud id is always minted here — every downstream
 /// coordinator waits on it — so an offline recording stays pending until the
-/// daemon is online and the start POST lands. Before opening the new recording
-/// it closes any earlier still-pending recording for the same source (see
-/// [`resolve_prior_pending`]).
+/// daemon is online and the start POST lands.
 struct StartNotifier;
 
 #[async_trait]
@@ -147,17 +149,6 @@ async fn notify_backend(
     // it, so a late notify (e.g. after reconnecting) still reports correctly.
     let start_time = start_timestamp_ns as f64 / 1_000_000_000.0;
 
-    // Before opening this recording server-side, close any earlier recording for
-    // the same source that finished locally (cancel/stop) but whose backend
-    // notification has not landed yet. The backend dedupes pending recordings
-    // per robot instance — it returns the existing pending recording instead of
-    // minting a new one — so a still-pending prior recording would otherwise
-    // hand its cloud id to this one, collapsing both into one backend recording
-    // (e.g. cancel-then-start with no gap). The start notifier processes
-    // `RecordingStarted` events in order, so the prior recording's cloud id is
-    // already on its row by the time we reach here.
-    resolve_prior_pending(store, client, &org_id, &robot_id, instance, recording_index).await;
-
     match client
         .recording_start(&org_id, &robot_id, instance, &dataset_id, start_time)
         .await
@@ -172,7 +163,9 @@ async fn notify_backend(
                     recording_index,
                     recording_id,
                     "POST succeeded but persisting the cloud recording_id failed; \
-                     the next sweep will re-post (the start notify is idempotent)",
+                     the next sweep re-posts and opens a second backend recording \
+                     for this one — the orphan carries no traces and the backend \
+                     reaps it once it passes the maximum recording duration",
                 );
             } else {
                 tracing::info!(
@@ -199,122 +192,6 @@ async fn notify_backend(
     }
 }
 
-/// Close, on the backend, any earlier recording for `(robot_id, instance)` that
-/// finished locally (cancelled or stopped) but is still pending server-side, so
-/// the backend does not hand its cloud id to the next `/recording/start` for
-/// this instance. See
-/// [`StateStore::recordings_pending_backend_resolution_for_source`].
-async fn resolve_prior_pending(
-    store: &Arc<SqliteStateStore>,
-    client: &Arc<ApiClient>,
-    org_id: &str,
-    robot_id: &str,
-    instance: i64,
-    before_index: i64,
-) {
-    let prior = match store
-        .recordings_pending_backend_resolution_for_source(robot_id, instance, before_index)
-        .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            tracing::warn!(
-                %error,
-                before_index,
-                "failed to query prior pending recordings for source; next start may reuse a cloud id",
-            );
-            return;
-        }
-    };
-    for row in prior {
-        let index = row.recording_index;
-        let is_cancelled = row.cancelled_at.is_some();
-        // Cancel and stop both report the recording's captured stop time as
-        // `end_time` (a cancel is a stop that discards data). Compute it before
-        // `recording_id` is moved out of `row`.
-        let end_time = row.stop_timestamp_ns.map(|ns| ns as f64 / 1_000_000_000.0);
-        // Defensive against the query contract: the pending-resolution query
-        // only returns cloud-id-assigned, stopped/cancelled rows (which always
-        // carry a stop timestamp), so these guards should never skip in
-        // practice — they just keep the extraction total.
-        let Some(recording_id) = row.recording_id else {
-            continue;
-        };
-        let Some(end_time) = end_time else {
-            continue;
-        };
-        if is_cancelled {
-            match client
-                .recording_cancel(org_id, &recording_id, end_time)
-                .await
-            {
-                Ok(()) => {
-                    let _ = store.mark_recording_cancel_notified(index).await;
-                    tracing::info!(
-                        recording_index = index,
-                        recording_id,
-                        next_recording_index = before_index,
-                        "cancelled prior pending recording on the backend before opening the next",
-                    );
-                }
-                Err(error) if error.is_not_found() => {
-                    // Already closed — the cancel-notifier sweep won the race.
-                    // The prior recording is not pending on the backend, so the
-                    // next start cannot reuse its id; mark it notified so the
-                    // sweep stops re-posting too.
-                    let _ = store.mark_recording_cancel_notified(index).await;
-                    tracing::debug!(
-                        recording_index = index,
-                        recording_id,
-                        next_recording_index = before_index,
-                        "prior pending recording already cancelled on backend (404)",
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        %error,
-                        recording_index = index,
-                        recording_id,
-                        "failed to cancel prior pending recording before next start; \
-                         the next start may reuse its cloud id",
-                    );
-                }
-            }
-        } else {
-            match client.recording_stop(org_id, &recording_id, end_time).await {
-                Ok(()) => {
-                    let _ = store.mark_recording_stop_notified(index).await;
-                    tracing::info!(
-                        recording_index = index,
-                        recording_id,
-                        next_recording_index = before_index,
-                        "stopped prior pending recording on the backend before opening the next",
-                    );
-                }
-                Err(error) if error.is_not_found() => {
-                    // Already closed — the stop-notifier sweep won the race. Mark
-                    // it notified so the sweep stops re-posting too.
-                    let _ = store.mark_recording_stop_notified(index).await;
-                    tracing::debug!(
-                        recording_index = index,
-                        recording_id,
-                        next_recording_index = before_index,
-                        "prior pending recording already stopped on backend (404)",
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        %error,
-                        recording_index = index,
-                        recording_id,
-                        "failed to stop prior pending recording before next start",
-                    );
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,7 +201,7 @@ mod tests {
     use tempfile::TempDir;
     use tokio::sync::broadcast;
     use tokio::time::{sleep, timeout};
-    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::api::auth::StaticAuthProvider;
@@ -428,37 +305,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancels_prior_pending_recording_before_opening_the_next() {
-        // Cancel-then-start (no gap) for one source: the prior recording was
-        // cancelled before its cloud id was notified, so it is still pending on
-        // the backend. Opening the next recording must cancel it FIRST, so the
-        // backend mints a fresh id instead of handing back the cancelled one
-        // (which would collapse both recordings into one cloud recording).
+    async fn consecutive_recordings_for_one_source_each_get_their_own_cloud_id() {
+        // Stop-then-start (or cancel-then-start) with no gap for one source: the
+        // prior recording's stop notification may not have landed yet when the
+        // next start is notified. Each start must still open its own backend
+        // recording and persist its own cloud id, or the two collapse into one
+        // and a recording is silently lost at every boundary.
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/org/org-1/recording/cancel"))
-            .and(body_partial_json(
-                serde_json::json!({ "recording_id": "cloud-cancelled-A" }),
-            ))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!("ok")))
+        start_ok_mock("cloud-rec-A")
+            .up_to_n_times(1)
             .mount(&server)
             .await;
-        start_ok_mock("cloud-fresh-B").mount(&server).await;
+        start_ok_mock("cloud-rec-B").mount(&server).await;
 
         let (store, _dir) = open_store().await;
-        // Prior recording A (same source): start-notified, then cancelled, with
-        // its backend cancel still pending.
-        let prior = seed_recording(&store).await;
-        store
-            .mark_recording_start_notified(prior, "cloud-cancelled-A")
-            .await
-            .expect("mark start notified");
-        store
-            .cancel_recording(prior, 5_000_000_000)
-            .await
-            .expect("cancel");
-        // The next recording B for the same source.
-        let next = seed_recording(&store).await;
+        let first = seed_recording(&store).await;
+        let second = seed_recording(&store).await;
 
         let auth = Arc::new(StaticAuthProvider::new("token-1"));
         let client = Arc::new(ApiClient::new(options(server.uri()), auth).expect("client"));
@@ -472,33 +334,32 @@ mod tests {
             shutdown_tx.subscribe(),
         );
 
-        bus.publish(DaemonEvent::RecordingStarted {
-            recording_index: next,
-        });
-
         timeout(Duration::from_secs(3), async {
             loop {
-                let prior_row = store
-                    .get_recording(prior)
+                let first_row = store
+                    .get_recording(first)
                     .await
                     .expect("get")
                     .expect("exists");
-                let next_row = store
-                    .get_recording(next)
+                let second_row = store
+                    .get_recording(second)
                     .await
                     .expect("get")
                     .expect("exists");
-                if prior_row.backend_cancel_notified_at.is_some() && next_row.recording_id.is_some()
+                if let (Some(first_id), Some(second_id)) =
+                    (first_row.recording_id, second_row.recording_id)
                 {
-                    // Prior cancelled server-side; next opened with a FRESH id.
-                    assert_eq!(next_row.recording_id.as_deref(), Some("cloud-fresh-B"));
+                    assert_ne!(
+                        first_id, second_id,
+                        "consecutive recordings must not share a cloud recording id",
+                    );
                     break;
                 }
                 sleep(Duration::from_millis(20)).await;
             }
         })
         .await
-        .expect("prior recording must be cancelled and next opened fresh within 3s");
+        .expect("both recordings must get a distinct cloud id within 3s");
 
         let _ = shutdown_tx.send(ShutdownSignal::Sigterm);
         handle.join().await;

--- a/rust/data_daemon/src/state/store.rs
+++ b/rust/data_daemon/src/state/store.rs
@@ -220,22 +220,6 @@ pub trait StateStore: Send + Sync {
     /// server-side; the start notifier fills it first, then this sweep fires).
     async fn recordings_pending_stop_notify(&self) -> Result<Vec<RecordingRow>, StateStoreError>;
 
-    /// List earlier recordings for `(robot_id, robot_instance)` that are still
-    /// *pending* on the backend: they have a cloud `recording_id` (so they were
-    /// opened server-side), are resolved locally (`cancelled_at` or `stopped_at`
-    /// is set), but have not yet had their backend cancel/stop notification
-    /// delivered. The backend dedupes pending recordings per robot instance —
-    /// it returns the existing pending recording for an instance instead of
-    /// minting a new one — so these must be closed server-side before the next
-    /// recording's `/recording/start`, or that start reuses their cloud id.
-    /// Restricted to `recording_index < before_index`, ordered oldest first.
-    async fn recordings_pending_backend_resolution_for_source(
-        &self,
-        robot_id: &str,
-        robot_instance: i64,
-        before_index: i64,
-    ) -> Result<Vec<RecordingRow>, StateStoreError>;
-
     /// List every recording row currently in the DB.
     ///
     /// Used by the progress reporter to discover stopped recordings whose
@@ -1404,34 +1388,6 @@ impl StateStore for SqliteStateStore {
                 AND cancelled_at IS NULL \
            ORDER BY stopped_at ASC",
         )
-        .fetch_all(&self.read_pool)
-        .await?;
-        rows.iter()
-            .map(RecordingRow::from_row)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Into::into)
-    }
-
-    async fn recordings_pending_backend_resolution_for_source(
-        &self,
-        robot_id: &str,
-        robot_instance: i64,
-        before_index: i64,
-    ) -> Result<Vec<RecordingRow>, StateStoreError> {
-        let rows = sqlx::query(
-            "SELECT * FROM recordings \
-              WHERE robot_id = ? \
-                AND robot_instance = ? \
-                AND recording_index < ? \
-                AND recording_id IS NOT NULL \
-                AND backend_stop_notified_at IS NULL \
-                AND backend_cancel_notified_at IS NULL \
-                AND (cancelled_at IS NOT NULL OR stopped_at IS NOT NULL) \
-           ORDER BY recording_index ASC",
-        )
-        .bind(robot_id)
-        .bind(robot_instance)
-        .bind(before_index)
         .fetch_all(&self.read_pool)
         .await?;
         rows.iter()


### PR DESCRIPTION
## What was happening

When one recording stopped and the next started straight away, the SDK could be left with no recording tracked for that robot for a couple of milliseconds. A recording notification arriving in that gap was taken to be the current recording, even though it described the one that had just finished. The stop for that older recording then arrived, matched, and stopped the recording that was actually running.

The recording was cut short as a result. In one run a ten second recording ended up with a window of 0.26 seconds, so only 31 of its 1200 camera frames reached the dataset. Anything logged after the cut was discarded because it no longer fell inside a recording.

The gap existed because the SDK started the data daemon, which does a few milliseconds of filesystem work, in between the producer starting to record and the recording being tracked.

## How this fixes it

- The recording is tracked before the daemon is started, so the gap is gone.
- Tracked recordings now carry their start time, so a notification about an older recording is recognised and ignored.
- Updates to the tracked state are locked, since the notification thread and the calling thread both read and change it.

This also removes `resolve_prior_pending` from the daemon. It closed a recording on the backend before the next one started so the backend could not reuse its id, which the backend no longer does.
