### PR TITLE
feat: poll for dataset statistics while they calculate

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -137,6 +137,23 @@ python example_retrieve_dataset.py
 If you want to just view your data, then the best way is via the [web interface](https://www.neuracore.com/dashboard/datasets).
 
 
+### Print Dataset statistics
+
+This example shows you how to:
+- Describe which data items a policy reads and which it predicts, by index
+- Ask Neuracore for a synchronized dataset's **statistics** (count, mean, std, min, max, q01, q99)
+- Print them per data type and item, without plotting anything
+
+These are the same statistics training uses to normalize your data. They are
+calculated on the platform, so the call reports progress while it waits, and
+asking again for the same recordings reuses the result instead of recalculating
+it.
+
+```bash
+python example_dataset_statistics.py
+```
+
+
 ### Edit Dataset metadata
 
 This example shows you how to:

--- a/examples/example_dataset_statistics.py
+++ b/examples/example_dataset_statistics.py
@@ -1,0 +1,158 @@
+"""This example demonstrates how you can retrieve the statistics of a dataset
+from the Neuracore platform and print them."""
+
+import numpy as np
+from neuracore_types import (
+    CrossEmbodimentDescription,
+    CrossEmbodimentUnion,
+    DataItemStats,
+    DataType,
+    NCDataStats,
+)
+
+import neuracore as nc
+
+# Statistics are reported for the data a policy reads and the data it predicts,
+# so each role gets its own set of data types.
+INPUT_DATA_TYPES = [DataType.JOINT_POSITIONS, DataType.RGB_IMAGES]
+OUTPUT_DATA_TYPES = [DataType.JOINT_POSITIONS]
+
+
+def format_array(values: np.ndarray) -> str:
+    """Format a statistics array compactly, however many dimensions it has."""
+    if values.size == 0:
+        return "-"
+    return np.array2string(
+        values,
+        precision=4,
+        suppress_small=True,
+        threshold=8,
+        edgeitems=3,
+        separator=", ",
+    )
+
+
+def print_item_statistics(stats: NCDataStats, indent: str) -> None:
+    """Print every statistic a data item carries.
+
+    Each data type reports its own set of attributes: a joint has one value, a
+    camera has its frame plus intrinsics and extrinsics, and so on.
+
+    Args:
+        stats: The statistics for one data item.
+        indent: Leading whitespace for the printed lines.
+    """
+    for attribute_name in vars(stats):
+        attribute = getattr(stats, attribute_name)
+        if not isinstance(attribute, DataItemStats):
+            continue
+
+        print(f"{indent}{attribute_name}:")
+        print(f"{indent}  observations: {format_array(attribute.count)}")
+        print(f"{indent}  mean:         {format_array(attribute.mean)}")
+        print(f"{indent}  std:          {format_array(attribute.std)}")
+        print(f"{indent}  min:          {format_array(attribute.min)}")
+        print(f"{indent}  max:          {format_array(attribute.max)}")
+        print(f"{indent}  q01:          {format_array(attribute.q01)}")
+        print(f"{indent}  q99:          {format_array(attribute.q99)}")
+
+
+def item_names_by_index(
+    cross_embodiment_description: CrossEmbodimentDescription,
+    data_type: DataType,
+) -> dict[int, str]:
+    """Collect the item name at each canonical index across every robot.
+
+    Statistics are aggregated across robots into one list per data type, indexed
+    by position rather than by name, so this recovers what each position holds.
+
+    Args:
+        cross_embodiment_description: The description the statistics were
+            calculated for.
+        data_type: The data type to collect names for.
+
+    Returns:
+        A mapping of canonical index to the name (or names) found there.
+    """
+    names_by_index: dict[int, set[str]] = {}
+    for data_types in cross_embodiment_description.values():
+        for index, name in data_types.get(data_type, {}).items():
+            names_by_index.setdefault(index, set()).add(name)
+    return {index: " / ".join(sorted(names)) for index, names in names_by_index.items()}
+
+
+def print_statistics(
+    role: str,
+    statistics: dict[DataType, list[NCDataStats]],
+    cross_embodiment_description: CrossEmbodimentDescription,
+) -> None:
+    """Print one role's statistics, data type by data type.
+
+    Args:
+        role: Either "input" or "output".
+        statistics: The statistics for that role, dense by canonical index.
+        cross_embodiment_description: The description they were calculated for.
+    """
+    print(f"\n{'=' * 70}\n{role.upper()} STATISTICS\n{'=' * 70}")
+    if not statistics:
+        print("No statistics for this role.")
+        return
+
+    for data_type, stats_by_index in statistics.items():
+        names = item_names_by_index(cross_embodiment_description, data_type)
+        print(f"\n{data_type.value} ({len(stats_by_index)} items)")
+        for index, stats in enumerate(stats_by_index):
+            print(f"  [{index}] {names.get(index, '<unnamed>')}")
+            print_item_statistics(stats, indent="      ")
+
+
+def main():
+    """Print the statistics of a synchronized dataset."""
+    nc.login()
+
+    # Freiburg Franka Play is one of the many public datasets
+    dataset = nc.get_dataset("NYU ROT")
+
+    # Statistics are calculated over a synchronized dataset, so the data types
+    # being described have to have been synchronized first.
+    data_types = sorted(set(INPUT_DATA_TYPES) | set(OUTPUT_DATA_TYPES))
+    cross_embodiment_union: CrossEmbodimentUnion = {}
+    input_description: CrossEmbodimentDescription = {}
+    output_description: CrossEmbodimentDescription = {}
+    for robot_id in dataset.robot_ids:
+        data_type_to_names = dataset.get_full_embodiment_description(robot_id)
+        cross_embodiment_union[robot_id] = {
+            data_type: list(data_type_to_names[data_type].values())
+            for data_type in data_types
+        }
+        # A description keeps the index of each item, because statistics are
+        # aggregated across robots by position.
+        input_description[robot_id] = {
+            data_type: data_type_to_names[data_type] for data_type in INPUT_DATA_TYPES
+        }
+        output_description[robot_id] = {
+            data_type: data_type_to_names[data_type] for data_type in OUTPUT_DATA_TYPES
+        }
+
+    synced_dataset = dataset.synchronize(
+        frequency=20,
+        cross_embodiment_union=cross_embodiment_union,
+    )
+    print(f"Number of episodes: {len(synced_dataset)}")
+
+    # Statistics are calculated on the platform, so this reports progress while
+    # it waits. Asking again for the same recordings and descriptions reuses the
+    # result rather than recalculating it.
+    statistics = synced_dataset.calculate_statistics(
+        input_cross_embodiment_description=input_description,
+        output_cross_embodiment_description=output_description,
+    )
+
+    print_statistics("input", statistics.dataset_statistics["input"], input_description)
+    print_statistics(
+        "output", statistics.dataset_statistics["output"], output_description
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -125,6 +125,7 @@ doctests
 DONTNEED
 dtype
 EADDRINUSE
+edgeitems
 eigenpy
 einops
 elementwise

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -1,12 +1,17 @@
 """SynchronizedDataset class for managing synchronized datasets."""
 
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Union, cast
 
+import requests
 from neuracore_types import (
+    CalculateDatasetStatisticsRequest,
     CrossEmbodimentDescription,
     CrossEmbodimentUnion,
+    DatasetStatisticsJob,
+    DatasetStatisticsJobStatus,
     SynchronizedDatasetStatistics,
 )
 from tqdm import tqdm
@@ -15,6 +20,8 @@ from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.data.recording import Recording
 from neuracore.core.data.synced_recording import SynchronizedRecording
+from neuracore.core.exceptions import DatasetError
+from neuracore.core.utils.http_errors import extract_error_detail
 from neuracore.core.utils.http_session import thread_local_session
 
 if TYPE_CHECKING:
@@ -22,6 +29,11 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+DATASET_STATISTICS_POLL_INTERVAL_S = 5.0
+DATASET_STATISTICS_TIMEOUT_S = 1800.0
+DATASET_STATISTICS_RESULT_TIMEOUT_S = (5.0, 120.0)
+_FATAL_PROGRESS_STATUS_CODES = frozenset({400, 401, 403, 404, 409, 422})
 
 
 class SynchronizedDataset:
@@ -231,6 +243,11 @@ class SynchronizedDataset:
     ) -> SynchronizedDatasetStatistics:
         """Calculate statistics for each data type in the synchronized dataset.
 
+        The calculation runs server-side, so this starts it and then blocks,
+        reporting progress, until it finishes. Repeat calls for the same
+        recordings and cross-embodiment descriptions join the running calculation
+        or reuse its result, so an interrupted call resumes rather than restarts.
+
         Args:
             input_cross_embodiment_description: Cross-embodiment
             description for input data types.
@@ -240,15 +257,171 @@ class SynchronizedDataset:
         Returns:
             SynchronizedDatasetStatistics containing the calculated statistics.
         """
-        session = thread_local_session()
+        job = self._start_statistics_job(
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+        )
+        job = self._await_statistics_job(job)
+        return self._fetch_statistics_result(job.job_id)
+
+    def _start_statistics_job(
+        self,
+        input_cross_embodiment_description: CrossEmbodimentDescription,
+        output_cross_embodiment_description: CrossEmbodimentDescription,
+    ) -> DatasetStatisticsJob:
+        """Start or join the statistics calculation for this dataset and spec.
+
+        Args:
+            input_cross_embodiment_description: Cross-embodiment
+            description for input data types.
+            output_cross_embodiment_description: Cross-embodiment
+            description for output data types.
+
+        Returns:
+            The calculation's initial state.
+
+        Raises:
+            DatasetError: If the calculation could not be started.
+        """
+        # The server derives the job from the request, so retrying is safe.
+        session = thread_local_session(retry_transient=True)
         response = session.post(
             f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset/calculate-dataset-statistics",
-            json=SynchronizedDatasetStatistics(
+            json=CalculateDatasetStatisticsRequest(
                 synchronized_dataset_id=self.id,
                 input_cross_embodiment_description=input_cross_embodiment_description,
                 output_cross_embodiment_description=output_cross_embodiment_description,
             ).model_dump(mode="json"),
             headers=get_auth().get_headers(),
         )
-        response.raise_for_status()
+        if not response.ok:
+            raise DatasetError(
+                extract_error_detail(response)
+                or "Failed to start calculating dataset statistics."
+            )
+        return DatasetStatisticsJob.model_validate(response.json())
+
+    def _poll_statistics_job(self, job_id: str) -> DatasetStatisticsJob | None:
+        """Read a statistics calculation's state, tolerating transient failures.
+
+        Args:
+            job_id: The statistics job to poll.
+
+        Returns:
+            The calculation's state, or None when this read should simply be
+            retried on the next poll.
+
+        Raises:
+            DatasetError: If the calculation failed, or the read failed in a way
+                that further polling cannot resolve.
+        """
+        session = thread_local_session(retry_transient=True, retry_read_timeout=True)
+        try:
+            response = session.get(
+                f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset"
+                f"/dataset-statistics-progress/{job_id}",
+                headers=get_auth().get_headers(),
+            )
+        except requests.RequestException as exc:
+            logger.debug(f"Dataset statistics progress poll failed: {exc}")
+            return None
+
+        if not response.ok:
+            if response.status_code in _FATAL_PROGRESS_STATUS_CODES:
+                raise DatasetError(
+                    extract_error_detail(response)
+                    or "Calculating dataset statistics failed."
+                )
+            logger.debug(
+                "Dataset statistics progress returned "
+                f"{response.status_code}; retrying."
+            )
+            return None
+
+        job = DatasetStatisticsJob.model_validate(response.json())
+        if job.status is DatasetStatisticsJobStatus.FAILED:
+            raise DatasetError(job.error or "Calculating dataset statistics failed.")
+        return job
+
+    def _await_statistics_job(self, job: DatasetStatisticsJob) -> DatasetStatisticsJob:
+        """Block until a statistics calculation completes, reporting progress.
+
+        Args:
+            job: The calculation's current state.
+
+        Returns:
+            The calculation's completed state.
+
+        Raises:
+            DatasetError: If the calculation fails or exceeds the deadline.
+        """
+        if job.status is DatasetStatisticsJobStatus.COMPLETE:
+            logger.debug(f"Dataset statistics already calculated (job {job.job_id}).")
+            return job
+
+        deadline = time.monotonic() + DATASET_STATISTICS_TIMEOUT_S
+        pbar = tqdm(
+            total=job.num_recordings,
+            desc="Calculating dataset statistics",
+            unit="recording",
+        )
+        try:
+            pbar.n = min(job.num_completed_recordings, job.num_recordings)
+            pbar.refresh()
+            aggregating = False
+            while job.status is not DatasetStatisticsJobStatus.COMPLETE:
+                if time.monotonic() >= deadline:
+                    raise DatasetError(
+                        f"Timed out after {DATASET_STATISTICS_TIMEOUT_S:.0f}s "
+                        f"waiting for dataset statistics (job {job.job_id}, "
+                        f"status {job.status.value}, "
+                        f"{job.num_completed_recordings}/{job.num_recordings} "
+                        "recordings). The calculation is still running; "
+                        "calculating again resumes it rather than starting over."
+                    )
+                time.sleep(DATASET_STATISTICS_POLL_INTERVAL_S)
+                polled = self._poll_statistics_job(job.job_id)
+                if polled is None:
+                    continue
+
+                job = polled
+                completed = min(job.num_completed_recordings, job.num_recordings)
+                if completed > pbar.n:
+                    pbar.update(completed - pbar.n)
+                if (
+                    job.status is DatasetStatisticsJobStatus.AGGREGATING
+                    and not aggregating
+                ):
+                    aggregating = True
+                    pbar.set_description("Aggregating dataset statistics")
+                # Keep the elapsed clock moving so aggregating does not look
+                # like a hang once the recording count stops changing.
+                pbar.refresh()
+        finally:
+            pbar.close()
+        return job
+
+    def _fetch_statistics_result(self, job_id: str) -> SynchronizedDatasetStatistics:
+        """Fetch a completed statistics calculation's result.
+
+        Args:
+            job_id: The completed statistics job.
+
+        Returns:
+            SynchronizedDatasetStatistics containing the calculated statistics.
+
+        Raises:
+            DatasetError: If the result could not be fetched.
+        """
+        session = thread_local_session(retry_transient=True, retry_read_timeout=True)
+        response = session.get(
+            f"{API_URL}/org/{self.dataset.org_id}/synchronized-dataset"
+            f"/dataset-statistics/{job_id}",
+            headers=get_auth().get_headers(),
+            timeout=DATASET_STATISTICS_RESULT_TIMEOUT_S,
+        )
+        if not response.ok:
+            raise DatasetError(
+                extract_error_detail(response) or "Failed to fetch dataset statistics."
+            )
         return SynchronizedDatasetStatistics.model_validate(response.json())

--- a/tests/unit/core/data/test_synchronized_dataset_statistics.py
+++ b/tests/unit/core/data/test_synchronized_dataset_statistics.py
@@ -1,0 +1,260 @@
+"""Tests for SynchronizedDataset.calculate_statistics against an async backend."""
+
+import re
+from unittest.mock import patch
+
+import pytest
+import requests
+from neuracore_types import DatasetStatisticsJobStatus, DataType
+
+from neuracore.core.const import API_URL
+from neuracore.core.data.synced_dataset import SynchronizedDataset
+from neuracore.core.exceptions import DatasetError
+
+SYNCED_DATASET_ID = "synced_dataset_id"
+JOB_ID = "synced_dataset_id-abc123def456"
+CROSS_EMBODIMENT = {"robot": {DataType.JOINT_POSITIONS: {0: "j"}}}
+
+
+def job_json(
+    status: DatasetStatisticsJobStatus,
+    num_completed: int = 0,
+    total: int = 2,
+    error: str | None = None,
+) -> dict:
+    """Build a statistics job payload."""
+    return {
+        "job_id": JOB_ID,
+        "synchronized_dataset_id": SYNCED_DATASET_ID,
+        "status": status.value,
+        "num_recordings": total,
+        "num_completed_recordings": num_completed,
+        "error": error,
+    }
+
+
+RESULT_JSON = {
+    "synchronized_dataset_id": SYNCED_DATASET_ID,
+    "input_cross_embodiment_description": {"robot": {"JOINT_POSITIONS": {"0": "j"}}},
+    "output_cross_embodiment_description": {"robot": {"JOINT_POSITIONS": {"0": "j"}}},
+    "dataset_statistics": {"input": {}, "output": {}},
+}
+
+
+@pytest.mark.usefixtures("mock_login")
+class TestCalculateStatistics:
+    """Tests for the start, poll and fetch flow."""
+
+    @pytest.fixture(autouse=True)
+    def no_poll_delay(self, monkeypatch):
+        """Remove the poll delay so the loop runs at full speed."""
+        monkeypatch.setattr(
+            "neuracore.core.data.synced_dataset.DATASET_STATISTICS_POLL_INTERVAL_S", 0
+        )
+
+    @pytest.fixture
+    def synced_dataset(self, dataset_dict, recordings_list, tmp_path):
+        """Create a SynchronizedDataset instance for testing."""
+        from neuracore.core.data.dataset import Dataset
+
+        dataset = Dataset(**dataset_dict, recordings=recordings_list)
+        dataset.cache_dir = tmp_path / "cache"
+        dataset.cache_dir.mkdir(parents=True, exist_ok=True)
+        with patch.object(SynchronizedDataset, "_perform_synced_data_prefetch"):
+            return SynchronizedDataset(
+                id=SYNCED_DATASET_ID,
+                dataset=dataset,
+                frequency=30,
+                cross_embodiment_union=None,
+                prefetch_videos=False,
+            )
+
+    @pytest.fixture
+    def endpoints(self, mocked_org_id):
+        """The three statistics endpoints."""
+        base = f"{API_URL}/org/{mocked_org_id}/synchronized-dataset"
+        return {
+            "start": f"{base}/calculate-dataset-statistics",
+            "progress": f"{base}/dataset-statistics-progress/{JOB_ID}",
+            "result": f"{base}/dataset-statistics/{JOB_ID}",
+        }
+
+    def calculate(self, synced_dataset: SynchronizedDataset):
+        """Run calculate_statistics with both cross-embodiment descriptions."""
+        return synced_dataset.calculate_statistics(
+            input_cross_embodiment_description=CROSS_EMBODIMENT,
+            output_cross_embodiment_description=CROSS_EMBODIMENT,
+        )
+
+    def test_warm_job_skips_polling_and_shows_no_progress_bar(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """An already-complete job returns its result without any noise."""
+        mock_data_requests.post(
+            endpoints["start"],
+            json=job_json(DatasetStatisticsJobStatus.COMPLETE, num_completed=2),
+        )
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json(DatasetStatisticsJobStatus.COMPLETE, 2)
+        )
+        result = mock_data_requests.get(endpoints["result"], json=RESULT_JSON)
+
+        statistics = self.calculate(synced_dataset)
+
+        assert statistics.synchronized_dataset_id == SYNCED_DATASET_ID
+        assert progress.call_count == 0
+        assert result.call_count == 1
+
+    def test_polls_until_complete_then_fetches_the_result(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """The client polls through the aggregate stage before fetching."""
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        progress = mock_data_requests.get(
+            endpoints["progress"],
+            [
+                {"json": job_json(DatasetStatisticsJobStatus.RUNNING, 1)},
+                {"json": job_json(DatasetStatisticsJobStatus.AGGREGATING, 2)},
+                {"json": job_json(DatasetStatisticsJobStatus.COMPLETE, 2)},
+            ],
+        )
+        result = mock_data_requests.get(endpoints["result"], json=RESULT_JSON)
+
+        statistics = self.calculate(synced_dataset)
+
+        assert statistics.synchronized_dataset_id == SYNCED_DATASET_ID
+        assert progress.call_count == 3
+        assert result.call_count == 1
+
+    def test_completion_keys_off_status_not_the_counter(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """The aggregate stage runs after the counter saturates."""
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        progress = mock_data_requests.get(
+            endpoints["progress"],
+            [
+                {"json": job_json(DatasetStatisticsJobStatus.RUNNING, 2)},
+                {"json": job_json(DatasetStatisticsJobStatus.AGGREGATING, 2)},
+                {"json": job_json(DatasetStatisticsJobStatus.COMPLETE, 2)},
+            ],
+        )
+        result = mock_data_requests.get(endpoints["result"], json=RESULT_JSON)
+
+        self.calculate(synced_dataset)
+
+        assert progress.call_count == 3
+        assert result.call_count == 1
+
+    def test_job_failure_surfaces_the_backend_message_verbatim(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """A 422 breaks the poll loop with the server's explanation."""
+        message = (
+            "The dataset changed while statistics were being calculated. "
+            "Calculating them again will use the dataset's current recordings."
+        )
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        mock_data_requests.get(
+            endpoints["progress"],
+            status_code=422,
+            json={"detail": {"error": message, "status": 422}},
+        )
+
+        with pytest.raises(DatasetError, match=re.escape(message)):
+            self.calculate(synced_dataset)
+
+    def test_failed_status_in_the_body_raises(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """A FAILED job is fatal even when the response is a 200."""
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        mock_data_requests.get(
+            endpoints["progress"],
+            json=job_json(DatasetStatisticsJobStatus.FAILED, 1, error="boom"),
+        )
+
+        with pytest.raises(DatasetError, match="boom"):
+            self.calculate(synced_dataset)
+
+    def test_transient_progress_failures_are_retried(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """A saturated backend must not discard minutes of waiting."""
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        mock_data_requests.get(
+            endpoints["progress"],
+            [
+                {"status_code": 503, "json": {}},
+                {"exc": requests.exceptions.ConnectionError},
+                {"json": job_json(DatasetStatisticsJobStatus.COMPLETE, 2)},
+            ],
+        )
+        result = mock_data_requests.get(endpoints["result"], json=RESULT_JSON)
+
+        statistics = self.calculate(synced_dataset)
+
+        assert statistics.synchronized_dataset_id == SYNCED_DATASET_ID
+        assert result.call_count == 1
+
+    def test_a_missing_job_is_not_retried(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """Polling cannot resolve a job the server does not have."""
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 0)
+        )
+        progress = mock_data_requests.get(
+            endpoints["progress"],
+            status_code=404,
+            json={"detail": {"error": "Statistics job not found", "status": 404}},
+        )
+
+        with pytest.raises(DatasetError, match="Statistics job not found"):
+            self.calculate(synced_dataset)
+
+        assert progress.call_count == 1
+
+    def test_deadline_exceeded_reports_the_job(
+        self, mock_data_requests, synced_dataset, endpoints, monkeypatch
+    ):
+        """A wedged job fails with enough context to resume it."""
+        monkeypatch.setattr(
+            "neuracore.core.data.synced_dataset.DATASET_STATISTICS_TIMEOUT_S", 0
+        )
+        mock_data_requests.post(
+            endpoints["start"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 1)
+        )
+        mock_data_requests.get(
+            endpoints["progress"], json=job_json(DatasetStatisticsJobStatus.RUNNING, 1)
+        )
+
+        with pytest.raises(DatasetError) as error:
+            self.calculate(synced_dataset)
+
+        assert JOB_ID in str(error.value)
+        assert "1/2" in str(error.value)
+        assert "resumes" in str(error.value)
+
+    def test_start_failure_surfaces_the_backend_message(
+        self, mock_data_requests, synced_dataset, endpoints
+    ):
+        """A rejected start is reported rather than polled for."""
+        mock_data_requests.post(
+            endpoints["start"],
+            status_code=404,
+            json={"detail": {"error": "Dataset not found", "status": 404}},
+        )
+
+        with pytest.raises(DatasetError, match="Dataset not found"):
+            self.calculate(synced_dataset)


### PR DESCRIPTION
Dataset statistics are the per-item mean/std/min/max/quantiles that training uses to normalize data. `PytorchSynchronizedDataset` fetches them from the platform before training, and the backend used to compute them inside the request — up to six minutes on a large dataset. They are now calculated in the background, so the client starts a job and waits on it.

### Features
 - `SynchronizedDataset.calculate_statistics` now starts the calculation, polls it with a progress bar, and fetches the result. Its signature and return type are unchanged, so `PytorchSynchronizedDataset` and its on-disk statistics cache needed no edits.
 - Repeat calls for the same recordings and cross-embodiment descriptions join the running calculation or reuse its result, so an interrupted call resumes instead of starting over. The timeout message says so.
 - The bar counts recordings, then switches to "Aggregating dataset statistics" for the final merge, so a long tail does not look like a hang. An already-complete calculation returns without printing anything.
 - New `examples/example_dataset_statistics.py` prints a dataset's statistics without plotting anything. 

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore_types/pull/109
 - https://github.com/NeuracoreAI/neuracore_backend/pull/488