### PR TITLE
fix: explicit boundary and flush marker mitigates against orphaned video chunks

### DIFF
--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -48,15 +48,18 @@ use crate::state::{DaemonEvent, NewRecording, SqliteStateStore, StateStore};
 use crate::storage::paths;
 
 /// Default holdback: each data envelope waits this long after daemon receipt
-/// before it is routed. Tunable via `NCD_HOLDBACK_MS`. A generous default is
-/// safe — joint/scalar data is sparse, so even a 1 s holdback retains only a
-/// few thousand small envelopes per source. Completeness (catching a datum
-/// whose publisher was preempted between capture and publish) scales directly
-/// with this value.
+/// before it is routed. Tunable via `NCD_HOLDBACK_MS`.
+///
+/// Lifecycle is applied on arrival while data is held, so a `StartRecording`
+/// racing its own data still opens the window first.
 const DEFAULT_HOLDBACK_MS: u64 = 500;
 
 /// Environment override for the holdback, in milliseconds.
 const HOLDBACK_ENV: &str = "NCD_HOLDBACK_MS";
+
+/// Hard bound on how long a stopped window waits for its producer's
+/// [`Envelope::SourceFlushed`] marker before being evicted anyway.
+const FLUSH_MARKER_WAIT_CAP: Duration = Duration::from_secs(30);
 
 /// A source silent (no data, no lifecycle) for this long has its open window
 /// force-closed as a crash backstop, so a producer that died without a Stop
@@ -180,6 +183,12 @@ struct ActiveWindow {
     stopped_at_ns: Option<i64>,
     /// Daemon clock at which the window closed — drives the eviction deadline.
     stop_recv_at: Option<Instant>,
+    /// Closed by a `StopRecording`, so its producer still owes a
+    /// [`Envelope::SourceFlushed`] marker.
+    awaiting_flush: bool,
+    /// Set when that marker has been released from the holdback queue, i.e.
+    /// every tail chunk it was ordered behind has already routed.
+    flushed: bool,
     /// Per-trace actors spawned within this window.
     traces: HashMap<TraceKey, TraceHandle>,
 }
@@ -188,6 +197,17 @@ impl ActiveWindow {
     /// Does this window's `[started_at_ns, stopped_at_ns)` contain `ts`?
     fn contains(&self, ts: i64) -> bool {
         ts >= self.started_at_ns && self.stopped_at_ns.is_none_or(|stop| ts < stop)
+    }
+
+    /// Time elapsed since stop once this window may be evicted: retention has
+    /// passed *and* either every owed flush marker is in or
+    /// [`FLUSH_MARKER_WAIT_CAP`] has expired. `None` while it must be kept.
+    fn eviction_elapsed(&self, now: Instant, retention: Duration) -> Option<Duration> {
+        let since_stop = self.stop_recv_at.map(|at| now.duration_since(at))?;
+        let retained = since_stop >= retention;
+        let flush_settled =
+            !self.awaiting_flush || self.flushed || since_stop >= FLUSH_MARKER_WAIT_CAP;
+        (retained && flush_settled).then_some(since_stop)
     }
 }
 
@@ -200,6 +220,17 @@ struct WindowsForSource {
     /// Daemon clock of the last envelope seen for this source — drives the
     /// idle reaper.
     last_seen: Option<Instant>,
+}
+
+impl WindowsForSource {
+    /// Nothing live, nothing retained, quiet past `IDLE_REAP`: droppable.
+    fn is_empty(&self, now: Instant) -> bool {
+        self.live.is_none()
+            && self.closing.is_empty()
+            && self
+                .last_seen
+                .is_none_or(|at| now.duration_since(at) >= IDLE_REAP)
+    }
 }
 
 /// One held data envelope awaiting its holdback release.
@@ -238,6 +269,8 @@ enum HeldPayload {
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
     },
+    /// End-of-tail marker for a source's stopped window.
+    SourceFlushed,
 }
 
 /// The dispatcher's task-local state.
@@ -455,6 +488,20 @@ impl Dispatcher {
                     },
                 });
             }
+            Envelope::SourceFlushed {
+                robot_id,
+                robot_instance,
+                publish_timestamp_ns,
+            } => {
+                let source = (robot_id, robot_instance);
+                self.touch_source(&source, recv_at);
+                self.held.push_back(Held {
+                    source,
+                    release_at: recv_at + self.holdback,
+                    publish_timestamp_ns,
+                    payload: HeldPayload::SourceFlushed,
+                });
+            }
             Envelope::RefreshConfig {} => self.handle_refresh_config().await,
         }
     }
