### PR TITLE
fix: add timeout for ffmpeg encode with disclosed error

### DIFF
--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -31,10 +31,34 @@ use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::time::Duration;
 
 use data_daemon_shared::service_name::VIDEO_SPOOL_TICKS_PER_SECOND;
 
 use tokio::process::Command;
+
+/// Floor for a single ffmpeg invocation's deadline.
+const FFMPEG_TIMEOUT_FLOOR: Duration = Duration::from_secs(120);
+
+/// Extra deadline granted per MiB of input, on top of the floor.
+const FFMPEG_TIMEOUT_PER_MIB_S: u64 = 1;
+
+/// Deadline for an ffmpeg invocation reading `input_bytes` of input.
+fn ffmpeg_timeout(input_bytes: u64) -> Duration {
+    FFMPEG_TIMEOUT_FLOOR
+        + Duration::from_secs(
+            (input_bytes / (1024 * 1024)).saturating_mul(FFMPEG_TIMEOUT_PER_MIB_S),
+        )
+}
+
+/// Total size of `paths`, skipping any that cannot be stat'd.
+fn total_input_bytes(paths: &[PathBuf]) -> u64 {
+    paths
+        .iter()
+        .filter_map(|path| std::fs::metadata(path).ok())
+        .map(|metadata| metadata.len())
+        .sum()
+}
 
 /// Default ffmpeg binary name. Tests override via [`VideoEncoder::with_binary`]
 /// when they need to point at a specific build.
@@ -225,6 +249,14 @@ pub enum VideoEncodeError {
         #[source]
         source: std::io::Error,
     },
+    /// `ffmpeg` outlived its deadline and was killed.
+    #[error("`ffmpeg` exceeded its {timeout_s}s deadline for {path} and was killed")]
+    Timeout {
+        /// Path being encoded or concatenated when the deadline expired.
+        path: PathBuf,
+        /// Deadline that was exceeded, in seconds.
+        timeout_s: u64,
+    },
     /// `concat_segments` was called with no input segments — caller bug.
     #[error("concat_segments called with empty segment list")]
     EmptySegments,
@@ -361,8 +393,9 @@ impl VideoEncoder {
         let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let mp4_probe_out =
             std::env::temp_dir().join(format!("ncd_ffmpeg_preflight_{}.mp4", std::process::id()));
+        let _cleanup = RemoveFileOnDrop(&mp4_probe_out);
 
-        let child = std::process::Command::new(&self.binary)
+        let mut child = std::process::Command::new(&self.binary)
             .arg("-y")
             .arg("-hide_banner")
             .arg("-loglevel")
@@ -419,14 +452,7 @@ impl VideoEncoder {
             .map_err(|source| FfmpegPreflightError::NotFound {
                 binary: self.binary.clone(),
                 source,
-            });
-        let mut child = match child {
-            Ok(child) => child,
-            Err(error) => {
-                let _ = std::fs::remove_file(&mp4_probe_out);
-                return Err(error);
-            }
-        };
+            })?;
 
         // The frame is far smaller than a pipe buffer, so writing then dropping
         // stdin cannot deadlock against ffmpeg's reads.
@@ -435,7 +461,6 @@ impl VideoEncoder {
         }
 
         let output = child.wait_with_output();
-        let _ = std::fs::remove_file(&mp4_probe_out);
         let output = output.map_err(|source| FfmpegPreflightError::NotFound {
             binary: self.binary.clone(),
             source,
@@ -633,13 +658,21 @@ impl VideoEncoder {
             });
         }
 
-        let output = command
-            .output()
-            .await
-            .map_err(|source| VideoEncodeError::Spawn {
+        // `kill_on_drop` is set on the command, so letting the timeout drop the
+        // future is what reaps the child.
+        let deadline = ffmpeg_timeout(total_input_bytes(std::slice::from_ref(&request.raw_nut)));
+        let output = match tokio::time::timeout(deadline, command.output()).await {
+            Ok(result) => result.map_err(|source| VideoEncodeError::Spawn {
                 binary: self.binary.clone(),
                 source,
-            })?;
+            })?,
+            Err(tokio::time::error::Elapsed { .. }) => {
+                return Err(VideoEncodeError::Timeout {
+                    path: request.raw_nut.clone(),
+                    timeout_s: deadline.as_secs(),
+                })
+            }
+        };
 
         if !output.status.success() {
             let stderr_tail = tail_stderr(&output.stderr);
@@ -687,39 +720,48 @@ impl VideoEncoder {
         let list_path = list_file_for(out);
         write_concat_list(&list_path, segments)?;
 
-        let result = Command::new(&self.binary)
-            .arg("-y")
-            .arg("-hide_banner")
-            .arg("-nostdin")
-            .arg("-loglevel")
-            .arg("error")
-            .arg("-f")
-            .arg("concat")
-            // `-safe 0` permits absolute paths (and any non-portable chars)
-            // in the list file. Without it ffmpeg rejects paths that aren't
-            // simple relative names.
-            .arg("-safe")
-            .arg("0")
-            .arg("-i")
-            .arg(&list_path)
-            .arg("-c")
-            .arg("copy")
-            .arg(out)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .output()
-            .await;
-
-        // Always try to clean up the list file, even on failure — leaving it
-        // around just clutters the trace directory.
-        let _ = std::fs::remove_file(&list_path);
-
-        let output = result.map_err(|source| VideoEncodeError::Spawn {
-            binary: self.binary.clone(),
-            source,
-        })?;
+        // Always try to clean up the list file, even on failure
+        let _cleanup = RemoveFileOnDrop(&list_path);
+        let deadline = ffmpeg_timeout(total_input_bytes(segments));
+        let output = match tokio::time::timeout(
+            deadline,
+            Command::new(&self.binary)
+                .arg("-y")
+                .arg("-hide_banner")
+                .arg("-nostdin")
+                .arg("-loglevel")
+                .arg("error")
+                .arg("-f")
+                .arg("concat")
+                // `-safe 0` permits absolute paths (and any non-portable chars)
+                // in the list file. Without it ffmpeg rejects paths that aren't
+                // simple relative names.
+                .arg("-safe")
+                .arg("0")
+                .arg("-i")
+                .arg(&list_path)
+                .arg("-c")
+                .arg("copy")
+                .arg(out)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await
+        {
+            Ok(result) => result.map_err(|source| VideoEncodeError::Spawn {
+                binary: self.binary.clone(),
+                source,
+            })?,
+            Err(tokio::time::error::Elapsed { .. }) => {
+                return Err(VideoEncodeError::Timeout {
+                    path: out.to_path_buf(),
+                    timeout_s: deadline.as_secs(),
+                })
+            }
+        };
 
         if !output.status.success() {
             let stderr_tail = tail_stderr(&output.stderr);
@@ -731,6 +773,15 @@ impl VideoEncoder {
 
         let bytes = non_empty_file_size(out)?;
         Ok(ConcatOutcome { bytes })
+    }
+}
+
+struct RemoveFileOnDrop<'a>(&'a Path);
+
+impl Drop for RemoveFileOnDrop<'_> {
+    /// Removes the file at path referenced when dropped, ignoring failures.
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.0);
     }
 }
 
