### PR TITLE
fix: chunk checkpoint uploads and run them off the training thread

### DIFF
--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -330,8 +330,14 @@ class DistributedTrainer:
             logger.error("Error during training.", exc_info=True)
             raise
         finally:
-            # Close the logger
             if self.rank == 0:
+                # Checkpoint/artifact uploads run in the background (see
+                # TrainingStorageHandler); block here until they've all
+                # landed so the process can't exit — and the training
+                # VM/container be torn down — while the final checkpoint is
+                # still mid-upload.
+                self.storage_handler.wait_for_pending_uploads()
+                # Close the logger
                 self.training_logger.close()
 
     def get_model_without_ddp(self) -> nn.Module:

--- a/neuracore/ml/utils/algorithm_storage_handler.py
+++ b/neuracore/ml/utils/algorithm_storage_handler.py
@@ -3,9 +3,7 @@
 import logging
 import zipfile
 from pathlib import Path
-from typing import IO
 
-import requests
 import wget
 
 from neuracore.core.auth import get_auth
@@ -129,16 +127,3 @@ class AlgorithmStorageHandler(UploadStorageMixin):
                 f"Failed to get upload URL for {filepath}: {response.text}"
             )
         return response.json()["url"]
-
-    def _execute_upload(
-        self,
-        upload_url: str,
-        data: bytes | IO[bytes],
-        content_type: str,
-    ) -> requests.Response:
-        session = thread_local_session(retry_transient=True)
-        return session.put(
-            upload_url,
-            data=data,
-            headers={"Content-Type": content_type},
-        )

--- a/neuracore/ml/utils/endpoint_storage_handler.py
+++ b/neuracore/ml/utils/endpoint_storage_handler.py
@@ -1,9 +1,6 @@
 """Storage handler for endpoint inference log uploads."""
 
 import logging
-from typing import IO
-
-import requests
 
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
@@ -50,19 +47,6 @@ class EndpointStorageHandler(UploadStorageMixin):
                 f"Failed to get upload URL for {filepath}: {response.text}"
             )
         return response.json()["url"]
-
-    def _execute_upload(
-        self,
-        upload_url: str,
-        data: bytes | IO[bytes],
-        content_type: str,
-    ) -> requests.Response:
-        session = thread_local_session(retry_transient=True)
-        return session.put(
-            upload_url,
-            data=data,
-            headers={"Content-Type": content_type},
-        )
 
     def report_endpoint_error(self, error: str) -> None:
         """Report endpoint startup/runtime failures to cloud metadata."""

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -1,8 +1,10 @@
 """TrainingStorageHandler for managing model training artifacts and checkpoints."""
 
 import logging
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import IO, Any
+from typing import Any
 
 import requests
 import torch
@@ -69,6 +71,16 @@ class TrainingStorageHandler(UploadStorageMixin):
                     f"Training job {self.training_job_id} not found or access denied."
                 )
 
+        # Checkpoint/artifact uploads run on this single background worker so
+        # save_checkpoint()/save_model_artifacts() don't block the training
+        # loop for the duration of a large upload. One worker means every
+        # submitted job runs in strict submission order, which is what makes
+        # delete_checkpoint() safe to call right after a save without extra
+        # coordination. Created lazily since it's only needed when uploading.
+        self._upload_executor: ThreadPoolExecutor | None = None
+        self._pending_uploads_lock = threading.Lock()
+        self._pending_uploads: dict[Path, Future] = {}
+
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for a file in cloud storage.
 
@@ -119,8 +131,97 @@ class TrainingStorageHandler(UploadStorageMixin):
             )
         return response.json()["url"]
 
