### PR TITLE
fix: allow a longer read timeout for VM teardown requests

### DIFF
--- a/neuracore/api/endpoints.py
+++ b/neuracore/api/endpoints.py
@@ -361,9 +361,13 @@ def delete_endpoint(endpoint_id: str) -> None:
     org_id = get_current_org()
     try:
         session = thread_local_session()
+        # Ideally the backend would queue the teardown and return immediately
+        # instead of blocking on VM deletion. Until it does, allow a longer
+        # read timeout.
         response = session.delete(
             f"{API_URL}/org/{org_id}/models/endpoints/{endpoint_id}",
             headers=auth.get_headers(),
+            timeout=(5.0, 60.0),
         )
         response.raise_for_status()
     except Exception as e:

--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -376,9 +376,11 @@ def cancel_training_job(job_id: str) -> None:
     org_id = get_current_org()
     try:
         session = thread_local_session()
+        # Blocks on VM teardown, so allow a longer read timeout.
         response = session.post(
             f"{API_URL}/org/{org_id}/training/jobs/{job_id}",
             headers=auth.get_headers(),
+            timeout=(5.0, 60.0),
         )
         response.raise_for_status()
     except Exception as e:
@@ -402,9 +404,11 @@ def delete_training_job(job_id: str, org_id: str | None = None) -> None:
     resolved_org_id = org_id or get_current_org()
     try:
         session = thread_local_session()
+        # Blocks on VM teardown, so allow a longer read timeout.
         response = session.delete(
             f"{API_URL}/org/{resolved_org_id}/training/jobs/{job_id}",
             headers=auth.get_headers(),
+            timeout=(5.0, 60.0),
         )
         response.raise_for_status()
     except Exception as e:


### PR DESCRIPTION
Gives `delete_endpoint`, `cancel_training_job` and `delete_training_job` an explicit 60s read timeout, since all three block on cloud VM deletion before the backend responds.