@@ -868,6 +919,36 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command as StdCommand;
     use tempfile::TempDir;
+
+    #[test]
+    fn ffmpeg_deadline_is_the_floor_plus_an_allowance_per_mib() {
+        // Sub-MiB inputs get the floor and nothing more.
+        assert_eq!(ffmpeg_timeout(0), FFMPEG_TIMEOUT_FLOOR);
+        assert_eq!(ffmpeg_timeout(1024), FFMPEG_TIMEOUT_FLOOR);
+
+        // A chunk sealed at the 256 MiB flush threshold — the largest input the
+        // encoder ever sees — still gets a deadline in minutes, so the bound
+        // can only ever catch a wedged child, never a slow-but-working one.
+        let biggest = ffmpeg_timeout(256 * 1024 * 1024);
+        assert_eq!(
+            biggest,
+            FFMPEG_TIMEOUT_FLOOR + Duration::from_secs(256 * FFMPEG_TIMEOUT_PER_MIB_S)
+        );
+        assert!(biggest >= Duration::from_secs(300));
+    }
+
+    #[test]
+    fn total_input_bytes_skips_paths_that_cannot_be_stated() {
+        let dir = TempDir::new().expect("tempdir");
+        let present = dir.path().join("segment.mp4");
+        std::fs::write(&present, vec![0u8; 2048]).expect("write");
+        let missing = dir.path().join("gone.mp4");
+
+        // A segment unlinked underneath us must not poison the deadline: it is
+        // skipped, leaving the floor rather than an overflowed sum.
+        assert_eq!(total_input_bytes(&[present.clone(), missing]), 2048);
+        assert_eq!(total_input_bytes(&[]), 0);
+    }
 
     /// Locate an ffmpeg-suite binary on `PATH`. Returns `None` (with a
     /// caller-side skip) so the suite stays green in sandboxes that lack

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -49,7 +49,7 @@ use crate::encoding::video_encoder::{
     ChunkEncodeRequest, LossyVideoCodec, VideoEncodeError, VideoEncoder, ENCODE_THREADS_PER_OUTPUT,
 };
 use crate::pipeline::json_writer::JsonWriteHandle;
-use crate::state::TraceWriteHandle;
+use crate::state::{TraceErrorCode, TraceWriteHandle};
 use crate::storage::budget::StorageBudget;
 use crate::storage::paths::{self, TracePath};
 
@@ -941,7 +941,7 @@ impl ActorState {
                         "error_kind": error.to_string(),
                     }),
                 );
-                self.mark_failed(context);
+                self.mark_failed_with(context, TraceErrorCode::EncodeFailed, error.to_string());
             }
         }
     }
@@ -1169,6 +1169,21 @@ impl ActorState {
         context
             .trace_writer
             .fail(&self.identity.trace_id, self.bytes_on_disk as i64);
+    }
+
+    /// Enqueue a `failed` write carrying the error that caused it.
+    fn mark_failed_with(
+        &mut self,
+        context: &Arc<TraceActorContext>,
+        error_code: TraceErrorCode,
+        error_message: impl Into<String>,
+    ) {
+        context.trace_writer.fail_with(
+            &self.identity.trace_id,
+            self.bytes_on_disk as i64,
+            error_code,
+            error_message,
+        );
     }
 
     /// Tear down the writer and release the trace's disk budget.

--- a/rust/data_daemon/src/state/trace_event_database_writer.rs
+++ b/rust/data_daemon/src/state/trace_event_database_writer.rs
@@ -135,7 +135,6 @@ impl TraceWriteHandle {
     }
 
     /// Mark the trace `failed` with a write-phase error code + message.
-    #[allow(dead_code)]
     pub fn fail_with(
         &self,
         trace_id: &str,


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - ffmpeg encoder processes maybe be hanging and we should be informed about that