+    def _get_upload_executor(self) -> ThreadPoolExecutor:
+        """Lazily create the single-worker background upload executor."""
+        if self._upload_executor is None:
+            self._upload_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="nc-checkpoint-upload"
+            )
+        return self._upload_executor
+
+    def _wait_for_pending_upload(self, local_path: Path) -> None:
+        """Block until any in-flight upload of ``local_path`` has finished.
+
+        Some destinations (e.g. a "latest" checkpoint, or model artifacts
+        that get regenerated in place) are reused across calls rather than
+        written to a fresh path each time. Waiting here before that path is
+        overwritten or deleted prevents a background upload thread from
+        reading a file out from under a newer write.
+        """
+        with self._pending_uploads_lock:
+            future = self._pending_uploads.get(local_path)
+        if future is not None and not future.done():
+            logger.debug(
+                "Waiting for pending upload of %s to finish before reusing it",
+                local_path,
+            )
+            future.result()
+
+    def _submit_upload(
+        self,
+        local_path: Path,
+        remote_filepath: str,
+        content_type: str,
+        delete_on_success: bool,
+    ) -> None:
+        """Upload ``local_path`` on the background worker.
+
+        Args:
+            local_path: Local file to upload.
+            remote_filepath: Destination path within cloud storage.
+            content_type: MIME type of the file being uploaded.
+            delete_on_success: Whether to unlink the local file once the
+                upload succeeds.
+        """
+
+        def _do_upload() -> None:
+            try:
+                uploaded = self.upload_file(local_path, remote_filepath, content_type)
+            except Exception:
+                logger.error(
+                    "Unexpected error uploading %s to cloud path %s",
+                    local_path,
+                    remote_filepath,
+                    exc_info=True,
+                )
+                return
+            if uploaded and delete_on_success:
+                try:
+                    local_path.unlink()
+                except Exception as e:
+                    logger.warning(
+                        "Could not delete local file %s after upload: %s",
+                        local_path,
+                        e,
+                    )
+
+        future = self._get_upload_executor().submit(_do_upload)
+        with self._pending_uploads_lock:
+            self._pending_uploads[local_path] = future
+
+    def wait_for_pending_uploads(self) -> None:
+        """Block until every submitted checkpoint/artifact upload has finished.
+
+        Call this before the process exits (e.g. at the end of training) —
+        checkpoint and artifact uploads run in the background, so without
+        this the container/VM can be torn down while the final checkpoint is
+        still mid-upload.
+        """
+        with self._pending_uploads_lock:
+            futures = list(self._pending_uploads.values())
+        for future in futures:
+            future.result()
+
     def save_checkpoint(self, checkpoint: dict, relative_checkpoint_path: Path) -> None:
         """Save checkpoint to storage.
+
+        Writes the checkpoint to disk synchronously, then — if cloud logging
+        is enabled — uploads it on a background thread so this call doesn't
+        block the training loop for the duration of the upload. If
+        ``relative_checkpoint_path`` names a file reused across calls (e.g. a
+        "latest" checkpoint), this first waits for any previous upload of
+        that same path to finish, so it's never overwritten while still
+        being read for upload.
 
         Args:
             checkpoint: Checkpoint dictionary to save.
@@ -129,35 +230,21 @@ class TrainingStorageHandler(UploadStorageMixin):
         save_path = self.local_dir / relative_checkpoint_path
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
+        if self.log_to_cloud:
+            self._wait_for_pending_upload(save_path)
+
         # Convert OmegaConf objects to plain Python types
         # for compatibility with weights_only=True
         checkpoint = self._convert_omegaconf_to_python(checkpoint)
         torch.save(checkpoint, save_path)
+
         if self.log_to_cloud:
-            upload_url = self._get_upload_url(
-                filepath=f"checkpoints/{relative_checkpoint_path.name}",
+            self._submit_upload(
+                save_path,
+                remote_filepath=f"checkpoints/{relative_checkpoint_path.name}",
                 content_type="application/octet-stream",
+                delete_on_success=True,
             )
-            with open(save_path, "rb") as f:
-                response = self._put_request(
-                    upload_url,
-                    data=f,
-                    headers={"Content-Type": "application/octet-stream"},
-                )
-            if response.status_code == 200:
-                try:
-                    save_path.unlink()
-                except Exception as e:
-                    logger.warning(
-                        "Could not delete local checkpoint "
-                        f"{relative_checkpoint_path}: {e}"
-                    )
-            else:
-                logger.error(
-                    f"Failed to save checkpoint {relative_checkpoint_path} "
-                    f"to cloud: {response.text}"
-                )
-                return
 
     def _convert_omegaconf_to_python(self, obj: Any) -> Any:
         """Recursively convert OmegaConf objects to plain Python types.
@@ -216,10 +303,17 @@ class TrainingStorageHandler(UploadStorageMixin):
     def delete_checkpoint(self, relative_checkpoint_path: Path) -> None:
         """Delete checkpoint from storage.
 
+        Waits for any pending upload of this same checkpoint to finish first
+        — deleting a file a background thread still has open for upload, or
+        deleting the cloud copy before the upload that creates it lands,
+        would otherwise race.
+
         Args:
             relative_checkpoint_path: Relative path of the checkpoint file to delete.
         """
         checkpoint_path = self.local_dir / relative_checkpoint_path
+        if self.log_to_cloud:
+            self._wait_for_pending_upload(checkpoint_path)
         if checkpoint_path.exists():
             checkpoint_path.unlink()
         if self.log_to_cloud:
