### PR TITLE
ci: build intel wheel for mac

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,9 +1,9 @@
 name: Build Wheels
 
 # Builds the merged `neuracore` wheels (SDK + Rust `_data_bridge` extension +
-# bundled `data-daemon` binary) for Linux and macOS arm64, one per Python minor
-# (cp310-cp314) — no sdist, no pure wheel. maturin owns the build; the daemon
-# binary is a separate crate compiled into the package tree first by
+# bundled `data-daemon` binary) for Linux, macOS arm64 and macOS x86_64, one per
+# Python minor (cp310-cp314) — no sdist, no pure wheel. maturin owns the build;
+# the daemon binary is a separate crate compiled into the package tree first by
 # rust/scripts/build_wheel_artefacts.sh. A separate smoke-test job installs and
 # launches the wheels on a different machine than the one that built them.
 
@@ -47,10 +47,12 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             interpreters: "3.10 3.11 3.12 3.13 3.14"
-          # Apple Silicon only (no Intel); runs natively so the smoke test can
-          # launch the arm64 binary.
           - os: macos-26
             target: aarch64-apple-darwin
+            interpreters: "python3.10 python3.11 python3.12 python3.13 python3.14"
+            macos-deployment-target: "11.0"
+          - os: macos-26-intel
+            target: x86_64-apple-darwin
             interpreters: "python3.10 python3.11 python3.12 python3.13 python3.14"
             macos-deployment-target: "11.0"
 
@@ -117,11 +119,12 @@ jobs:
 
   # Install and launch the wheels on a DIFFERENT machine than the one that
   # built them — no checkout, no Rust toolchain, just the downloaded artefact.
-  # This is what proves the wheels work outside the build environment: the
-  # macOS leg runs on a different, older OS image (macos-15) than the macos-26
+  # This is what proves the wheels work outside the build environment: both
+  # macOS legs run on a different, older OS image (macos-15) than their macos-26
   # builder, so a signature that only validated on the build machine, a
   # deployment-target mismatch, or a glibc-floor problem fails here instead of
-  # at a user's install.
+  # at a user's install. Each macOS leg must keep the builder's architecture —
+  # an arm64 runner cannot install an x86_64 wheel, and vice versa.
   smoke-test:
     name: smoke (${{ matrix.target }})
     needs: build
@@ -134,6 +137,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-15
             target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
 
     steps:
       - name: Set up Pythons

--- a/.github/workflows/integration-pf-data-daemon-production.yaml
+++ b/.github/workflows/integration-pf-data-daemon-production.yaml
@@ -108,7 +108,7 @@ jobs:
       matrix:
         python-version: ["3.14"]
         # Need large mac for more RAM to run the performance suite.
-        os: ["ubuntu-24.04", "macos-26-large"]
+        os: ["ubuntu-24.04", "macos-26-xlarge"]
 
     steps:
     - name: Show disk space

--- a/.github/workflows/integration-pf-data-daemon-staging.yaml
+++ b/.github/workflows/integration-pf-data-daemon-staging.yaml
@@ -175,7 +175,7 @@ jobs:
       matrix:
         python-version: ["3.14"]
         # Need large mac for more RAM to run the performance suite.
-        os: ["ubuntu-24.04", "macos-26-large"]
+        os: ["ubuntu-24.04", "macos-26-xlarge"]
 
     steps:
     - name: Show disk space

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -486,7 +486,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           ls -l dist/
-          [ "$(ls dist/*.whl | wc -l)" -eq 10 ] || { echo "expected 10 wheels"; exit 1; }
+          # 3 platform legs x 5 Python minors (cp310-cp314)
+          [ "$(ls dist/*.whl | wc -l)" -eq 15 ] || { echo "expected 15 wheels"; exit 1; }
           # packaging>=24.2 is required for twine to parse maturin's
           # Metadata-Version 2.4 License-File field; the runner ships an older one.
           python -m pip install --upgrade twine "packaging>=24.2"

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -231,10 +231,9 @@ artefacts script when you want a working daemon in a source checkout.
 
 The Rust daemon ships **inside the `neuracore` wheel**, built by maturin from
 the root [pyproject.toml](../pyproject.toml). Wheels are published for Linux
-x86_64 (`manylinux_2_28`) and Apple-Silicon macOS only, one per Python minor
-(cp310–cp314) — **no sdist and no pure wheel**, so `pip install neuracore` on
-Windows, Intel Macs, or other platforms resolves to the last pure-Python
-release (13.3.0).
+x86_64 (`manylinux_2_28`), Apple-Silicon macOS and Intel macOS, one per Python
+minor (cp310–cp314) — **no sdist and no pure wheel**, so `pip install neuracore`
+on Windows or other platforms resolves to the last pure-Python release (13.3.0).
 
 The two Rust artefacts and how `neuracore` finds them:
 
@@ -283,27 +282,29 @@ Wheels are platform- and Python-specific: pyo3 uses `extension-module` without
 protocol only enters the limited API at 3.11), so each wheel is one Python
 minor × one platform and `--interpreter` must be passed.
 
-> **Daemon: Linux and Apple-Silicon macOS only.** The daemon stack uses
-> `iceoryx2` shared-memory IPC; platform-specific syscalls (e.g.
-> `sync_file_range`, `gettid` on Linux) are gated behind `cfg(target_os)` so the
-> stack also builds and runs on macOS. Wheels ship for `linux-x86_64` and
-> `macosx-arm64` — **not** Intel Macs or Windows.
+> **Daemon: Linux and macOS only.** The daemon stack uses `iceoryx2`
+> shared-memory IPC; platform-specific syscalls (e.g. `sync_file_range`,
+> `gettid` on Linux) are gated behind `cfg(target_os)` so the stack also builds
+> and runs on macOS. Wheels ship for `linux-x86_64`, `macosx-arm64` and
+> `macosx-x86_64` — **not** Windows.
 
 ### CI
 
 [.github/workflows/build-wheels.yaml](../.github/workflows/build-wheels.yaml) builds
