### PR TITLE
chore: limit perf testing to only mac and linux py314

### DIFF
--- a/.github/workflows/integration-pf-data-daemon-production.yaml
+++ b/.github/workflows/integration-pf-data-daemon-production.yaml
@@ -103,10 +103,11 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 1
-      # Run the performance suite on a single matrix row to limit wasted actions runner time.
+      # Pinned rather than driven by the workflow inputs: the performance suite is
+      # the expensive half of this workflow, so it runs one Python on each OS.
       matrix:
-        python-version: ${{ fromJSON(inputs.python-version || '["3.14"]') }}
-        os: ${{ fromJSON(inputs.os || '["ubuntu-24.04"]') }}
+        python-version: ["3.14"]
+        os: ["ubuntu-24.04", "macos-26"]
 
     steps:
     - name: Show disk space

--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -170,10 +170,11 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 1
-      # Run the performance suite on a single matrix row to limit wasted actions runner time.
+      # Pinned rather than driven by the workflow inputs: the performance suite is
+      # the expensive half of this workflow, so it runs one Python on each OS.
       matrix:
-        python-version: ${{ fromJSON(inputs.python-version || '["3.14"]') }}
-        os: ${{ fromJSON(inputs.os || '["ubuntu-24.04"]') }}
+        python-version: ["3.14"]
+        os: ["ubuntu-24.04", "macos-26"]
 
     steps:
     - name: Show disk space


### PR DESCRIPTION
As discussed in meeting, limit the perf tests to py3.14 on mac and linux. 