### PR TITLE
feat: add depth image support to Rust data daemon

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -124,6 +124,8 @@ docstrings
 doctests
 DONTNEED
 dtype
+dtyped
+dtypes
 EADDRINUSE
 edgeitems
 eigenpy
@@ -225,6 +227,7 @@ inertiagrouprange
 initargs
 inproc
 inspectable
+ipynb
 ipython
 iquat
 Irqfx

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -539,6 +539,7 @@ def _log_camera_data(
             storage_name,
             int(image.shape[1]),
             int(image.shape[0]),
+            image.dtype.name,
             memoryview(contiguous).cast("B"),
             camera_data_without_frame.timestamp,
         )

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -154,6 +154,7 @@ class RecordingContext:
         name: str,
         width: int,
         height: int,
+        dtype: str,
         payload: bytes | memoryview,
         timestamp: float,
     ) -> None:
@@ -164,6 +165,10 @@ class RecordingContext:
             name: the camera/sensor name e.g. left_wrist_camera.
             width: Video frame width.
             height: Video frame height.
+            dtype: The frame's original numpy dtype name (``image.dtype.name``),
+                e.g. ``"uint8"`` for RGB or ``"float16"`` / ``"float32"`` for
+                depth. Parsed once at the native boundary so every internal
+                Rust component works with a strongly typed representation.
             payload: Raw video frame bytes.
             timestamp: the Unix timestamp of the sample.
         """
@@ -176,6 +181,7 @@ class RecordingContext:
             name,
             int(width),
             int(height),
+            dtype,
             payload,
             timestamp_ns,
             timestamp,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -392,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +459,7 @@ name = "data_daemon_bridge"
 version = "0.1.0"
 dependencies = [
  "data_daemon_shared",
+ "half",
  "iceoryx2",
  "libc",
  "miniz_oxide",
@@ -853,6 +860,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"] }
 crc32c = "0.6"
 dashmap = "6"
 dirs = "5"
+half = "2"
 iceoryx2 = "0.8"
 libc = "0.2"
 nix = { version = "0.29", features = ["fs", "process", "signal"] }

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use data_daemon_shared::{BatchedDataItem, Envelope};
+use data_daemon_shared::{BatchedDataItem, Envelope, FrameDtype};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -236,6 +236,7 @@ enum HeldPayload {
         byte_count: u64,
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
+        dtype: FrameDtype,
     },
 }
 
@@ -432,6 +433,7 @@ impl Dispatcher {
                 frame_count,
                 frame_timestamps_ns,
                 frame_timestamps_s,
+                dtype,
             } => {
                 let source = (robot_id, robot_instance);
                 self.touch_source(&source, recv_at);
@@ -449,6 +451,7 @@ impl Dispatcher {
                         byte_count,
                         frame_count,
                         frame_timestamps_s,
+                        dtype,
                     },
                 });
             }
@@ -934,6 +937,7 @@ impl Dispatcher {
                 byte_count,
                 frame_count,
                 frame_timestamps_s,
+                dtype,
             } => {
                 self.route_video(
                     &held.source,
@@ -946,6 +950,7 @@ impl Dispatcher {
                     byte_count,
                     frame_count,
                     frame_timestamps_s,
+                    dtype,
                 )
                 .await;
             }
@@ -1024,6 +1029,7 @@ impl Dispatcher {
         byte_count: u64,
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
+        dtype: FrameDtype,
     ) {
         let recordings_root = self.actor_context.recordings_root.clone();
         // The chunk's `publish_timestamp_ns` (its open time) keys both the
@@ -1078,6 +1084,7 @@ impl Dispatcher {
                 byte_count,
                 frame_count,
                 frame_timestamps_s,
+                dtype,
             })
             .await
             .is_err()
@@ -1566,6 +1573,7 @@ mod tests {
             frame_count: 1,
             frame_timestamps_ns: vec![publish_ts],
             frame_timestamps_s: vec![publish_ts as f64 / 1e9],
+            dtype: FrameDtype::Rgb8,
         }
     }
 

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -36,6 +36,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use data_daemon_shared::FrameDtype;
 use serde_json::Value;
 use tokio::sync::{mpsc, watch, Semaphore};
 use tokio::task::{self, JoinSet};
@@ -279,6 +280,10 @@ pub enum TraceActorMessage {
         frame_count: u32,
         /// Per-frame `timestamp_s` for the metadata sidecar, in capture order.
         frame_timestamps_s: Vec<f64>,
+        /// Original dtype of every frame in this chunk. The daemon never
+        /// decodes pixels — this is threaded straight into the completed
+        /// chunk and, for depth, the trace's `trace.json` sidecar.
+        dtype: FrameDtype,
     },
     /// The recording window has closed and its holdback has drained: finalise
     /// the trace. Every routed datum has already been delivered ahead of this
@@ -333,6 +338,10 @@ struct CompletedChunk {
     frame_timestamps_s: Vec<f64>,
     /// Frame count carried by the chunk message.
     frame_count: u32,
+    /// This chunk's original frame dtype — stored per chunk (not once for the
+    /// whole trace) so each chunk's metadata entries get their own dtype even
+    /// if it somehow differs between chunks of one trace.
+    dtype: FrameDtype,
 }
 
 /// Outcome of one background chunk-encode task.
@@ -376,6 +385,7 @@ pub async fn run(
                 byte_count,
                 frame_count,
                 frame_timestamps_s,
+                dtype,
             } => {
                 state
                     .handle_video(
@@ -387,6 +397,7 @@ pub async fn run(
                         byte_count,
                         frame_count,
                         frame_timestamps_s,
+                        dtype,
                     )
                     .await;
             }
@@ -600,6 +611,7 @@ impl ActorState {
         byte_count: u64,
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
+        dtype: FrameDtype,
     ) {
         let trace_dir = self.trace_directory(context);
         let chunks_dir = trace_dir.join(paths::CHUNKS_DIRNAME);
@@ -783,6 +795,7 @@ impl ActorState {
                             bytes: segment_bytes,
                             frame_timestamps_s,
                             frame_count,
+                            dtype,
                         }),
                     }
                 }
@@ -1039,7 +1052,12 @@ impl ActorState {
                 };
 
                 // Build the metadata accumulator in the same chunk-index
-                // order so per-frame entries appear in capture order.
+                // order so per-frame entries appear in capture order. Each
+                // chunk applies its own stored dtype (not just the first
+                // chunk's) to its frame entries — a depth chunk's entries gain
+                // a `"dtype"` field carrying the canonical `trace.json` string
+                // ("float16" / "float32"); RGB chunks add nothing, keeping the
+                // existing RGB `trace.json` schema byte-for-byte unchanged.
                 let mut metadata = VideoMetadataAccumulator::new();
                 for chunk in completed_chunks.values() {
                     for timestamp_s in &chunk.frame_timestamps_s {
@@ -1047,6 +1065,9 @@ impl ActorState {
                         entry.insert("timestamp".to_string(), Value::from(*timestamp_s));
                         entry.insert("width".to_string(), Value::from(width as u64));
                         entry.insert("height".to_string(), Value::from(height as u64));
+                        if let Some(dtype_label) = chunk.dtype.depth_label() {
+                            entry.insert("dtype".to_string(), Value::from(dtype_label));
+                        }
                         metadata.record_frame(entry);
                     }
                 }
@@ -1456,6 +1477,7 @@ mod tests {
                     byte_count,
                     4,
                     frame_timestamps_s,
+                    FrameDtype::Rgb8,
                 )
                 .await;
         }
@@ -1477,6 +1499,102 @@ mod tests {
             .expect("trace exists");
         assert_eq!(trace.write_status, TraceWriteStatus::Written);
         assert!(trace.total_bytes > 0);
+
+        // RGB metadata entries must stay exactly as before: no `dtype` field.
+        let sidecar: Value = serde_json::from_slice(
+            &std::fs::read(trace_dir.join(paths::TRACE_JSON_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        for entry in sidecar.as_array().unwrap() {
+            assert!(
+                entry.as_object().unwrap().get("dtype").is_none(),
+                "RGB trace.json entries must not gain a dtype field: {entry}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn depth_chunks_record_their_own_dtype_in_metadata_sidecar() {
+        // Depth frame entries must carry "dtype": "float16" / "float32" per
+        // chunk — and a later chunk with a different depth dtype must apply
+        // its *own* dtype to its own entries, not the first chunk's.
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping depth metadata sidecar test.");
+            return;
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+            .await
+            .expect("open store");
+        let store_arc = Arc::new(store.clone());
+        let context = test_context(&tempdir.path().join("recordings"), store_arc.clone());
+
+        let mut state = ActorState::new(identity(1, "trace-depth", "DEPTH_IMAGES"));
+        state.send_create(&context);
+
+        let trace_dir = TracePath::new("1", "DEPTH_IMAGES", "trace-depth")
+            .directory(context.recordings_root.as_path());
+        let spool_dir = tempdir.path().join("spool");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let dtypes = [FrameDtype::DepthF16, FrameDtype::DepthF32];
+        for (chunk_index, dtype) in dtypes.into_iter().enumerate() {
+            let chunk_index = chunk_index as u32;
+            let spool_nut = spool_dir.join(format!("chunk_{chunk_index}.nut"));
+            let status = std::process::Command::new("ffmpeg")
+                .args([
+                    "-y",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                ])
+                .arg("testsrc=duration=2:size=16x16:rate=1")
+                .args(["-c:v", "rawvideo", "-pix_fmt", "rgb24", "-f", "nut"])
+                .arg(&spool_nut)
+                .status()
+                .expect("synth status");
+            assert!(status.success(), "synth NUT failed");
+
+            let byte_count = spool_nut.metadata().unwrap().len();
+            let frame_timestamps_s: Vec<f64> =
+                (0..2u32).map(|i| (chunk_index * 2 + i) as f64).collect();
+            state
+                .handle_video(
+                    &context,
+                    chunk_index,
+                    spool_nut,
+                    16,
+                    16,
+                    byte_count,
+                    2,
+                    frame_timestamps_s,
+                    dtype,
+                )
+                .await;
+        }
+
+        state.finalise_trace(&context).await;
+        context.trace_writer.flush().await;
+
+        let sidecar: Value = serde_json::from_slice(
+            &std::fs::read(trace_dir.join(paths::TRACE_JSON_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        let entries = sidecar.as_array().unwrap();
+        assert_eq!(entries.len(), 4, "two chunks of two frames each");
+        // First chunk's two entries carry float16; second chunk's carry float32.
+        for entry in &entries[0..2] {
+            assert_eq!(entry["dtype"], json!("float16"));
+        }
+        for entry in &entries[2..4] {
+            assert_eq!(entry["dtype"], json!("float32"));
+        }
+        assert_eq!(entries[0]["width"], json!(16));
+        assert_eq!(entries[0]["height"], json!(16));
     }
 
     #[tokio::test]

--- a/rust/data_daemon_bridge/Cargo.toml
+++ b/rust/data_daemon_bridge/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 data_daemon_shared = { path = "../data_daemon_shared" }
+half.workspace = true
 iceoryx2.workspace = true
 libc.workspace = true
 miniz_oxide = "0.8"

--- a/rust/data_daemon_bridge/src/depth.rs
+++ b/rust/data_daemon_bridge/src/depth.rs
@@ -1,0 +1,319 @@
+//! Depth-to-RGB24 storage conversion for the producer's video path.
+//!
+//! The NUT/PNG pipeline ([`crate::nut_writer`]) only ever accepts packed
+//! RGB24. A depth frame is therefore converted into that representation
+//! *before* compression, mirroring the Python reference algorithm in
+//! `neuracore.core.utils.depth_utils.depth_to_rgb_storage` bit-for-bit:
+//!
+//! 1. Clip depth values (metres) to `[0, MAX_DEPTH]`.
+//! 2. Normalize to `[0, 1]`.
+//! 3. Scale to 24-bit range (`0..=2^24 - 1`).
+//! 4. Floor and split the 24-bit value into R, G, B bytes (most-significant
+//!    byte first).
+//!
+//! Matching this exactly is what lets `rgb_to_depth_storage` (Python) decode a
+//! Rust-converted depth frame correctly.
+
+use data_daemon_shared::FrameDtype;
+
+/// Maximum depth value (metres) the canonical storage encoding represents.
+/// Must match `neuracore.core.utils.depth_utils.MAX_DEPTH` — this Rust
+/// conversion and the Python decoder are two implementations of the same wire
+/// contract, so a drift here would silently corrupt every depth recording's
+/// decoded values without either side raising an error.
+const MAX_DEPTH: f32 = 10.0;
+
+/// 24-bit maximum value depth is scaled into, as `f32`: `2^24 - 1`.
+const MAX_24_BIT: f32 = 16_777_215.0;
+
+/// Clip one decoded depth sample (metres) into `[0, MAX_DEPTH]`.
+///
+/// `f32::clamp` does not touch `NaN` (comparisons against `NaN` are always
+/// false, so the "self" branch is taken unchanged) — left alone, a `NaN`
+/// sample would propagate through the scale/floor/cast chain into a
+/// platform-dependent byte pattern, which is exactly the "undefined
+/// conversion" this module must not produce. The Python reference has the
+/// same gap (`np.clip` propagates `NaN`, and the final `astype(np.uint8)`
+/// cast of a `NaN` is itself platform/version-dependent), so there is no
+/// existing canonical behaviour to match; we deliberately and
+/// deterministically treat a `NaN` sample as invalid depth (zero) rather than
+/// inherit that ambiguity. `+inf`/`-inf` need no special case: `clamp` already
+/// pins them to `MAX_DEPTH`/`0` respectively, matching `np.clip`.
+fn clip_depth_meters(value: f32) -> f32 {
+    if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(0.0, MAX_DEPTH)
+    }
+}
+
+/// Convert one clipped depth sample (metres) to its packed 24-bit storage
+/// value, matching `depth_to_rgb_storage`'s `normalize -> scale -> floor`
+/// chain exactly (see the module docs for why floor-once-then-split is
+/// equivalent to Python's per-channel floor/mod on the un-floored float).
+fn depth_meters_to_24bit(clipped_meters: f32) -> u32 {
+    let normalized = clipped_meters / MAX_DEPTH;
+    let scaled = normalized * MAX_24_BIT;
+    scaled.floor() as u32
+}
+
+/// Decode one little-endian IEEE-754 depth sample from `chunk`, which must be
+/// exactly `dtype.bytes_per_pixel()` bytes. Callers get that guarantee from
+/// [`depth_to_rgb24`], which asserts the whole buffer's length once and then
+/// hands out chunks via [`slice::chunks_exact`] — so this function never has
+/// to re-validate a length itself. Numpy arrays are native-endian, and every
+/// platform this wheel ships for (Linux x86_64, Apple Silicon macOS) is
+/// little-endian.
+///
+/// # Panics
+///
+/// Panics unconditionally (in every build profile, not just debug) if
+/// `dtype` is [`FrameDtype::Rgb8`]. This function only ever decodes depth
+/// samples; every production call site is gated by a `match` on `dtype` that
+/// structurally excludes `Rgb8` (see [`depth_to_rgb24`]), so reaching this
+/// arm means an internal caller broke that contract. Returning a placeholder
+/// value here would silently corrupt the converted frame instead of
+/// surfacing the bug.
+fn decode_meters(dtype: FrameDtype, chunk: &[u8]) -> f32 {
+    match dtype {
+        FrameDtype::DepthF16 => {
+            let bytes: [u8; 2] = chunk
+                .try_into()
+                .expect("chunks_exact(2) guarantees a 2-byte chunk");
+            half::f16::from_le_bytes(bytes).to_f32()
+        }
+        FrameDtype::DepthF32 => {
+            let bytes: [u8; 4] = chunk
+                .try_into()
+                .expect("chunks_exact(4) guarantees a 4-byte chunk");
+            f32::from_le_bytes(bytes)
+        }
+        FrameDtype::Rgb8 => unreachable!("decode_meters called with a non-depth dtype"),
+    }
+}
+
+/// Convert one raw depth frame (`dtype` is [`FrameDtype::DepthF16`] or
+/// [`FrameDtype::DepthF32`]) into packed RGB24 storage bytes, matching
+/// `depth_to_rgb_storage` exactly.
+///
+/// Always returns exactly `width * height * 3` bytes.
+///
+/// # Panics
+///
+/// Panics if `raw.len()` is not exactly `width * height * dtype.bytes_per_pixel()`,
+/// or if `width * height * bytes_per_pixel` overflows `usize`. The buffer
+/// length is a **caller-enforced invariant**, not user input to validate
+/// defensively here: the native boundary ([`crate::log_frame`](crate))
+/// already rejects a mismatched buffer before it is ever copied, and the
+/// writer re-checks the same exact length again in `submit_frame` before
+/// this function ever runs — so by the time a buffer reaches here, its
+/// length has already been validated twice. A mismatch reaching this point
+/// means one of those upstream checks was bypassed by a bug, and that bug
+/// must surface immediately rather than silently degrade to zero-depth
+/// pixels for the missing samples.
+pub fn depth_to_rgb24(dtype: FrameDtype, width: u32, height: u32, raw: &[u8]) -> Vec<u8> {
+    debug_assert!(
+        matches!(dtype, FrameDtype::DepthF16 | FrameDtype::DepthF32),
+        "depth_to_rgb24 called with {dtype:?}, expected a depth dtype"
+    );
+    let bytes_per_pixel = dtype.bytes_per_pixel();
+    let pixel_count = (width as usize)
+        .checked_mul(height as usize)
+        .expect("width * height overflows usize");
+    let expected_len = pixel_count
+        .checked_mul(bytes_per_pixel)
+        .expect("width * height * bytes_per_pixel overflows usize");
+    assert!(
+        raw.len() == expected_len,
+        "depth_to_rgb24: buffer is {} bytes; expected exactly {expected_len} bytes for a \
+         {width}x{height} {dtype:?} frame. The caller must validate frame size before \
+         calling — this is an internal invariant violation, not user input.",
+        raw.len(),
+    );
+
+    let mut rgb = Vec::with_capacity(pixel_count * 3);
+    // Branch on `dtype` once, here, rather than re-deciding it for every
+    // pixel: each arm below calls `decode_meters` with a compile-time
+    // literal `FrameDtype` (not the runtime `dtype` binding), so the
+    // function's internal `match` collapses to straight-line code once
+    // inlined — there is no per-pixel dtype decision left at runtime.
+    match dtype {
+        FrameDtype::DepthF16 => {
+            for chunk in raw.chunks_exact(bytes_per_pixel) {
+                push_pixel(&mut rgb, decode_meters(FrameDtype::DepthF16, chunk));
+            }
+        }
+        FrameDtype::DepthF32 => {
+            for chunk in raw.chunks_exact(bytes_per_pixel) {
+                push_pixel(&mut rgb, decode_meters(FrameDtype::DepthF32, chunk));
+            }
+        }
+        FrameDtype::Rgb8 => unreachable!("depth_to_rgb24 called with Rgb8"),
+    }
+    rgb
+}
+
+/// Clip, quantize, and append one decoded depth sample's 24-bit storage
+/// value to `rgb` as three bytes (R, G, B — most-significant byte first).
+fn push_pixel(rgb: &mut Vec<u8>, meters: f32) {
+    let value = depth_meters_to_24bit(clip_depth_meters(meters));
+    rgb.push((value >> 16) as u8);
+    rgb.push(((value >> 8) & 0xFF) as u8);
+    rgb.push((value & 0xFF) as u8);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode one `f32` metres value as little-endian bytes for the given
+    /// dtype, mirroring how a numpy array's raw buffer looks on the wire.
+    fn encode_meters(dtype: FrameDtype, meters: f32) -> Vec<u8> {
+        match dtype {
+            FrameDtype::DepthF16 => half::f16::from_f32(meters).to_le_bytes().to_vec(),
+            FrameDtype::DepthF32 => meters.to_le_bytes().to_vec(),
+            FrameDtype::Rgb8 => panic!("not a depth dtype"),
+        }
+    }
+
+    /// Convert a single 1x1 "frame" at `meters` and return its RGB triple.
+    fn single_pixel(dtype: FrameDtype, meters: f32) -> [u8; 3] {
+        let raw = encode_meters(dtype, meters);
+        let rgb = depth_to_rgb24(dtype, 1, 1, &raw);
+        [rgb[0], rgb[1], rgb[2]]
+    }
+
+    #[test]
+    fn zero_depth_is_black() {
+        for dtype in [FrameDtype::DepthF16, FrameDtype::DepthF32] {
+            assert_eq!(single_pixel(dtype, 0.0), [0, 0, 0], "dtype {dtype:?}");
+        }
+    }
+
+    #[test]
+    fn max_depth_saturates_all_channels() {
+        for dtype in [FrameDtype::DepthF16, FrameDtype::DepthF32] {
+            assert_eq!(
+                single_pixel(dtype, MAX_DEPTH),
+                [255, 255, 255],
+                "dtype {dtype:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn half_depth_matches_hand_computed_bytes() {
+        // 5.0m is exactly half of MAX_DEPTH (10.0): normalized = 0.5, scaled =
+        // 0.5 * (2^24 - 1) = 8_388_607.5, floor = 8_388_607 = 0x7FFFFF.
+        assert_eq!(single_pixel(FrameDtype::DepthF32, 5.0), [0x7F, 0xFF, 0xFF]);
+        // f16 can represent 5.0 exactly too, so both dtypes agree here.
+        assert_eq!(single_pixel(FrameDtype::DepthF16, 5.0), [0x7F, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn negative_depth_clips_to_zero() {
+        for dtype in [FrameDtype::DepthF16, FrameDtype::DepthF32] {
+            assert_eq!(single_pixel(dtype, -3.0), [0, 0, 0], "dtype {dtype:?}");
+        }
+    }
+
+    #[test]
+    fn above_max_depth_clips_to_saturation() {
+        for dtype in [FrameDtype::DepthF16, FrameDtype::DepthF32] {
+            assert_eq!(
+                single_pixel(dtype, 4_000.0),
+                [255, 255, 255],
+                "dtype {dtype:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn nan_is_treated_as_zero_depth_deterministically() {
+        // Python's own NaN -> uint8 cast is platform/version-dependent, so
+        // there is nothing canonical to match; this pins our deliberate,
+        // deterministic choice (never a panic, never UB).
+        assert_eq!(single_pixel(FrameDtype::DepthF32, f32::NAN), [0, 0, 0]);
+        assert_eq!(
+            single_pixel(FrameDtype::DepthF16, half::f16::NAN.to_f32()),
+            [0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn positive_infinity_saturates_negative_infinity_clips_to_zero() {
+        assert_eq!(
+            single_pixel(FrameDtype::DepthF32, f32::INFINITY),
+            [255, 255, 255]
+        );
+        assert_eq!(
+            single_pixel(FrameDtype::DepthF32, f32::NEG_INFINITY),
+            [0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn output_is_exactly_width_times_height_times_three_bytes() {
+        let raw = vec![0u8; 4 * 4 * 4]; // f32 buffer, all-zero depth
+        let rgb = depth_to_rgb24(FrameDtype::DepthF32, 4, 4, &raw);
+        assert_eq!(rgb.len(), 4 * 4 * 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected exactly 64 bytes")]
+    fn truncated_buffer_panics_loudly() {
+        // Half the bytes a 4x4 f32 frame needs. The buffer-length invariant
+        // is caller-enforced (see `depth_to_rgb24`'s doc comment), so a
+        // mismatch here means an internal caller broke that contract — it
+        // must panic immediately, not silently decode the missing samples
+        // as zero depth.
+        let full_len = 4 * 4 * 4;
+        let raw = vec![0xFFu8; full_len / 2];
+        let _ = depth_to_rgb24(FrameDtype::DepthF32, 4, 4, &raw);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected exactly 8 bytes")]
+    fn empty_buffer_panics_loudly() {
+        let _ = depth_to_rgb24(FrameDtype::DepthF16, 2, 2, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "width * height * bytes_per_pixel overflows usize")]
+    fn overflowing_dimensions_panic_instead_of_wrapping() {
+        let _ = depth_to_rgb24(FrameDtype::DepthF32, u32::MAX, u32::MAX, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "decode_meters called with a non-depth dtype")]
+    fn decode_meters_panics_on_rgb8() {
+        // Calls `decode_meters` directly — not through `depth_to_rgb24` — so
+        // this exercises `decode_meters`'s own unconditional panic rather
+        // than `depth_to_rgb24`'s separate (debug-only) outer guard. Rgb8's
+        // `bytes_per_pixel()` is 3, so a 3-byte chunk is the "right shape"
+        // input for the arm under test.
+        let _ = decode_meters(FrameDtype::Rgb8, &[0u8; 3]);
+    }
+
+    #[test]
+    fn f16_and_f32_agree_on_a_representative_mid_range_value() {
+        // 3.25m is exactly representable in both f16 and f32, so both dtypes
+        // must produce identical bytes for it.
+        assert_eq!(
+            single_pixel(FrameDtype::DepthF16, 3.25),
+            single_pixel(FrameDtype::DepthF32, 3.25)
+        );
+    }
+
+    #[test]
+    fn multi_pixel_frame_decodes_each_pixel_independently() {
+        // Two f32 pixels: 0.0m then MAX_DEPTH — proves pixel offsets advance
+        // correctly (not just the single-pixel path).
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&0.0f32.to_le_bytes());
+        raw.extend_from_slice(&MAX_DEPTH.to_le_bytes());
+        let rgb = depth_to_rgb24(FrameDtype::DepthF32, 2, 1, &raw);
+        assert_eq!(&rgb[0..3], &[0, 0, 0]);
+        assert_eq!(&rgb[3..6], &[255, 255, 255]);
+    }
+}

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -42,12 +42,13 @@
 
 pub mod nut_writer;
 
+mod depth;
 mod paths;
 mod publisher;
 mod query;
 mod writer;
 
-use data_daemon_shared::{Envelope, RecordingIdQuery};
+use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery};
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -162,8 +163,14 @@ fn log_joints(
 /// `(source, sensor)` in-progress NUT chunk under the inbox; when the chunk
 /// crosses the chunk-flush threshold a [`Envelope::VideoChunkReady`] is
 /// published.
+///
+/// `dtype` is the Python-facing wire label (`image.dtype.name`): `"uint8"`
+/// for RGB24 frames, `"float16"` / `"float32"` for 2D depth frames (metres).
+/// It is parsed once, here, at the native boundary — every internal Rust
+/// component downstream (the writer, the daemon) works with the strongly
+/// typed [`FrameDtype`] rather than re-validating a string.
 #[pyfunction]
-#[pyo3(signature = (robot_id, robot_instance, data_type, name, width, height, payload, timestamp_ns, timestamp_s = None))]
+#[pyo3(signature = (robot_id, robot_instance, data_type, name, width, height, dtype, payload, timestamp_ns, timestamp_s = None))]
 #[allow(clippy::too_many_arguments)]
 fn log_frame(
     py: Python<'_>,
@@ -173,6 +180,7 @@ fn log_frame(
     name: &str,
     width: u32,
     height: u32,
+    dtype: &str,
     payload: PyBuffer<u8>,
     timestamp_ns: i64,
     timestamp_s: Option<f64>,
@@ -182,18 +190,10 @@ fn log_frame(
             "robot_id, data_type and name must not be empty",
         ));
     }
-    if width == 0 || height == 0 {
-        return Err(PyValueError::new_err("width and height must be non-zero"));
-    }
-    let expected_bytes = (width as usize)
-        .saturating_mul(height as usize)
-        .saturating_mul(3);
+    let frame_dtype = parse_frame_dtype(data_type, dtype).map_err(PyValueError::new_err)?;
     let actual_bytes = payload.item_count();
-    if actual_bytes != expected_bytes {
-        return Err(PyValueError::new_err(format!(
-            "video frame buffer is {actual_bytes} bytes; expected width*height*3 = {expected_bytes}"
-        )));
-    }
+    validate_frame_payload(frame_dtype, width, height, actual_bytes)
+        .map_err(PyValueError::new_err)?;
     if !payload.is_c_contiguous() {
         return Err(PyValueError::new_err(
             "video frame buffer must be C-contiguous",
@@ -225,6 +225,7 @@ fn log_frame(
         sensor_name: name.to_string(),
         width,
         height,
+        dtype: frame_dtype,
         timestamp_ns,
         timestamp_s: resolved_timestamp_s,
         data,
@@ -431,6 +432,36 @@ fn cancel_recording(
     })
 }
 
+/// Parse a NumPy dtype label and validate it against the declared video type.
+///
+/// RGB frames must use `uint8`; depth frames must use `float16` or `float32`.
+/// Validating the pair at the native boundary prevents incorrectly typed frames
+/// from entering the writer and being stored under the wrong trace type.
+fn parse_frame_dtype(data_type: &str, dtype: &str) -> Result<FrameDtype, String> {
+    let frame_dtype = FrameDtype::from_wire_label(dtype).ok_or_else(|| {
+        format!(
+            "unsupported video frame dtype {dtype:?}; expected one of: \
+             uint8, float16, float32"
+        )
+    })?;
+
+    let valid_pair = matches!(
+        (data_type, frame_dtype),
+        ("RGB_IMAGES", FrameDtype::Rgb8)
+            | ("DEPTH_IMAGES", FrameDtype::DepthF16)
+            | ("DEPTH_IMAGES", FrameDtype::DepthF32)
+    );
+
+    if !valid_pair {
+        return Err(format!(
+            "video data type {data_type:?} is incompatible with dtype {dtype:?}; \
+             expected RGB_IMAGES + uint8 or DEPTH_IMAGES + float16/float32"
+        ));
+    }
+
+    Ok(frame_dtype)
+}
+
 /// Resolve the daemon-owned cloud `recording_id` for a recording, blocking with
 /// the GIL released until the id is available or `timeout_s` elapses.
 ///
@@ -499,4 +530,131 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;
     Ok(())
+}
+
+/// Validate a `log_frame` payload against its declared dtype and geometry.
+///
+/// Pulled out of [`log_frame`] as a pure function (no `PyBuffer`/GIL
+/// involvement) so the native bridge's size-validation rules — the "Native
+/// bridge validation" contract every frame must satisfy before it is ever
+/// enqueued — are directly unit-testable without standing up a Python
+/// interpreter.
+fn validate_frame_payload(
+    dtype: FrameDtype,
+    width: u32,
+    height: u32,
+    actual_bytes: usize,
+) -> Result<(), String> {
+    if width == 0 || height == 0 {
+        return Err("width and height must be non-zero".to_string());
+    }
+    let expected_bytes = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixels| pixels.checked_mul(dtype.bytes_per_pixel()))
+        .ok_or_else(|| "width * height * bytes_per_pixel overflows".to_string())?;
+    if actual_bytes != expected_bytes {
+        return Err(format!(
+            "video frame buffer is {actual_bytes} bytes; expected width*height*{} = \
+             {expected_bytes} bytes for dtype {dtype:?}",
+            dtype.bytes_per_pixel(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_rgb_uint8_frame_is_accepted() {
+        assert!(validate_frame_payload(FrameDtype::Rgb8, 4, 4, 4 * 4 * 3).is_ok());
+    }
+
+    #[test]
+    fn valid_depth_f16_frame_is_accepted() {
+        assert!(validate_frame_payload(FrameDtype::DepthF16, 4, 4, 4 * 4 * 2).is_ok());
+    }
+
+    #[test]
+    fn valid_depth_f32_frame_is_accepted() {
+        assert!(validate_frame_payload(FrameDtype::DepthF32, 4, 4, 4 * 4 * 4).is_ok());
+    }
+
+    #[test]
+    fn rgb_frame_with_depth_sized_payload_is_rejected() {
+        // Same byte count as a valid 4x4 f32 depth frame, but declared RGB —
+        // must be rejected, not silently accepted because the lengths differ
+        // from *some* valid combination.
+        let err = validate_frame_payload(FrameDtype::Rgb8, 4, 4, 4 * 4 * 4).unwrap_err();
+        assert!(err.contains("expected width*height*3"), "got: {err}");
+    }
+
+    #[test]
+    fn depth_frame_with_rgb_sized_payload_is_rejected() {
+        let err = validate_frame_payload(FrameDtype::DepthF16, 4, 4, 4 * 4 * 3).unwrap_err();
+        assert!(err.contains("expected width*height*2"), "got: {err}");
+    }
+
+    #[test]
+    fn zero_dimensions_are_rejected_for_every_dtype() {
+        for dtype in [FrameDtype::Rgb8, FrameDtype::DepthF16, FrameDtype::DepthF32] {
+            assert!(validate_frame_payload(dtype, 0, 4, 0).is_err());
+            assert!(validate_frame_payload(dtype, 4, 0, 0).is_err());
+        }
+    }
+
+    #[test]
+    fn overflowing_dimensions_reject_cleanly_instead_of_wrapping() {
+        // u32::MAX * u32::MAX * 4 overflows usize on 32-bit targets and would
+        // wrap silently under an unchecked multiply; on 64-bit it still
+        // overflows once cubed against bytes_per_pixel for a large enough
+        // combination. Either way this must error, never panic or wrap.
+        let result = validate_frame_payload(FrameDtype::DepthF32, u32::MAX, u32::MAX, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("overflows"));
+    }
+
+    #[test]
+    fn wrong_byte_length_produces_a_clear_rgb_error() {
+        // Regression guard: the existing RGB error message shape (byte counts
+        // + the expected formula) must stay meaningful after adding dtype.
+        let err = validate_frame_payload(FrameDtype::Rgb8, 10, 10, 42).unwrap_err();
+        assert!(err.contains("42 bytes"), "got: {err}");
+        assert!(err.contains("300 bytes"), "got: {err}");
+    }
+
+    #[test]
+    fn unsupported_dtype_label_is_rejected() {
+        assert_eq!(FrameDtype::from_wire_label("int32"), None);
+        assert_eq!(FrameDtype::from_wire_label("float64"), None);
+    }
+
+    #[test]
+    fn valid_data_type_dtype_pairs_are_accepted() {
+        assert_eq!(
+            parse_frame_dtype("RGB_IMAGES", "uint8"),
+            Ok(FrameDtype::Rgb8)
+        );
+        assert_eq!(
+            parse_frame_dtype("DEPTH_IMAGES", "float16"),
+            Ok(FrameDtype::DepthF16)
+        );
+        assert_eq!(
+            parse_frame_dtype("DEPTH_IMAGES", "float32"),
+            Ok(FrameDtype::DepthF32)
+        );
+    }
+
+    #[test]
+    fn invalid_data_type_dtype_pairs_are_rejected() {
+        for (data_type, dtype) in [
+            ("RGB_IMAGES", "float16"),
+            ("RGB_IMAGES", "float32"),
+            ("DEPTH_IMAGES", "uint8"),
+        ] {
+            let error = parse_frame_dtype(data_type, dtype).unwrap_err();
+            assert!(error.contains("incompatible"), "unexpected error: {error}");
+        }
+    }
 }

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -47,7 +47,7 @@ use std::sync::{Arc, Condvar, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::service_name::{MAX_VIDEO_CHUNK_FRAMES, VIDEO_SPOOL_TICKS_PER_SECOND};
-use data_daemon_shared::Envelope;
+use data_daemon_shared::{Envelope, FrameDtype};
 
 use crate::nut_writer::{NutVideoConfig, NutWriter};
 use crate::paths::{source_prefix, split_stream_key, spool_chunk_filename, spool_dir, stream_key};
@@ -161,6 +161,11 @@ struct VideoChunkState {
     width: u32,
     /// Frame height in pixels (constant across a stream's chunks).
     height: u32,
+    /// Original frame dtype for the in-progress chunk. A [`Envelope::VideoChunkReady`]
+    /// announcement carries exactly one dtype, so — like `width`/`height` — a
+    /// dtype change mid-stream seals the open chunk and reopens at the new
+    /// dtype rather than mixing dtypes inside one chunk.
+    dtype: FrameDtype,
     /// `{recordings_root}/.rgb_spool/{robot_id}/{instance}/{data_type}/{sensor_name}/`.
     spool_dir: PathBuf,
     /// Active NUT writer for the in-progress chunk. `None` between chunks.
@@ -233,8 +238,12 @@ fn with_video_chunks<R>(operation: impl FnOnce(&mut HashMap<String, VideoChunkSl
     operation(&mut registry.streams)
 }
 
-/// One frame handed to the background writer. Owns its pixel bytes (copied out
-/// of the caller's buffer under the GIL) so the caller can return immediately.
+/// One frame handed to the background writer. Owns its raw sample bytes
+/// (copied out of the caller's buffer under the GIL) so the caller can return
+/// immediately. `data` is packed RGB24 for [`FrameDtype::Rgb8`] or raw
+/// little-endian depth samples for a depth `dtype` — the depth-to-RGB24
+/// conversion happens later, on a compression-pool worker (see
+/// [`compress_worker`]), never on this hot path.
 pub(crate) struct FrameJob {
     pub(crate) robot_id: String,
     pub(crate) robot_instance: i64,
@@ -242,6 +251,7 @@ pub(crate) struct FrameJob {
     pub(crate) sensor_name: String,
     pub(crate) width: u32,
     pub(crate) height: u32,
+    pub(crate) dtype: FrameDtype,
     pub(crate) timestamp_ns: i64,
     pub(crate) timestamp_s: f64,
     pub(crate) data: Vec<u8>,
@@ -651,11 +661,15 @@ impl FrameResult {
     }
 }
 
-/// One frame submitted to the compression pool.
+/// One frame submitted to the compression pool. `raw` is packed RGB24 for
+/// [`FrameDtype::Rgb8`] or raw depth samples otherwise — [`compress_worker`]
+/// converts depth to RGB24 before PNG-encoding it, so the raw bytes reach the
+/// pool unconverted (the hot `log_frame` path never does that work).
 struct CompressJob {
     width: u32,
     height: u32,
-    rgb: Vec<u8>,
+    dtype: FrameDtype,
+    raw: Vec<u8>,
     result: Arc<FrameResult>,
 }
 
@@ -693,8 +707,14 @@ impl CompressPool {
 }
 
 /// Compression worker: pull frames FIFO and compress each to PNG, publishing the
-/// result into its one-shot slot. Compression is stateless per frame, so any
-/// worker can take any frame — the writer restores per-stream order on collect.
+/// result into its one-shot slot. Compression (and, for depth, the RGB24
+/// conversion ahead of it) is stateless per frame, so any worker can take any
+/// frame — the writer restores per-stream order on collect.
+///
+/// RGB frames are already packed RGB24 and pass straight to the PNG encoder,
+/// leaving the existing RGB/NUT path unchanged. Depth frames are numerically
+/// converted to RGB24 storage bytes first (see [`crate::depth::depth_to_rgb24`])
+/// — `encode_png_frame` must never see raw depth bytes.
 fn compress_worker(work: &(Mutex<VecDeque<CompressJob>>, Condvar)) {
     let (lock, cond) = work;
     loop {
@@ -707,7 +727,13 @@ fn compress_worker(work: &(Mutex<VecDeque<CompressJob>>, Condvar)) {
                 queue = cond.wait(queue).unwrap_or_else(|p| p.into_inner());
             }
         };
-        let png = crate::nut_writer::encode_png_frame(job.width, job.height, &job.rgb);
+        let rgb = match job.dtype {
+            FrameDtype::Rgb8 => job.raw,
+            FrameDtype::DepthF16 | FrameDtype::DepthF32 => {
+                crate::depth::depth_to_rgb24(job.dtype, job.width, job.height, &job.raw)
+            }
+        };
+        let png = crate::nut_writer::encode_png_frame(job.width, job.height, &rgb);
         job.result.set(png);
     }
 }
@@ -720,31 +746,44 @@ struct PendingFrame {
     result: Arc<FrameResult>,
 }
 
+/// Bytes a well-formed frame of `dtype` must occupy at `width` x `height`, or
+/// `None` on overflow. Shared by [`submit_frame`]'s geometry check and unit
+/// tests below — the same overflow-safe calculation the native boundary
+/// already performed in `log_frame`, re-checked here since `submit_frame`
+/// runs on the writer thread with no path back to a Python exception (a
+/// mismatch is logged and the frame dropped, not propagated).
+fn expected_frame_bytes(dtype: FrameDtype, width: u32, height: u32) -> Option<usize> {
+    (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixels| pixels.checked_mul(dtype.bytes_per_pixel()))
+}
+
 /// Validate one frame and submit it to the compression pool, recording it in the
 /// in-order pipeline. A frame whose byte length disagrees with its geometry is
 /// dropped here (the pre-split inline encode rejected it the same way) rather
 /// than handed to a worker.
 fn submit_frame(pool: &CompressPool, in_flight: &mut VecDeque<PendingFrame>, mut job: FrameJob) {
-    let expected = (job.width as usize)
-        .checked_mul(job.height as usize)
-        .and_then(|pixels| pixels.checked_mul(3));
+    let expected = expected_frame_bytes(job.dtype, job.width, job.height);
     if expected != Some(job.data.len()) {
         tracing::warn!(
             sensor_name = job.sensor_name,
             ?expected,
             actual = job.data.len(),
+            dtype = ?job.dtype,
             "video frame size disagrees with geometry; dropping frame"
         );
         return;
     }
     let result = FrameResult::new();
-    // Move the raw pixels into the compression job; the pending frame keeps only
-    // the routing metadata (its `data` is now empty and never read again).
-    let rgb = std::mem::take(&mut job.data);
+    // Move the raw sample bytes into the compression job; the pending frame
+    // keeps only the routing metadata (its `data` is now empty and never read
+    // again).
+    let raw = std::mem::take(&mut job.data);
     pool.submit(CompressJob {
         width: job.width,
         height: job.height,
-        rgb,
+        dtype: job.dtype,
+        raw,
         result: result.clone(),
     });
     in_flight.push_back(PendingFrame { job, result });
@@ -759,6 +798,7 @@ fn write_pending_frame(pending: PendingFrame, png: Vec<u8>) {
         &pending.job.sensor_name,
         pending.job.width,
         pending.job.height,
+        pending.job.dtype,
         &png,
         pending.job.timestamp_ns,
         pending.job.timestamp_s,
@@ -954,6 +994,7 @@ fn record_video_frame(
     sensor_name: &str,
     width: u32,
     height: u32,
+    dtype: FrameDtype,
     png_payload: &[u8],
     timestamp_ns: i64,
     timestamp_s: f64,
@@ -974,6 +1015,7 @@ fn record_video_frame(
         let slot = Arc::new(Mutex::new(VideoChunkState {
             width,
             height,
+            dtype,
             spool_dir: spool,
             nut_writer: None,
             chunk_publish_ns: 0,
@@ -1013,6 +1055,7 @@ fn record_video_frame(
             sensor_name,
             width,
             height,
+            dtype,
             png_payload,
             timestamp_ns,
             timestamp_s,
@@ -1046,26 +1089,34 @@ fn append_frame_locked(
     sensor_name: &str,
     width: u32,
     height: u32,
+    dtype: FrameDtype,
     png_payload: &[u8],
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Vec<Envelope> {
     let mut announcements: Vec<Envelope> = Vec::new();
 
-    // A mid-stream resolution change can't share a chunk with the prior
-    // geometry: the NUT header advertises the opening frame's size, so a
-    // differently-sized frame fails the writer's size check and is silently
-    // dropped (or, on a coincidental `w*h*3` match, corrupts the encode). Seal
-    // the open chunk (announced below) and reopen a fresh one with the new
-    // geometry rather than dropping every later frame.
-    if state.nut_writer.is_some() && (state.width != width || state.height != height) {
+    // A mid-stream resolution *or dtype* change can't share a chunk with the
+    // prior state: the NUT header advertises the opening frame's size, and a
+    // `VideoChunkReady` announcement carries exactly one dtype for the whole
+    // chunk. A differently-sized frame fails the writer's size check and is
+    // silently dropped (or, on a coincidental `w*h*3` match, corrupts the
+    // encode); a differently-dtyped frame would otherwise mislabel every
+    // frame in the chunk as the first frame's dtype. Seal the open chunk
+    // (announced below) and reopen a fresh one with the new geometry/dtype
+    // rather than dropping every later frame or mixing dtypes in one chunk.
+    if state.nut_writer.is_some()
+        && (state.width != width || state.height != height || state.dtype != dtype)
+    {
         tracing::warn!(
             sensor_name,
             old_width = state.width,
             old_height = state.height,
             new_width = width,
             new_height = height,
-            "video frame geometry changed mid-stream; sealing chunk and reopening"
+            old_dtype = ?state.dtype,
+            new_dtype = ?dtype,
+            "video frame geometry or dtype changed mid-stream; sealing chunk and reopening"
         );
         if let Some(envelope) =
             flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
@@ -1074,6 +1125,7 @@ fn append_frame_locked(
         }
     }
     state.width = width;
+    state.dtype = dtype;
     state.height = height;
 
     // Each fresh chunk opens with a header syncpoint at global_key_pts=0, so
@@ -1241,6 +1293,7 @@ fn flush_chunk_locked(
         frame_count,
         frame_timestamps_ns,
         frame_timestamps_s,
+        dtype: state.dtype,
     })
 }
 
@@ -1344,11 +1397,16 @@ mod tests {
         assert!(should_flush_chunk(CHUNK_FLUSH_BYTES, 1));
     }
 
-    /// Build a fresh, empty per-stream chunk state rooted at `spool_dir`.
+    /// Build a fresh, empty per-stream chunk state rooted at `spool_dir`. The
+    /// initial `dtype` is irrelevant with no open chunk yet — the first
+    /// `append_frame_locked` call always overwrites it before the seal check
+    /// can ever compare against it — so this defaults to RGB for the many
+    /// dtype-agnostic tests below.
     fn fresh_state(spool_dir: PathBuf, width: u32, height: u32) -> VideoChunkState {
         VideoChunkState {
             width,
             height,
+            dtype: FrameDtype::Rgb8,
             spool_dir,
             nut_writer: None,
             chunk_publish_ns: 0,
@@ -1374,7 +1432,17 @@ mod tests {
         // First frame at 2x2 (rgb24 = 2*2*3 bytes) just opens a chunk.
         let frame_2x2 = vec![0u8; 2 * 2 * 3];
         let opened = append_frame_locked(
-            &mut state, "r", 0, "RGB", "cam", 2, 2, &frame_2x2, 1_000, 0.0,
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame_2x2,
+            1_000,
+            0.0,
         );
         assert!(
             opened.is_empty(),
@@ -1386,7 +1454,17 @@ mod tests {
         // Second frame at 4x4 must seal the 2x2 chunk and reopen at 4x4.
         let frame_4x4 = vec![0u8; 4 * 4 * 3];
         let sealed = append_frame_locked(
-            &mut state, "r", 0, "RGB", "cam", 4, 4, &frame_4x4, 2_000, 0.001,
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            4,
+            4,
+            FrameDtype::Rgb8,
+            &frame_4x4,
+            2_000,
+            0.001,
         );
         assert_eq!(sealed.len(), 1, "the geometry change seals the prior chunk");
         match &sealed[0] {
@@ -1418,6 +1496,120 @@ mod tests {
     }
 
     #[test]
+    fn dtype_change_seals_chunk_and_reopens_at_new_dtype() {
+        // A VideoChunkReady announcement carries exactly one dtype for the
+        // whole chunk, so a mid-stream depth dtype change must seal the open
+        // chunk rather than mixing float16 and float32 frames.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+
+        // append_frame_locked receives the already converted PNG/RGB24 payload.
+        // The dtype describes the original depth array, not this stored payload.
+        let png_payload = vec![0u8; 2 * 2 * 3];
+
+        let opened = append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "DEPTH_IMAGES",
+            "cam",
+            2,
+            2,
+            FrameDtype::DepthF16,
+            &png_payload,
+            1_000,
+            0.0,
+        );
+        assert!(opened.is_empty());
+        assert_eq!(state.dtype, FrameDtype::DepthF16);
+
+        // Same geometry, but the original depth dtype changes. The float16 chunk
+        // must be sealed before opening a new float32 chunk.
+        let sealed = append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "DEPTH_IMAGES",
+            "cam",
+            2,
+            2,
+            FrameDtype::DepthF32,
+            &png_payload,
+            2_000,
+            0.001,
+        );
+
+        assert_eq!(sealed.len(), 1, "the dtype change seals the prior chunk");
+
+        match &sealed[0] {
+            Envelope::VideoChunkReady {
+                dtype, frame_count, ..
+            } => {
+                assert_eq!(
+                    *dtype,
+                    FrameDtype::DepthF16,
+                    "the sealed chunk keeps its original dtype"
+                );
+                assert_eq!(*frame_count, 1);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+
+        assert_eq!(
+            state.dtype,
+            FrameDtype::DepthF32,
+            "state adopts the new dtype"
+        );
+        assert_eq!(
+            state.frame_count, 1,
+            "the new chunk holds the float32 frame"
+        );
+    }
+
+    #[test]
+    fn sealed_chunk_announcement_carries_its_dtype() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "DEPTH_IMAGES",
+            "cam",
+            2,
+            2,
+            FrameDtype::DepthF32,
+            &frame,
+            1_000,
+            0.0,
+        );
+        let envelope = flush_chunk_locked("r", 0, "DEPTH_IMAGES", "cam", &mut state)
+            .expect("open chunk seals");
+        match envelope {
+            Envelope::VideoChunkReady { dtype, .. } => {
+                assert_eq!(dtype, FrameDtype::DepthF32);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expected_frame_bytes_matches_each_dtype() {
+        assert_eq!(expected_frame_bytes(FrameDtype::Rgb8, 4, 4), Some(48));
+        assert_eq!(expected_frame_bytes(FrameDtype::DepthF16, 4, 4), Some(32));
+        assert_eq!(expected_frame_bytes(FrameDtype::DepthF32, 4, 4), Some(64));
+    }
+
+    #[test]
+    fn expected_frame_bytes_overflow_is_none_not_a_panic() {
+        assert_eq!(
+            expected_frame_bytes(FrameDtype::DepthF32, u32::MAX, u32::MAX),
+            None
+        );
+    }
+
+    #[test]
     fn flush_seals_chunk_with_populated_announcement_and_resets_state() {
         // The normal seal path the daemon routes on (size/frame-cap roll or the
         // stop barrier). The announcement must carry every frame's identity in
@@ -1436,6 +1628,7 @@ mod tests {
                 "cam",
                 2,
                 2,
+                FrameDtype::Rgb8,
                 &frame,
                 timestamp_ns,
                 timestamp_s,
@@ -1508,6 +1701,7 @@ mod tests {
                 "cam",
                 2,
                 2,
+                FrameDtype::Rgb8,
                 &frame,
                 timestamp_ns,
                 0.0,
@@ -1533,6 +1727,7 @@ mod tests {
             sensor_name: "camera".to_string(),
             width: 0,
             height: 0,
+            dtype: FrameDtype::Rgb8,
             timestamp_ns: 0,
             timestamp_s: 0.0,
             data: vec![0u8; bytes],
@@ -1664,6 +1859,7 @@ mod tests {
             "cam",
             4096,
             4096,
+            FrameDtype::Rgb8,
             &[0u8; 4],
             timestamp_us * 1_000,
             timestamp_us as f64 / 1e6,

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -400,6 +400,11 @@ pub enum Envelope {
         /// Length equals `frame_count`; values round-trip bit-exact through
         /// postcard for the metadata sidecar.
         frame_timestamps_s: Vec<f64>,
+        /// Original dtype of every frame in this chunk (never mixed — the
+        /// producer seals and reopens a chunk on a dtype change, mirroring a
+        /// geometry change). The daemon never decodes pixels; it threads this
+        /// straight into the trace's `trace.json` sidecar for depth frames.
+        dtype: FrameDtype,
     },
     /// Force the daemon to re-read its profile config immediately, rather than
     /// waiting for the config watcher's next poll. Sent by the SDK's
@@ -409,6 +414,62 @@ pub enum Envelope {
     /// recording window; the dispatcher handles it by refreshing the in-memory
     /// config (see `cloud::config_watcher`).
     RefreshConfig {},
+}
+
+/// Original pixel/sample representation of one video-family frame.
+///
+/// Carried on [`Envelope::VideoChunkReady`] so the daemon can record a depth
+/// frame's original dtype in its `trace.json` sidecar without ever seeing the
+/// pixels themselves — the daemon never decodes or converts frame data, it
+/// only threads this label through to metadata (see the crate-level docs on
+/// the thin-shipper model). The producer is the only side that interprets the
+/// raw bytes: RGB frames are already packed RGB24 for the NUT/PNG pipeline;
+/// depth frames are converted to RGB24 storage bytes by the producer before
+/// ever reaching the NUT writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FrameDtype {
+    /// Packed RGB24, one byte per channel — the existing RGB/NUT contract.
+    Rgb8,
+    /// 2D depth frame, IEEE-754 binary16 (metres).
+    DepthF16,
+    /// 2D depth frame, IEEE-754 binary32 (metres).
+    DepthF32,
+}
+
+impl FrameDtype {
+    /// Bytes occupied by one pixel/sample of this representation, before any
+    /// depth-to-RGB24 conversion.
+    pub fn bytes_per_pixel(self) -> usize {
+        match self {
+            FrameDtype::Rgb8 => 3,
+            FrameDtype::DepthF16 => 2,
+            FrameDtype::DepthF32 => 4,
+        }
+    }
+
+    /// Parse the Python-facing wire label — `numpy.dtype.name`, i.e.
+    /// `"uint8"` for RGB and `"float16"` / `"float32"` for depth. `None` for
+    /// anything else, so the native boundary rejects an unsupported dtype
+    /// with a clear error rather than silently misinterpreting the buffer.
+    pub fn from_wire_label(label: &str) -> Option<Self> {
+        match label {
+            "uint8" => Some(FrameDtype::Rgb8),
+            "float16" => Some(FrameDtype::DepthF16),
+            "float32" => Some(FrameDtype::DepthF32),
+            _ => None,
+        }
+    }
+
+    /// The canonical `trace.json` dtype string for a depth frame — `None` for
+    /// RGB, which keeps the existing RGB `trace.json` schema untouched (no
+    /// consumer or established schema calls for an RGB dtype field).
+    pub fn depth_label(self) -> Option<&'static str> {
+        match self {
+            FrameDtype::Rgb8 => None,
+            FrameDtype::DepthF16 => Some("float16"),
+            FrameDtype::DepthF32 => Some("float32"),
+        }
+    }
 }
 
 /// One sensor's sample inside an [`Envelope::BatchedData`] batch.
@@ -793,11 +854,73 @@ mod tests {
                 1_700_000_000.033_333_3,
                 7.0_f64 / 60.0_f64,
             ],
+            dtype: FrameDtype::Rgb8,
         };
         let bytes = original.encode().expect("encode");
         let decoded = Envelope::decode(&bytes).expect("decode");
         assert_eq!(original, decoded);
         assert_eq!(original.kind(), "video_chunk_ready");
+    }
+
+    #[test]
+    fn video_chunk_ready_round_trips_for_every_frame_dtype() {
+        // The whole point of carrying dtype on the wire is that a depth
+        // chunk's announcement survives the daemon's postcard round trip —
+        // guard every variant, not just the RGB default above.
+        for (data_type, dtype) in [
+            ("RGB_IMAGES", FrameDtype::Rgb8),
+            ("DEPTH_IMAGES", FrameDtype::DepthF16),
+            ("DEPTH_IMAGES", FrameDtype::DepthF32),
+        ] {
+            let original = Envelope::VideoChunkReady {
+                robot_id: "robot-1".into(),
+                robot_instance: 0,
+                data_type: data_type.into(),
+                sensor_name: Some("depth_camera".into()),
+                publish_timestamp_ns: 1_700_000_000_000_000_000,
+                thread_id: 7,
+                width: 128,
+                height: 128,
+                byte_count: 4096,
+                frame_count: 1,
+                frame_timestamps_ns: vec![1_700_000_000_000_000_000],
+                frame_timestamps_s: vec![1_700_000_000.0],
+                dtype,
+            };
+            let bytes = original.encode().expect("encode");
+            let decoded = Envelope::decode(&bytes).expect("decode");
+            assert_eq!(original, decoded, "dtype {dtype:?} did not round-trip");
+        }
+    }
+
+    #[test]
+    fn frame_dtype_wire_labels_round_trip() {
+        assert_eq!(FrameDtype::from_wire_label("uint8"), Some(FrameDtype::Rgb8));
+        assert_eq!(
+            FrameDtype::from_wire_label("float16"),
+            Some(FrameDtype::DepthF16)
+        );
+        assert_eq!(
+            FrameDtype::from_wire_label("float32"),
+            Some(FrameDtype::DepthF32)
+        );
+        assert_eq!(FrameDtype::from_wire_label("int32"), None);
+        assert_eq!(FrameDtype::from_wire_label(""), None);
+    }
+
+    #[test]
+    fn frame_dtype_depth_label_is_none_for_rgb() {
+        // RGB must not gain a `trace.json` dtype field — only depth does.
+        assert_eq!(FrameDtype::Rgb8.depth_label(), None);
+        assert_eq!(FrameDtype::DepthF16.depth_label(), Some("float16"));
+        assert_eq!(FrameDtype::DepthF32.depth_label(), Some("float32"));
+    }
+
+    #[test]
+    fn frame_dtype_bytes_per_pixel() {
+        assert_eq!(FrameDtype::Rgb8.bytes_per_pixel(), 3);
+        assert_eq!(FrameDtype::DepthF16.bytes_per_pixel(), 2);
+        assert_eq!(FrameDtype::DepthF32.bytes_per_pixel(), 4);
     }
 
     #[test]
@@ -820,6 +943,7 @@ mod tests {
             frame_count: frame_timestamps_ns.len() as u32,
             frame_timestamps_ns,
             frame_timestamps_s,
+            dtype: FrameDtype::Rgb8,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(
@@ -854,6 +978,7 @@ mod tests {
             frame_count: count as u32,
             frame_timestamps_ns,
             frame_timestamps_s,
+            dtype: FrameDtype::Rgb8,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -22,6 +22,13 @@ PRE_NETWORK_INTEGRITY_CASES = (
         video_count=1,
         image_height=64,
         image_width=64,
+        # Depth alongside RGB and joint data, logged via the synchronous
+        # producer (the default `producer_channels`). Covers `float32` —
+        # `float16` is covered below via the threaded-producer case, so
+        # together the two selected cases exercise both dtypes and both
+        # producer modes.
+        depth_count=1,
+        depth_mode="float32",
     ),
     DataDaemonTestCase(
         duration_sec=10,
@@ -47,6 +54,13 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_channels=PRODUCER_PER_THREAD,
         parallel_contexts=2,
         mode=MODE_STAGGERED,
+        # Depth via the threaded producer, covering `float16` under a more
+        # complex scenario (multiple recordings, staggered contexts) — a
+        # good stress case for the synchronized-frame-identity mapping used
+        # in the depth round-trip assertion (see assertions.py), since it
+        # can't rely on sync-iteration order lining up with capture order.
+        depth_count=1,
+        depth_mode="float16",
     ),
     DataDaemonTestCase(
         duration_sec=10,

--- a/tests/integration/platform/data_daemon/shared/assertions.py
+++ b/tests/integration/platform/data_daemon/shared/assertions.py
@@ -66,6 +66,9 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     DataDaemonTestCase,
     case_timeout_seconds,
 )
+from tests.integration.platform.data_daemon.shared.test_case.build_test_case_context import (  # noqa: E501
+    encode_depth_frame,
+)
 
 if TYPE_CHECKING:
     from tests.integration.platform.data_daemon.shared.test_case.build_test_case_context import (  # noqa: E501
@@ -73,11 +76,13 @@ if TYPE_CHECKING:
     )
 
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
+    DEPTH_ROUND_TRIP_ATOL_M,
     DURATION_MODE_VARIABLE,
     DURATION_VARIABLE_MAX_FACTOR,
     DURATION_VARIABLE_MIN_FACTOR,
     FRAME_BYTE_LENGTH,
     FRAME_GRID_SIZE,
+    DepthMode,
 )
 
 logger = logging.getLogger(__name__)
@@ -240,6 +245,15 @@ def _collect_episode_summary(synced_episode: object) -> dict[str, object]:
     - ``rgb_counts`` — per-camera frame counts.
         - ``frame_codes`` — per-camera list of decoded frame numbers from
             :func:`decode_frame_number`.
+    - ``depth_counts`` — per-camera frame counts.
+        - ``depth_frames`` — per-camera list of ``(frame_idx, frame)`` pairs,
+          where ``frame_idx`` is the *original capture-order* index the
+          synchronized episode reports for that frame (see
+          ``CameraData.frame_idx`` — "needed so we can index video after
+          sync"), **not** this loop's own ``frame_index``. Synchronization can
+          repeat or skip frames, so ``frame_idx`` is what lets the verifier
+          look up which value was actually logged for this exact frame,
+          regardless of where it lands in the synced iteration order.
     - ``joint_position_counts``, ``joint_velocity_counts``,
       ``joint_torque_counts`` — per-joint frame counts.
     - ``joint_position_values`` — list of ``(frame_index, joint_name, value)``
@@ -259,6 +273,8 @@ def _collect_episode_summary(synced_episode: object) -> dict[str, object]:
         "timestamps": [],
         "rgb_counts": {},
         "frame_codes": {},
+        "depth_counts": {},
+        "depth_frames": {},
         "joint_position_counts": {},
         "joint_velocity_counts": {},
         "joint_torque_counts": {},
@@ -284,6 +300,18 @@ def _collect_episode_summary(synced_episode: object) -> dict[str, object]:
                 )
             summary["rgb_counts"] = rgb_counts
             summary["frame_codes"] = frame_codes
+
+        if DataType.DEPTH_IMAGES in sync_point.data:
+            depth_counts = dict(summary["depth_counts"])
+            depth_frames = dict(summary["depth_frames"])
+            for camera_name, camera_data in sync_point[DataType.DEPTH_IMAGES].items():
+                name = str(camera_name)
+                depth_counts[name] = depth_counts.get(name, 0) + 1
+                depth_frames.setdefault(name, []).append(
+                    (int(camera_data.frame_idx), np.array(camera_data.frame))
+                )
+            summary["depth_counts"] = depth_counts
+            summary["depth_frames"] = depth_frames
 
         if DataType.JOINT_POSITIONS in sync_point.data:
             counts = dict(summary["joint_position_counts"])
@@ -445,6 +473,68 @@ def _assert_synced_camera_codes_are_sane(
         )
 
 
+def _assert_synced_depth_values_round_trip(
+    *,
+    depth_frames: object,
+    camera_name: str,
+    context_index: int,
+    recording_index: int,
+    camera_index: int,
+    image_width: int,
+    image_height: int,
+    depth_mode: DepthMode,
+) -> None:
+    """Verify every retrieved depth frame numerically matches what was logged.
+
+    Unlike RGB's frame-code check (which only proves ordering/completeness
+    via a decoded identity tag), this compares actual depth *values*.
+
+    Each retrieved frame is mapped back to its expected value via
+    ``frame_idx`` — the *original capture-order* index the synchronized
+    episode reports for that frame (``CameraData.frame_idx``, "needed so we
+    can index video after sync") — **not** the position of this frame within
+    the synced iteration. Synchronization (``dataset.synchronize()`` defaults
+    to a resampling frequency, not aperiodic-verbatim replay) can repeat or
+    skip frames, so sync-iteration order is not assumed to equal capture
+    order anywhere in this check. The expected value is regenerated with
+    :func:`encode_depth_frame` using the exact same composite frame identity
+    (``context_index``, ``recording_index``, ``camera_index``, ``frame_idx``)
+    the producer used when it called ``nc.log_depth()`` for that frame, then
+    compared against the retrieved value within
+    :data:`~.constants.DEPTH_ROUND_TRIP_ATOL_M`.
+    """
+    assert depth_frames, f"No depth frames retrieved for camera {camera_name!r}"
+
+    mismatches: list[tuple[int, float]] = []
+    for frame_idx, actual in depth_frames:
+        frame_code = (
+            (context_index * 1_000_000_000)
+            + (recording_index * 10_000_000)
+            + (camera_index * 100_000)
+            + frame_idx
+        )
+        expected = encode_depth_frame(
+            frame_code, image_width, image_height, depth_mode
+        ).astype(np.float32)
+        actual_f32 = np.asarray(actual, dtype=np.float32)
+        if actual_f32.shape != expected.shape or not np.allclose(
+            actual_f32, expected, atol=DEPTH_ROUND_TRIP_ATOL_M
+        ):
+            max_abs_diff = (
+                float(np.max(np.abs(actual_f32 - expected)))
+                if actual_f32.shape == expected.shape
+                else float("nan")
+            )
+            mismatches.append((frame_idx, max_abs_diff))
+
+    assert not mismatches, (
+        f"Camera {camera_name!r}: {len(mismatches)}/{len(depth_frames)} depth "
+        f"frame(s) failed the round-trip value check against what was logged "
+        f"(tolerance={DEPTH_ROUND_TRIP_ATOL_M}m); "
+        f"first (frame_idx, max_abs_diff_m): {mismatches[:5]}"
+    )
+
+
 def _verify_synched_episode_summary(
     *,
     summary: dict[str, object],
@@ -522,6 +612,39 @@ def _verify_synched_episode_summary(
     assert (
         not unexpected_markers
     ), f"Unexpected custom marker(s) in episode: {unexpected_markers}"
+
+    # --- Depth cameras: presence, counts, and value round-trip ---
+    # Runs independently of the RGB-only gates below — depth is never
+    # lossy-only (it always keeps its lossless archive), so its round-trip
+    # check must not be skipped by `case.lossy_only`, and a depth-only case
+    # (no RGB) must still be checked. Gated on `has_depth` so a depth-count=0
+    # case executes no depth-specific assertion or lookup at all.
+    if result.has_depth:
+        depth_counts = dict(summary["depth_counts"])
+        for depth_camera_name in result.depth_camera_names:
+            assert depth_counts.get(depth_camera_name) == sync_points, (
+                f"Depth frames missing for camera {depth_camera_name!r}: "
+                f"got {depth_counts.get(depth_camera_name)}, expected {sync_points}"
+            )
+        unexpected_depth_cameras = set(depth_counts) - set(result.depth_camera_names)
+        assert (
+            not unexpected_depth_cameras
+        ), f"Unexpected camera(s) in depth counts: {unexpected_depth_cameras}"
+
+        depth_frames_by_camera = dict(summary["depth_frames"])
+        for depth_camera_index, depth_camera_name in enumerate(
+            result.depth_camera_names
+        ):
+            _assert_synced_depth_values_round_trip(
+                depth_frames=depth_frames_by_camera.get(depth_camera_name),
+                camera_name=depth_camera_name,
+                context_index=result.context_index,
+                recording_index=recording_index,
+                camera_index=depth_camera_index,
+                image_width=int(case.image_width),
+                image_height=int(case.image_height),
+                depth_mode=result.depth_mode,
+            )
 
     # --- Video presence gate ---
     if not result.has_video:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -35,6 +35,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     PRODUCER_SYNCHRONOUS,
     STOP_METHOD_CLI,
     STORAGE_STATE_EMPTY,
+    DepthMode,
     StopMethod,
     StorageStateAction,
 )
@@ -167,6 +168,15 @@ class DataDaemonTestCase:
             recording, so RGB cameras upload a single lossy CRF-23 video and the
             lossless archive is dropped.  ``None`` keeps the default
             lossless+lossy behaviour.
+        depth_count: Number of depth camera streams to log per recording. A
+            value of ``0`` disables depth entirely. Depth cameras are
+            independent streams from RGB cameras (distinct trace identities,
+            see :func:`depth_camera_names`) but reuse ``image_width``,
+            ``image_height``, ``video_fps``, and the RGB video timestamp
+            schedule — depth intentionally adds no separate resolution or
+            frame-rate knobs.
+        depth_mode: The NumPy dtype depth frames are logged as — ``"float16"``
+            or ``"float32"``. Ignored when ``depth_count`` is ``0``.
 
     Note:
         ``mode="staggered"`` and ``context_duration_mode="variable"``:
@@ -196,11 +206,18 @@ class DataDaemonTestCase:
     random_phase: bool = False
     skip: bool = False
     video_codec: str | None = None
+    depth_count: int = 0
+    depth_mode: DepthMode = "float32"
 
     @property
     def has_video(self) -> bool:
         """Return True when this case logs at least one camera stream."""
         return self.video_count > 0
+
+    @property
+    def has_depth(self) -> bool:
+        """Return True when this case logs at least one depth camera stream."""
+        return self.depth_count > 0
 
     @property
     def lossy_only(self) -> bool:
@@ -216,6 +233,15 @@ class DataDaemonTestCase:
     def expected_video_frames(self) -> int:
         """Return expected video frames: ``video_fps * duration_sec``."""
         return self.video_fps * self.duration_sec
+
+    @property
+    def expected_depth_frames(self) -> int:
+        """Return expected depth frames per camera.
+
+        Depth cameras reuse the RGB video timestamp schedule (see
+        :attr:`depth_count`), so this equals :attr:`expected_video_frames`.
+        """
+        return self.expected_video_frames
 
     @property
     def recordings_per_context(self) -> int:
@@ -308,6 +334,9 @@ def case_id(case: DataDaemonTestCase) -> str:
             parts.append(f"{case.video_fps}hz")
         if case.video_codec is not None:
             parts.append(case.video_codec)
+    if case.has_depth:
+        parts.append(f"{case.depth_count}depth")
+        parts.append(case.depth_mode)
     if case.producer_channels == PRODUCER_PER_THREAD:
         parts.append("threaded")
     if case.random_phase:
@@ -364,8 +393,18 @@ def joint_names_for_count(joint_count: int) -> list[str]:
 
 
 def camera_names(video_count: int) -> list[str]:
-    """Return a list of camera names for the given count."""
+    """Return a list of RGB camera names for the given count."""
     return [f"camera_{index}" for index in range(video_count)]
+
+
+def depth_camera_names(depth_count: int) -> list[str]:
+    """Return a list of depth camera names for the given count.
+
+    Distinct from :func:`camera_names` — depth cameras are independent
+    stream identities (``DEPTH_IMAGES/depth_camera_N`` traces) even though a
+    depth-enabled case reuses the RGB spec's resolution and frame rate.
+    """
+    return [f"depth_camera_{index}" for index in range(depth_count)]
 
 
 def generate_joint_values(
@@ -385,11 +424,12 @@ def case_timeout_seconds(case: DataDaemonTestCase) -> float:
     """Compute a reasonable timeout for waiting on a case to complete."""
     image_pixels = 0
     if (
-        case.has_video
+        (case.has_video or case.has_depth)
         and case.image_width is not None
         and case.image_height is not None
     ):
-        image_pixels = case.video_count * case.image_width * case.image_height
+        camera_count = case.video_count + case.depth_count
+        image_pixels = camera_count * case.image_width * case.image_height
     workload_units = (
         case.recording_count
         * case.duration_sec
@@ -451,12 +491,20 @@ def log_run_analysis(
             f"                 {case.video_count} camera(s)"
             f" @ {case.image_width}x{case.image_height}  video@{case.video_fps}Hz"
         )
+    if case.has_depth:
+        lines.append(
+            f"                 {case.depth_count} depth camera(s)"
+            f" @ {case.image_width}x{case.image_height} ({case.depth_mode})"
+        )
     lines.append(
         f"  Total joint frames:  {case.recording_count * case.expected_joint_frames}"
     )
     if case.has_video:
         total_video_frames = case.recording_count * case.expected_video_frames
         lines.append(f"  Total video frames:  {total_video_frames}")
+    if case.has_depth:
+        total_depth_frames = case.recording_count * case.expected_depth_frames
+        lines.append(f"  Total depth frames:  {total_depth_frames}")
 
     if test_wall_s is not None:
         lines.append(f"\n  Test wall time:  {test_wall_s:.1f}s")

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import neuracore as nc
 from neuracore.core.streaming.recording_state_manager import RecordingStateManager
+from neuracore.core.utils.depth_utils import MAX_DEPTH
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import (
     MAX_TIME_TO_LOG_S,
@@ -32,11 +33,17 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     DataDaemonTestCase,
     camera_names,
     case_id,
+    depth_camera_names,
     generate_joint_values,
     joint_names_for_count,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DATASET_POLL_INTERVAL_S,
+    DEPTH_FRAME_BASE_FRACTION,
+    DEPTH_FRAME_BASE_MODULUS,
+    DEPTH_FRAME_COL_FRACTION,
+    DEPTH_FRAME_FLOOR_FRACTION,
+    DEPTH_FRAME_ROW_FRACTION,
     DURATION_MODE_VARIABLE,
     DURATION_VARIABLE_MAX_FACTOR,
     DURATION_VARIABLE_MIN_FACTOR,
@@ -53,6 +60,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STOP_RECORDING_OVERHEAD_PER_SEC,
     STOP_RECORDING_UPLOAD_SLA_PER_JOINT_SAMPLE_S,
     STOP_RECORDING_UPLOAD_SLA_PER_VIDEO_PIXEL_S,
+    DepthMode,
     random_phase_jitter_window,
 )
 
@@ -150,6 +158,110 @@ def preallocate_frame_buffer(
     return frame_buffer
 
 
+def encode_depth_frame(
+    frame_num: int,
+    width: int,
+    height: int,
+    mode: DepthMode,
+    out: np.ndarray | None = None,
+) -> np.ndarray:
+    """Build a deterministic, non-zero, spatially non-uniform depth frame.
+
+    The value at ``(row, col)`` is::
+
+        floor + base(frame_num) + row_gradient(row) + col_gradient(col)
+
+    where each term is a distinct fraction of ``MAX_DEPTH`` (see module
+    docs on :data:`~.constants.DEPTH_FRAME_BASE_FRACTION` and friends):
+
+    - ``floor`` — a small constant so no pixel is ever exactly zero (a
+      round-trip check against an all-zero frame would trivially pass for
+      the wrong reason).
+    - ``base(frame_num)`` — a pseudo-random-looking but deterministic
+      per-frame offset, keyed off the same composite ``frame_num`` the RGB
+      producer already derives from ``(context_index, recording_index,
+      camera_index, frame_index)`` — so distinct frames/cameras/recordings
+      never collide on the same pattern.
+    - ``row_gradient``/``col_gradient`` — linear ramps with *different*
+      amplitudes, so a width/height mix-up or an accidental transpose
+      shifts the decoded pattern into a detectably wrong shape rather than
+      leaving it looking correct.
+
+    The sum of all terms never exceeds ``0.85 * MAX_DEPTH``, so the pattern
+    never saturates at the encoding's clip boundary — saturation would flatten
+    the very differences this pattern exists to preserve.
+
+    Args:
+        frame_num: Composite per-frame identity (see above). Only
+            ``frame_num % DEPTH_FRAME_BASE_MODULUS`` affects the output.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        mode: ``"float16"`` or ``"float32"`` — the array is cast to this
+            dtype before being returned, matching what ``nc.log_depth()``
+            actually transmits (the cast is the ground truth a round-trip
+            check must compare against, not the pre-cast float pattern).
+        out: If given, write into this preallocated ``(height, width)``
+            array instead of allocating a new one. Must already have the
+            dtype matching ``mode``. Callers that pass ``out`` must never
+            retain the returned array past the point where its contents may
+            next be overwritten.
+
+    Returns:
+        A NumPy array with shape ``(height, width)`` and dtype ``float16``
+        or ``float32`` per ``mode``.
+    """
+    dtype = np.float16 if mode == "float16" else np.float32
+    base = (
+        (frame_num % DEPTH_FRAME_BASE_MODULUS)
+        / DEPTH_FRAME_BASE_MODULUS
+        * (MAX_DEPTH * DEPTH_FRAME_BASE_FRACTION)
+    )
+    row_gradient = (np.arange(height, dtype=np.float32) / max(height - 1, 1)) * (
+        MAX_DEPTH * DEPTH_FRAME_ROW_FRACTION
+    )
+    col_gradient = (np.arange(width, dtype=np.float32) / max(width - 1, 1)) * (
+        MAX_DEPTH * DEPTH_FRAME_COL_FRACTION
+    )
+    floor = MAX_DEPTH * DEPTH_FRAME_FLOOR_FRACTION
+
+    pattern = floor + base + row_gradient[:, None] + col_gradient[None, :]
+
+    if out is None:
+        return pattern.astype(dtype)
+    out[:] = pattern.astype(dtype)
+    return out
+
+
+def preallocate_depth_buffer(
+    should_allocate: bool,
+    image_width: int | None,
+    image_height: int | None,
+    mode: DepthMode,
+) -> np.ndarray | None:
+    """Preallocate a reusable depth frame buffer, or return ``None``.
+
+    Mirrors :func:`preallocate_frame_buffer` for depth cameras: callers reuse
+    a single buffer across iterations (via :func:`encode_depth_frame`'s
+    ``out`` param) instead of allocating a new array per frame.
+
+    Args:
+        should_allocate: Whether this caller needs a buffer at all (e.g. the
+            recording has depth cameras, or this thread's role is "depth").
+        image_width: Frame width in pixels, or ``None`` if not depth.
+        image_height: Frame height in pixels, or ``None`` if not depth.
+        mode: ``"float16"`` or ``"float32"`` — determines the buffer's dtype.
+
+    Returns:
+        A preallocated ``(image_height, image_width)`` array of the dtype
+        matching ``mode``, or ``None`` if ``should_allocate`` is ``False`` or
+        either dimension is ``None``.
+    """
+    if not should_allocate or image_width is None or image_height is None:
+        return None
+    dtype = np.float16 if mode == "float16" else np.float32
+    return np.empty((image_height, image_width), dtype=dtype)
+
+
 @dataclass(frozen=True, slots=True)
 class RecordingExpectedTimestamps:
     """Expected timestamps per trace for one recording, keyed by semantic trace name.
@@ -194,6 +306,8 @@ class ContextCaseSpec:
     video_fps: int
     wait: bool
     random_phase: bool
+    depth_count: int = 0
+    depth_mode: DepthMode = "float32"
 
     @property
     def stop_recording_sla_s(self) -> float:
@@ -204,10 +318,14 @@ class ContextCaseSpec:
         until every trace has uploaded, so its budget is the sum of the
         joint-data and video-data upload costs: total joint samples
         (``duration_sec * joint_count * joint_fps``) and total video pixels
-        (``duration_sec * video_fps * video_count * image_width *
-        image_height``), each times an observed per-unit upload cost. The
-        budget is floored at the duration-based overhead so short or
-        low-volume recordings keep a sane minimum.
+        across both RGB and depth cameras (``duration_sec * video_fps *
+        (video_count + depth_count) * image_width * image_height``), each
+        times an observed per-unit upload cost. Depth cameras reuse the RGB
+        per-pixel upload constant as a first approximation — both are
+        video-family traces that always keep a lossless archive, so their
+        upload cost is comparable order-of-magnitude, though not necessarily
+        identical. The budget is floored at the duration-based overhead so
+        short or low-volume recordings keep a sane minimum.
         """
         if not self.wait:
             return STOP_RECORDING_NO_WAIT_SLA_S
@@ -219,11 +337,12 @@ class ContextCaseSpec:
             * STOP_RECORDING_UPLOAD_SLA_PER_JOINT_SAMPLE_S
         )
         video_budget = 0.0
-        if self.video_count and self.image_width and self.image_height:
+        camera_count = self.video_count + self.depth_count
+        if camera_count and self.image_width and self.image_height:
             video_budget = (
                 self.duration_sec
                 * self.video_fps
-                * self.video_count
+                * camera_count
                 * self.image_width
                 * self.image_height
                 * STOP_RECORDING_UPLOAD_SLA_PER_VIDEO_PIXEL_S
@@ -278,6 +397,10 @@ class ContextResult:
     timer_stats: dict[str, dict[str, float]] = field(default_factory=dict)
     recording_indexes: list[int] = field(default_factory=list)
     source: tuple[str, int] = ("", 0)
+    depth_camera_names: list[str] = field(default_factory=list)
+    depth_frame_count: int = 0
+    depth_mode: DepthMode = "float32"
+    has_depth: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -353,6 +476,8 @@ def build_context_specs(
                     video_fps=case.video_fps,
                     wait=case.wait,
                     random_phase=case.random_phase,
+                    depth_count=case.depth_count,
+                    depth_mode=case.depth_mode,
                 ),
                 context_index=context_index,
                 robot_name=f"matrix_robot_{uuid.uuid4().hex[:10]}",
@@ -441,6 +566,8 @@ def log_synchronous_frames(
     recording_index: int,
     joint_names: list[str],
     camera_name_list: list[str],
+    depth_camera_name_list: list[str],
+    depth_mode: DepthMode,
     image_width: int | None,
     image_height: int | None,
     joint_fps: int,
@@ -455,14 +582,21 @@ def log_synchronous_frames(
     as the transport allows, save for the fixed *log_interval_s* sleep after
     each iteration — the timestamps themselves are never paced to wall clock.
     Frames are interleaved in timestamp order so the daemon receives them the
-    way a real producer would order them.
+    way a real producer would order them. Depth cameras (if any) share the
+    RGB video timestamp sequence and are logged alongside the RGB cameras at
+    each video timestamp.
     """
     frame_buffer = preallocate_frame_buffer(
         bool(camera_name_list), image_width, image_height
     )
+    depth_buffer = preallocate_depth_buffer(
+        bool(depth_camera_name_list), image_width, image_height, depth_mode
+    )
 
     joint_frame_count = len(joint_timestamps)
-    video_frame_count = len(video_timestamps) if camera_name_list else 0
+    video_frame_count = (
+        len(video_timestamps) if camera_name_list or depth_camera_name_list else 0
+    )
     joint_index = 0
     video_index = 0
 
@@ -540,6 +674,29 @@ def log_synchronous_frames(
                         robot_name=robot_name,
                         timestamp=timestamp,
                     )
+            for depth_camera_index, depth_camera_name in enumerate(
+                depth_camera_name_list
+            ):
+                frame_code = (
+                    (context_index * 1_000_000_000)
+                    + (recording_index * 10_000_000)
+                    + (depth_camera_index * 100_000)
+                    + video_index
+                )
+                depth_image = encode_depth_frame(
+                    frame_code, image_width, image_height, depth_mode, out=depth_buffer
+                )
+                with Timer(
+                    MAX_TIME_TO_LOG_S,
+                    label="nc.log_depth",
+                    assert_deadline=assert_deadline,
+                ):
+                    nc.log_depth(
+                        depth_camera_name,
+                        depth_image,
+                        robot_name=robot_name,
+                        timestamp=timestamp,
+                    )
             video_index += 1
 
         if log_interval_s:
@@ -550,6 +707,7 @@ def build_thread_roles(
     *,
     joint_names: list[str],
     camera_name_list: list[str],
+    depth_camera_name_list: list[str],
 ) -> list[dict[str, object]]:
     """Build role specs for per-thread logging."""
     roles: list[dict[str, object]] = []
@@ -558,6 +716,12 @@ def build_thread_roles(
             "role": "rgb",
             "camera_names": [camera_name],
             "marker_name": f"marker_{camera_name}",
+        })
+    for depth_camera_name in depth_camera_name_list:
+        roles.append({
+            "role": "depth",
+            "camera_names": [depth_camera_name],
+            "marker_name": f"marker_{depth_camera_name}",
         })
     for role_name in ("joint_positions", "joint_velocities", "joint_torques"):
         roles.append({
@@ -578,6 +742,8 @@ def run_threaded_logging(
     context_index: int,
     joint_names: list[str],
     camera_name_list: list[str],
+    depth_camera_name_list: list[str],
+    depth_mode: DepthMode,
     image_width: int | None,
     image_height: int | None,
     assert_deadline: bool = False,  # only set by performance tests
@@ -588,13 +754,16 @@ def run_threaded_logging(
     Every role emits the timestamp sequence its stream was given, as fast as the
     transport allows, save for the fixed *log_interval_s* sleep after each
     iteration — the timestamps themselves are never paced to wall clock.  Each
-    role paces its own stream, so the rgb roles that feed the daemon's spool are
-    capped independently of the joint roles.  All joint roles share the joint
-    sequence, so the three joint data types stay aligned exactly as they do in
-    the synchronous producer.
+    role paces its own stream, so the rgb/depth roles that feed the daemon's
+    spool are capped independently of the joint roles.  All joint roles share
+    the joint sequence, so the three joint data types stay aligned exactly as
+    they do in the synchronous producer. Depth roles share the RGB video
+    timestamp sequence, exactly as in the synchronous producer.
     """
     roles = build_thread_roles(
-        joint_names=joint_names, camera_name_list=camera_name_list
+        joint_names=joint_names,
+        camera_name_list=camera_name_list,
+        depth_camera_name_list=depth_camera_name_list,
     )
     barrier = threading.Barrier(len(roles))
     thread_errors: list[BaseException] = []
@@ -606,8 +775,12 @@ def run_threaded_logging(
             role_name = str(role_spec["role"])
             marker_name = str(role_spec["marker_name"])
             is_rgb = role_name == "rgb"
-            timestamps = video_timestamps if is_rgb else joint_timestamps
+            is_depth = role_name == "depth"
+            timestamps = video_timestamps if (is_rgb or is_depth) else joint_timestamps
             frame_buffer = preallocate_frame_buffer(is_rgb, image_width, image_height)
+            depth_buffer = preallocate_depth_buffer(
+                is_depth, image_width, image_height, depth_mode
+            )
             for frame_index, timestamp in enumerate(timestamps):
                 if is_rgb:
                     for camera_offset, camera_name in enumerate(
@@ -632,6 +805,39 @@ def run_threaded_logging(
                             nc.log_rgb(
                                 camera_id,
                                 rgb_image,
+                                robot_name=robot_name,
+                                timestamp=timestamp,
+                            )
+                elif is_depth:
+                    for camera_offset, camera_name in enumerate(
+                        role_spec["camera_names"]
+                    ):
+                        depth_camera_id = str(camera_name)
+                        depth_camera_index = (
+                            depth_camera_name_list.index(depth_camera_id)
+                            + camera_offset
+                        )
+                        frame_code = (
+                            (context_index * 1_000_000_000)
+                            + (recording_index * 10_000_000)
+                            + (depth_camera_index * 100_000)
+                            + frame_index
+                        )
+                        depth_image = encode_depth_frame(
+                            frame_code,
+                            image_width,
+                            image_height,
+                            depth_mode,
+                            out=depth_buffer,
+                        )
+                        with Timer(
+                            MAX_TIME_TO_LOG_S,
+                            label="nc.log_depth",
+                            assert_deadline=assert_deadline,
+                        ):
+                            nc.log_depth(
+                                depth_camera_id,
+                                depth_image,
                                 robot_name=robot_name,
                                 timestamp=timestamp,
                             )
@@ -748,6 +954,7 @@ def log_frames(
     joint_timestamps, video_timestamps = recording_timestamps(spec, recording_index)
     joint_name_list = joint_names_for_count(spec.case.joint_count)
     camera_name_list = camera_names(spec.case.video_count)
+    depth_camera_name_list = depth_camera_names(spec.case.depth_count)
 
     if spec.case.producer_channels == PRODUCER_PER_THREAD:
         return run_threaded_logging(
@@ -759,6 +966,8 @@ def log_frames(
             context_index=spec.context_index,
             joint_names=joint_name_list,
             camera_name_list=camera_name_list,
+            depth_camera_name_list=depth_camera_name_list,
+            depth_mode=spec.case.depth_mode,
             image_width=spec.case.image_width,
             image_height=spec.case.image_height,
             assert_deadline=spec.assert_deadline,
@@ -772,6 +981,8 @@ def log_frames(
         recording_index=recording_index,
         joint_names=joint_name_list,
         camera_name_list=camera_name_list,
+        depth_camera_name_list=depth_camera_name_list,
+        depth_mode=spec.case.depth_mode,
         image_width=spec.case.image_width,
         image_height=spec.case.image_height,
         joint_fps=spec.case.joint_fps,
@@ -838,6 +1049,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
     case = spec.case
     joint_name_list = joint_names_for_count(case.joint_count)
     camera_name_list = camera_names(case.video_count)
+    depth_camera_name_list = depth_camera_names(case.depth_count)
     marker_names: list[str] = []
     recording_ids: list[str] = []
     recording_indexes: list[int] = []
@@ -909,6 +1121,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
             for camera in camera_name_list:
                 safe_cam = validate_safe_name(camera)
                 by_trace[f"RGB_IMAGES/{safe_cam}"] = video_ts
+            for depth_camera in depth_camera_name_list:
+                safe_depth_cam = validate_safe_name(depth_camera)
+                by_trace[f"DEPTH_IMAGES/{safe_depth_cam}"] = video_ts
             # CUSTOM_1D marker — name depends on producer_channels mode
             if case.producer_channels == PRODUCER_PER_THREAD:
                 # One marker per joint data type thread
@@ -921,6 +1136,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                     by_trace[f"CUSTOM_1D/{safe_marker}"] = joint_ts
                 for camera in camera_name_list:
                     safe_marker = validate_safe_name(f"marker_{camera}")
+                    by_trace[f"CUSTOM_1D/{safe_marker}"] = video_ts
+                for depth_camera in depth_camera_name_list:
+                    safe_marker = validate_safe_name(f"marker_{depth_camera}")
                     by_trace[f"CUSTOM_1D/{safe_marker}"] = video_ts
             else:
                 safe_marker = validate_safe_name("marker_synchronous")
@@ -976,6 +1194,12 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                 by_recording=expected_by_recording
             ),
             timer_stats=captured_timer_stats,
+            depth_camera_names=depth_camera_name_list,
+            depth_frame_count=(
+                spec.expected_video_frames if depth_camera_name_list else 0
+            ),
+            depth_mode=case.depth_mode,
+            has_depth=bool(depth_camera_name_list),
         )
     except Exception:
         if robot is not None:

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -86,6 +86,9 @@ DURATION_MODES = (DURATION_MODE_FIXED, DURATION_MODE_VARIABLE)
 
 StopMethod = Literal["cli", "sigterm", "sigkill"]
 StorageStateAction = Literal["delete", "preserve", "empty"]
+DepthMode = Literal["float16", "float32"]
+"""Depth camera sample dtype, matching the wire labels `nc.log_depth()`
+derives from the array's own dtype (`image.dtype.name`)."""
 
 MAX_TIME_TO_START_S = 20.0
 STOP_RECORDING_OVERHEAD_PER_SEC = 0.5
@@ -103,3 +106,31 @@ FRAME_DEFAULT_FILL_VALUE = 100
 FRAME_MAX_COLOR_VALUE = 255
 FRAME_HALF_DIVISOR = 2
 FRAME_COLOR_CHANNELS = 3
+
+# ---------------------------------------------------------------------------
+# Depth round-trip generation and verification
+# ---------------------------------------------------------------------------
+
+# `encode_depth_frame` builds each frame as
+# floor + per-frame-base + row-gradient + col-gradient, all expressed as
+# fractions of MAX_DEPTH (see neuracore.core.utils.depth_utils.MAX_DEPTH) so
+# the pattern automatically stays proportional if that constant ever changes.
+# The floor keeps every pixel strictly non-zero; the row/col fractions are
+# deliberately unequal so a width/height transpose bug shifts the decoded
+# pattern rather than leaving it looking correct.
+DEPTH_FRAME_FLOOR_FRACTION = 0.025
+DEPTH_FRAME_BASE_FRACTION = 0.375
+DEPTH_FRAME_ROW_FRACTION = 0.3
+DEPTH_FRAME_COL_FRACTION = 0.15
+DEPTH_FRAME_BASE_MODULUS = 997  # prime; spreads per-frame bases pseudo-randomly
+
+# Numerical tolerance for comparing a value retrieved from a synchronized
+# recording against the value that was actually passed to `nc.log_depth()`
+# (after its source-dtype cast). The only lossy step between those two points
+# is the 24-bit depth-to-RGB24 storage quantization
+# (MAX_DEPTH / (2**24 - 1) ~= 5.96e-7 m) plus ordinary float32 rounding across
+# the encode/decode arithmetic — both far smaller than this. Genuine
+# corruption (wrong channel order, wrong dtype, transposed axes) produces
+# errors many orders of magnitude larger, so this stays tight enough to catch
+# it.
+DEPTH_ROUND_TRIP_ATOL_M = 1e-4

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -7,6 +7,7 @@ from neuracore_types import DataType, ParallelGripperOpenAmountData
 
 import neuracore as nc
 from neuracore.api import logging as api_logging
+from neuracore.api.core import _get_robot
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import RobotError
 from neuracore.core.robot import Robot
@@ -72,6 +73,60 @@ def test_log_with_extrinsics_intrinsics(
     # Log with extrinsics and intrinsics
     nc.log_rgb("front_camera", rgb_uint8, extrinsics=extrinsics, intrinsics=intrinsics)
     nc.log_depth("depth_camera", depth, extrinsics=extrinsics, intrinsics=intrinsics)
+
+
+def test_log_frame_forwards_dtype_derived_from_the_array(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mock_urdf,
+    monkeypatch,
+    mocked_org_id,
+):
+    """log_frame's native dtype must be derived from the array, per call.
+
+    RGB forwards "uint8"; depth forwards "float16" or "float32" depending on
+    the actual array passed to `nc.log_depth` — the public API takes no
+    dtype parameter, so this is the only place dtype can come from.
+    """
+    nc.login("test_api_key")
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json={"robot_id": "mock_robot_id", "has_urdf": True},
+        status_code=200,
+    )
+    nc.connect_robot("test_robot", urdf_path=mock_urdf)
+
+    native = MagicMock()
+    monkeypatch.setattr(recording_context, "_load_native", lambda: native)
+    robot = _get_robot(None, 0)
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: "rec-1")
+
+    rgb_uint8 = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    nc.log_rgb("front_camera", rgb_uint8)
+    depth_f16 = np.ones((100, 100), dtype=np.float16)
+    nc.log_depth("depth_camera_16", depth_f16)
+    depth_f32 = np.ones((100, 100), dtype=np.float32)
+    nc.log_depth("depth_camera_32", depth_f32)
+
+    assert native.log_frame.call_count == 3
+    calls_by_dtype = {
+        call.args[2]: call.args[6] for call in native.log_frame.call_args_list
+    }
+    assert calls_by_dtype[DataType.RGB_IMAGES.value] == "uint8"
+    assert calls_by_dtype[DataType.DEPTH_IMAGES.value] in ("float16", "float32")
+    # Both depth calls are distinguishable by dtype even though they share a
+    # data_type label, so inspect each call directly rather than the dict
+    # above (which the second depth call would overwrite).
+    depth_calls = [
+        call
+        for call in native.log_frame.call_args_list
+        if call.args[2] == DataType.DEPTH_IMAGES.value
+    ]
+    assert {call.args[6] for call in depth_calls} == {"float16", "float32"}
+
+    # Avoid Robot.__del__ consulting the process-global recording manager.
+    robot.id = None
 
 
 def test_log_gripper_data(


### PR DESCRIPTION
### Features
 - Added native float16 and float32 depth-image support to the Rust data daemon, preserving the original dtype through the pipeline and into trace.json.
- Depth frames are converted into the existing lossless RGB24 storage representation before entering the PNG/NUT pipeline, keeping established RGB behaviour unchanged.
 - Added regression coverage for depth validation, conversion, dtype propagation and existing RGB recording behaviour.

### Items
 - [NC-1197](https://neuracore.atlassian.net/browse/NCP-1197)

### Related PRs
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/415
