### PR TITLE
feat: route streaming endpoints to the stream service

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,5 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+Streaming connections (WebRTC signalling and recording notifications) now use the backend's dedicated streaming service. This version requires a backend running the matching release.

--- a/neuracore/core/const.py
+++ b/neuracore/core/const.py
@@ -17,6 +17,13 @@ if API_URL not in STANDARD_API_URLS:
 
 
 API_URL = os.getenv("NEURACORE_API_URL", "https://api.neuracore.com/api")
+
+# Long-lived connections (WebRTC signalling, recording notifications) are served
+# by a backend service of their own, selected by this path prefix. A prefix is
+# what the load balancer can route on: the organization id sits in the middle of
+# the path, which it cannot match.
+STREAM_API_URL = f"{API_URL}/stream"
+
 DEFAULT_CACHE_DIR = Path.home() / ".neuracore" / "training"
 DEFAULT_RECORDING_CACHE_DIR = DEFAULT_CACHE_DIR / "recording_cache"
 MAX_DATA_STREAMS = 1000

--- a/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
+++ b/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
@@ -19,7 +19,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.p2p.base_p2p_connection_manager import (
     BaseP2PStreamManager,
 )
@@ -133,7 +133,7 @@ class ClientConsumerStreamManager(BaseP2PStreamManager):
         # The response is read within a context manager so the underlying
         # connection is released back to the session pool.
         async with self.client_session.get(
-            f"{API_URL}/org/{self.org_id}/signalling/turn_servers/{self.local_stream_id}",
+            f"{STREAM_API_URL}/org/{self.org_id}/signalling/turn_servers/{self.local_stream_id}",
             headers=self.auth.get_headers(),
         ) as response:
             self.ice_config = IceConfig.model_validate(await response.json())

