### PR TITLE
test: report p95/p99 logging latency from a merged histogram

### DIFF
--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -91,13 +91,66 @@ def _rearm_stack_dump() -> None:
     faulthandler.dump_traceback_later(max(remaining, 0.001), exit=False)
 
 
+LATENCY_BUCKETS_S: tuple[float, ...] = (
+    0.0005,
+    0.001,
+    0.002,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+)
+"""Upper bounds of the latency histogram, in seconds, log-spaced."""
+
+BUCKET_KEYS: tuple[str, ...] = tuple(f"le_{bound}" for bound in LATENCY_BUCKETS_S) + (
+    "gt_max",
+)
+"""Stat keys for the histogram, one per bucket plus an overflow bucket."""
+
+
+def _empty_stats() -> dict[str, float]:
+    """Return a zeroed stat accumulator for one label."""
+    stats = {"count": 0.0, "total": 0.0, "max": 0.0}
+    stats.update({key: 0.0 for key in BUCKET_KEYS})
+    return stats
+
+
+def _bucket_key(interval: float) -> str:
+    """Return the histogram key *interval* falls in."""
+    for bound, key in zip(LATENCY_BUCKETS_S, BUCKET_KEYS):
+        if interval <= bound:
+            return key
+    return "gt_max"
+
+
+def percentile_upper_bound(stats: dict[str, float], quantile: float) -> float | None:
+    """Return the bucket upper bound containing *quantile* of the samples.
+
+    ``None`` when the samples overflow the largest bucket, or the label has no
+    histogram.
+    """
+    count = stats.get("count", 0.0)
+    if count <= 0:
+        return None
+    target = quantile * count
+    seen = 0.0
+    for bound, key in zip(LATENCY_BUCKETS_S, BUCKET_KEYS):
+        seen += stats.get(key, 0.0)
+        if seen >= target:
+            return bound
+    return None
+
+
 class Timer:
     """Context manager that measures wall-clock elapsed time for a block.
 
-    Accumulates per-label statistics (count, total, max) in the class-level
-    ``_stats`` dictionary so that test suites can report aggregate timing at
-    the end of a run.  Optionally asserts that the block completed within
-    ``max_time`` seconds.
+    Accumulates per-label statistics in the class-level ``_stats`` so a suite
+    can report aggregate timing, and optionally asserts the block ran within
+    ``max_time``.
 
     Every logged line and assertion message apportions the elapsed time between
     HTTP requests this thread made and everything else, so a breach states on its
@@ -107,7 +160,10 @@ class Timer:
 
     Attributes:
         _stats: Class-level dict mapping label strings to aggregate timing
-            statistics with keys ``"count"``, ``"total"``, and ``"max"``.
+            statistics with keys ``"count"``, ``"total"``, ``"max"``, and one
+            per :data:`BUCKET_KEYS` entry.
+        _stats_lock: Guards :attr:`_stats`, which several producer threads
+            accumulate into at once.
         max_time: Upper time limit in seconds.
         label: Human-readable name for this timer.  Pass ``None`` to skip
             stat accumulation.
@@ -117,12 +173,16 @@ class Timer:
             this value.  ``None`` disables.
         assert_deadline: When ``True`` (default), raise ``AssertionError`` if
             the block exceeds ``max_time``.  Set to ``False`` to log only.
+        log_breaches: When ``True`` (default), log a line every time the block
+            exceeds ``max_time``.  Per-frame timers set ``False``: one line per
+            call buries the run, and the histogram already reports the tail.
         http_calls: Requests this thread issued inside the block.  Set on exit.
         http_seconds: Seconds those requests took.  Set on exit.
         dumps_stack: Whether this timer armed the stack dump.
     """
 
     _stats: dict[str, dict[str, float]] = {}
+    _stats_lock = threading.Lock()
 
     def __init__(
         self,
@@ -131,12 +191,14 @@ class Timer:
         always_log: bool = False,
         log_threshold: float | None = None,
         assert_deadline: bool = True,
+        log_breaches: bool = True,
     ) -> None:
         self.max_time = max_time
         self.label = label
         self.always_log = always_log
         self.log_threshold = log_threshold
         self.assert_deadline = assert_deadline
+        self.log_breaches = log_breaches
 
     def __enter__(self) -> Timer:
         self.wall_start = time.time()
@@ -163,17 +225,17 @@ class Timer:
         self.http_seconds = http_seconds - self.http_seconds_start
         had_exception = len(args) > 0 and args[0] is not None
         if self.label:
-            stats = self._stats.setdefault(
-                self.label, {"count": 0.0, "total": 0.0, "max": 0.0}
-            )
-            stats["count"] += 1
-            stats["total"] += self.interval
-            stats["max"] = max(stats["max"], self.interval)
+            with self._stats_lock:
+                stats = self._stats.setdefault(self.label, _empty_stats())
+                stats["count"] += 1
+                stats["total"] += self.interval
+                stats["max"] = max(stats["max"], self.interval)
+                stats[_bucket_key(self.interval)] += 1
 
             should_log = self.always_log
             if self.log_threshold is not None and self.interval >= self.log_threshold:
                 should_log = True
