### PR TITLE
fix: stop uploading checkpoint_latest.pt, resolve it server-side

### DIFF
--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -376,11 +376,7 @@ class DistributedTrainer:
             "global_val_step": self.global_val_step,
         }
 
-        # Save regular checkpoint
-        # TODO: remove latest in future PR and just keep numbered ones
-        latest_checkpoint_path = self.checkpoint_dir / "checkpoint_latest.pt"
         checkpoint_path = self.checkpoint_dir / f"checkpoint_{epoch}.pt"
-        self.storage_handler.save_checkpoint(checkpoint, latest_checkpoint_path)
         self.storage_handler.save_checkpoint(checkpoint, checkpoint_path)
         checkpoint_epoch_to_remove = epoch - self.keep_last_n_checkpoints
         if checkpoint_epoch_to_remove > 0:

--- a/neuracore/ml/utils/policy_inference.py
+++ b/neuracore/ml/utils/policy_inference.py
@@ -205,22 +205,18 @@ class PolicyInference:
                 raise ValueError(
                     "Organization ID and Job ID must be set to load checkpoints."
                 )
-            checkpoint_name = f"checkpoint_{epoch if epoch != -1 else 'latest'}.pt"
+            if epoch == -1:
+                checkpoint_url, checkpoint_name = self._get_latest_checkpoint_url()
+            else:
+                checkpoint_name = f"checkpoint_{epoch}.pt"
+                checkpoint_url = self._get_checkpoint_url(checkpoint_name)
             checkpoint_path = (
                 Path(tempfile.gettempdir()) / self.job_id / checkpoint_name
             )
             if not checkpoint_path.exists():
                 checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-                session = thread_local_session()
-                response = session.get(
-                    f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}/checkpoint_url/{checkpoint_name}",
-                    headers=get_auth().get_headers(),
-                    timeout=30,
-                )
-                if response.status_code == 404:
-                    raise ValueError(f"Checkpoint {checkpoint_name} does not exist.")
                 checkpoint_path = download_with_progress(
-                    response.json()["url"],
+                    checkpoint_url,
                     f"Downloading checkpoint {checkpoint_name}",
                     destination=checkpoint_path,
                 )
@@ -233,6 +229,53 @@ class PolicyInference:
             torch.load(checkpoint_path, map_location=self.device, weights_only=True),
             strict=False,
         )
+
+    def _get_checkpoint_url(self, checkpoint_name: str) -> str:
+        """Get a signed download URL for a specific checkpoint.
+
+        Args:
+            checkpoint_name: Name of the checkpoint file, e.g. "checkpoint_5.pt".
+
+        Returns:
+            The signed download URL.
+
+        Raises:
+            ValueError: If the checkpoint does not exist.
+        """
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}"
+            f"/checkpoint_url/{checkpoint_name}",
+            headers=get_auth().get_headers(),
+            timeout=30,
+        )
+        if response.status_code == 404:
+            raise ValueError(f"Checkpoint {checkpoint_name} does not exist.")
+        return response.json()["url"]
+
+    def _get_latest_checkpoint_url(self) -> tuple[str, str]:
+        """Get a signed download URL for the job's latest checkpoint.
+
+        "Latest" is resolved server-side by listing checkpoints in storage,
+        not by a separately-maintained pointer file.
+
+        Returns:
+            A ``(download_url, checkpoint_name)`` tuple.
+
+        Raises:
+            ValueError: If the job has no checkpoints.
+        """
+        session = thread_local_session()
+        response = session.get(
+            f"{API_URL}/org/{self.org_id}/training/jobs/{self.job_id}"
+            "/latest_checkpoint_url",
+            headers=get_auth().get_headers(),
+            timeout=30,
+        )
+        if response.status_code == 404:
+            raise ValueError(f"No checkpoints found for job {self.job_id}.")
+        body = response.json()
+        return body["url"], body["checkpoint_name"]
 
     def _assign_names_to_model_outputs(
         self,

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -142,11 +142,11 @@ class TrainingStorageHandler(UploadStorageMixin):
     def _wait_for_pending_upload(self, local_path: Path) -> None:
         """Block until any in-flight upload of ``local_path`` has finished.
 
-        Some destinations (e.g. a "latest" checkpoint, or model artifacts
-        that get regenerated in place) are reused across calls rather than
-        written to a fresh path each time. Waiting here before that path is
-        overwritten or deleted prevents a background upload thread from
-        reading a file out from under a newer write.
+        Some destinations (e.g. model artifacts, which get regenerated in
+        place) are reused across calls rather than written to a fresh path
+        each time. Waiting here before that path is overwritten or deleted
+        prevents a background upload thread from reading a file out from
+        under a newer write.
         """
         with self._pending_uploads_lock:
             future = self._pending_uploads.get(local_path)
@@ -217,11 +217,10 @@ class TrainingStorageHandler(UploadStorageMixin):
 
         Writes the checkpoint to disk synchronously, then — if cloud logging
         is enabled — uploads it on a background thread so this call doesn't
-        block the training loop for the duration of the upload. If
-        ``relative_checkpoint_path`` names a file reused across calls (e.g. a
-        "latest" checkpoint), this first waits for any previous upload of
-        that same path to finish, so it's never overwritten while still
-        being read for upload.
+        block the training loop for the duration of the upload. If a caller
+        reuses the same ``relative_checkpoint_path`` across calls, this first
+        waits for any previous upload of that same path to finish, so it's
+        never overwritten while still being read for upload.
 
         Args:
             checkpoint: Checkpoint dictionary to save.

--- a/tests/unit/ml/utils/test_policy_inference.py
+++ b/tests/unit/ml/utils/test_policy_inference.py
@@ -14,6 +14,7 @@ from neuracore_types import (
     SynchronizedPoint,
 )
 
+from neuracore.core.const import API_URL
 from neuracore.ml.preprocessing.base import PreprocessingMethod
 from neuracore.ml.utils.policy_inference import PolicyInference
 
@@ -399,3 +400,72 @@ def test_init_raises_when_input_preprocessing_method_is_not_allowed_for_data_typ
             org_id="org",
             robot_id="robot-1",
         )
