### PR TITLE
feat: add daemon version check

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,3 +6,11 @@ tag_name = v{new_version}
 message = Bump version to {new_version} [skip ci]
 
 [bumpversion:file:pyproject.toml]
+
+[bumpversion:file:rust/Cargo.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:rust/Cargo.lock]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -378,7 +378,7 @@ jobs:
       run: |
         NEW_VERSION="${{ needs.generate-changelog.outputs.new_version }}"
 
-        git add .bumpversion.cfg pyproject.toml changelogs/pending-changelog.md
+        git add .bumpversion.cfg pyproject.toml changelogs/pending-changelog.md rust/Cargo.toml rust/Cargo.lock
         git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
 
         TARGET_BRANCH="${{ inputs.emergency_deploy && github.ref_name || 'main' }}"
@@ -525,7 +525,7 @@ jobs:
             summary += '**This was a DRY RUN** - no changes were made\n\n';
             summary += '## What Would Happen\n\n';
             summary += `- **Version Bump:** \`${bumpType}\` -> \`${newVersion}\`\n`;
-            summary += `- Version updated in \`.bumpversion.cfg\` and \`neuracore/__init__.py\`\n`;
+            summary += `- Version updated in \`.bumpversion.cfg\`, \`pyproject.toml\`, \`rust/Cargo.toml\` and \`rust/Cargo.lock\`\n`;
             summary += `- Changes committed and pushed to \`main\`\n`;
             summary += `- Package published to PyPI\n`;
             summary += `- Git tag \`v${newVersion}\` created\n`;

--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,5 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+The data daemon now reports the neuracore version it was built from, and the SDK checks it before it uses the daemon. A daemon left over from an earlier install is reported with the steps to fix it instead of being used silently.

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -309,7 +309,8 @@ signature, work outside the build environment.
 ### Release path
 
 The [release workflow](../.github/workflows/release.yaml) bumps the version
-(root pyproject only, via [.bumpversion.cfg](../.bumpversion.cfg)), pushes the
+(root pyproject plus the rust workspace: `rust/Cargo.toml` and
+`rust/Cargo.lock`, via [.bumpversion.cfg](../.bumpversion.cfg)), pushes the
 tag, re-runs `build-wheels.yaml` against that tag, and publishes **all** wheels
 in a single job only after every platform leg succeeds — so a version can never
 be half-published. `twine --skip-existing` makes re-running idempotent.

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -388,6 +388,7 @@ pyfunction
 pygments
 pyinstrument
 pymodule
+pyproject
 pyquaternion
 pytest
 pytestmark

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -222,9 +222,11 @@ class RecordingStateManager(BaseSSEConsumer):
                 recording_id=recording_id,
                 start_time=start_time,
             )
-        # After the state is visible, and outside the lock: this takes a few
-        # milliseconds of filesystem work, which is long enough for a
+        # After the state is visible, and outside the lock: this normally takes
+        # a few milliseconds of filesystem work, which is long enough for a
         # notification to arrive and be resolved against the tracked recording.
+        # Against a stale daemon it can block for a multiple of the daemon
+        # startup budget before the failure is logged.
         self._ensure_daemon_for_recording()
 
     def _ensure_daemon_for_recording(self) -> None:

--- a/neuracore/data_daemon/binary.py
+++ b/neuracore/data_daemon/binary.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 from importlib.resources import files
 from pathlib import Path
 
+REBUILD_COMMAND_HINT = (
+    "`bash rust/scripts/build_wheel_artefacts.sh && pip install -e .`"
+)
+
+INSTALL_COMMAND_HINT = "`pip install --force-reinstall neuracore`"
+
 MISSING_BINARY_HINT = (
     "The neuracore data-daemon binary was not found. It ships in the neuracore "
     "wheel (prebuilt for Linux x86_64 and Apple-Silicon macOS); reinstall with "
-    "`pip install neuracore` on one of those platforms, or build it into a "
-    "source checkout with `bash rust/scripts/build_wheel_artefacts.sh && "
-    "pip install -e .`."
+    f"{INSTALL_COMMAND_HINT} on one of those platforms, or build it into a "
+    f"source checkout with {REBUILD_COMMAND_HINT}."
 )
 
 

--- a/neuracore/data_daemon/daemon_control.py
+++ b/neuracore/data_daemon/daemon_control.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
+import logging
 import os
 import subprocess
 import time
@@ -11,13 +13,56 @@ from typing import IO, Any, cast
 
 import filelock
 
-from neuracore.data_daemon.binary import require_data_daemon_binary
+from neuracore.data_daemon.binary import (
+    INSTALL_COMMAND_HINT,
+    REBUILD_COMMAND_HINT,
+    data_daemon_binary_path,
+    require_data_daemon_binary,
+)
 from neuracore.data_daemon.const import DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS
 from neuracore.data_daemon.helpers import get_daemon_db_path, get_daemon_pid_path
+
+# Reported for a daemon that answers the health probe but has no version
+# service, which is every daemon built before that service existed.
+UNKNOWN_DAEMON_VERSION = "unknown (daemon too old to report a version)"
+
+STOP_COMMAND_HINT = (
+    "`neuracore data-daemon stop` (or `python -m neuracore.data_daemon stop`)"
+)
+
+STALE_EXTENSION_MESSAGE = (
+    "The neuracore native extension of this install has no daemon version "
+    "query, so it is older than this neuracore code. Build the artefacts "
+    f"again with {REBUILD_COMMAND_HINT} (source checkouts), or install the "
+    f"package again with {INSTALL_COMMAND_HINT}."
+)
+
+# The daemon's own stop path budgets 10 seconds for a graceful SIGTERM exit
+# (see rust/data_daemon/src/cli/stop.rs). A just-launched idle daemon exits
+# well inside that; the wait mostly reaps the child promptly.
+STALE_DAEMON_STOP_WAIT_SECONDS = 10.0
+
+logger = logging.getLogger(__name__)
 
 
 class DaemonLifecycleError(RuntimeError):
     """Raised when daemon lifecycle checks fail."""