@@ -236,12 +330,31 @@ class TrainingStorageHandler(UploadStorageMixin):
     def save_model_artifacts(self, model: nn.Module, output_dir: Path) -> None:
         """Save model artifacts to storage.
 
+        ``create_nc_archive`` regenerates fixed-name files (e.g.
+        ``model.nc.zip``) in ``artifacts_dir`` on every call, so — like
+        ``save_checkpoint`` — this waits for any artifact upload still in
+        flight from a previous call before regenerating them, then uploads
+        the new ones on the background worker without blocking the training
+        loop. Only artifact-path uploads are waited on here, not checkpoint
+        uploads, so the two don't block each other.
+
         Args:
             model: PyTorch model to save.
             output_dir: Directory to save the artifacts.
         """
         artifacts_dir = self.local_dir / output_dir / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        if self.log_to_cloud:
+            with self._pending_uploads_lock:
+                pending_paths = [
+                    path
+                    for path in self._pending_uploads
+                    if path.is_relative_to(artifacts_dir)
+                ]
+            for path in pending_paths:
+                self._wait_for_pending_upload(path)
+
         create_nc_archive(
             model=model,
             output_dir=artifacts_dir,
@@ -253,32 +366,12 @@ class TrainingStorageHandler(UploadStorageMixin):
         )
         if self.log_to_cloud:
             for file_path in artifacts_dir.glob("*"):