+
+
+@pytest.fixture(autouse=True)
+def _mock_auth(monkeypatch):
+    """Patch get_auth so checkpoint-URL tests don't need real credentials."""
+    monkeypatch.setattr(
+        "neuracore.ml.utils.policy_inference.get_auth",
+        lambda: SimpleNamespace(get_headers=lambda: {"Authorization": "Bearer test"}),
+    )
+
+
+def _checkpoint_urls_base(job_id: str) -> str:
+    return f"{API_URL}/org/test_org/training/jobs/{job_id}"
+
+
+class TestGetCheckpointUrl:
+    def test_returns_signed_url_for_named_checkpoint(self, requests_mock):
+        policy_inference = _make_policy_inference()
+        policy_inference.job_id = "job123"
+        requests_mock.get(
+            f"{_checkpoint_urls_base('job123')}/checkpoint_url/checkpoint_5.pt",
+            json={"url": "https://storage.example.com/signed"},
+            status_code=200,
+        )
+
+        url = policy_inference._get_checkpoint_url("checkpoint_5.pt")
+
+        assert url == "https://storage.example.com/signed"
+
+    def test_raises_value_error_when_checkpoint_missing(self, requests_mock):
+        policy_inference = _make_policy_inference()
+        policy_inference.job_id = "job123"
+        requests_mock.get(
+            f"{_checkpoint_urls_base('job123')}/checkpoint_url/checkpoint_5.pt",
+            status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="checkpoint_5.pt"):
+            policy_inference._get_checkpoint_url("checkpoint_5.pt")
+
+
+class TestGetLatestCheckpointUrl:
+    def test_returns_url_and_resolved_checkpoint_name(self, requests_mock):
+        policy_inference = _make_policy_inference()
+        policy_inference.job_id = "job123"
+        requests_mock.get(
+            f"{_checkpoint_urls_base('job123')}/latest_checkpoint_url",
+            json={
+                "url": "https://storage.example.com/signed",
+                "checkpoint_name": "checkpoint_47.pt",
+            },
+            status_code=200,
+        )
+
+        url, checkpoint_name = policy_inference._get_latest_checkpoint_url()
+
+        assert url == "https://storage.example.com/signed"
+        assert checkpoint_name == "checkpoint_47.pt"
+
+    def test_raises_value_error_when_no_checkpoints_exist(self, requests_mock):
+        policy_inference = _make_policy_inference()
+        policy_inference.job_id = "job123"
+        requests_mock.get(
+            f"{_checkpoint_urls_base('job123')}/latest_checkpoint_url",
+            status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="No checkpoints found"):
+            policy_inference._get_latest_checkpoint_url()


### PR DESCRIPTION
### Features
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Stop uploading a duplicate `checkpoint_latest.pt` on every checkpoint save. `PolicyInference.set_checkpoint(epoch=-1)` now calls the backend's new `GET .../latest_checkpoint_url` endpoint instead of requesting a `checkpoint_latest.pt` object directly. Resume needs no client change as the backend now resolves "latest" itself.

### Items
 - None

### Related PRs
 - [NeuracoreAI/neuracore_backend#503](https://github.com/NeuracoreAI/neuracore_backend/pull/503) — adds the `latest_checkpoint_url` endpoint this depends on
 - Stacked on #861 (`fix/resumable-checkpoint-uploads`) — base branch, not yet merged