-            if self.interval >= self.max_time:
+            if self.log_breaches and self.interval >= self.max_time:
                 should_log = True
 
             if should_log:
@@ -221,13 +283,14 @@ class Timer:
     @classmethod
     def merge_stats(cls, stats: dict[str, dict[str, float]]) -> None:
         """Merge external timer stats (e.g. from a worker process) into the accumulator."""  # noqa: E501
-        for label, incoming in stats.items():
-            existing = cls._stats.setdefault(
-                label, {"count": 0.0, "total": 0.0, "max": 0.0}
-            )
-            existing["count"] += incoming["count"]
-            existing["total"] += incoming["total"]
-            existing["max"] = max(existing["max"], incoming["max"])
+        with cls._stats_lock:
+            for label, incoming in stats.items():
+                existing = cls._stats.setdefault(label, _empty_stats())
+                existing["count"] += incoming["count"]
+                existing["total"] += incoming["total"]
+                existing["max"] = max(existing["max"], incoming["max"])
+                for key in BUCKET_KEYS:
+                    existing[key] += incoming.get(key, 0.0)
 
 
 def surface_worker_errors(fn):

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -24,7 +24,12 @@ if TYPE_CHECKING:
     )
 
 from neuracore.core.config.config_manager import get_config_manager
-from tests.integration.platform.data_daemon.shared.process_control import Timer
+from tests.integration.platform.data_daemon.shared.process_control import (
+    BUCKET_KEYS,
+    LATENCY_BUCKETS_S,
+    Timer,
+    percentile_upper_bound,
+)
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     BASE_DATASET_READY_TIMEOUT_S,
     DURATION_MODE_FIXED,
@@ -446,11 +451,36 @@ def case_timeout_seconds(case: DataDaemonTestCase) -> float:
 # ---------------------------------------------------------------------------
 
 
+MIN_SAMPLES_FOR_PERCENTILE = 100
+"""Below this sample count a percentile is not reported — it would just be the max."""
+
+
+def _percentile_text(stats: dict[str, float], quantile: float) -> str:
+    """Render one percentile column, or empty when it would say nothing."""
+    count = int(stats["count"])
+    label = f"p{int(quantile * 100)}"
+    if count < MIN_SAMPLES_FOR_PERCENTILE:
+        return ""
+    if not any(stats.get(key, 0.0) for key in BUCKET_KEYS):
+        return f"{label}=n/a"
+    bound = percentile_upper_bound(stats, quantile)
+    if bound is None:
+        return f"{label}>{LATENCY_BUCKETS_S[-1]:.3f}s"
+    # A bucket edge, not an interpolated value — "<=" keeps that honest.
+    return f"{label}<={min(bound, stats['max']):.3f}s"
+
+
 def _format_timer_stats_line(label: str, stats: dict[str, float]) -> str:
     """Format a timer stats line for analysis output."""
     count = int(stats["count"])
     avg = stats["total"] / count if count > 0 else 0.0
