### PR TITLE
fix: validate client version should retry on transient errors

### DIFF
--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -165,14 +165,15 @@ class Auth(metaclass=SingletonMetaclass):
         correctly and prevents issues from version mismatches.
 
         Raises:
-            AuthenticationError: If version validation fails due to
-                incompatible versions or server communication issues.
+            VersionMismatchError: If the server reports an incompatible client
+                version (HTTP 4xx).
+            AuthenticationError: If version validation fails due to server
+                communication issues (including transient HTTP 5xx after retries).
         """
-        # Placeholder for version validation logic
         from neuracore_types import __version__ as nc_types_version
 
         try:
-            session = thread_local_session()
+            session = thread_local_session(retry_transient=True)
             response = session.get(
                 f"{API_URL}/auth/verify-version",
                 params={"version": nc_types_version},
@@ -183,9 +184,15 @@ class Auth(metaclass=SingletonMetaclass):
             if response is None:
                 raise AuthenticationError(str(exc)) from exc
 
-            error_message = _format_version_validation_error(response)
-            raise VersionMismatchError(
-                error_message, response_payload=_response_json_payload(response)
+            if 400 <= response.status_code < 500:
+                error_message = _format_version_validation_error(response)
+                raise VersionMismatchError(
+                    error_message, response_payload=_response_json_payload(response)
+                ) from exc
+
+            detail = extract_error_detail(response) or str(exc)
+            raise AuthenticationError(
+                detail, response_payload=_response_json_payload(response)
             ) from exc
         except requests.exceptions.ConnectionError as exc:
             raise AuthenticationError(str(exc)) from exc

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -10,7 +10,7 @@ from neuracore.api import core as api_core
 from neuracore.core import robot as core_robot
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
-from neuracore.core.exceptions import AuthenticationError
+from neuracore.core.exceptions import AuthenticationError, VersionMismatchError
 
 
 def test_login_with_api_key(temp_config_dir, monkeypatch):
@@ -120,13 +120,32 @@ def test_login_version_mismatch_surfaces_installed_version(
             status_code=400,
         )
 
-        with pytest.raises(AuthenticationError) as exc_info:
+        with pytest.raises(VersionMismatchError) as exc_info:
             nc.login("test_api_key")
 
     message = str(exc_info.value)
     assert "Neuracore client version mismatch" in message
     assert f"Installed version: {nc.__version__}" in message
     assert "pip install --upgrade neuracore" in message
+
+
+def test_login_version_check_service_unavailable_is_not_version_mismatch(
+    temp_config_dir, reset_neuracore
+):
+    """Transient backend errors should not be reported as a client version mismatch."""
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{API_URL}/auth/verify-version",
+            text="Service Unavailable",
+            status_code=503,
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            nc.login("test_api_key")
+
+    assert not isinstance(exc_info.value, VersionMismatchError)
+    assert "Service Unavailable" in str(exc_info.value)
+    assert "pip install --upgrade neuracore" not in str(exc_info.value)
 
 
 def test_login_version_check_connection_error_surfaces_cleanly(
@@ -139,7 +158,7 @@ def test_login_version_check_connection_error_surfaces_cleanly(
 
     monkeypatch.setattr(
         "neuracore.core.auth.thread_local_session",
-        lambda: type("_Session", (), {"get": raise_connection_error})(),
+        lambda **_kwargs: type("_Session", (), {"get": raise_connection_error})(),
     )
 
     with pytest.raises(AuthenticationError) as exc_info:


### PR DESCRIPTION
### Bugfixes
- validate version can fail on transient backend service unavailable errors and asks users to upgrade neuracore (https://github.com/NeuracoreAI/neuracore/actions/runs/31136836144/job/92738329547)
- enable transient retries on `verify-version`
- only raise `VersionMismatchError` on 4xx version responses to avoid confusion