--- a/neuracore/core/streaming/p2p/consumer/consumer_connection.py
+++ b/neuracore/core/streaming/p2p/consumer/consumer_connection.py
@@ -31,7 +31,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.event_loop_utils import get_running_loop
 from neuracore.core.streaming.p2p.consumer.ice_models import IceConfig
 from neuracore.core.streaming.p2p.consumer.sync_point_parser import (
@@ -254,7 +254,7 @@ class PeerToPeerConsumerConnection:
         # The response body is ignored; the context manager ensures the
         # connection is released back to the session pool.
         async with self.client_session.post(
-            f"{API_URL}/org/{self.org_id}/signalling/message/submit",
+            f"{STREAM_API_URL}/org/{self.org_id}/signalling/message/submit",
             headers=self.auth.get_headers(),
             json=HandshakeMessage(
                 connection_id=self.id,

--- a/neuracore/core/streaming/p2p/consumer/org_nodes_manager.py
+++ b/neuracore/core/streaming/p2p/consumer/org_nodes_manager.py
@@ -24,7 +24,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.base_sse_consumer import (
     BaseSSEConsumer,
     EventSourceConfig,
@@ -115,7 +115,7 @@ class OrgNodesManager(BaseSSEConsumer):
             the configuration to be used to connect to the client
         """
         return EventSourceConfig(
-            url=f"{API_URL}/org/{self.org_id}/signalling/available_robots",
+            url=f"{STREAM_API_URL}/org/{self.org_id}/signalling/available_robots",
             request_options={
                 "headers": self.auth.get_headers(),
             },
@@ -254,7 +254,7 @@ class OrgNodesManager(BaseSSEConsumer):
         # The response is read within a context manager so the underlying
         # connection is released back to the session pool.
         async with self.client_session.post(
-            url=f"{API_URL}/org/{self.org_id}/signalling/connection?signature=temp",
+            url=f"{STREAM_API_URL}/org/{self.org_id}/signalling/connection?signature=temp",
             json=connection_request.model_dump(mode="json"),
             headers=self.auth.get_headers(),
         ) as response:

--- a/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
+++ b/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
@@ -21,7 +21,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.p2p.base_p2p_connection_manager import (
     BaseP2PStreamManager,
 )
@@ -200,7 +200,7 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
             track: The track metadata to submit.
         """
         await self.client_session.post(
-            f"{API_URL}/org/{self.org_id}/signalling/track",
+            f"{STREAM_API_URL}/org/{self.org_id}/signalling/track",
             headers=self.auth.get_headers(),
             json=track.model_dump(mode="json"),
         )

--- a/neuracore/core/streaming/p2p/provider/provider_connection.py
+++ b/neuracore/core/streaming/p2p/provider/provider_connection.py
@@ -23,7 +23,7 @@ from neuracore_types import HandshakeMessage, MessageType, OpenConnectionDetails
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.event_loop_utils import get_running_loop
 from neuracore.core.streaming.p2p.enabled_manager import EnabledManager
 from neuracore.core.streaming.p2p.provider.json_source import JSONSource
@@ -225,7 +225,7 @@ class PeerToPeerProviderConnection:
         # The response body is ignored; the context manager ensures the
         # connection is released back to the session pool.
         async with self.client_session.post(
-            f"{API_URL}/org/{self.org_id}/signalling/message/submit",
+            f"{STREAM_API_URL}/org/{self.org_id}/signalling/message/submit",
             headers=self.auth.get_headers(),
             json=HandshakeMessage(
                 connection_id=self.id,

--- a/neuracore/core/streaming/p2p/signalling_events_consumer.py
+++ b/neuracore/core/streaming/p2p/signalling_events_consumer.py
@@ -17,7 +17,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.base_sse_consumer import (
     BaseSSEConsumer,
     EventSourceConfig,
@@ -89,7 +89,7 @@ class SignallingEventsConsumer(BaseSSEConsumer):
             the configuration to be used to connect to the client
         """
         return EventSourceConfig(
-            url=f"{API_URL}/org/{self.org_id}/signalling/notifications/{self.local_stream_id}",
+            url=f"{STREAM_API_URL}/org/{self.org_id}/signalling/notifications/{self.local_stream_id}",
             request_options={
                 "headers": self.auth.get_headers(),
             },
@@ -135,7 +135,7 @@ class SignallingEventsConsumer(BaseSSEConsumer):
         # The response is read within a context manager so the underlying
         # connection is released back to the session pool.
         async with self.client_session.post(
-            f"{API_URL}/org/{self.org_id}/signalling/alive/{self.local_stream_id}",
+            f"{STREAM_API_URL}/org/{self.org_id}/signalling/alive/{self.local_stream_id}",
             headers=self.auth.get_headers(),
             data="pong",
         ) as raw_response:

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -25,7 +25,7 @@ from neuracore_types import (
 
 from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
-from neuracore.core.const import API_URL
+from neuracore.core.const import STREAM_API_URL
 from neuracore.core.streaming.base_sse_consumer import (
     BaseSSEConsumer,
     EventSourceConfig,
@@ -485,7 +485,7 @@ class RecordingStateManager(BaseSSEConsumer):
             the configuration to be used to connect to the client
         """
         return EventSourceConfig(
-            url=f"{API_URL}/org/{self.org_id}/recording/notifications",
+            url=f"{STREAM_API_URL}/org/{self.org_id}/recording/notifications",
             request_options={
                 "headers": self.auth.get_headers(),
             },


### PR DESCRIPTION
The backend now serves long-lived connections from a Cloud Run service of its own, reached under an `/api/stream/` path prefix. This points the client's streaming calls at it.

### Features
 - Added `STREAM_API_URL` and switched the WebRTC signalling calls and the recording notification stream over to it. Ordinary API calls still use `API_URL`. **Breaking:** this version needs a backend running the matching release.

### Related PRs
 - NeuracoreAI/neuracore_backend#511
 - NeuracoreAI/neuracore_frontend#423

> [!IMPORTANT]
> Must merge together with the backend PR. The backend serves these endpoints only at the new paths, so an older client version cannot open streams against the new backend.
