### PR TITLE
test: split daemon log cleanup into its own preserve/delete axis

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -6,6 +6,7 @@ adarms
 ADARMS
 addfinalizer
 addinivalue
+addoption
 agentview
 agilex
 aiofiles
@@ -196,6 +197,7 @@ geomadr
 geomid
 geomnum
 getbuffer
+getgroup
 getpgid
 getpid
 gettid

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -8,6 +8,7 @@ adarms
 ADARMS
 addfinalizer
 addinivalue
+addoption
 agentview
 agilex
 aiofiles
@@ -201,6 +202,7 @@ geomadr
 geomid
 geomnum
 getbuffer
+getgroup
 getpgid
 getpid
 gettid

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
@@ -39,8 +39,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STOP_RECORDING_OVERHEAD_PER_SEC,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
     set_case_analysis_report,
 )
@@ -85,13 +83,9 @@ def test_cancel_recording_produces_no_data(
     specs = build_context_specs(case, dataset_name=dataset_name)
     spec = specs[0]
     robot_name = spec.robot_name
-    cloud_names = cloud_resource_names(specs)
 
     try:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with online_daemon_running():
                 assert_exactly_one_daemon_pid()
 
@@ -167,14 +161,10 @@ def test_cancel_then_start_new_recording(
     specs = build_context_specs(case, dataset_name=dataset_name)
     spec = specs[0]
     robot_name = spec.robot_name
-    cloud_names = cloud_resource_names(specs)
     results: list[ContextResult] = []
 
     try:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with online_daemon_running():
                 assert_exactly_one_daemon_pid()
 

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
@@ -39,8 +39,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STOP_RECORDING_OVERHEAD_PER_SEC,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
     set_case_analysis_report,
 )
@@ -85,13 +83,9 @@ def test_cancel_recording_produces_no_data(
     specs = build_context_specs(case, dataset_name=dataset_name)
     spec = specs[0]
     robot_name = spec.robot_name
-    cloud_names = cloud_resource_names(specs)
 
     try:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with online_daemon_running():
                 assert_exactly_one_daemon_pid()
 
@@ -168,14 +162,10 @@ def test_cancel_then_start_new_recording(
     specs = build_context_specs(case, dataset_name=dataset_name)
     spec = specs[0]
     robot_name = spec.robot_name
-    cloud_names = cloud_resource_names(specs)
     results: list[ContextResult] = []
 
     try:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with online_daemon_running():
                 assert_exactly_one_daemon_pid()
 

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
@@ -135,7 +135,7 @@ def _same_source_producer(
         # Keep every producer and its SSE consumer alive while the parent
         # verifies that the daemon finalized all three traces.
         verification_complete.wait(timeout=_PROCESS_TIMEOUT_S)
-    except BaseException:  # noqa: BLE001 - propagate full child traceback
+    except BaseException:  # noqa: BLE001
         result_queue.put({
             "ok": False,
             "producer_index": producer_index,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_offline_to_online.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_offline_to_online.py
@@ -29,8 +29,6 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case_con
     run_case_contexts,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
     set_case_analysis_report,
 )
@@ -76,14 +74,10 @@ def test_offline_pending_data_recovers_when_online(
 
     dataset_name = create_testing_dataset_name(case)
     specs = build_context_specs(case, dataset_name=dataset_name)
-    cloud_names = cloud_resource_names(specs)
     results: list[ContextResult] = []
 
     try:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with offline_daemon_running():
                 assert_exactly_one_daemon_pid()
                 results = run_case_contexts(case, specs=specs)

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -39,7 +39,6 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     _format_timer_stats_line,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
-    DATA_DAEMON_TEST_STATE_ROOT,
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
@@ -48,8 +47,7 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 )
 
 # cspell:ignore terminalreporter exitstatus finalizer NODEIDS exitfirst unparameterized
-# cspell:ignore sessionfinish nodeid getfixturevalue modifyitems callspec addoption
-# cspell:ignore getgroup
+# cspell:ignore nodeid getfixturevalue modifyitems callspec
 
 # Add the repo root to the path so sub workers on macos can unpickle pool tasks
 # correctly. pytest --import-mode=importlib imports tests files without touching the
@@ -364,17 +362,3 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     lines.append(separator)
     terminalreporter.write_line("\n".join(lines))
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Remove the shared ``daemon.log`` after an all-green run.
-
-    It is the one artefact under ``.data_daemon_test_state`` that no
-    per-test cleanup owns (the DB and recordings folder are handled by
-    ``apply_storage_state_action``), and each background launch truncates it
-    anyway, so a passing run has nothing left in it worth keeping. Leave it
-    on a failure, since it may hold the daemon's own stderr/tracing for the
-    post-mortem.
-    """
-    del session
-    (DATA_DAEMON_TEST_STATE_ROOT / "daemon.log").unlink(missing_ok=True)

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -42,7 +42,6 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     _format_timer_stats_line,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
-    DATA_DAEMON_TEST_STATE_ROOT,
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
@@ -51,8 +50,7 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 )
 
 # cspell:ignore terminalreporter exitstatus finalizer NODEIDS exitfirst unparameterized
-# cspell:ignore sessionfinish nodeid getfixturevalue modifyitems callspec addoption
-# cspell:ignore getgroup
+# cspell:ignore nodeid getfixturevalue modifyitems callspec
 
 # Add the repo root to the path so sub workers on macos can unpickle pool tasks
 # correctly. pytest --import-mode=importlib imports tests files without touching the
@@ -362,17 +360,3 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     lines.append(separator)
     terminalreporter.write_line("\n".join(lines))
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Remove the shared ``daemon.log`` after an all-green run.
-
-    It is the one artefact under ``.data_daemon_test_state`` that no
-    per-test cleanup owns (the DB and recordings folder are handled by
-    ``apply_storage_state_action``), and each background launch truncates it
-    anyway, so a passing run has nothing left in it worth keeping. Leave it
-    on a failure, since it may hold the daemon's own stderr/tracing for the
-    post-mortem.
-    """
-    del session
-    (DATA_DAEMON_TEST_STATE_ROOT / "daemon.log").unlink(missing_ok=True)

--- a/tests/integration/platform/data_daemon/data_integrity/test_network.py
+++ b/tests/integration/platform/data_daemon/data_integrity/test_network.py
@@ -33,8 +33,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
     set_case_analysis_report,
 )
@@ -82,13 +80,9 @@ def test_cloud_data_integrity(
 
     dataset_name = create_testing_dataset_name(case)
     specs = build_context_specs(case, dataset_name=dataset_name)
-    cloud_names = cloud_resource_names(specs)
     results: list[ContextResult] = []
 
-    with (
-        cloud_resource_deleter(*cloud_names),
-        scoped_storage_state(case),
-    ):
+    with scoped_storage_state(case, specs):
         try:
             with online_daemon_running():
                 assert_exactly_one_daemon_pid()

--- a/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/data_integrity/test_pre_network.py
@@ -35,8 +35,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
     set_case_analysis_report,
     setup_per_test_artifact_dirs,
@@ -80,11 +78,7 @@ def test_disk_db_data_integrity(
     results: list[ContextResult] = []
     dataset_name = create_testing_dataset_name(case)
     specs = build_context_specs(case, dataset_name=dataset_name)
-    cloud_names = cloud_resource_names(specs)
-    with (
-        cloud_resource_deleter(*cloud_names),
-        scoped_storage_state(case),
-    ):
+    with scoped_storage_state(case, specs):
         try:
             with offline_daemon_running():
                 assert_exactly_one_daemon_pid()

--- a/tests/integration/platform/data_daemon/performance/test_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_network.py
@@ -28,8 +28,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
 )
 
@@ -65,13 +63,9 @@ def test_cloud_upload_and_readiness_performance(
         )
     dataset_name = create_testing_dataset_name(case)
     specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=True)
-    cloud_names = cloud_resource_names(specs)
     with performance_report(case, dataset_name=dataset_name) as report:
         results: list[ContextResult] = []
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with online_daemon_running():
                 with report.step("Record workload and stop recordings"):
                     with Timer(

--- a/tests/integration/platform/data_daemon/performance/test_pre_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_pre_network.py
@@ -24,8 +24,6 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STORAGE_STATE_DELETE,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
-    cloud_resource_deleter,
-    cloud_resource_names,
     scoped_storage_state,
 )
 
@@ -54,12 +52,8 @@ def test_disk_db_write_performance(
 
     dataset_name = create_testing_dataset_name(case)
     specs = build_context_specs(case, dataset_name=dataset_name, assert_deadline=True)
-    cloud_names = cloud_resource_names(specs)
     with performance_report(case, dataset_name=dataset_name) as report:
-        with (
-            cloud_resource_deleter(*cloud_names),
-            scoped_storage_state(case),
-        ):
+        with scoped_storage_state(case, specs):
             with offline_daemon_running():
                 assert_exactly_one_daemon_pid()
                 report.capture_results(

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -34,13 +34,16 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     BASE_DATASET_READY_TIMEOUT_S,
     DURATION_MODE_FIXED,
     DURATION_MODE_VARIABLE,
+    LOG_PRESERVE,
     MAX_DATASET_READY_TIMEOUT_S,
     MODE_SEQUENTIAL,
     PRODUCER_PER_THREAD,
     PRODUCER_SYNCHRONOUS,
     STOP_METHOD_CLI,
+    STORAGE_STATE_DELETE,
     STORAGE_STATE_EMPTY,
     DepthMode,
+    LogAction,
     StopMethod,
     StorageStateAction,
 )
@@ -72,6 +75,7 @@ BASE_JOINT_NAMES = [
 _BATCH_PARAMS = frozenset({
     "kill_daemon_between_tests",
     "storage_state_action",
+    "daemon_log_action",
     "preserve_artifacts_per_test",
     "stop_method",
 })
@@ -202,6 +206,7 @@ class DataDaemonTestCase:
     image_height: int | None = None
     kill_daemon_between_tests: bool = True
     storage_state_action: StorageStateAction = STORAGE_STATE_EMPTY
+    daemon_log_action: LogAction = LOG_PRESERVE
     stop_method: StopMethod = STOP_METHOD_CLI
     preserve_artifacts_per_test: bool = False
     context_duration_mode: str = DURATION_MODE_FIXED
@@ -265,8 +270,8 @@ class DataDaemonTestBatch:
     Groups ``DataDaemonTestCase`` instances that should run under the same
     daemon lifecycle, storage, and artifact settings.  The batch-level params
     (``kill_daemon_between_tests``, ``storage_state_action``,
-    ``preserve_artifacts_per_test``, ``stop_method``) are propagated to every
-    case when :meth:`as_cases` is called, overriding any per-case values.
+    ``daemon_log_action``, ``preserve_artifacts_per_test``, ``stop_method``)
+    are propagated to every case via :meth:`as_cases`.
 
     Attributes:
         cases: The individual test case workload definitions.
@@ -285,7 +290,8 @@ class DataDaemonTestBatch:
 
     cases: tuple[DataDaemonTestCase, ...]
     kill_daemon_between_tests: bool = True
-    storage_state_action: StorageStateAction = STORAGE_STATE_EMPTY
+    storage_state_action: StorageStateAction = STORAGE_STATE_DELETE
+    daemon_log_action: LogAction = LOG_PRESERVE
     preserve_artifacts_per_test: bool = False
     stop_method: StopMethod = STOP_METHOD_CLI
     skip: bool = False
@@ -295,6 +301,7 @@ class DataDaemonTestBatch:
         batch_overrides = {
             "kill_daemon_between_tests": self.kill_daemon_between_tests,
             "storage_state_action": self.storage_state_action,
+            "daemon_log_action": self.daemon_log_action,
             "preserve_artifacts_per_test": self.preserve_artifacts_per_test,
             "stop_method": self.stop_method,
         }

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -37,6 +37,10 @@ STORAGE_STATE_PRESERVE = "preserve"
 STORAGE_STATE_EMPTY = "empty"
 STORAGE_STATE_DELETE = "delete"
 
+# daemon_log_action (the shared daemon.log, independent of storage_state_action)
+LOG_PRESERVE = "preserve"
+LOG_DELETE = "delete"
+
 # mode
 MODE_SEQUENTIAL = "sequential"
 MODE_STAGGERED = "staggered"
@@ -76,6 +80,7 @@ STORAGE_STATE_ACTIONS = (
     STORAGE_STATE_PRESERVE,
     STORAGE_STATE_EMPTY,
 )
+LOG_ACTIONS = (LOG_DELETE, LOG_PRESERVE)
 MODES = (MODE_SEQUENTIAL, MODE_STAGGERED)
 PRODUCER_CHANNELS = (PRODUCER_SYNCHRONOUS, PRODUCER_PER_THREAD)
 DURATION_MODES = (DURATION_MODE_FIXED, DURATION_MODE_VARIABLE)
@@ -89,6 +94,7 @@ StorageStateAction = Literal["delete", "preserve", "empty"]
 DepthMode = Literal["float16", "float32"]
 """Depth camera sample dtype, matching the wire labels `nc.log_depth()`
 derives from the array's own dtype (`image.dtype.name`)."""
+LogAction = Literal["preserve", "delete"]
 
 MAX_TIME_TO_START_S = 20.0
 STOP_RECORDING_OVERHEAD_PER_SEC = 0.5

--- a/tests/integration/platform/data_daemon/shared/test_infrastructure.py
+++ b/tests/integration/platform/data_daemon/shared/test_infrastructure.py
@@ -37,8 +37,11 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DATA_DAEMON_TEST_ARTIFACTS_DIR,
+    DATA_DAEMON_TEST_STATE_ROOT,
+    LOG_DELETE,
     STORAGE_STATE_DELETE,
     STORAGE_STATE_EMPTY,
+    STORAGE_STATE_PRESERVE,
 )
 
 if TYPE_CHECKING:
@@ -106,45 +109,71 @@ def setup_per_test_artifact_dirs(
 
 
 @contextmanager
-def scoped_storage_state(case: DataDaemonTestCase) -> Generator[None]:
-    """Apply local storage cleanup before and after the block.
+def scoped_storage_state(
+    case: DataDaemonTestCase,
+    specs: Sequence[ContextSpec] = (),
+) -> Generator[None]:
+    """Apply local storage, daemon-log, and cloud cleanup around the block.
 
-    ``"delete"`` removes the DB file and recordings folder.  ``"empty"`` clears
-    DB tables and deletes recordings folder contents.  ``"preserve"`` leaves all
-    local storage untouched.
-
-    Does **not** start, stop, or signal any daemon process, and does not touch
-    cloud resources. Wrap it in cloud_resource_deleter to delete the cloud
-    dataset and robots.
+    ``"delete"`` removes the DB file and recordings folder, ``"empty"`` clears
+    DB tables and recordings folder contents, and ``"preserve"`` leaves both
+    plus the cloud dataset and robots intact for inspection. Cleanup runs
+    whether the body succeeds or raises.
 
     Args:
-        case: Test case whose ``storage_state_action`` controls local cleanup.
+        case: Test case whose ``storage_state_action`` and ``daemon_log_action``
+            decide what is cleaned.
+        specs: Context specs naming the cloud dataset and robots to delete.
+            Empty skips cloud cleanup entirely.
 
     Yields:
         ``None``.
     """
-    with report_step("Prepare local daemon storage"):
-        with Timer(
-            30.0,
-            label="storage.prepare",
-            always_log=True,
-            assert_deadline=False,
-        ):
-            apply_storage_state_action(case.storage_state_action)
-    try:
-        yield
-    finally:
-        with report_step("Clean local daemon storage"):
+    dataset_name, robot_names = cloud_resource_names(specs)
+    if case.storage_state_action == STORAGE_STATE_PRESERVE and (
+        dataset_name is not None or robot_names
+    ):
+        logger.info(
+            "Preserving cloud dataset %r and robots %s",
+            dataset_name,
+            list(robot_names),
+        )
+        dataset_name, robot_names = None, []
+
+    with cloud_resource_deleter(dataset_name, robot_names):
+        with report_step("Prepare local daemon storage"):
             with Timer(
                 30.0,
-                label="storage.local_cleanup",
+                label="storage.prepare",
                 always_log=True,
                 assert_deadline=False,
             ):
                 apply_storage_state_action(case.storage_state_action)
-        assert_post_test_storage_state(
-            storage_state_action=case.storage_state_action,
-        )
+        try:
+            with scoped_daemon_log_action(case):
+                yield
+        finally:
+            with report_step("Clean local daemon storage"):
+                with Timer(
+                    30.0,
+                    label="storage.local_cleanup",
+                    always_log=True,
+                    assert_deadline=False,
+                ):
+                    apply_storage_state_action(case.storage_state_action)
+            assert_post_test_storage_state(
+                storage_state_action=case.storage_state_action,
+            )
+
+
+@contextmanager
+def scoped_daemon_log_action(case: DataDaemonTestCase) -> Generator[None]:
+    """Delete the shared ``daemon.log`` after the block, when the case asks."""
+    try:
+        yield
+    finally:
+        if case.daemon_log_action == LOG_DELETE:
+            (DATA_DAEMON_TEST_STATE_ROOT / "daemon.log").unlink(missing_ok=True)
 
 
 def apply_storage_state_action(storage_state_action: str) -> None:

--- a/tests/integration/platform/data_daemon/shared/test_infrastructure.py
+++ b/tests/integration/platform/data_daemon/shared/test_infrastructure.py
@@ -38,8 +38,11 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DATA_DAEMON_TEST_ARTIFACTS_DIR,
+    DATA_DAEMON_TEST_STATE_ROOT,
+    LOG_DELETE,
     STORAGE_STATE_DELETE,
     STORAGE_STATE_EMPTY,
+    STORAGE_STATE_PRESERVE,
 )
 
 if TYPE_CHECKING:
@@ -107,45 +110,71 @@ def setup_per_test_artifact_dirs(
 
 
 @contextmanager
-def scoped_storage_state(case: DataDaemonTestCase) -> Generator[None]:
-    """Apply local storage cleanup before and after the block.
+def scoped_storage_state(
+    case: DataDaemonTestCase,
+    specs: Sequence[ContextSpec] = (),
+) -> Generator[None]:
+    """Apply local storage, daemon-log, and cloud cleanup around the block.
 
-    ``"delete"`` removes the DB file and recordings folder.  ``"empty"`` clears
-    DB tables and deletes recordings folder contents.  ``"preserve"`` leaves all
-    local storage untouched.
-
-    Does **not** start, stop, or signal any daemon process, and does not touch
-    cloud resources. Wrap it in cloud_resource_deleter to delete the cloud
-    dataset and robots.
+    ``"delete"`` removes the DB file and recordings folder, ``"empty"`` clears
+    DB tables and recordings folder contents, and ``"preserve"`` leaves both
+    plus the cloud dataset and robots intact for inspection. Cleanup runs
+    whether the body succeeds or raises.
 
     Args:
-        case: Test case whose ``storage_state_action`` controls local cleanup.
+        case: Test case whose ``storage_state_action`` and ``daemon_log_action``
+            decide what is cleaned.
+        specs: Context specs naming the cloud dataset and robots to delete.
+            Empty skips cloud cleanup entirely.
 
     Yields:
         ``None``.
     """
-    with report_step("Prepare local daemon storage"):
-        with Timer(
-            30.0,
-            label="storage.prepare",
-            always_log=True,
-            assert_deadline=False,
-        ):
-            apply_storage_state_action(case.storage_state_action)
-    try:
-        yield
-    finally:
-        with report_step("Clean local daemon storage"):
+    dataset_name, robot_names = cloud_resource_names(specs)
+    if case.storage_state_action == STORAGE_STATE_PRESERVE and (
+        dataset_name is not None or robot_names
+    ):
+        logger.info(
+            "Preserving cloud dataset %r and robots %s",
+            dataset_name,
+            list(robot_names),
+        )
+        dataset_name, robot_names = None, []
+
+    with cloud_resource_deleter(dataset_name, robot_names):
+        with report_step("Prepare local daemon storage"):
             with Timer(
                 30.0,
-                label="storage.local_cleanup",
+                label="storage.prepare",
                 always_log=True,
                 assert_deadline=False,
             ):
                 apply_storage_state_action(case.storage_state_action)
-        assert_post_test_storage_state(
-            storage_state_action=case.storage_state_action,
-        )
+        try:
+            with scoped_daemon_log_action(case):
+                yield
+        finally:
+            with report_step("Clean local daemon storage"):
+                with Timer(
+                    30.0,
+                    label="storage.local_cleanup",
+                    always_log=True,
+                    assert_deadline=False,
+                ):
+                    apply_storage_state_action(case.storage_state_action)
+            assert_post_test_storage_state(
+                storage_state_action=case.storage_state_action,
+            )
+
+
+@contextmanager
+def scoped_daemon_log_action(case: DataDaemonTestCase) -> Generator[None]:
+    """Delete the shared ``daemon.log`` after the block, when the case asks."""
+    try:
+        yield
+    finally:
+        if case.daemon_log_action == LOG_DELETE:
+            (DATA_DAEMON_TEST_STATE_ROOT / "daemon.log").unlink(missing_ok=True)
 
 
 def apply_storage_state_action(storage_state_action: str) -> None:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Decouple log preservation from storage state of daemon test directory

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>