@@ -484,10 +531,7 @@ impl Dispatcher {
     }
 
     fn touch_source(&mut self, source: &Source, recv_at: Instant) {
-        // Hot path: every inbound `Data` / `BatchedData` / `VideoChunkReady`
-        // envelope touches its source. The common case is an existing window, so
-        // probe with `get_mut` (no allocation) and only clone the `(String, i64)`
-        // key on the rare first-insert.
+        // Hot path: probe with `get_mut` and only clone the key on insert.
         if let Some(window) = self.windows.get_mut(source) {
             window.last_seen = Some(recv_at);
         } else {
@@ -566,6 +610,8 @@ impl Dispatcher {
             started_at_ns: publish_timestamp_ns,
             stopped_at_ns: None,
             stop_recv_at: None,
+            awaiting_flush: false,
+            flushed: false,
             traces: HashMap::new(),
         });
 
@@ -624,6 +670,7 @@ impl Dispatcher {
             // time.
             window.stopped_at_ns = Some(publish_timestamp_ns);
             window.stop_recv_at = Some(recv_at);
+            window.awaiting_flush = true;
             let recording_index = window.recording_index;
             entry.closing.push(window);
             // Persist `stopped_at` before publishing the event: the cloud
@@ -657,8 +704,11 @@ impl Dispatcher {
             // keeping the boundary at the successor start mis-routes nothing.
             //
             // Refresh the closing-retention deadline so the extra late tail data
-            // this delayed stop implies still has a window to land in.
+            // this delayed stop implies still has a window to land in, and wait
+            // on this stop's flush marker for the same reason.
             window.stop_recv_at = Some(recv_at);
+            window.awaiting_flush = true;
+            window.flushed = false;
             tracing::warn!(
                 robot_id = source.0,
                 recording_index,
@@ -778,51 +828,9 @@ impl Dispatcher {
     /// window scans, so throttled to [`HOUSEKEEP_INTERVAL`] by the caller rather
     /// than run per inbound envelope.
     async fn housekeep(&mut self, now: Instant) {
-        // 2. Window evictions: a closing window is retained for 2·HOLDBACK
-        //    after its stop, by which point all in-window data has released.
         let retention = self.holdback * 2;
-        let mut closing_actors: Vec<TraceHandle> = Vec::new();
-        let mut empty_sources: Vec<Source> = Vec::new();
-        for (source, entry) in self.windows.iter_mut() {
-            entry.closing.retain_mut(|window| {
-                let evict = window
-                    .stop_recv_at
-                    .is_some_and(|at| now.duration_since(at) >= retention);
-                if evict {
-                    let elapsed = window
-                        .stop_recv_at
-                        .map(|at| now.duration_since(at))
-                        .unwrap_or_default();
-                    crate::perf_events::emit(
-                        "holdback",
-                        "completed",
-                        Some(window.recording_index),
-                        None,
-                        Some(elapsed),
-                        serde_json::json!({
-                            "trace_actor_count": window.traces.len(),
-                            "configured_retention_ms": retention.as_secs_f64() * 1_000.0,
-                        }),
-                    );
-                    for (_, handle) in window.traces.drain() {
-                        closing_actors.push(handle);
-                    }
-                    false
-                } else {
-                    true
-                }
-            });
-            if entry.live.is_none()
-                && entry.closing.is_empty()
-                && entry
-                    .last_seen
-                    .is_none_or(|at| now.duration_since(at) >= IDLE_REAP)
-            {
-                empty_sources.push(source.clone());
-            }
-        }
-        // Send WindowClosing to every actor of an evicted window. Their senders
-        // drop after, so each actor finalises and exits.
+        let (closing_actors, empty_sources) = self.evict_closing_windows(now, retention);
+
         for handle in closing_actors {
             let _ = handle.sender.send(TraceActorMessage::WindowClosing).await;
         }
@@ -830,9 +838,71 @@ impl Dispatcher {
             self.windows.remove(&source);
         }
 
-        // 3. Idle reaper: force-close a live window whose source has gone
-        //    silent (producer crashed without a Stop).
+        // Idle reaper: force-close a live window whose source has gone
+        // silent (producer crashed without a Stop).
         self.reap_idle(now).await;
+    }
+
+    /// Evict every closing window past retention and collect the sources left
+    /// with nothing to track. Returns the evicted windows' trace actors, still
+    /// owed a `WindowClosing`, and the now-empty source keys.
+    fn evict_closing_windows(
+        &mut self,
+        now: Instant,
+        retention: Duration,
+    ) -> (Vec<TraceHandle>, Vec<Source>) {
+        let mut closing_actors: Vec<TraceHandle> = Vec::new();
+        let mut empty_sources: Vec<Source> = Vec::new();
+        for (source, entry) in self.windows.iter_mut() {
+            entry.closing.retain_mut(|window| {
+                let Some(elapsed) = window.eviction_elapsed(now, retention) else {
+                    return true;
+                };
+                Self::finish_eviction(source, window, elapsed, retention, &mut closing_actors);
+                false
+            });
+            if entry.is_empty(now) {
+                empty_sources.push(source.clone());
+            }
+        }
+        (closing_actors, empty_sources)
+    }
+
+    /// Emit one evicted window's completion event and drain its trace actors
+    /// into `closing_actors`.
+    fn finish_eviction(
+        source: &Source,
+        window: &mut ActiveWindow,
+        elapsed: Duration,
+        retention: Duration,
+        closing_actors: &mut Vec<TraceHandle>,
+    ) {
+        if window.awaiting_flush && !window.flushed {
+            tracing::warn!(
+                recording_index = window.recording_index,
+                robot_id = source.0,
+                elapsed_s = elapsed.as_secs_f64(),
+                "no producer flush marker before the cap; retiring the \
+                 window anyway — any tail video chunk still in flight \
+                 will be dropped as an orphan"
+            );
+        }
+        crate::perf_events::emit(
+            "holdback",
+            "completed",
+            Some(window.recording_index),
+            None,
+            Some(elapsed),
+            serde_json::json!({
+                "trace_actor_count": window.traces.len(),
+                "configured_retention_ms": retention.as_secs_f64() * 1_000.0,
+                "awaited_flush_marker": window.awaiting_flush,
+                "flush_marker_seen": window.flushed,
+            }),
+        );
+        for (_, handle) in window.traces.drain() {
+            closing_actors.push(handle);
+        }
     }
 
     /// Force-close any live window whose source has been silent past
@@ -954,7 +1024,28 @@ impl Dispatcher {
                 )
                 .await;
             }
+            HeldPayload::SourceFlushed => self.mark_source_flushed(&held.source),
         }
+    }
+
+    /// Record that a source's flush barrier has drained, releasing the oldest
+    /// closing window still waiting on one for eviction.
+    fn mark_source_flushed(&mut self, source: &Source) {
+        let Some(entry) = self.windows.get_mut(source) else {
+            return;
+        };
+        let Some(window) = entry
+            .closing
+            .iter_mut()
+            .find(|window| window.awaiting_flush && !window.flushed)
+        else {
+            return;
+        };
+        window.flushed = true;
+        tracing::debug!(
+            recording_index = window.recording_index,
+            "producer flush barrier drained; window may retire"
+        );
     }
 
     /// Find the window for `source` containing `ts`. Closing windows are
@@ -1245,6 +1336,14 @@ mod tests {
             robot_instance: 0,
             publish_timestamp_ns,
             timestamp_ns: publish_timestamp_ns,
+        }
+    }
+
+    fn source_flushed(robot: &str, publish_timestamp_ns: i64) -> Envelope {
+        Envelope::SourceFlushed {
+            robot_id: robot.into(),
+            robot_instance: 0,
+            publish_timestamp_ns,
         }
     }
 
@@ -1886,6 +1985,9 @@ mod tests {
         // A closing window is retained for 2·holdback (so its in-window data has
         // released) and then evicted; without this the window map — and the
         // actor handles it holds — leak for the daemon's lifetime.
+        //
+        // Retention is the floor, not the whole gate: the flush marker is
+        // settled first so the deadline itself is what is tested.
         fast_holdback();
         let (store, dir) = open_store().await;
         let context = test_context(dir.path().join("recordings"), store.clone());
@@ -1905,6 +2007,12 @@ mod tests {
             1,
             "the stopped window is retained as closing"
         );
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 900), stopped_at)
+            .await;
+        dispatcher
+            .release_due_holdback(stopped_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
 
         // Just past the 2·holdback retention window.
         let retention = dispatcher.holdback * 2;
@@ -1916,5 +2024,127 @@ mod tests {
             .get(&source)
             .map_or(0, |entry| entry.closing.len());
         assert_eq!(closing, 0, "a closing window past 2·holdback is evicted");
+    }
+
+    #[tokio::test]
+    async fn housekeep_holds_a_stopped_window_until_the_flush_marker() {
+        // The stop is published before the writer's flush barrier, so the tail
+        // chunks it seals arrive after their own stop by an unbounded backlog.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        let stopped_at = opened_at + Duration::from_millis(1);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        // Well past the retention deadline.
+        let past_retention = stopped_at + dispatcher.holdback * 2 + Duration::from_millis(1);
+        dispatcher.housekeep(past_retention).await;
+        assert_eq!(
+            dispatcher.windows.get(&source).unwrap().closing.len(),
+            1,
+            "a stopped window still owed a flush marker outlives the retention deadline"
+        );
+
+        // The barrier drains and announces its marker.
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 900), past_retention)
+            .await;
+        let released_at = past_retention + dispatcher.holdback + Duration::from_millis(1);
+        dispatcher.release_due_holdback(released_at).await;
+        dispatcher.housekeep(released_at).await;
+
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "the window retires once the marker has released"
+        );
+    }
+
+    #[tokio::test]
+    async fn housekeep_evicts_a_stopped_window_when_the_flush_marker_never_comes() {
+        // The marker is best-effort: a producer that never sends one must not
+        // pin the window open forever.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        let stopped_at = opened_at + Duration::from_millis(1);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        let at_cap = stopped_at + FLUSH_MARKER_WAIT_CAP + Duration::from_millis(1);
+        dispatcher.housekeep(at_cap).await;
+
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "a marker that never arrives is capped, not waited on forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn tail_video_chunk_announced_past_the_retention_deadline_still_routes() {
+        // A burst producer is still draining when `stop_recording` returns, so
+        // its in-window tail chunk is announced past the retention deadline;
+        // without the marker gating eviction it is orphan-dropped.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let (tx, handle) = spawn(store.clone(), context.clone(), shutdown_rx);
+
+        let (publish_ts, thread_id) = (150, 7); // opened inside window [100, 200)
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+
+        tx.send(start("robot-1", 100)).await.unwrap();
+        tx.send(stop("robot-1", 200)).await.unwrap();
+
+        // Stand in for a slow flush barrier, well past the retention.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        tx.send(video_chunk("robot-1", publish_ts, thread_id))
+            .await
+            .unwrap();
+        tx.send(source_flushed("robot-1", 500)).await.unwrap();
+
+        drop(tx);
+        timeout(Duration::from_secs(10), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 1);
+        let traces = store
+            .list_traces_for_recording(recordings[0].recording_index)
+            .await
+            .unwrap();
+        assert!(
+            traces
+                .iter()
+                .any(|trace| trace.data_type.as_deref() == Some("RGB_IMAGES")),
+            "a tail chunk announced after the retention deadline must still route"
+        );
     }
 }

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -947,7 +947,7 @@ impl ActorState {
     }
 
     async fn finalise_writer(
-        &self,
+        &mut self,
         writer: TraceWriterKind,
         context: &Arc<TraceActorContext>,
     ) -> Result<u64, FrameAppendError> {
@@ -1003,6 +1003,13 @@ impl ActorState {
                     let completed = result.outcome?;
                     completed_chunks.insert(result.chunk_index, completed);
                 }
+                // Restate the frame count from the finished chunk set rather
+                // than trusting the running total. That total is only bumped by
+                // `drain_completed_encodes.
+                self.frame_count = completed_chunks
+                    .values()
+                    .map(|chunk| chunk.frame_count as u64)
+                    .sum();
                 crate::perf_events::emit(
                     "video_encoding",
                     "completed",
@@ -1499,6 +1506,11 @@ mod tests {
             .expect("trace exists");
         assert_eq!(trace.write_status, TraceWriteStatus::Written);
         assert!(trace.total_bytes > 0);
+        assert_eq!(
+            state.frame_count, 8,
+            "finalised frame count must cover every chunk, not just those \
+             drained before close"
+        );
 
         // RGB metadata entries must stay exactly as before: no `dtype` field.
         let sidecar: Value = serde_json::from_slice(

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -95,7 +95,7 @@ fn start_recording(
         // (publish clock when omitted). Decoupled from the window boundary.
         let capture_timestamp_ns = timestamp_ns.unwrap_or(publish_timestamp_ns);
         publish(&Envelope::StartRecording {
-            robot_id,
+            robot_id: robot_id.clone(),
             robot_instance,
             robot_name,
             dataset_id,
@@ -103,6 +103,12 @@ fn start_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // Tell the writer where the window opened, so no chunk spans it.
+        let _ = writer_queue().push(WriterMsg::Boundary {
+            robot_id,
+            robot_instance,
+            publish_ns: publish_timestamp_ns,
+        });
         Ok(capture_timestamp_ns)
     })
 }
@@ -229,6 +235,9 @@ fn log_frame(
         width,
         height,
         dtype: frame_dtype,
+        // Stamped on the caller's thread while the owning recording is open,
+        // not on the writer thread, which may reach the frame after the stop.
+        publish_ns: now_ns(),
         timestamp_ns,
         timestamp_s: resolved_timestamp_s,
         data,
@@ -300,23 +309,23 @@ fn log_json(
 /// Drain the data publisher, publish one `StopRecording`, then flush any tail
 /// video chunks for the source before returning.
 ///
-/// Three barriers, in order: the data publisher's queue is drained first (so
+/// Three barriers, in order: the data publisher's queue is drained first, so
 /// the recording's joint/JSON tail is on the wire before the window's upper
-/// bound is stamped), then the stop is published, then the writer is flushed
-/// and its chunk announcements drained. Together these make the call's
-/// post-condition uniform across every data path — once `stop_recording`
-/// returns, nothing belonging to the recording is still sitting in an
-/// in-process queue that a subsequent process exit would discard.
+/// bound is stamped, then the stop is published, then the writer seals and
+/// announces the tail chunks. Once this returns, nothing belonging to the
+/// recording is still sitting in an in-process queue that a process exit would
+/// discard.
 ///
-/// The stop is published BEFORE the writer flush barrier:
-/// it shares the calling thread's publisher with `StartRecording`, so sending
-/// it first guarantees the daemon sees this stop ahead of the next recording's
-/// start. Stamping the boundary early but sending only after a slow flush
-/// (~19 ms observed) let the stop reach the wire after the following start —
-/// the daemon then retired the wrong window and dropped both recordings' data.
-/// Late tail chunks (announced on the writer's port after this stop) route
-/// into the just-closed window by the daemon's holdback + closing-window
-/// retention, so chunk-before-stop ordering is not required.
+/// The stop is published BEFORE the writer flush barrier because it shares the
+/// calling thread's publisher with `StartRecording`, so sending it first is
+/// what guarantees the daemon sees this stop ahead of the next recording's
+/// start. Stamping the boundary early but sending after the flush let the stop
+/// reach the wire behind the following start, and the daemon then retired the
+/// wrong window and dropped both recordings' data.
+/// Late tail chunks (announced on the writer's port after this stop, by the
+/// flush barrier below) route into the just-closed window by the daemon's
+/// holdback + the `SourceFlushed` marker, so chunk-before-stop ordering is not
+/// required.
 ///
 /// The producer stamps the window's upper bound on the publish clock here
 /// (`publish_timestamp_ns`, always wall-clock now at the send), so the whole
@@ -367,13 +376,13 @@ fn stop_recording(
             timestamp_ns: capture_timestamp_ns,
         })?;
         // Then barrier on the writer: it drains every frame still queued for
-        // this source (FIFO), seals the tail chunks and announces them, then
-        // acks. Blocking here means `stop_recording` still returns only once
-        // those chunks are durably spooled + announced, so a process exit right
-        // after the call can't lose them. The tail chunks ride the writer's
-        // port and land after this stop; the daemon's holdback + closing-window
-        // retention route them into the just-closed window by their in-window
-        // open timestamp.
+        // this source (FIFO), seals the tail chunks and announces them,
+        // publishes the `SourceFlushed` marker, then acks. Blocking here means
+        // `stop_recording` still returns only once those chunks are durably
+        // spooled + announced, so a process exit right after the call can't
+        // lose them. The tail chunks ride the writer's port and land after this
+        // stop; the daemon's holdback + that marker route them into the
+        // just-closed window by their in-window open timestamp.
         let (ack_tx, ack_rx) = std::sync::mpsc::channel();
         // Control messages bypass the frame caps, so this never blocks or stalls.
         let _ = writer_queue().push(WriterMsg::FlushSource {

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -27,9 +27,14 @@
 //! publishing `CancelRecording`, so no tail chunk is ever announced after the
 //! daemon tears the window down. Chunk-before-stop ordering is not a same-port
 //! guarantee here but is safe anyway: the daemon holds every `VideoChunkReady`
-//! back (`NCD_HOLDBACK_MS`, default 500 ms) and retains a just-closed window,
-//! so a tail chunk announced just after the stop still routes into the
-//! (closing) window by its in-window open timestamp.
+//! back (`NCD_HOLDBACK_MS`, default 500 ms), so a tail chunk announced just
+//! after the stop still routes into the (closing) window by its in-window open
+//! timestamp — but how long the daemon must then keep that closing window
+//! around is not something it can work out: the barrier lasts as long as this
+//! writer's backlog, which under burst logging runs well past any fixed
+//! retention. So it says so outright — after the last tail chunk it announces
+//! an [`Envelope::SourceFlushed`] marker on the same publisher port, and the
+//! daemon retires the window on that rather than on a timer.
 //!
 //! ## Fork safety
 //!
@@ -177,6 +182,12 @@ struct VideoChunkState {
     /// path. Re-stamped on every chunk open, so each chunk is named uniquely
     /// and no two recordings collide on a filename. `0` between chunks.
     chunk_publish_ns: i64,
+    /// Previous chunk's `chunk_publish_ns`, so the next open can be forced
+    /// strictly above it. `0` before the first chunk.
+    last_chunk_publish_ns: i64,
+    /// A recording-window boundary this stream has yet to cross: the first
+    /// frame to reach it seals the open chunk, so none spans the boundary.
+    pending_split_ns: Option<i64>,
     /// OS thread id (`gettid`) of the thread that opened the in-progress chunk.
     chunk_thread_id: i64,
     /// Frames already written into the in-progress chunk.
@@ -212,30 +223,39 @@ type VideoChunkSlot = Arc<Mutex<VideoChunkState>>;
 struct VideoChunkRegistry {
     owner_pid: u32,
     streams: HashMap<String, VideoChunkSlot>,
+    /// Latest recording-window boundary seen per source prefix.
+    boundaries: HashMap<String, i64>,
 }
 
 static VIDEO_CHUNKS: LazyLock<Mutex<VideoChunkRegistry>> = LazyLock::new(|| {
     Mutex::new(VideoChunkRegistry {
         owner_pid: 0,
         streams: HashMap::new(),
+        boundaries: HashMap::new(),
     })
 });
 
-/// Lock the video chunk registry and run `operation` against its streams map.
+/// Lock the video chunk registry and run `operation` against it.
 ///
 /// Heals on fork: when the stored `owner_pid` no longer matches the current
-/// process the map was inherited from a pre-fork parent, so it is cleared
+/// process the state was inherited from a pre-fork parent, so it is cleared
 /// before use.
-fn with_video_chunks<R>(operation: impl FnOnce(&mut HashMap<String, VideoChunkSlot>) -> R) -> R {
+fn with_video_registry<R>(operation: impl FnOnce(&mut VideoChunkRegistry) -> R) -> R {
     let mut registry = VIDEO_CHUNKS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let pid = std::process::id();
     if registry.owner_pid != pid {
         registry.streams.clear();
+        registry.boundaries.clear();
         registry.owner_pid = pid;
     }
-    operation(&mut registry.streams)
+    operation(&mut registry)
+}
+
+/// Lock the video chunk registry and run `operation` against its streams map.
+fn with_video_chunks<R>(operation: impl FnOnce(&mut HashMap<String, VideoChunkSlot>) -> R) -> R {
+    with_video_registry(|registry| operation(&mut registry.streams))
 }
 
 /// One frame handed to the background writer. Owns its raw sample bytes
@@ -252,6 +272,8 @@ pub(crate) struct FrameJob {
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) dtype: FrameDtype,
+    /// Stamped on the *calling* thread when `log_frame` accepted the frame.
+    pub(crate) publish_ns: i64,
     pub(crate) timestamp_ns: i64,
     pub(crate) timestamp_s: f64,
     pub(crate) data: Vec<u8>,
@@ -277,6 +299,12 @@ pub(crate) enum WriterMsg {
         robot_id: String,
         robot_instance: i64,
         ack: Sender<()>,
+    },
+    /// A window opened at `publish_ns`; no chunk may straddle it.
+    Boundary {
+        robot_id: String,
+        robot_instance: i64,
+        publish_ns: i64,
     },
 }
 
@@ -800,6 +828,7 @@ fn write_pending_frame(pending: PendingFrame, png: Vec<u8>) {
         pending.job.height,
         pending.job.dtype,
         &png,
+        pending.job.publish_ns,
         pending.job.timestamp_ns,
         pending.job.timestamp_s,
     ) {
@@ -878,6 +907,7 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
                 if let Err(error) = flush_source_chunks(&robot_id, robot_instance) {
                     tracing::warn!(%error, "failed to flush tail video chunks on stop");
                 }
+                announce_source_flushed(&robot_id, robot_instance);
                 let _ = ack.send(());
             }
             Some(WriterMsg::DropSource {
@@ -897,6 +927,13 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
                 });
                 let _ = ack.send(());
             }
+            Some(WriterMsg::Boundary {
+                robot_id,
+                robot_instance,
+                publish_ns,
+            }) => {
+                arm_boundary_split(&robot_id, robot_instance, publish_ns);
+            }
             // pop_timeout elapsed with no message: fall through to the rescan.
             None => {}
         }
@@ -912,31 +949,10 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
     }
 }
 
-/// A chunk-open timestamp that is strictly increasing within this process.
-///
-/// The spool filename is `chunk_{publish_ns}_{thread_id}.nut`. All video chunks
-/// are now opened by the single background writer thread, so they share one
-/// `thread_id` and uniqueness rests entirely on `publish_ns`. `now_ns()` reads
-/// `CLOCK_REALTIME`, whose granularity can repeat across two opens issued back
-/// to back, which would collide two cameras' chunk files. Bumping past the last
-/// value returned keeps every chunk's name distinct while staying within the
-/// recording window (the window spans seconds; a few ns of skew is irrelevant
-/// to membership). Only the writer thread calls this, but the atomic keeps it
-/// correct regardless.
-fn next_chunk_open_ns() -> i64 {
-    use std::sync::atomic::{AtomicI64, Ordering};
-    static LAST: AtomicI64 = AtomicI64::new(0);
-    let mut candidate = now_ns();
-    loop {
-        let last = LAST.load(Ordering::Relaxed);
-        if candidate <= last {
-            candidate = last + 1;
-        }
-        match LAST.compare_exchange_weak(last, candidate, Ordering::Relaxed, Ordering::Relaxed) {
-            Ok(_) => return candidate,
-            Err(_) => candidate = now_ns(),
-        }
-    }
+/// The chunk-open timestamp for a chunk whose first frame published at
+/// `frame_publish_ns`, kept strictly increasing within its stream.
+fn next_chunk_open_ns(last_chunk_publish_ns: i64, frame_publish_ns: i64) -> i64 {
+    frame_publish_ns.max(last_chunk_publish_ns.saturating_add(1))
 }
 
 /// OS thread id of the calling thread. Used to disambiguate a video chunk's
@@ -996,6 +1012,7 @@ fn record_video_frame(
     height: u32,
     dtype: FrameDtype,
     png_payload: &[u8],
+    publish_ns: i64,
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Result<(), ProducerError> {
@@ -1007,11 +1024,16 @@ fn record_video_frame(
     // at high frame rates. The recordings root is pre-validated on the GIL in
     // `log_frame`, so `spool_dir` only returns `None` on a genuine
     // misconfiguration — drop the frame (never panic on the writer thread).
-    let slot: VideoChunkSlot = match with_video_chunks(|streams| {
-        if let Some(slot) = streams.get(&key) {
+    let slot: VideoChunkSlot = match with_video_registry(|registry| {
+        if let Some(slot) = registry.streams.get(&key) {
             return Some(slot.clone());
         }
         let spool = spool_dir(robot_id, robot_instance, data_type, sensor_name)?;
+        // This stream is new, but its first frames may predate the window.
+        let pending_split_ns = registry
+            .boundaries
+            .get(&source_prefix(robot_id, robot_instance))
+            .copied();
         let slot = Arc::new(Mutex::new(VideoChunkState {
             width,
             height,
@@ -1019,6 +1041,8 @@ fn record_video_frame(
             spool_dir: spool,
             nut_writer: None,
             chunk_publish_ns: 0,
+            last_chunk_publish_ns: 0,
+            pending_split_ns,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1028,7 +1052,7 @@ fn record_video_frame(
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }));
-        streams.insert(key.clone(), slot.clone());
+        registry.streams.insert(key.clone(), slot.clone());
         Some(slot)
     }) {
         Some(slot) => slot,
@@ -1057,6 +1081,7 @@ fn record_video_frame(
             height,
             dtype,
             png_payload,
+            publish_ns,
             timestamp_ns,
             timestamp_s,
         )
@@ -1091,10 +1116,30 @@ fn append_frame_locked(
     height: u32,
     dtype: FrameDtype,
     png_payload: &[u8],
+    publish_ns: i64,
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Vec<Envelope> {
     let mut announcements: Vec<Envelope> = Vec::new();
+
+    // A recording window opened partway through the frames queued ahead of this
+    // one. Seal here, so the chunk carrying the pre-window frames is announced
+    // on its own and this frame opens a fresh chunk stamped inside the window.
+    // Without the split one chunk spans the boundary, and since the daemon
+    // routes a chunk whole by its open stamp, the pre-window stamp orphans the
+    // entire chunk — silently discarding every in-window frame in it.
+    if let Some(split_ns) = state.pending_split_ns {
+        if publish_ns >= split_ns {
+            state.pending_split_ns = None;
+            if state.nut_writer.is_some() {
+                if let Some(envelope) =
+                    flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
+                {
+                    announcements.push(envelope);
+                }
+            }
+        }
+    }
 
     // A mid-stream resolution *or dtype* change can't share a chunk with the
     // prior state: the NUT header advertises the opening frame's size, and a
@@ -1187,11 +1232,14 @@ fn append_frame_locked(
     }
 
     if state.nut_writer.is_none() {
-        // Stamp the chunk's identity at open: its `publish_timestamp_ns`
-        // (this instant — inside the active recording window) plus the
-        // opening thread's id. These name the spool file and ride the
+        // The chunk's identity: publish stamp plus opening thread id, which
+        // name the spool file and ride the
         // announcement so the daemon can both route and locate the chunk.
-        state.chunk_publish_ns = next_chunk_open_ns();
+        //
+        // The stamp is the OPENING FRAME's publish time, taken back on the
+        // caller's thread (see `FrameJob::publish_ns`) — not this instant.
+        state.chunk_publish_ns = next_chunk_open_ns(state.last_chunk_publish_ns, publish_ns);
+        state.last_chunk_publish_ns = state.chunk_publish_ns;
         state.chunk_thread_id = current_thread_id();
         let chunk_path = state.spool_dir.join(spool_chunk_filename(
             state.chunk_publish_ns,
@@ -1297,6 +1345,25 @@ fn flush_chunk_locked(
     })
 }
 
+/// Arm a pending window-boundary split on every stream of a source.
+fn arm_boundary_split(robot_id: &str, robot_instance: i64, publish_ns: i64) {
+    let prefix = source_prefix(robot_id, robot_instance);
+    let slots: Vec<VideoChunkSlot> = with_video_registry(|registry| {
+        // Recorded per source, so a not-yet-created stream still picks it up.
+        registry.boundaries.insert(prefix.clone(), publish_ns);
+        registry
+            .streams
+            .iter()
+            .filter(|(key, _)| key.starts_with(&prefix))
+            .map(|(_, slot)| slot.clone())
+            .collect()
+    });
+    for slot in slots {
+        let mut state = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending_split_ns = Some(publish_ns);
+    }
+}
+
 /// Flush and remove every open video chunk for a source. Each flushed chunk is
 /// announced so the daemon can route it before the `StopRecording` lands.
 fn flush_source_chunks(robot_id: &str, robot_instance: i64) -> Result<(), ProducerError> {
@@ -1332,9 +1399,21 @@ fn flush_source_chunks(robot_id: &str, robot_instance: i64) -> Result<(), Produc
     Ok(())
 }
 
+/// Announce that the source's flush barrier is complete — no further tail
+/// chunks are coming for its just-stopped recording.
+fn announce_source_flushed(robot_id: &str, robot_instance: i64) {
+    let _ = publisher_tx().send(PublishMsg::Announce(Envelope::SourceFlushed {
+        robot_id: robot_id.to_string(),
+        robot_instance,
+        publish_timestamp_ns: now_ns(),
+    }));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_PUBLISH_NS: i64 = 1_700_000_000_000_000_000;
 
     #[test]
     fn flushes_when_byte_threshold_reached() {
@@ -1410,6 +1489,8 @@ mod tests {
             spool_dir,
             nut_writer: None,
             chunk_publish_ns: 0,
+            last_chunk_publish_ns: 0,
+            pending_split_ns: None,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1419,6 +1500,171 @@ mod tests {
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }
+    }
+
+    #[test]
+    fn chunk_is_stamped_from_its_opening_frame_not_the_writer_clock() {
+        // `publish_ns` is stamped on the caller's thread while the recording is
+        // open. Taking the writer's "now" instead would stamp the chunk outside
+        // the window and orphan every frame in it.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+
+        // The writer is far behind, so `now_ns()` is necessarily much larger.
+        let logged_at = now_ns() - 1_000_000_000;
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            logged_at,
+            1_000,
+            0.0,
+        );
+
+        assert_eq!(
+            state.chunk_publish_ns, logged_at,
+            "the chunk carries its opening frame's publish time verbatim"
+        );
+        match flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal") {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                ..
+            } => assert_eq!(
+                publish_timestamp_ns, logged_at,
+                "and announces it, so the daemon routes by when the frame was logged"
+            ),
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_window_boundary_splits_the_chunk_it_would_have_spanned() {
+        // Frames logged either side of `start_recording` can sit in the queue
+        // together, and a chunk spanning the boundary is orphaned whole.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+        let boundary = TEST_PUBLISH_NS;
+
+        // A frame logged before the window opened.
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            boundary - 1_000_000,
+            1_000,
+            0.0,
+        );
+        let pre_window_stamp = state.chunk_publish_ns;
+        state.pending_split_ns = Some(boundary);
+
+        // The first frame at/after the boundary must seal that chunk first.
+        let sealed = append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            boundary,
+            2_000,
+            0.001,
+        );
+
+        assert_eq!(
+            sealed.len(),
+            1,
+            "crossing the boundary seals the open chunk"
+        );
+        match &sealed[0] {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                frame_count,
+                ..
+            } => {
+                assert_eq!(
+                    *publish_timestamp_ns, pre_window_stamp,
+                    "the sealed chunk keeps its pre-window stamp, so the daemon \
+                     orphans only the frames that really are pre-window"
+                );
+                assert_eq!(*frame_count, 1);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+        assert_eq!(
+            state.chunk_publish_ns, boundary,
+            "and the replacement chunk opens inside the window"
+        );
+        assert!(
+            state.pending_split_ns.is_none(),
+            "a boundary is applied exactly once"
+        );
+    }
+
+    #[test]
+    fn consecutive_chunks_of_a_stream_never_share_an_open_stamp() {
+        // The spool filename carries the publish stamp and thread id, so two
+        // chunks sharing a stamp would collide under a coarse clock tick.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+        let repeated = TEST_PUBLISH_NS;
+
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            repeated,
+            1_000,
+            0.0,
+        );
+        let first = state.chunk_publish_ns;
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal");
+
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            repeated,
+            2_000,
+            0.001,
+        );
+        let second = state.chunk_publish_ns;
+
+        assert_eq!(first, repeated, "the first chunk takes the frame's stamp");
+        assert!(
+            second > first,
+            "a repeated publish stamp is bumped past the previous chunk's \
+             ({second} must exceed {first})"
+        );
     }
 
     #[test]
@@ -1441,6 +1687,7 @@ mod tests {
             2,
             FrameDtype::Rgb8,
             &frame_2x2,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1463,6 +1710,7 @@ mod tests {
             4,
             FrameDtype::Rgb8,
             &frame_4x4,
+            TEST_PUBLISH_NS,
             2_000,
             0.001,
         );
@@ -1517,6 +1765,7 @@ mod tests {
             2,
             FrameDtype::DepthF16,
             &png_payload,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1535,6 +1784,7 @@ mod tests {
             2,
             FrameDtype::DepthF32,
             &png_payload,
+            TEST_PUBLISH_NS,
             2_000,
             0.001,
         );
@@ -1581,6 +1831,7 @@ mod tests {
             2,
             FrameDtype::DepthF32,
             &frame,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1630,6 +1881,7 @@ mod tests {
                 2,
                 FrameDtype::Rgb8,
                 &frame,
+                TEST_PUBLISH_NS,
                 timestamp_ns,
                 timestamp_s,
             );
@@ -1703,6 +1955,7 @@ mod tests {
                 2,
                 FrameDtype::Rgb8,
                 &frame,
+                TEST_PUBLISH_NS,
                 timestamp_ns,
                 0.0,
             );
@@ -1728,6 +1981,7 @@ mod tests {
             width: 0,
             height: 0,
             dtype: FrameDtype::Rgb8,
+            publish_ns: TEST_PUBLISH_NS,
             timestamp_ns: 0,
             timestamp_s: 0.0,
             data: vec![0u8; bytes],
@@ -1861,6 +2115,7 @@ mod tests {
             4096,
             FrameDtype::Rgb8,
             &[0u8; 4],
+            TEST_PUBLISH_NS + timestamp_us * 1_000,
             timestamp_us * 1_000,
             timestamp_us as f64 / 1e6,
         )

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -412,8 +412,8 @@ pub enum Envelope {
         /// Number of frames packed into this chunk.
         frame_count: u32,
         /// Per-frame capture time in nanoseconds since the Unix epoch, in
-        /// arrival order. Length equals `frame_count`. Used to bucket the
-        /// chunk's frames against the source's active-window map.
+        /// arrival order. Length equals `frame_count`. Capture-clock content for
+        /// the trace sidecar; routing uses `frame_publish_offsets_ms`.
         frame_timestamps_ns: Vec<i64>,
         /// Per-frame `timestamp_s` (Unix seconds, f64) in arrival order.
         /// Length equals `frame_count`; values round-trip bit-exact through
@@ -433,6 +433,18 @@ pub enum Envelope {
     /// recording window; the dispatcher handles it by refreshing the in-memory
     /// config (see `cloud::config_watcher`).
     RefreshConfig {},
+    /// End-of-stream marker for a just-stopped window's late data.
+    ///
+    /// Published on the same port as the chunk announcements, so it is ordered
+    /// strictly behind every chunk it vouches for and the dispatcher can evict
+    /// the closing window with no timing assumption.
+    SourceFlushed {
+        robot_id: String,
+        robot_instance: i64,
+        /// Publish time at the marker's send. Diagnostic only: deliberately
+        /// not used for window membership.
+        publish_timestamp_ns: i64,
+    },
 }
 
 /// Original pixel/sample representation of one video-family frame.
@@ -518,6 +530,7 @@ impl Envelope {
             Envelope::BatchedData { .. } => "batched_data",
             Envelope::VideoChunkReady { .. } => "video_chunk_ready",
             Envelope::RefreshConfig {} => "refresh_config",
+            Envelope::SourceFlushed { .. } => "source_flushed",
         }
     }
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Setting explicit boundary informs the writer to open the new chunk at the start of the recording window 
 - Setting a flush marker instead of using inherent holdback duration to ensure chunks that are intended for the recording survive. Timeout still in play in case flush marker doesn't arrive.
