### PR TITLE
fix: widen HTTP timeouts for streamed uploads and slow training endpoints

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -198,10 +198,13 @@ def start_training_run(
     auth = get_auth()
     org_id = get_current_org()
     session = thread_local_session()
+    # Ideally the backend would queue the job and return immediately instead of
+    # blocking on VM provisioning. Until it does, allow a longer read timeout.
     response = session.post(
         f"{API_URL}/org/{org_id}/training/jobs",
         headers=auth.get_headers(),
         json=data.model_dump(mode="json"),
+        timeout=(5.0, 60.0),
     )
 
     response.raise_for_status()
@@ -229,9 +232,11 @@ def resume_training_run(job_id: str, additional_epochs: int) -> dict:
     org_id = get_current_org()
     try:
         session = thread_local_session()
+        # Blocks on VM provisioning, as start_training_run does.
         response = session.post(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}/resume/{additional_epochs}",
             headers=auth.get_headers(),
+            timeout=(5.0, 60.0),
         )
     except Exception as e:
         raise ValueError(f"Error resuming job {job_id}: {e}") from e

--- a/neuracore/core/utils/http_session.py
+++ b/neuracore/core/utils/http_session.py
@@ -49,8 +49,19 @@ from urllib3.exceptions import ProtocolError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT: tuple[float, float] = (5.0, 30.0)
-"""``(connect, read)`` seconds applied to requests that set no timeout."""
+DEFAULT_TIMEOUT: tuple[float, float] = (15.0, 30.0)
+"""``(connect, read)`` seconds applied to requests that set no timeout.
+
+The connect budget also bounds the request body write, not just connection
+setup: urllib3 leaves the connect timeout on the socket for the whole of
+``conn.request()`` and only swaps in the read timeout at ``getresponse()``. It
+therefore has to cover each ``send()`` of a streamed upload once the kernel
+send buffer fills and every send waits on the drain rate — five seconds was
+enough for connecting but not for that.
+
+Callers whose response is genuinely slow should pass their own timeout rather
+than widening this one.
+"""
 
 _KEEPALIVE_IDLE_S = 60
 """Seconds of idleness before the first keep-alive probe.


### PR DESCRIPTION
Raises the connect timeout to 15s so it can cover streamed upload writes (urllib3 applies it, not the read timeout, for the whole request body), and gives the training start/resume endpoints an explicit 60s read timeout since they block on VM provisioning.