+
+
+class DaemonVersionMismatchError(DaemonLifecycleError):
+    """Raised when the running daemon comes from a different neuracore version."""
+
+
+def _sdk_version() -> str | None:
+    """Return the installed neuracore package version, or None without metadata.
+
+    A bare source tree that was never pip-installed has no metadata and so no
+    version to compare against the daemon.
+    """
+    try:
+        return importlib.metadata.version("neuracore")
+    except importlib.metadata.PackageNotFoundError:
+        return None
 
 
 def read_pid_from_file(pid_path: Path) -> int | None:
@@ -38,16 +83,21 @@ def read_pid_from_file(pid_path: Path) -> int | None:
     return pid_value if pid_value > 0 else None
 
 
+def _import_data_bridge() -> Any | None:
+    """Return the native bridge module, or None when it cannot be imported."""
+    try:
+        return cast(Any, importlib.import_module("neuracore.data_daemon._data_bridge"))
+    except (ImportError, OSError):
+        return None
+
+
 def _daemon_ready(pid_path: Path, *, timeout_s: float = 0.0) -> bool:
     """Return True once the daemon answers an IPC health probe."""
     pid_value = read_pid_from_file(pid_path)
     if pid_value is None or not pid_is_running(pid_value):
         return False
-    try:
-        data_bridge = cast(
-            Any, importlib.import_module("neuracore.data_daemon._data_bridge")
-        )
-    except (ImportError, OSError):
+    data_bridge = _import_data_bridge()
+    if data_bridge is None:
         return False
 
     try:
@@ -55,6 +105,81 @@ def _daemon_ready(pid_path: Path, *, timeout_s: float = 0.0) -> bool:
     except (AttributeError, RuntimeError):
         return False
     return ready_pid == pid_value
+
+
+def _format_version_mismatch(
+    daemon_version: str | None, sdk_version: str, just_launched: bool
+) -> str:
+    """Build the user-facing message for a daemon from a different version."""
+    reported_version = (
+        UNKNOWN_DAEMON_VERSION if daemon_version is None else daemon_version
+    )
+    opening = (
+        f"The running data daemon was built from neuracore {reported_version}, "
+        f"but neuracore {sdk_version} is installed. "
+    )
+    if just_launched:
+        return opening + (
+            "This daemon was just launched from the daemon binary of this "
+            "install, so that binary is stale; it was stopped again. Build "
+            f"the binary again with {REBUILD_COMMAND_HINT} (source "
+            f"checkouts), or install the package again with {INSTALL_COMMAND_HINT}."
+        )
+    if data_daemon_binary_path() is None:
+        return opening + (
+            "This install has no daemon binary to replace it: install the "
+            f"package again with {INSTALL_COMMAND_HINT}, then stop the old daemon "
+            f"with {STOP_COMMAND_HINT}. The next use of neuracore starts the "
+            "daemon of this install automatically."
+        )
+    return opening + (
+        f"Stop the old daemon with {STOP_COMMAND_HINT}. The next use of "
+        "neuracore starts the daemon of this install automatically. In a "
+        "source checkout, the bundled daemon can itself be older than the "
+        f"installed package: build it again with {REBUILD_COMMAND_HINT}."
+    )
+
+
+def _check_daemon_version(timeout_s: float, *, just_launched: bool = False) -> None:
+    """Raise unless the running daemon matches the installed neuracore version.
+
+    Callers run this right after a passing health probe and pass the probe's
+    own time budget, so a daemon that stays silent for the whole budget has no
+    version service and is too old.
+
+    The check is skipped with a warning when the package has no installed
+    metadata (there is no version to compare), when the native extension is
+    not importable (defensive only: a passing health probe has already
+    imported it), and when the query fails in transport, where the daemon's
+    version is not the problem. A native extension that imports but has no
+    ``daemon_version`` raises a plain :class:`DaemonLifecycleError` naming the
+    extension, not the daemon, as stale.
+    """
+    sdk_version = _sdk_version()
+    if sdk_version is None:
+        logger.warning(
+            "Skipped the daemon version check: the neuracore package has no "
+            "installed metadata."
+        )
+        return
+    data_bridge = _import_data_bridge()
+    if data_bridge is None:
+        logger.warning(
+            "Skipped the daemon version check: the native extension is not "
+            "importable."
+        )
+        return
+    try:
+        daemon_version = cast("str | None", data_bridge.daemon_version(timeout_s))
+    except AttributeError:
+        raise DaemonLifecycleError(STALE_EXTENSION_MESSAGE) from None
+    except RuntimeError as error:
+        logger.warning("Skipped the daemon version check: %s", error)
+        return
+    if daemon_version != sdk_version:
+        raise DaemonVersionMismatchError(
+            _format_version_mismatch(daemon_version, sdk_version, just_launched)
+        )
 
 
 def _is_zombie(pid_value: int) -> bool:
