### PR TITLE
fix: flush publisher queue before stopping a recording

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -20,6 +20,7 @@ asarray
 ascontiguousarray
 assimp
 asyncio
+atexit
 atfork
 attns
 autocast
@@ -262,6 +263,7 @@ libx
 linalg
 lineno
 listconfig
+livelock
 llava
 Llava
 logdir

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -52,7 +52,9 @@ use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
-use crate::publisher::{now_ns, publish, publisher_tx, ProducerError, PublishMsg};
+use crate::publisher::{
+    flush_published_data, now_ns, publish, publisher_tx, ProducerError, PublishMsg,
+};
 use crate::query::{resolve_recording_id, wait_until_ready as wait_until_ready_impl};
 use crate::writer::{writer_queue, FrameJob, WriterMsg};
 
@@ -291,8 +293,18 @@ fn log_json(
     Ok(())
 }
 
-/// Publish one `StopRecording`, then flush any tail video chunks for the
-/// source before returning. The stop is published BEFORE the flush barrier:
+/// Drain the data publisher, publish one `StopRecording`, then flush any tail
+/// video chunks for the source before returning.
+///
+/// Three barriers, in order: the data publisher's queue is drained first (so
+/// the recording's joint/JSON tail is on the wire before the window's upper
+/// bound is stamped), then the stop is published, then the writer is flushed
+/// and its chunk announcements drained. Together these make the call's
+/// post-condition uniform across every data path — once `stop_recording`
+/// returns, nothing belonging to the recording is still sitting in an
+/// in-process queue that a subsequent process exit would discard.
+///
+/// The stop is published BEFORE the writer flush barrier:
 /// it shares the calling thread's publisher with `StartRecording`, so sending
 /// it first guarantees the daemon sees this stop ahead of the next recording's
 /// start. Stamping the boundary early but sending only after a slow flush
@@ -322,6 +334,18 @@ fn stop_recording(
     }
     let robot_id = robot_id.to_string();
     py.detach(|| -> PyResult<()> {
+        // Drain the data publisher before stamping the window's upper bound.
+        // `log_joint_*` / `log_json` only hand their envelope to the background
+        // publisher thread's unbounded queue, which nothing drains at process
+        // exit — so the recording's samples are only durable once this returns.
+        // Draining before the stop (rather than after) also puts them ahead of
+        // it on the wire, so they never depend on the daemon's closing-window
+        // retention to be routed.
+        //
+        // Ordering with the stop below is unaffected: data rides the background
+        // publisher's port, while `StartRecording`/`StopRecording` share the
+        // calling thread's own publisher and stay in program order on it.
+        flush_published_data();
         let publish_timestamp_ns = now_ns();
         // Caller-supplied capture time, mirroring the `log_*` timestamp default
         // (publish clock when omitted). Decoupled from the window boundary.
@@ -354,6 +378,10 @@ fn stop_recording(
             ack: ack_tx,
         });
         let _ = ack_rx.recv();
+        // The writer announces its sealed tail chunks by pushing `Announce`
+        // onto the data publisher's queue, so the ack above means spooled and
+        // queued, not published. Drain once more to put them on the wire.
+        flush_published_data();
         Ok(())
     })
 }

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -29,6 +29,12 @@
 //! publisher is safe. The queue is unbounded: messages are small/infrequent and
 //! the thread keeps up in steady state; a transient daemon stall buffers only a
 //! few hundred small items.
+//!
+//! Nothing bounds how much is pending at process exit, and no `Drop` impl,
+//! join, or `atexit` hook drains the queue — anything still in it when the
+//! process dies is discarded silently, never reaching the daemon.
+//! [`flush_published_data`] is the barrier against that; `stop_recording` calls
+//! it, so a recording's data is on the wire before the call returns.
 
 use std::cell::RefCell;
 use std::sync::mpsc::{Receiver, Sender};
@@ -138,6 +144,14 @@ pub(crate) enum PublishMsg {
     /// A pre-built `VideoChunkReady` envelope to announce (built by the writer
     /// thread once the chunk is sealed on disk).
     Announce(Envelope),
+    /// FIFO barrier: acked once every message queued *before* it has been
+    /// published. Because the queue is FIFO, the ack drains exactly the backlog
+    /// that existed at the moment the barrier was pushed — concurrent producers
+    /// enqueueing behind it cannot livelock the waiter.
+    Flush {
+        /// Signalled after the preceding backlog has been published.
+        ack: Sender<()>,
+    },
 }
 
 /// Process-wide publisher handle, healed across `fork` via `owner_pid` (mirrors
@@ -213,6 +227,26 @@ fn publisher_tx_global() -> (Sender<PublishMsg>, bool) {
     }
 }
 
+/// Block until every data envelope queued so far has been published.
+///
+/// The publisher thread is the only place `BatchedData` / `Data` /
+/// `VideoChunkReady` envelopes reach iceoryx2, and its queue is unbounded and
+/// undrained at exit — so a caller that needs its data to survive the process
+/// must reach this barrier first.
+///
+/// Returns `false` if the publisher thread is gone (spawn failure), so callers
+/// proceed rather than hang — a lost ack must never wedge `stop_recording`.
+pub(crate) fn flush_published_data() -> bool {
+    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+    if publisher_tx()
+        .send(PublishMsg::Flush { ack: ack_tx })
+        .is_err()
+    {
+        return false;
+    }
+    ack_rx.recv().is_ok()
+}
+
 /// The publisher thread's run loop: publish every queued data envelope. Exits
 /// when the last [`Sender`] is dropped (the channel closes).
 fn publish_loop(rx: Receiver<PublishMsg>) {
@@ -279,6 +313,12 @@ fn publish_loop(rx: Receiver<PublishMsg>) {
                 payload,
             }),
             PublishMsg::Announce(envelope) => publish(&envelope),
+            PublishMsg::Flush { ack } => {
+                // Everything queued ahead of this barrier has now been
+                // published. A dropped receiver just means the waiter gave up.
+                let _ = ack.send(());
+                Ok(())
+            }
         };
         if let Err(error) = result {
             tracing::warn!(%error, "failed to publish data envelope");


### PR DESCRIPTION
`log_joint_*` and `log_custom_1d` hand their envelope to the background publisher thread's unbounded queue, which nothing drains at process exit. `stop_recording` now barriers on that queue before stamping the recording window's upper bound, and again after the writer flush so sealed chunk announcements reach the wire before the call returns.

Draining before the stop rather than after also puts those envelopes ahead of it, so they no longer depend on the daemon's closing-window retention to be routed.