-                upload_url = self._get_upload_url(
-                    filepath=str(file_path.name),
+                self._submit_upload(
+                    file_path,
+                    remote_filepath=str(file_path.name),
                     content_type="application/octet-stream",
+                    delete_on_success=False,
                 )
-                with open(file_path, "rb") as f:
-                    response = self._put_request(
-                        upload_url,
-                        data=f,
-                        headers={"Content-Type": "application/octet-stream"},
-                    )
-                if response.status_code != 200:
-                    logger.error(
-                        f"Failed to save artifact {file_path} to cloud: {response.text}"
-                    )
-
-    def _execute_upload(
-        self,
-        upload_url: str,
-        data: bytes | IO[bytes],
-        content_type: str,
-    ) -> requests.Response:
-        return self._put_request(
-            upload_url,
-            data=data,
-            headers={"Content-Type": content_type},
-        )
 
     def update_training_progress(self, epoch: int, step: int) -> None:
         """Update training epoch/step progress in cloud storage.

--- a/neuracore/ml/utils/upload_storage_mixin.py
+++ b/neuracore/ml/utils/upload_storage_mixin.py
@@ -3,10 +3,40 @@
 from __future__ import annotations
 
 import logging
+import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import IO, Protocol
 
+from neuracore.core.utils.http_session import thread_local_session
+
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 16 * 1024 * 1024
+"""Size of each resumable-upload chunk, in bytes.
+
+Must be a multiple of 256 KiB (the GCS resumable-upload requirement for every
+non-final chunk); 16 MiB = 64 x 256 KiB. Keeping chunks bounded means a
+transient connection stall costs at most one chunk retry instead of
+restarting the whole upload.
+"""
+
+_MAX_CHUNK_RETRIES = 5
+"""Maximum attempts for a single chunk before the upload is given up on."""
+
+_BACKOFF_BASE_SECONDS = 1.0
+"""Base for the exponential backoff between chunk retry attempts (1,2,4,8s)."""
+
+_RETRYABLE_UPLOAD_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+"""Transient statuses for the upload PUT itself: the session is still good,
+only this chunk needs to be resent."""
+
+_SESSION_EXPIRED_STATUS_CODES = frozenset({404, 410})
+"""Statuses GCS returns when a resumable upload session URI has expired."""
+
+
+class _UploadFailedError(Exception):
+    """A chunk could not be delivered after exhausting all retries."""
 
 
 class UploadResponseLike(Protocol):
@@ -20,9 +50,66 @@ class UploadResponseLike(Protocol):
     def text(self) -> str:
         """Response body text."""
 
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """Response headers."""
+
+
+def _payload_size(data: bytes | IO[bytes]) -> int:
+    """Return the total size of a payload without disturbing its position."""
+    if isinstance(data, bytes):
+        return len(data)
+    position = data.tell()
+    data.seek(0, 2)
+    size = data.tell()
+    data.seek(position)
+    return size
+
+
+def _read_chunk(data: bytes | IO[bytes], offset: int, length: int) -> bytes:
+    """Read exactly ``length`` bytes starting at ``offset``.
+
+    Always seeks to ``offset`` first so resuming after a partial 308 commit
+    (which can land anywhere, not just at a chunk boundary) reads the right
+    bytes.
+    """
+    if isinstance(data, bytes):
+        return data[offset : offset + length]
+    data.seek(offset)
+    return data.read(length)
+
+
+def _parse_committed_offset(headers: Mapping[str, str], attempted_end: int) -> int:
+    """Parse the byte offset GCS reports as committed from a 308 response.
+
+    Args:
+        headers: Response headers from the 308 response.
+        attempted_end: Inclusive end byte of the chunk we attempted to send,
+            used as a fallback if the ``Range`` header is malformed.
+
+    Returns:
+        The offset to resume uploading from. GCS omits the ``Range`` header
+        entirely when zero bytes are committed.
+    """
+    range_header = headers.get("Range")
+    if not range_header:
+        return 0
+    try:
+        return int(range_header.split("-")[1]) + 1
+    except (IndexError, ValueError):
+        return attempted_end + 1
+
 
 class UploadStorageMixin:
-    """Mixin that provides upload_file and upload_bytes helpers."""
+    """Mixin that provides upload_file and upload_bytes helpers.
+
+    Uploads go through the GCS resumable-upload protocol in bounded chunks
+    (``CHUNK_SIZE``) rather than a single PUT of the whole payload: a
+    transient connection stall only costs a retry of the current chunk, not
+    the whole file, and each chunk PUT's write phase stays comfortably within
+    the shared HTTP session's per-``send()`` timeout (see
+    ``neuracore.core.utils.http_session``).
+    """
 
     log_to_cloud: bool
 
@@ -32,10 +119,139 @@ class UploadStorageMixin:
     def _execute_upload(
         self,
         upload_url: str,
-        data: bytes | IO[bytes],
+        data: bytes,
         content_type: str,
+        headers: dict[str, str] | None = None,
     ) -> UploadResponseLike:
-        raise NotImplementedError
+        """Send one PUT to the (resumable) upload URL.
+
+        Args:
+            upload_url: The signed/resumable URL to PUT to.
+            data: The chunk (or whole small payload) to send.
+            content_type: MIME type of the file being uploaded.
+            headers: Extra headers (``Content-Range``, ``Content-Length``)
+                merged over the default ``Content-Type`` header.
+        """
+        session = thread_local_session(retry_transient=True)
+        return session.put(
+            upload_url,
+            data=data,
+            headers={"Content-Type": content_type, **(headers or {})},
+        )
+
+    def _put_chunk_with_retry(
+        self,
+        upload_url: str,
+        chunk: bytes,
+        chunk_start: int,
+        total: int,
+        content_type: str,
+    ) -> tuple[int, bool]:
+        """PUT one chunk, retrying transient failures with backoff.
+
+        Args:
+            upload_url: The resumable session URI to PUT to.
+            chunk: The chunk bytes to send.
+            chunk_start: Offset of ``chunk`` within the full payload.
+            total: Total size of the full payload.
+            content_type: MIME type of the file being uploaded.
+
+        Returns:
+            A ``(next_offset, session_expired)`` tuple. ``next_offset`` is
+            the byte offset to resume from — usually ``chunk_start +
+            len(chunk)``, but can be less if GCS only committed a prefix of
+            the chunk. ``session_expired`` signals the resumable session URI
+            needs to be refreshed and the upload restarted from offset 0.
+
+        Raises:
+            _UploadFailedError: The chunk could not be delivered after
+                ``_MAX_CHUNK_RETRIES`` attempts.
+        """
+        chunk_end = chunk_start + len(chunk) - 1
+        is_final = chunk_start + len(chunk) >= total
+        if total == 0:
+            content_range = "bytes */0"
+        elif is_final:
+            content_range = f"bytes {chunk_start}-{chunk_end}/{total}"
+        else:
+            content_range = f"bytes {chunk_start}-{chunk_end}/*"
+        headers = {"Content-Length": str(len(chunk)), "Content-Range": content_range}
+
+        last_error = "unknown error"
+        for attempt in range(_MAX_CHUNK_RETRIES):
+            try:
+                response = self._execute_upload(
+                    upload_url, data=chunk, content_type=content_type, headers=headers
+                )
+            except Exception as e:  # connection-level failure, e.g. write timeout
+                last_error = str(e)
+            else:
+                if response.status_code in (200, 201):
+                    return chunk_start + len(chunk), False
+                if response.status_code == 308:
+                    return _parse_committed_offset(response.headers, chunk_end), False
+                if response.status_code in _SESSION_EXPIRED_STATUS_CODES:
+                    return 0, True
+                if response.status_code not in _RETRYABLE_UPLOAD_STATUS_CODES:
+                    raise _UploadFailedError(
+                        f"HTTP {response.status_code}: {response.text}"
+                    )
+                last_error = f"HTTP {response.status_code}: {response.text}"
+
+            if attempt < _MAX_CHUNK_RETRIES - 1:
+                time.sleep(_BACKOFF_BASE_SECONDS * 2**attempt)
+
+        raise _UploadFailedError(
+            f"chunk at offset {chunk_start} failed after "
+            f"{_MAX_CHUNK_RETRIES} attempts: {last_error}"
+        )
+
+    def _upload_chunked(
+        self,
+        data: bytes | IO[bytes],
+        remote_filepath: str,
+        content_type: str,
+    ) -> None:
+        """Upload a payload to cloud storage in ``CHUNK_SIZE`` chunks.
+
+        Args:
+            data: The payload to upload — an open file handle or in-memory
+                bytes. A payload smaller than one chunk still resolves in
+                exactly one PUT, matching the previous single-shot behavior.
+            remote_filepath: Destination path within cloud storage.
+            content_type: MIME type of the file being uploaded.
+
+        Raises:
+            _UploadFailedError: A chunk could not be delivered after
+                exhausting retries.
+        """
+        total = _payload_size(data)
+        upload_url = self._get_upload_url(
+            filepath=remote_filepath, content_type=content_type
+        )
+
+        if total == 0:
+            self._put_chunk_with_retry(upload_url, b"", 0, 0, content_type)
+            return
+
+        offset = 0
+        while offset < total:
+            chunk = _read_chunk(data, offset, min(CHUNK_SIZE, total - offset))
+            next_offset, session_expired = self._put_chunk_with_retry(
+                upload_url, chunk, offset, total, content_type
+            )
+            if session_expired:
+                logger.warning(
+                    "Upload session expired for %s; fetching a new session "
+                    "and restarting from the beginning",
+                    remote_filepath,
+                )
+                upload_url = self._get_upload_url(
+                    filepath=remote_filepath, content_type=content_type
+                )
+                offset = 0
+                continue
+            offset = next_offset
 
     def _upload_payload(
         self,
@@ -47,21 +263,14 @@ class UploadStorageMixin:
         if not self.log_to_cloud:
             return False
 
-        upload_url = self._get_upload_url(
-            filepath=remote_filepath,
-            content_type=content_type,
-        )
-        response = self._execute_upload(
-            upload_url=upload_url,
-            data=data,
-            content_type=content_type,
-        )
-        if response.status_code != 200:
+        try:
+            self._upload_chunked(data, remote_filepath, content_type)
+        except _UploadFailedError as e:
             logger.error(
                 "Failed to upload %s to cloud path %s: %s",
                 payload_type,
                 remote_filepath,
-                response.text,
+                e,
             )
             return False
         return True

--- a/tests/unit/ml/utils/test_training_storage_handler.py
+++ b/tests/unit/ml/utils/test_training_storage_handler.py
@@ -1,6 +1,7 @@
 """Tests for TrainingStorageHandler."""
 
 import io
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -8,6 +9,7 @@ import pytest
 import torch
 
 from neuracore.core.const import API_URL
+from neuracore.ml.utils import upload_storage_mixin
 from neuracore.ml.utils.training_storage_handler import TrainingStorageHandler
 
 ORG_ID = "test-org-id"
@@ -16,6 +18,12 @@ BASE_JOB_URL = f"{API_URL}/org/{ORG_ID}/training/jobs/{JOB_ID}"
 SIGNED_URL = "https://storage.example.com/signed-url"
 INPUT_CROSS_EMBODIMENT_DESCRIPTION = {"robot": {"joints": {"0": {"name": "j0"}}}}
 OUTPUT_CROSS_EMBODIMENT_DESCRIPTION = {"robot": {"actions": {"0": {"name": "a0"}}}}
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleeps(monkeypatch):
+    """Skip real backoff sleeps so retry-triggering tests run fast."""
+    monkeypatch.setattr(upload_storage_mixin.time, "sleep", lambda *_: None)
 
 
 @pytest.fixture
@@ -189,6 +197,7 @@ class TestSaveCheckpoint:
         requests_mock.put(SIGNED_URL, status_code=200)
 
         handler.save_checkpoint({"epoch": 2}, Path("checkpoint_2.pt"))
+        handler.wait_for_pending_uploads()
 
         put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
         assert len(put_requests) == 1
@@ -203,6 +212,7 @@ class TestSaveCheckpoint:
         requests_mock.put(SIGNED_URL, status_code=500, text="Server Error")
 
         handler.save_checkpoint({"epoch": 3}, Path("checkpoint_3.pt"))
+        handler.wait_for_pending_uploads()
 
         assert (tmp_path / "checkpoint_3.pt").exists()
 
@@ -225,6 +235,162 @@ class TestSaveCheckpoint:
         loaded = torch.load(tmp_path / "checkpoint_1.pt", weights_only=True)
         assert loaded["config"] == {"optimizer": {"lr": 0.001, "betas": [0.9, 0.999]}}
         assert isinstance(loaded["config"]["optimizer"], dict)
+
+
+class TestSaveCheckpointConcurrencyGuard:
+    """Covers the background-upload race guarded against in save_checkpoint.
+
+    checkpoint_latest.pt (and similar reused paths) get torch.save()'d again
+    on every call while a prior call's upload may still be reading the same
+    file; save_checkpoint must wait for that prior upload before overwriting.
+    """
+
+    def test_second_save_to_same_path_waits_for_first_upload_to_finish(
+        self, handler, requests_mock, tmp_path
+    ):
+        requests_mock.get(
+            f"{BASE_JOB_URL}/upload-url", json={"url": SIGNED_URL}, status_code=200
+        )
+        first_upload_started = threading.Event()
+        release_first_upload = threading.Event()
+        call_count = {"n": 0}
+
+        def slow_put(request, context):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                first_upload_started.set()
+                release_first_upload.wait(timeout=5)
+            context.status_code = 200
+            return ""
+
+        requests_mock.put(SIGNED_URL, text=slow_put)
+
+        path = Path("checkpoint_latest.pt")
+        handler.save_checkpoint({"epoch": 1}, path)
+        assert first_upload_started.wait(timeout=2), "first upload should have started"
+
+        second_save_returned = threading.Event()
+
+        def do_second_save():
+            handler.save_checkpoint({"epoch": 2}, path)
+            second_save_returned.set()
+
+        second_save_thread = threading.Thread(target=do_second_save)
+        second_save_thread.start()
+
+        # The second save must not proceed (and overwrite checkpoint_latest.pt
+        # locally) while the first upload still has it open for reading.
+        assert not second_save_returned.wait(timeout=0.3)
+
+        release_first_upload.set()
+        second_save_thread.join(timeout=5)
+        assert second_save_returned.is_set()
+
+        handler.wait_for_pending_uploads()
+        assert call_count["n"] == 2
+        # Both uploads succeeded, so the local file was deleted after the
+        # second (successful) upload; confirm it was the epoch-2 checkpoint
+        # that was actually sent, not stale/corrupted bytes from the first.
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        last_uploaded = torch.load(io.BytesIO(put_requests[-1].body), weights_only=True)
+        assert last_uploaded["epoch"] == 2
+        assert not (tmp_path / "checkpoint_latest.pt").exists()
+
+    def test_saves_to_different_paths_do_not_block_each_other(
+        self, handler, requests_mock
+    ):
+        requests_mock.get(
+            f"{BASE_JOB_URL}/upload-url", json={"url": SIGNED_URL}, status_code=200
+        )
+        release_upload = threading.Event()
+
+        def slow_put(request, context):
+            release_upload.wait(timeout=5)
+            context.status_code = 200
+            return ""
+
+        requests_mock.put(SIGNED_URL, text=slow_put)
+
+        # First save's upload blocks on the background worker until released.
+        handler.save_checkpoint({"epoch": 1}, Path("checkpoint_1.pt"))
+
+        second_returned = threading.Event()
+
+        def do_second_save():
+            handler.save_checkpoint({"epoch": 2}, Path("checkpoint_2.pt"))
+            second_returned.set()
+
+        second_save_thread = threading.Thread(target=do_second_save)
+        second_save_thread.start()
+
+        assert second_returned.wait(timeout=2), (
+            "save_checkpoint for a distinct path must not wait on an "
+            "unrelated in-flight upload"
+        )
+
+        release_upload.set()
+        second_save_thread.join(timeout=5)
+        handler.wait_for_pending_uploads()
+
+    def test_delete_waits_for_pending_upload_of_same_path_before_deleting(
+        self, handler, requests_mock, tmp_path
+    ):
+        requests_mock.get(
+            f"{BASE_JOB_URL}/upload-url", json={"url": SIGNED_URL}, status_code=200
+        )
+        requests_mock.delete(
+            f"{BASE_JOB_URL}/checkpoints/checkpoint_1.pt", status_code=200
+        )
+        upload_started = threading.Event()
+        release_upload = threading.Event()
+
+        def slow_put(request, context):
+            upload_started.set()
+            release_upload.wait(timeout=5)
+            context.status_code = 200
+            return ""
+
+        requests_mock.put(SIGNED_URL, text=slow_put)
+
+        path = Path("checkpoint_1.pt")
+        handler.save_checkpoint({"epoch": 1}, path)
+        assert upload_started.wait(timeout=2)
+
+        delete_returned = threading.Event()
+
+        def do_delete():
+            handler.delete_checkpoint(path)
+            delete_returned.set()
+
+        delete_thread = threading.Thread(target=do_delete)
+        delete_thread.start()
+
+        assert not delete_returned.wait(timeout=0.3)
+
+        release_upload.set()
+        delete_thread.join(timeout=5)
+        assert delete_returned.is_set()
+
+    def test_wait_for_pending_uploads_drains_and_does_not_raise_on_failure(
+        self, handler, requests_mock, tmp_path
+    ):
+        requests_mock.get(
+            f"{BASE_JOB_URL}/upload-url", json={"url": SIGNED_URL}, status_code=200
+        )
+        requests_mock.put(SIGNED_URL, status_code=500, text="Server Error")
+
+        handler.save_checkpoint({"epoch": 1}, Path("checkpoint_1.pt"))
+
+        # Must not raise even though the upload ultimately fails after
+        # exhausting retries.
+        handler.wait_for_pending_uploads()
+
+        assert (tmp_path / "checkpoint_1.pt").exists()
+
+    def test_wait_for_pending_uploads_is_a_no_op_with_nothing_pending(
+        self, local_handler
+    ):
+        local_handler.wait_for_pending_uploads()
 
 
 class TestLoadCheckpoint:
@@ -372,6 +538,7 @@ class TestSaveModelArtifacts:
             side_effect=fake_archive,
         ):
             handler.save_model_artifacts(mock_model, output_dir)
+        handler.wait_for_pending_uploads()
 
         put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
         assert len(put_requests) == 2

--- a/tests/unit/ml/utils/test_upload_storage_mixin.py
+++ b/tests/unit/ml/utils/test_upload_storage_mixin.py
@@ -1,0 +1,186 @@
+"""Tests for the chunked/resumable upload logic in UploadStorageMixin."""
+
+import pytest
+
+from neuracore.ml.utils import upload_storage_mixin
+from neuracore.ml.utils.upload_storage_mixin import UploadStorageMixin
+
+UPLOAD_URL = "https://storage.example.com/session-1"
+REFRESHED_UPLOAD_URL = "https://storage.example.com/session-2"
+
+
+class _FakeHandler(UploadStorageMixin):
+    """Minimal concrete UploadStorageMixin for exercising the chunk loop."""
+
+    def __init__(self, upload_url: str = UPLOAD_URL):
+        self.log_to_cloud = True
+        self._upload_url = upload_url
+        self.get_upload_url_calls = 0
+
+    def _get_upload_url(self, filepath: str, content_type: str) -> str:
+        self.get_upload_url_calls += 1
+        return self._upload_url
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleeps(monkeypatch):
+    """Skip real backoff sleeps so retry tests run fast."""
+    monkeypatch.setattr(upload_storage_mixin.time, "sleep", lambda *_: None)
+
+
+@pytest.fixture(autouse=True)
+def _small_chunk_size(monkeypatch):
+    """Shrink CHUNK_SIZE so small test payloads still span multiple chunks."""
+    monkeypatch.setattr(upload_storage_mixin, "CHUNK_SIZE", 4)
+
+
+class TestSingleChunkUpload:
+    def test_payload_smaller_than_one_chunk_sends_exactly_one_put(self, requests_mock):
+        requests_mock.put(UPLOAD_URL, status_code=200)
+        handler = _FakeHandler()
+
+        result = handler.upload_bytes(b"ab", "dest.bin")
+
+        assert result is True
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert len(put_requests) == 1
+        assert put_requests[0].headers["Content-Range"] == "bytes 0-1/2"
+
+
+class TestMultiChunkUpload:
+    def test_large_payload_is_split_into_multiple_chunks_in_order(self, requests_mock):
+        requests_mock.put(UPLOAD_URL, status_code=200)
+        handler = _FakeHandler()
+        payload = b"0123456789AB"  # 12 bytes / CHUNK_SIZE=4 -> 3 chunks
+
+        result = handler.upload_bytes(payload, "dest.bin")
+
+        assert result is True
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert len(put_requests) == 3
+        assert [r.headers["Content-Range"] for r in put_requests] == [
+            "bytes 0-3/*",
+            "bytes 4-7/*",
+            "bytes 8-11/12",
+        ]
+        # Bytes actually sent reassemble to the original payload, in order.
+        assert b"".join(r.body for r in put_requests) == payload
+
+    def test_308_partial_commit_resumes_from_server_reported_offset(
+        self, requests_mock
+    ):
+        # First chunk (bytes 0-3) is only partially committed by the server
+        # (2 of 4 bytes); the client must resume at byte 2, not byte 4.
+        requests_mock.put(
+            UPLOAD_URL,
+            [
+                {"status_code": 308, "headers": {"Range": "bytes=0-1"}},
+                {"status_code": 200},
+                {"status_code": 200},
+            ],
+        )
+        handler = _FakeHandler()
+        payload = b"0123456789AB"
+
+        result = handler.upload_bytes(payload, "dest.bin")
+
+        assert result is True
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        # attempt 1: 0-3 (partial commit -> resume at 2), attempt 2: 2-5,
+        # attempt 3: 6-9 (still capped at CHUNK_SIZE=4), attempt 4: 10-11 (final)
+        assert [r.headers["Content-Range"] for r in put_requests] == [
+            "bytes 0-3/*",
+            "bytes 2-5/*",
+            "bytes 6-9/*",
+            "bytes 10-11/12",
+        ]
+
+
+class TestSessionExpiry:
+    @pytest.mark.parametrize("expired_status", [404, 410])
+    def test_expired_session_fetches_new_url_and_restarts_from_zero(
+        self, requests_mock, expired_status
+    ):
+        handler = _FakeHandler()
+        urls = [UPLOAD_URL, REFRESHED_UPLOAD_URL]
+
+        def _get_url(filepath: str, content_type: str) -> str:
+            handler.get_upload_url_calls += 1
+            return urls[handler.get_upload_url_calls - 1]
+
+        handler._get_upload_url = _get_url
+        requests_mock.put(UPLOAD_URL, status_code=expired_status)
+        requests_mock.put(REFRESHED_UPLOAD_URL, status_code=200)
+
+        result = handler.upload_bytes(b"ab", "dest.bin")
+
+        assert result is True
+        assert handler.get_upload_url_calls == 2
+        expired_puts = [
+            r
+            for r in requests_mock.request_history
+            if r.method == "PUT" and r.url == UPLOAD_URL
+        ]
+        refreshed_puts = [
+            r
+            for r in requests_mock.request_history
+            if r.method == "PUT" and r.url == REFRESHED_UPLOAD_URL
+        ]
+        assert len(expired_puts) == 1
+        assert len(refreshed_puts) == 1
+
+
+class TestRetryExhaustion:
+    def test_persistent_failure_returns_false_without_raising(self, requests_mock):
+        requests_mock.put(UPLOAD_URL, status_code=500, text="Server Error")
+        handler = _FakeHandler()
+
+        result = handler.upload_bytes(b"ab", "dest.bin")
+
+        assert result is False
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert len(put_requests) == upload_storage_mixin._MAX_CHUNK_RETRIES
+
+    def test_connection_error_during_send_is_retried_then_gives_up(self, requests_mock):
+        import requests as requests_lib
+
+        requests_mock.put(UPLOAD_URL, exc=requests_lib.exceptions.ConnectionError)
+        handler = _FakeHandler()
+
+        result = handler.upload_bytes(b"ab", "dest.bin")
+
+        assert result is False
+
+
+class TestNotLoggingToCloud:
+    def test_returns_false_and_makes_no_requests_when_cloud_logging_disabled(
+        self, requests_mock
+    ):
+        handler = _FakeHandler()
+        handler.log_to_cloud = False
+
+        result = handler.upload_bytes(b"ab", "dest.bin")
+
+        assert result is False
+        assert len(requests_mock.request_history) == 0
+
+
+class TestUploadFile:
+    def test_upload_file_reads_from_disk_and_chunks_it(self, tmp_path, requests_mock):
+        requests_mock.put(UPLOAD_URL, status_code=200)
+        handler = _FakeHandler()
+        local_path = tmp_path / "checkpoint.pt"
+        local_path.write_bytes(b"0123456789AB")
+
+        result = handler.upload_file(local_path, "checkpoints/checkpoint.pt")
+
+        assert result is True
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert len(put_requests) == 3
+
+    def test_upload_file_returns_false_when_local_file_missing(self, tmp_path):
+        handler = _FakeHandler()
+
+        result = handler.upload_file(tmp_path / "missing.pt", "checkpoints/x.pt")
+
+        assert result is False


### PR DESCRIPTION
### Features
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Checkpoint/artifact/algorithm/endpoint uploads were a single PUT of the whole file to a GCS resumable session, so a transient stall on large checkpoints aborted the entire upload with no resume, forcing a full restart. Uploads now go in 16MiB `Content-Range` chunks with per-chunk retry/backoff, `308`-continue resume, and session-expiry (`404`/`410`) recovery.
 - `save_checkpoint()`/`save_model_artifacts()` now upload on a background worker instead of blocking the training loop, with a wait-before-overwrite guard for reused local paths (`checkpoint_latest.pt`, `model.nc.zip`) and a flush before `DistributedTrainer.train()` returns so the process can't exit mid-upload.

### Items
 - None

### Related PRs
 - None
 
 
 Note: there will be another PR to remove checkpoint_latest. 
