### PR TITLE
fix: ensure data daemon receives recording commands

### DIFF
--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -12,6 +12,8 @@ import logging
 from importlib import import_module
 from types import ModuleType
 
+from neuracore.data_daemon.daemon_control import ensure_daemon_running
+
 logger = logging.getLogger(__name__)
 
 _DATA_BRIDGE_MODULE: ModuleType | None = None
@@ -104,6 +106,7 @@ class RecordingContext:
         seconds), matching the ``log_*`` methods; when ``None`` the producer
         stamps the publish clock now.
         """
+        ensure_daemon_running()
         self.bind_source(robot_id, robot_instance)
         timestamp_ns = int(timestamp * 1_000_000_000) if timestamp is not None else None
 

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -524,6 +524,33 @@ fn clock_fallback_ns() -> i64 {
     BASE_NS.saturating_add(ANCHOR.elapsed().as_nanos() as i64)
 }
 
+fn send_until_delivered<F>(
+    mut send_once: F,
+    timeout: std::time::Duration,
+    retry_delay: std::time::Duration,
+) -> Result<(), ProducerError>
+where
+    F: FnMut() -> Result<usize, ProducerError>,
+{
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let recipients = send_once()?;
+
+        if recipients > 0 {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(ProducerError::Send(format!(
+                "no data-daemon command subscriber connected within {timeout:?}"
+            )));
+        }
+
+        std::thread::sleep(retry_delay);
+    }
+}
+
 /// Encode `envelope` and publish it on the commands service.
 pub(crate) fn publish(envelope: &Envelope) -> Result<(), ProducerError> {
     let bytes = envelope.encode()?;
@@ -535,14 +562,21 @@ pub(crate) fn publish(envelope: &Envelope) -> Result<(), ProducerError> {
     }
     with_producer(|state| {
         let publisher = &state.commands_publisher;
-        let sample = publisher
-            .loan_slice_uninit(bytes.len())
-            .map_err(|error| ProducerError::Loan(error.to_string()))?;
-        let sample = sample.write_from_slice(&bytes);
-        sample
-            .send()
-            .map_err(|error| ProducerError::Send(error.to_string()))?;
-        Ok(())
+
+        send_until_delivered(
+            || {
+                let sample = publisher
+                    .loan_slice_uninit(bytes.len())
+                    .map_err(|error| ProducerError::Loan(error.to_string()))?;
+                let sample = sample.write_from_slice(&bytes);
+
+                sample
+                    .send()
+                    .map_err(|error| ProducerError::Send(error.to_string()))
+            },
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_millis(10),
+        )
     })
 }
 
@@ -574,5 +608,22 @@ mod tests {
             let bytes = serde_json::to_vec(&ScalarFrameEntry { timestamp, value }).expect("encode");
             assert_eq!(String::from_utf8(bytes).unwrap(), expected);
         }
+    }
+
+    #[test]
+    fn command_send_retries_until_a_subscriber_receives_it() {
+        let mut attempts = 0;
+
+        let result = send_until_delivered(
+            || {
+                attempts += 1;
+                Ok(if attempts == 3 { 1 } else { 0 })
+            },
+            std::time::Duration::from_millis(50),
+            std::time::Duration::ZERO,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(attempts, 3);
     }
 }


### PR DESCRIPTION
### Bugfixes

- Start the data daemon before publishing `StartRecording`.
- Retry bounded IPC sends when Iceoryx reports zero subscribers.
- Prevent recording commands being lost during daemon cold starts.

This was exposed by frontend integration tests, which stop the daemon between tests and immediately begin a new recording. 

(Discussed with damon/stephen)

### Testing

- Added a Rust regression test for zero-recipient retries.

### Related PRs
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/411