-the `neuracore` wheels — a `PyO3/maturin-action` matrix over `linux-x86_64` and
-`macosx-arm64`, each leg building all five interpreters (cp310–cp314). The Linux
-leg builds the daemon binary inside the `manylinux_2_28` container (glibc match,
-plus a `clang` install for iceoryx2's bindgen — `manylinux_2_28` is required over
-the default `manylinux2014` because iceoryx2's bindgen needs libclang >= 5.0,
-which 2014's clang 3.4 can't provide); the macOS leg builds natively on a
-`macos-15` Apple-silicon runner (libclang via `brew install llvm`, deployment
-target pinned to 11.0). A separate `smoke-test` job then installs each wheel
+the `neuracore` wheels — a `PyO3/maturin-action` matrix over `linux-x86_64`,
+`macosx-arm64` and `macosx-x86_64`, each leg building all five interpreters
+(cp310–cp314). The Linux leg builds the daemon binary inside the
+`manylinux_2_28` container (glibc match, plus a `clang` install for iceoryx2's
+bindgen — `manylinux_2_28` is required over the default `manylinux2014` because
+iceoryx2's bindgen needs libclang >= 5.0, which 2014's clang 3.4 can't provide);
+both macOS legs build natively (libclang via `brew install llvm`, deployment
+target pinned to 11.0) on `macos-26` for arm64 and `macos-26-intel` for Intel —
+the label suffix picks the architecture: bare and `-xlarge` are arm64, `-intel`
+and `-large` are x86_64. A separate `smoke-test` job then installs each wheel
 and launches the daemon binary on a *different* machine than the builder (the
-macOS leg on a different OS image, `macos-14`, with a `codesign --verify`) —
-proving the wheels, including the binary's ad-hoc signature, work outside the
-build environment.
+macOS legs on a different OS image, `macos-15`/`macos-15-intel`, with a
+`codesign --verify`) — proving the wheels, including the binary's ad-hoc
+signature, work outside the build environment.
 
 ### Release path
 

--- a/rust/scripts/build_wheel_artefacts.sh
+++ b/rust/scripts/build_wheel_artefacts.sh
@@ -17,10 +17,12 @@
 #   ./rust/scripts/build_wheel_artefacts.sh                 # native host target
 #   ./rust/scripts/build_wheel_artefacts.sh --target <triple>
 #     Linux: --target x86_64-unknown-linux-gnu inside the manylinux container.
-#     macOS: --target aarch64-apple-darwin (Apple Silicon only; Intel Macs are
-#            not supported) on a native arm64 runner, before `maturin build`.
-#            This also pins MACOSX_DEPLOYMENT_TARGET so the binary matches the
-#            wheel's platform tag.
+#     macOS: --target aarch64-apple-darwin (Apple Silicon) or
+#            --target x86_64-apple-darwin (Intel), each on a native runner of
+#            that architecture, before `maturin build`. This also pins
+#            MACOSX_DEPLOYMENT_TARGET so the binary matches the wheel's
+#            platform tag, and ad-hoc-signs the binary — rustc leaves x86_64
+#            unsigned, so this is what gives the Intel wheel a signature.
 #
 # See docs/rust_data_daemon_development.md#packaging-the-wheel for the pipeline.
 
@@ -52,16 +54,18 @@ repo_root="$(cd "$workspace_root/.." && pwd)"
 package_dir="$repo_root/neuracore/data_daemon"
 bin_dst="$package_dir/bin/data-daemon"
 
-# For the Apple target, pin the same macOS deployment floor the maturin build
-# uses so the cargo-built binary's `LC_BUILD_VERSION`/`minos` agrees with the
-# wheel's platform tag — a mismatch causes confusing "incompatible architecture"
-# or version load failures. arm64 only exists from 11.0. Honour a caller-provided
-# MACOSX_DEPLOYMENT_TARGET if already set.
+# Both macOS targets — arm64 and Intel — need two things the Linux path doesn't: a
+# pinned deployment floor before the build, and an ad-hoc signature after it.
 case "$target" in
-  aarch64-apple-darwin)
-    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-    ;;
+  *-apple-darwin) apple_target=1 ;;
+  *)              apple_target=0 ;;
 esac
+
+# Pin the same macOS deployment floor the maturin build uses so the cargo-built
+# binary's `LC_BUILD_VERSION`/`minos` agrees with the wheel's platform tag.
+if [[ "$apple_target" == 1 ]]; then
+  export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+fi
 if [[ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]]; then
   echo "==> MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"
 fi
@@ -85,4 +89,16 @@ fi
 mkdir -p "$(dirname "$bin_dst")"
 install -m 0755 "$bin_src" "$bin_dst"
 echo "    wrote $bin_dst"
+
+# The x86_64 binary arrives here unsigned: rustc only ad-hoc-signs arm64 Mach-O
+# at link time, because macOS refuses to exec unsigned arm64 code and has no such
+# requirement on Intel.
+if [[ "$apple_target" == 1 ]]; then
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$bin_dst"
+    echo "    ad-hoc signed $bin_dst"
+  else
+    echo "    warning: codesign not found; daemon binary left unsigned" >&2
+  fi
+fi
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Build intel wheel for mac as `macos-26-large` runner runs on intel mac and needed for perf tests
 - Wheel builds on `macos-26-intel`, smaller intel box but assumption is that wheel doesn't need the resources of large to be built