-    return f"    {label:<42}  {count:3}x" f"  avg={avg:.3f}s  max={stats['max']:.3f}s"
+    p95_text = _percentile_text(stats, 0.95)
+    p99_text = _percentile_text(stats, 0.99)
+    return (
+        f"    {label:<42}  {count:3}x"
+        f"  avg={avg:.3f}s  {p95_text:<12}  {p99_text:<12}"
+        f"  max={stats['max']:.3f}s"
+    )
 
 
 def log_run_analysis(

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -619,6 +619,7 @@ def log_synchronous_frames(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_positions",
                 assert_deadline=assert_deadline,
+                log_breaches=False,
             ):
                 nc.log_joint_positions(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -627,6 +628,7 @@ def log_synchronous_frames(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_velocities",
                 assert_deadline=assert_deadline,
+                log_breaches=False,
             ):
                 nc.log_joint_velocities(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -635,6 +637,7 @@ def log_synchronous_frames(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_joint_torques",
                 assert_deadline=assert_deadline,
+                log_breaches=False,
             ):
                 nc.log_joint_torques(
                     joint_values, robot_name=robot_name, timestamp=timestamp
@@ -643,6 +646,7 @@ def log_synchronous_frames(
                 MAX_TIME_TO_LOG_S,
                 label="nc.log_custom_1d",
                 assert_deadline=assert_deadline,
+                log_breaches=False,
             ):
                 nc.log_custom_1d(
                     marker_name,
@@ -667,6 +671,7 @@ def log_synchronous_frames(
                     MAX_TIME_TO_LOG_S,
                     label="nc.log_rgb",
                     assert_deadline=assert_deadline,
+                    log_breaches=False,
                 ):
                     nc.log_rgb(
                         camera_name,
@@ -690,6 +695,7 @@ def log_synchronous_frames(
                     MAX_TIME_TO_LOG_S,
                     label="nc.log_depth",
                     assert_deadline=assert_deadline,
+                    log_breaches=False,
                 ):
                     nc.log_depth(
                         depth_camera_name,
@@ -801,6 +807,7 @@ def run_threaded_logging(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_rgb",
                             assert_deadline=assert_deadline,
+                            log_breaches=False,
                         ):
                             nc.log_rgb(
                                 camera_id,
@@ -834,6 +841,7 @@ def run_threaded_logging(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_depth",
                             assert_deadline=assert_deadline,
+                            log_breaches=False,
                         ):
                             nc.log_depth(
                                 depth_camera_id,
@@ -851,6 +859,7 @@ def run_threaded_logging(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_positions",
                             assert_deadline=assert_deadline,
+                            log_breaches=False,
                         ):
                             nc.log_joint_positions(
                                 joint_values,
@@ -862,6 +871,7 @@ def run_threaded_logging(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_velocities",
                             assert_deadline=assert_deadline,
+                            log_breaches=False,
                         ):
                             nc.log_joint_velocities(
                                 joint_values,
@@ -873,6 +883,7 @@ def run_threaded_logging(
                             MAX_TIME_TO_LOG_S,
                             label="nc.log_joint_torques",
                             assert_deadline=assert_deadline,
+                            log_breaches=False,
                         ):
                             nc.log_joint_torques(
                                 joint_values,
@@ -883,6 +894,7 @@ def run_threaded_logging(
                     MAX_TIME_TO_LOG_S,
                     label="nc.log_custom_1d",
                     assert_deadline=assert_deadline,
+                    log_breaches=False,
                 ):
                     nc.log_custom_1d(
                         marker_name,

--- a/tests/unit/data_daemon/test_timer_stats.py
+++ b/tests/unit/data_daemon/test_timer_stats.py
@@ -1,0 +1,88 @@
+"""``Timer`` stat accumulation under concurrent producers."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from tests.integration.platform.data_daemon.shared.process_control import Timer
+
+# cspell:ignore getswitchinterval setswitchinterval
+
+THREAD_COUNT = 16
+ITERATIONS_PER_THREAD = 200
+LABEL = "test.concurrent_timer"
+
+# Repeated so a scheduling fluke cannot hide the race.
+ROUNDS = 20
+
+# CPython's thread-switch interval; the default is too slow to catch the race.
+FAST_SWITCH_INTERVAL_S = 1e-6
+
+
+@contextmanager
+def aggressive_thread_switching() -> Generator[None]:
+    """Force CPython to switch threads as often as it is willing to."""
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(FAST_SWITCH_INTERVAL_S)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(previous)
+
+
+def _time_blocks_concurrently() -> tuple[dict[str, float], float, int]:
+    """Run one round of concurrent timing.
+
+    Returns:
+        ``(stats, slowest measured interval, blocks run)``.
+    """
+    Timer._stats.pop(LABEL, None)
+    observed: list[list[float]] = []
+    observed_lock = threading.Lock()
+
+    def hammer() -> None:
+        intervals: list[float] = []
+        for _ in range(ITERATIONS_PER_THREAD):
+            with Timer(0.5, label=LABEL, assert_deadline=False) as timer:
+                pass
+            intervals.append(timer.interval)
+        with observed_lock:
+            observed.append(intervals)
+
+    threads = [
+        threading.Thread(target=hammer, name=f"timer-hammer-{index}")
+        for index in range(THREAD_COUNT)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    return (
+        dict(Timer._stats[LABEL]),
+        max(interval for intervals in observed for interval in intervals),
+        sum(len(intervals) for intervals in observed),
+    )
+
+
+def test_concurrent_timers_keep_the_worst_interval() -> None:
+    """The reported ``max`` is the slowest block, whoever else was timing one."""
+    try:
+        with aggressive_thread_switching():
+            for round_index in range(ROUNDS):
+                stats, slowest, total = _time_blocks_concurrently()
+
+                assert stats["count"] == float(total), (
+                    f"round {round_index}: lost {total - stats['count']:.0f} of "
+                    f"{total} timer counts across {THREAD_COUNT} threads"
+                )
+                assert stats["max"] == slowest, (
+                    f"round {round_index}: reported max {stats['max']:.6f}s is not "
+                    f"the slowest block {slowest:.6f}s — a concurrent update "
+                    "overwrote it"
+                )
+    finally:
+        Timer._stats.pop(LABEL, None)


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Add percentile time for log_* functions so we have more visility on overall timing of each - log_* near the recording boundary may include flushing the spool for instance

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>