@@ -266,6 +391,19 @@ def ensure_daemon_running(
     A stale PID file from an unclean exit needs no cleanup here: the daemon's
     ``launch`` reclaims it before acquiring its own, alongside any leftover
     iceoryx2 artefacts.
+
+    Both paths check the daemon's build version against the installed
+    neuracore version: an adopted daemon can be left over from an earlier
+    install, and a daemon just launched from a source checkout can come from a
+    binary that was built before the last change.
+
+    The readiness probe and the version check each get the full ``timeout_s``
+    budget, so against a daemon too old to serve versions the PID file lock
+    can be held for up to twice that budget before this raises; on the launch
+    path a version mismatch adds up to ``STALE_DAEMON_STOP_WAIT_SECONDS`` on
+    top, because the just-launched daemon is stopped and reaped before the
+    raise. Only a version mismatch stops that daemon: a stale-extension error
+    leaves it running, since the daemon itself may be the correct version.
     """
     pid_path = get_daemon_pid_path()
     db_path = get_daemon_db_path()
@@ -278,6 +416,7 @@ def ensure_daemon_running(
         existing_pid = read_pid_from_file(pid_path)
         if existing_pid is not None and pid_is_running(existing_pid):
             if _daemon_ready(pid_path, timeout_s=timeout_s):
+                _check_daemon_version(timeout_s)
                 return existing_pid
             raise DaemonLifecycleError(
                 f"Daemon process is running (pid={existing_pid}) but did not "
@@ -291,11 +430,24 @@ def ensure_daemon_running(
             timeout_s=timeout_s,
             env_overrides=env_overrides,
         )
+        try:
+            _check_daemon_version(timeout_s, just_launched=True)
+        except DaemonVersionMismatchError:
+            process.terminate()
+            try:
+                process.wait(timeout=STALE_DAEMON_STOP_WAIT_SECONDS)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "The stale daemon (pid=%s) did not exit after SIGTERM.",
+                    process.pid,
+                )
+            raise
         return process.pid
 
 
 __all__ = [
     "DaemonLifecycleError",
+    "DaemonVersionMismatchError",
     "ensure_daemon_running",
     "launch_daemon_subprocess",
     "pid_is_running",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "data-daemon"
-version = "0.1.0"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "data_daemon_bridge"
-version = "0.1.0"
+version = "15.0.0"
 dependencies = [
  "data_daemon_shared",
  "half",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "data_daemon_shared"
-version = "0.1.0"
+version = "15.0.0"
 dependencies = [
  "dirs",
  "nix",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,10 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
+# Kept equal to the neuracore version in pyproject.toml: the release bump
+# rewrites both (see .bumpversion.cfg), so the daemon can report the neuracore
+# version it was built from as CARGO_PKG_VERSION.
+version = "15.0.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use data_daemon_shared::{
-    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply,
+    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, VersionReply,
+    VersionRequest,
 };
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
@@ -75,6 +76,7 @@ pub async fn run(
         commands = data_daemon_shared::service_name::COMMANDS,
         recording_ids = data_daemon_shared::service_name::RECORDING_IDS,
         health = data_daemon_shared::service_name::HEALTH,
+        version = data_daemon_shared::service_name::VERSION,
         "ipc listener started"
     );
 
@@ -114,6 +116,12 @@ pub async fn run(
         // point proves the daemon has opened IPC, spawned the dispatcher, and
         // entered the listener loop that drains commands.
         serve_health(transport.health_server());
+
+        // -- Answer version queries ---------------------------------------------
+        // The SDK compares this answer with its own installed version, so a
+        // daemon left behind by an earlier install is reported to the user
+        // instead of being adopted silently.
+        serve_version(transport.version_server());
 
         // -- Answer recording-id queries ----------------------------------------
         // Each recording-id request is resolved against the daemon's own store (a single
@@ -176,6 +184,49 @@ fn serve_health(server: &Server<ipc::Service, [u8], (), [u8], ()>) {
                 Err(error) => tracing::warn!(%error, "failed to loan health reply sample"),
             },
             Err(error) => tracing::warn!(%error, "failed to encode health reply"),
+        }
+    }
+}
+
+/// Drain every pending version query, answering each with the neuracore
+/// version this daemon was built from.
+///
+/// The rust workspace version is held equal to the neuracore version in
+/// `pyproject.toml`, so `CARGO_PKG_VERSION` is that version.
+fn serve_version(server: &Server<ipc::Service, [u8], (), [u8], ()>) {
+    loop {
+        let active = match server.receive() {
+            Ok(Some(active)) => active,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(%error, "version server receive failed");
+                return;
+            }
+        };
+
+        let request = match VersionRequest::decode(active.payload()) {
+            Ok(request) => request,
+            Err(error) => {
+                tracing::warn!(%error, "dropping malformed version query");
+                continue;
+            }
+        };
+
+        let reply = VersionReply {
+            nonce: request.nonce,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        match reply.encode() {
+            Ok(bytes) => match active.loan_slice_uninit(bytes.len()) {
+                Ok(response) => {
+                    let response = response.write_from_slice(&bytes);
+                    if let Err(error) = response.send() {
+                        tracing::warn!(%error, "failed to send version reply");
+                    }
+                }
+                Err(error) => tracing::warn!(%error, "failed to loan version reply sample"),
+            },
+            Err(error) => tracing::warn!(%error, "failed to encode version reply"),
         }
     }
 }

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -14,7 +14,7 @@ use data_daemon_shared::service_name::{
     COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
     MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
-    RECORDING_ID_MAX_PAYLOAD_BYTES,
+    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
 use iceoryx2::port::server::Server;
@@ -101,6 +101,11 @@ pub struct IpcTransport {
     health_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the health server.
     _health_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response server on `neuracore/data_daemon/version` that reports
+    /// the neuracore version this daemon was built from.
+    version_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the version server.
+    _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
 }
 
 impl IpcTransport {
@@ -128,6 +133,8 @@ impl IpcTransport {
             open_query_server(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
         let (health_service, health_server) =
             open_query_server(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
+        let (version_service, version_server) =
+            open_query_server(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
 
         Ok(IpcTransport {
             _node: node,
@@ -137,6 +144,8 @@ impl IpcTransport {
             _recording_id_service: recording_id_service,
             health_server,
             _health_service: health_service,
+            version_server,
+            _version_service: version_service,
         })
     }
 
@@ -153,6 +162,11 @@ impl IpcTransport {
     /// Borrow the `health` request-response server port.
     pub fn health_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
         &self.health_server
+    }
+
+    /// Borrow the `version` request-response server port.
+    pub fn version_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.version_server
     }
 }
 

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -56,7 +56,10 @@ use pyo3::prelude::*;
 use crate::publisher::{
     flush_published_data, now_ns, publish, publisher_tx, ProducerError, PublishMsg,
 };
-use crate::query::{resolve_recording_id, wait_until_ready as wait_until_ready_impl};
+use crate::query::{
+    daemon_version as daemon_version_impl, resolve_recording_id,
+    wait_until_ready as wait_until_ready_impl,
+};
 use crate::writer::{writer_queue, FrameJob, WriterMsg};
 
 /// Announce that a recording has started for a source. Fire-and-forget: the
@@ -501,6 +504,16 @@ fn wait_until_ready(py: Python<'_>, timeout_s: f64) -> PyResult<Option<u32>> {
     py.detach(|| -> PyResult<Option<u32>> { Ok(wait_until_ready_impl(timeout_s)?) })
 }
 
+/// Ask the running daemon which neuracore version it was built from.
+///
+/// Returns `None` when nothing answered within `timeout_s`, which the SDK
+/// reads as a daemon older than this query.
+#[pyfunction]
+#[pyo3(signature = (timeout_s))]
+fn daemon_version(py: Python<'_>, timeout_s: f64) -> PyResult<Option<String>> {
+    py.detach(|| -> PyResult<Option<String>> { Ok(daemon_version_impl(timeout_s)?) })
+}
+
 /// Ask the running daemon to reload its profile config immediately (see
 /// [`Envelope::RefreshConfig`]). Published on the caller thread's command port
 /// so it is strictly ordered ahead of a subsequent `start_recording` from the
@@ -528,6 +541,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
+    module.add_function(wrap_pyfunction!(daemon_version, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;
     Ok(())
 }

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -45,7 +45,8 @@ use data_daemon_shared::service_name::{
     COMMANDS, COMMANDS_MAX_PAYLOAD_BYTES, HEALTH, HEALTH_MAX_PAYLOAD_BYTES,
     LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE, MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE,
-    MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES,
+    MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION,
+    VERSION_MAX_PAYLOAD_BYTES,
 };
 use data_daemon_shared::{BatchedDataItem, Envelope};
 use iceoryx2::node::{Node, NodeBuilder};
@@ -111,6 +112,11 @@ pub(crate) struct ProducerState {
     _health_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
     /// Request-response client used by launch readiness probes.
     pub(crate) health_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the version client so port discovery
+    /// doesn't race the handle going out of scope.
+    _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response client used to read the running daemon's build version.
+    pub(crate) version_client: Client<ipc::Service, [u8], (), [u8], ()>,
 }
 
 /// Work item for the publisher thread.
@@ -370,6 +376,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         open_query_client(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
     let (health_service, health_client) =
         open_query_client(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
+    let (version_service, version_client) =
+        open_query_client(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
 
     Ok(ProducerState {
         _node: node,
@@ -379,6 +387,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         recording_id_client,
         _health_service: health_service,
         health_client,
+        _version_service: version_service,
+        version_client,
     })
 }
 

--- a/rust/data_daemon_bridge/src/query.rs
+++ b/rust/data_daemon_bridge/src/query.rs
@@ -7,7 +7,9 @@
 
 use std::time::{Duration, Instant};
 
-use data_daemon_shared::{HealthReply, HealthRequest, RecordingIdReply};
+use data_daemon_shared::{
+    HealthReply, HealthRequest, RecordingIdReply, VersionReply, VersionRequest,
+};
 
 use crate::publisher::{now_ns, with_producer, ProducerError, ProducerState};
 
@@ -23,6 +25,12 @@ const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const HEALTH_RESPONSE_WAIT: Duration = Duration::from_millis(20);
 /// Poll cadence while waiting for one health reply.
 const HEALTH_RECEIVE_POLL: Duration = Duration::from_millis(2);
+/// Interval between successive version requests to the daemon.
+const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+/// How long a single version request waits for the daemon's reply before re-asking.
+const VERSION_RESPONSE_WAIT: Duration = Duration::from_millis(20);
+/// Poll cadence while waiting for one version reply.
+const VERSION_RECEIVE_POLL: Duration = Duration::from_millis(2);
 
 fn bounded_timeout(timeout_s: f64) -> Duration {
     // Clamp before converting: `Duration::from_secs_f64` panics on a non-finite
@@ -83,6 +91,61 @@ fn health_probe_once(request_bytes: &[u8], nonce: u64) -> Result<Option<u32>, Pr
                 return Ok(None);
             }
             std::thread::sleep(HEALTH_RECEIVE_POLL);
+        }
+    })
+}
+
+/// Block (with the GIL released by the caller) until the daemon reports the
+/// neuracore version it was built from, or `timeout_s` elapses.
+///
+/// `Ok(None)` means nothing answered within `timeout_s`: either no daemon is
+/// running, or the running daemon is older than the version service and has
+/// no server on it. The caller runs this only after a passing health probe
+/// and passes the probe's own time budget, so sustained silence means an old
+/// daemon rather than a missing or briefly busy one.
+pub(crate) fn daemon_version(timeout_s: f64) -> Result<Option<String>, ProducerError> {
+    let nonce = now_ns() as u64;
+    let request_bytes = VersionRequest { nonce }.encode()?;
+    let deadline = Instant::now() + bounded_timeout(timeout_s);
+    loop {
+        if let Some(version) = version_probe_once(&request_bytes, nonce)? {
+            return Ok(Some(version));
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(VERSION_POLL_INTERVAL);
+    }
+}
+
+fn version_probe_once(request_bytes: &[u8], nonce: u64) -> Result<Option<String>, ProducerError> {
+    with_producer(|state| {
+        let request = state
+            .version_client
+            .loan_slice_uninit(request_bytes.len())
+            .map_err(|error| ProducerError::Loan(error.to_string()))?;
+        let request = request.write_from_slice(request_bytes);
+        let pending = request
+            .send()
+            .map_err(|error| ProducerError::Send(error.to_string()))?;
+
+        let response_deadline = Instant::now() + VERSION_RESPONSE_WAIT;
+        loop {
+            match pending.receive() {
+                Ok(Some(response)) => {
+                    let reply = VersionReply::decode(response.payload())?;
+                    return Ok((reply.nonce == nonce).then_some(reply.version));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(%error, "version receive failed; treating as no reply");
+                    return Ok(None);
+                }
+            }
+            if Instant::now() >= response_deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(VERSION_RECEIVE_POLL);
         }
     })
 }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -192,6 +192,22 @@ pub mod service_name {
     /// Maximum size of a single health-service sample.
     pub const HEALTH_MAX_PAYLOAD_BYTES: usize = 1024;
 
+    /// Request-response service the SDK uses to read the neuracore version the
+    /// running daemon was built from.
+    ///
+    /// The SDK compares that version with its own installed version, so a
+    /// daemon left behind by an earlier install is reported instead of being
+    /// adopted silently. It is a service of its own rather than a field on
+    /// [`crate::HealthReply`] because postcard does not tag fields: a daemon
+    /// built before this service simply never answers here, while a changed
+    /// health reply would fail to decode and break the readiness contract.
+    /// See [`crate::VersionRequest`] / [`crate::VersionReply`].
+    pub const VERSION: &str = "neuracore/data_daemon/version";
+
+    /// Maximum size of a single version-service sample. Both the request and
+    /// the reply are a nonce plus a short version string.
+    pub const VERSION_MAX_PAYLOAD_BYTES: usize = 1024;
+
     /// Request-response service the SDK uses to resolve a recording's
     /// daemon-owned cloud `recording_id`.
     ///
@@ -578,6 +594,23 @@ pub struct HealthReply {
     pub nonce: u64,
 }
 
+/// Request sent over [`service_name::VERSION`] asking the daemon which
+/// neuracore version it was built from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionRequest {
+    /// Caller-generated token echoed by the reply.
+    pub nonce: u64,
+}
+
+/// Reply to a [`VersionRequest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionReply {
+    /// Echo of [`VersionRequest::nonce`].
+    pub nonce: u64,
+    /// The neuracore version the answering daemon was built from.
+    pub version: String,
+}
+
 impl RecordingIdQuery {
     /// Encode as a postcard byte vector for a `recording_ids` service request sample.
     pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
@@ -626,6 +659,30 @@ impl HealthReply {
     }
 }
 
+impl VersionRequest {
+    /// Encode as a postcard byte vector for a version-service request sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a version-service request sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl VersionReply {
+    /// Encode as a postcard byte vector for a version-service response sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a version-service response sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -644,6 +701,24 @@ mod tests {
         };
         assert_eq!(
             HealthReply::decode(&reply.encode().unwrap()).unwrap(),
+            reply
+        );
+    }
+
+    #[test]
+    fn version_request_and_reply_round_trip() {
+        let request = VersionRequest { nonce: 42 };
+        assert_eq!(
+            VersionRequest::decode(&request.encode().unwrap()).unwrap(),
+            request
+        );
+
+        let reply = VersionReply {
+            nonce: 42,
+            version: "13.7.2".into(),
+        };
+        assert_eq!(
+            VersionReply::decode(&reply.encode().unwrap()).unwrap(),
             reply
         );
     }

--- a/rust/scripts/run_integration_tests.sh
+++ b/rust/scripts/run_integration_tests.sh
@@ -196,13 +196,14 @@ export RUST_BACKTRACE=1
 # Each entry is a pytest target relative to repo root. The order is hand-rolled
 # so a failure surfaces in the cheapest suite first:
 #   1. behavioural_correctness/test_startup        — single startup smoke
-#   2. behavioural_correctness/test_signal_cleanup — many short signal tests
-#   3. behavioural_correctness/test_cancel_recording — short, no upload
-#   4. behavioural_correctness/test_offline_to_online — recorded -> online flip
-#   5. data_integrity/test_pre_network             — disk-only integrity
-#   6. data_integrity/test_network                 — adds upload + dataset wait
-#   7. performance/test_pre_network                — disk-only perf budgets
-#   8. performance/test_network                    — full network perf run
+#   2. behavioural_correctness/test_daemon_version — daemon version check
+#   3. behavioural_correctness/test_signal_cleanup — many short signal tests
+#   4. behavioural_correctness/test_cancel_recording — short, no upload
+#   5. behavioural_correctness/test_offline_to_online — recorded -> online flip
+#   6. data_integrity/test_pre_network             — disk-only integrity
+#   7. data_integrity/test_network                 — adds upload + dataset wait
+#   8. performance/test_pre_network                — disk-only perf budgets
+#   9. performance/test_network                    — full network perf run
 #
 # The 300s (5-minute) 1920x1080 performance cases are pulled OUT of the normal
 # order and run last (see `run_tests`): they dominate wall time and their
@@ -215,6 +216,7 @@ export RUST_BACKTRACE=1
 
 test_targets=(
   "tests/integration/platform/data_daemon/behavioural_correctness/test_startup.py"
+  "tests/integration/platform/data_daemon/behavioural_correctness/test_daemon_version.py"
   "tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py"
   "tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py"
   "tests/integration/platform/data_daemon/behavioural_correctness/test_offline_to_online.py"

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_daemon_version.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_daemon_version.py
@@ -1,0 +1,85 @@
+"""Behavioural correctness tests for daemon version signalling.
+
+Verifies that a live daemon answers the iceoryx2 version query with the
+neuracore version it was built from, that this matches the installed neuracore
+package, and that a daemon built from a different version is refused with a
+message naming both versions. These tests force online mode so startup never
+inherits an offline profile.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import neuracore.data_daemon.daemon_control as daemon_control
+from neuracore.data_daemon.daemon_control import (
+    DaemonVersionMismatchError,
+    ensure_daemon_running,
+    pid_is_running,
+)
+from tests.integration.platform.data_daemon.shared.runners import online_daemon_running
+
+STALE_SDK_VERSION = "0.0.0+stale"
+
+VERSION_QUERY_TIMEOUT_SECONDS = 5.0
+
+
+def _query_daemon_version() -> str | None:
+    """Ask the running daemon for its build version over iceoryx2."""
+    data_bridge = daemon_control._import_data_bridge()
+    assert data_bridge is not None, "The native extension must import here"
+    return data_bridge.daemon_version(VERSION_QUERY_TIMEOUT_SECONDS)
+
+
+def test_running_daemon_reports_the_installed_neuracore_version() -> None:
+    """Verify the daemon answers with the version of the installed package.
+
+    The daemon comes from the binary this install ships, so the version it
+    reports over iceoryx2 must equal the installed neuracore version.
+    """
+    with online_daemon_running():
+        sdk_version = daemon_control._sdk_version()
+        reported_version = _query_daemon_version()
+        assert reported_version == sdk_version, (
+            f"Daemon reported neuracore version {reported_version!r}, "
+            f"expected the installed version {sdk_version!r}"
+        )
+
+        daemon_pid = ensure_daemon_running()
+        assert pid_is_running(
+            daemon_pid
+        ), f"ensure_daemon_running returned pid {daemon_pid}, which is not running"
+
+
+def test_daemon_from_another_neuracore_version_is_rejected() -> None:
+    """Verify a mismatched daemon is refused with both versions in the message.
+
+    The daemon stays real and only the installed version is replaced, so the
+    comparison runs over the true iceoryx2 round trip. The replacement starts
+    inside the block because ``online_daemon_running`` itself calls
+    ``ensure_daemon_running``, which the mismatch would then break.
+    """
+    with online_daemon_running():
+        reported_version = _query_daemon_version()
+        assert (
+            reported_version is not None
+        ), "Daemon did not answer the version query, so no mismatch can be shown"
+
+        with mock.patch.object(
+            daemon_control, "_sdk_version", return_value=STALE_SDK_VERSION
+        ):
+            with pytest.raises(DaemonVersionMismatchError) as exc_info:
+                ensure_daemon_running()
+
+        message = str(exc_info.value)
+        assert (
+            reported_version in message
+        ), f"Mismatch message does not name the daemon version: {message!r}"
+        assert (
+            STALE_SDK_VERSION in message
+        ), f"Mismatch message does not name the installed version: {message!r}"
+        assert (
+            "neuracore data-daemon stop" in message
+        ), f"Mismatch message does not give the stop command: {message!r}"

--- a/tests/unit/data_daemon/test_daemon_control.py
+++ b/tests/unit/data_daemon/test_daemon_control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import sys
 from pathlib import Path
@@ -13,10 +14,15 @@ import pytest
 import neuracore.data_daemon.daemon_control as daemon_control
 from neuracore.data_daemon.daemon_control import (
     DaemonLifecycleError,
+    DaemonVersionMismatchError,
     launch_daemon_subprocess,
 )
 
 DEAD_PID = 999999
+# Not the repo's real version, so a test that stops using the _sdk_version
+# seam fails instead of matching the genuine installed metadata.
+INSTALLED_SDK_VERSION = "99.9.9"
+STALE_DAEMON_VERSION = "13.0.1"
 
 
 class _FakePopen:
@@ -29,6 +35,7 @@ class _FakePopen:
         self._poll_value = poll_value
         self.returncode = poll_value
         self.stderr = None
+        self.wait_calls = 0
 
     def poll(self) -> int | None:
         return self._poll_value
@@ -36,6 +43,10 @@ class _FakePopen:
     def terminate(self) -> None:
         self.returncode = -15
         self._poll_value = -15
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        self.wait_calls += 1
+        return self.returncode
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +56,7 @@ def bundled_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setattr(
         daemon_control, "require_data_daemon_binary", lambda: binary_path
     )
+    monkeypatch.setattr(daemon_control, "data_daemon_binary_path", lambda: binary_path)
     return binary_path
 
 
@@ -122,6 +134,7 @@ def test_ensure_daemon_running_existing_pid_waits_for_health(
     monkeypatch.setattr(daemon_control, "get_daemon_pid_path", lambda: pid_path)
     monkeypatch.setattr(daemon_control, "get_daemon_db_path", lambda: db_path)
     monkeypatch.setattr(daemon_control, "_daemon_ready", fake_ready)
+    _install_matching_version_daemon(monkeypatch)
 
     assert daemon_control.ensure_daemon_running(timeout_s=2.5) == os.getpid()
     assert calls == [2.5]
@@ -252,17 +265,45 @@ def test_launch_premature_exit_includes_stderr(
 
 
 def _install_fake_bridge(
-    monkeypatch: pytest.MonkeyPatch, wait_until_ready: object
+    monkeypatch: pytest.MonkeyPatch,
+    wait_until_ready: object,
+    daemon_version: object | None = None,
 ) -> None:
     """Expose a stand-in ``_data_bridge`` module to the health probe.
 
     ``importlib.import_module`` returns an existing ``sys.modules`` entry, so
     seeding one lets these tests drive the probe without a built extension.
+    A ``daemon_version`` of ``None`` leaves that name off the module, which is
+    what an extension built before the version query looks like.
     """
-    monkeypatch.setitem(
-        sys.modules,
-        "neuracore.data_daemon._data_bridge",
-        SimpleNamespace(wait_until_ready=wait_until_ready),
+    fake_bridge = SimpleNamespace(wait_until_ready=wait_until_ready)
+    if daemon_version is not None:
+        fake_bridge.daemon_version = daemon_version
+    monkeypatch.setitem(sys.modules, "neuracore.data_daemon._data_bridge", fake_bridge)
+
+
+def _install_sdk_version(monkeypatch: pytest.MonkeyPatch, sdk_version: str) -> None:
+    """Pin the version the installed neuracore package reports."""
+    monkeypatch.setattr(daemon_control, "_sdk_version", lambda: sdk_version)
+
+
+def _install_matching_version_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the fake daemon report exactly the installed neuracore version."""
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: INSTALLED_SDK_VERSION,
+    )
+
+
+def _use_live_daemon_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the lifecycle helpers at a PID file holding a live PID."""
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+    monkeypatch.setattr(daemon_control, "get_daemon_pid_path", lambda: pid_path)
+    monkeypatch.setattr(
+        daemon_control, "get_daemon_db_path", lambda: tmp_path / "state.db"
     )
 
 
@@ -340,3 +381,237 @@ def test_daemon_ready_returns_true_when_probe_answers_same_pid(
 
     assert daemon_control._daemon_ready(pid_path, timeout_s=1.5) is True
     assert timeouts == [1.5]
+
+
+def test_ensure_daemon_running_adopts_daemon_built_from_the_installed_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A daemon reporting the installed neuracore version is used as it is."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    version_timeouts: list[float] = []
+
+    def fake_daemon_version(timeout_s: float) -> str:
+        version_timeouts.append(timeout_s)
+        return INSTALLED_SDK_VERSION
+
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=fake_daemon_version,
+    )
+
+    assert daemon_control.ensure_daemon_running(timeout_s=2.5) == os.getpid()
+    # The query gets the same time budget as the health probe, so a daemon
+    # that is slow to answer is not misread as one without a version service.
+    assert version_timeouts == [2.5]
+
+
+def test_ensure_daemon_running_rejects_daemon_built_from_another_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A daemon left over from an earlier install must be named, not adopted."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: STALE_DAEMON_VERSION,
+    )
+
+    with pytest.raises(DaemonVersionMismatchError) as exc_info:
+        daemon_control.ensure_daemon_running(timeout_s=0.0)
+
+    assert isinstance(exc_info.value, DaemonLifecycleError)
+    message = str(exc_info.value)
+    assert STALE_DAEMON_VERSION in message
+    assert INSTALLED_SDK_VERSION in message
+    assert "neuracore data-daemon stop" in message
+    assert "build_wheel_artefacts.sh" in message
+
+
+def test_ensure_daemon_running_rejects_daemon_that_answers_no_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A healthy daemon that never answers the version query is too old."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: None,
+    )
+
+    with pytest.raises(DaemonVersionMismatchError) as exc_info:
+        daemon_control.ensure_daemon_running(timeout_s=0.0)
+
+    message = str(exc_info.value)
+    assert daemon_control.UNKNOWN_DAEMON_VERSION in message
+    assert INSTALLED_SDK_VERSION in message
+    assert "neuracore data-daemon stop" in message
+
+
+def test_ensure_daemon_running_rejects_extension_without_the_version_query(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An extension without the query names itself as stale, not the daemon."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    _install_fake_bridge(monkeypatch, lambda _timeout_s: os.getpid())
+
+    with pytest.raises(DaemonLifecycleError) as exc_info:
+        daemon_control.ensure_daemon_running(timeout_s=0.0)
+
+    assert not isinstance(exc_info.value, DaemonVersionMismatchError)
+    message = str(exc_info.value)
+    assert "native extension" in message
+    assert "build_wheel_artefacts.sh" in message
+
+
+def test_version_check_is_skipped_when_the_query_fails_in_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An IPC failure is not evidence of a version mismatch."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+
+    def raise_runtime_error(_timeout_s: float) -> str:
+        raise RuntimeError("iceoryx2 node limit reached")
+
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=raise_runtime_error,
+    )
+
+    with caplog.at_level("WARNING"):
+        assert daemon_control.ensure_daemon_running(timeout_s=0.0) == os.getpid()
+
+    assert "Skipped the daemon version check" in caplog.text
+
+
+def test_ensure_daemon_running_checks_the_daemon_it_has_just_launched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stale local build must be refused, not accepted because it is new.
+
+    In an editable install the bundled binary can be older than the installed
+    package, so the daemon this call starts can report an earlier version.
+    """
+    pid_path = tmp_path / "daemon.pid"
+    launched_pid = 24680
+    launched_processes: list[_FakePopen] = []
+
+    def fake_popen(command: list[str], **kwargs: object) -> _FakePopen:
+        process = _FakePopen(pid=launched_pid, poll_value=None)
+        launched_processes.append(process)
+        return process
+
+    monkeypatch.setattr(daemon_control, "get_daemon_pid_path", lambda: pid_path)
+    monkeypatch.setattr(
+        daemon_control, "get_daemon_db_path", lambda: tmp_path / "state.db"
+    )
+    monkeypatch.setattr(daemon_control.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_control, "_daemon_ready", lambda *_, **__: True)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    version_timeouts: list[float] = []
+
+    def fake_daemon_version(timeout_s: float) -> str:
+        version_timeouts.append(timeout_s)
+        return STALE_DAEMON_VERSION
+
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: launched_pid,
+        daemon_version=fake_daemon_version,
+    )
+
+    with pytest.raises(DaemonVersionMismatchError) as exc_info:
+        daemon_control.ensure_daemon_running(timeout_s=1.0)
+
+    message = str(exc_info.value)
+    assert STALE_DAEMON_VERSION in message
+    assert INSTALLED_SDK_VERSION in message
+    assert "build_wheel_artefacts.sh" in message
+    # The launch path must give the query the caller's budget as well.
+    assert version_timeouts == [1.0]
+    # The mismatched daemon this call started must not be left running, and
+    # must be reaped so no zombie remains.
+    assert [process.returncode for process in launched_processes] == [-15]
+    assert [process.wait_calls for process in launched_processes] == [1]
+
+
+def test_version_mismatch_message_asks_for_an_install_without_a_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An install with no daemon binary cannot start a correct daemon."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+    monkeypatch.setattr(daemon_control, "data_daemon_binary_path", lambda: None)
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: STALE_DAEMON_VERSION,
+    )
+
+    with pytest.raises(DaemonVersionMismatchError) as exc_info:
+        daemon_control.ensure_daemon_running(timeout_s=0.0)
+
+    message = str(exc_info.value)
+    # The install must come first: the stop command itself needs the binary.
+    assert message.index("pip install --force-reinstall neuracore") < message.index(
+        "data-daemon stop"
+    )
+
+
+def test_version_check_is_skipped_without_package_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A bare source tree has no version to compare, so the check must not run.
+
+    Raising here would reject every daemon forever: no stop, reinstall, or
+    rebuild can give the package metadata it never had.
+    """
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+
+    def raise_package_not_found(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError("neuracore")
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_package_not_found)
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: STALE_DAEMON_VERSION,
+    )
+
+    with caplog.at_level("WARNING"):
+        assert daemon_control.ensure_daemon_running(timeout_s=0.0) == os.getpid()
+
+    assert daemon_control._sdk_version() is None
+    assert "no installed metadata" in caplog.text
+
+
+def test_version_check_is_skipped_when_the_extension_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The check cannot run without the native extension, so it must not raise."""
+    _install_sdk_version(monkeypatch, INSTALLED_SDK_VERSION)
+
+    def raise_import_error(_name: str) -> object:
+        raise ImportError("no module named _data_bridge")
+
+    monkeypatch.setattr(
+        daemon_control,
+        "importlib",
+        SimpleNamespace(import_module=raise_import_error),
+    )
+
+    with caplog.at_level("WARNING"):
+        daemon_control._check_daemon_version(0.0)
+
+    assert "not importable" in caplog.text

--- a/tests/unit/data_daemon/test_version_sync.py
+++ b/tests/unit/data_daemon/test_version_sync.py
@@ -1,0 +1,43 @@
+"""Guard that the rust workspace version tracks the python package version.
+
+The daemon version check compares the two at runtime, so a drift between
+`pyproject.toml` and `rust/Cargo.toml` would make every install raise
+`DaemonVersionMismatchError` after the next release. `bump2version` rewrites
+both files together; this test moves a drift failure from release time to CI.
+
+Parsed by hand because `tomllib` needs python 3.11 and this suite also runs
+on 3.10.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _version_in_section(toml_path: Path, section: str) -> str:
+    in_section = False
+    for line in toml_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_section = stripped == f"[{section}]"
+            continue
+        if in_section:
+            match = re.fullmatch(r'version\s*=\s*"([^"]+)"', stripped)
+            if match:
+                return match.group(1)
+    raise AssertionError(f"No version found in [{section}] of {toml_path}")
+
+
+def test_rust_workspace_version_matches_python_package_version() -> None:
+    python_version = _version_in_section(REPO_ROOT / "pyproject.toml", "project")
+    rust_version = _version_in_section(
+        REPO_ROOT / "rust" / "Cargo.toml", "workspace.package"
+    )
+    assert rust_version == python_version, (
+        f"rust/Cargo.toml workspace version {rust_version} does not match "
+        f"pyproject.toml version {python_version}; the daemon version check "
+        "compares these at runtime, so keep them in lockstep"
+    )


### PR DESCRIPTION
### Features
 - The data daemon exposes a new iceoryx2 request/response service (`neuracore/data_daemon/version`) that reports the neuracore version it was built with. The service copies the existing `health` service pattern, so old producers are unaffected.
 - `ensure_daemon_running()` now checks the running daemon's version against the installed package before the daemon is used, with the same time budget as the health probe. On mismatch it raises `DaemonVersionMismatchError` with steps tailored to the situation: an adopted stale daemon gets stop and restart guidance, a just-launched stale daemon is stopped again and gets rebuild guidance, and an install without a binary is told to reinstall first. A daemon that answers the health probe but stays silent on the version query for the whole budget is reported as too old to report a version.
 - Failure causes other than a real mismatch do not blame the daemon: missing package metadata (bare source tree) and transport failures skip the check with a warning, and a native extension that predates the version query raises an error naming the extension, with reinstall and rebuild commands that work (`pip install --force-reinstall`).
 - The rust workspace version is now synced to the python package version (13.7.2). All three crates inherit it, the daemon reports plain `CARGO_PKG_VERSION`, and `bump2version` now rewrites `rust/Cargo.toml` and `rust/Cargo.lock` together with `pyproject.toml` on every release. A new unit test pins the two versions together so a drift fails CI instead of the release job.

### Items
 - [NCP-1213](https://neuracore.atlassian.net/browse/NCP-1213)

> Note:
> An emergency deploy from a branch cut before this change will fail the version bump (`rust/Cargo.toml` still at 0.1.0 there); the fix is to cherry-pick the Cargo version sync onto the branch.
