### PR TITLE
fix: keep the python log gate a superset of the recording window

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -268,9 +268,8 @@ class Robot:
 
         Args:
             dataset_id: Unique identifier of the dataset to record into.
-            timestamp: Optional capture time (Unix seconds) for the recording's
-                start, matching the ``log_*`` methods. It pins the window's
-                lower bound; the producer stamps wall-clock now when omitted.
+
+
 
         Returns:
             A local correlation handle. The daemon owns recording identity and
@@ -291,20 +290,30 @@ class Robot:
         # wall-clock now, which is at or after this value, so notifications stay
         # orderable against it.
         start_time = timestamp if timestamp is not None else time.time()
-        self._get_daemon_recording_context().start_recording(
-            robot_id=self.id,
-            robot_instance=self.instance,
-            robot_name=self.name,
-            dataset_id=dataset_id,
-            dataset_name=None,
-            timestamp=timestamp,
-        )
+        # Open the local gate BEFORE announcing the window: opening it second
+        # would have the SDK silently discard in-window data. The gate is a
+        # deliberate superset, leaving the daemon to reject the early samples.
         get_recording_state_manager().recording_started(
             robot_id=self.id,
             instance=self.instance,
             recording_id=local_handle,
             start_time=start_time,
         )
+        try:
+            self._get_daemon_recording_context().start_recording(
+                robot_id=self.id,
+                robot_instance=self.instance,
+                robot_name=self.name,
+                dataset_id=dataset_id,
+                dataset_name=None,
+                timestamp=timestamp,
+            )
+        except Exception:
+            # The gate is open with no window behind it.
+            get_recording_state_manager().recording_stopped(
+                robot_id=self.id, instance=self.instance, recording_id=local_handle
+            )
+            raise
         return local_handle
 
     def stop_recording(
@@ -321,8 +330,9 @@ class Robot:
             recording_id: Unused — the daemon stops the active recording for
                 this source. Retained for call-site compatibility.
             timestamp: Optional capture time (Unix seconds) for the recording's
-                stop, matching the ``log_*`` methods. It pins the window's upper
-                bound; the producer stamps wall-clock now when omitted.
+                stop, matching the ``log_*`` methods. It is the reported stop
+                time, not the window's upper bound, which the daemon takes from
+                the publish stamp at the send.
 
         Raises:
             RobotError: If the robot is not initialized.
@@ -330,12 +340,7 @@ class Robot:
         if not self.id:
             raise RobotError("Robot not initialized. Call init() first.")
 
-        active_handle = get_recording_state_manager().get_current_recording_id(
-            self.id, self.instance
-        )
-        get_recording_state_manager().recording_stopped(
-            robot_id=self.id, instance=self.instance, recording_id=active_handle
-        )
+        # The gate closes inside the drain, not here.
         self._drain_streams_and_notify_daemon(recording_id, timestamp=timestamp)
 
     def _drain_streams_and_notify_daemon(
@@ -343,15 +348,41 @@ class Robot:
         recording_id: str | None,
         timestamp: float | None = None,
     ) -> None:
-        """Stop all streams and send the recording-stopped IPC message to the daemon."""
+        """Stop all streams and send the recording-stopped IPC message to the daemon.
+
+        The local ``log_*`` gate closes in the instant between the window
+        closing and the writer's tail-chunk barrier. Closing
+        it before the notify would silently discard data the daemon would still
+        have accepted — the window is open until it receives the stop. Closing it
+        after the barrier instead leaves it open for as long as the writer's
+        backlog takes to drain (over a second under burst logging), publishing
+        data the daemon has already stopped accepting and simply throws away.
+        """
         try:
             self._stop_all_streams()
-            self._get_daemon_recording_context().stop_recording(timestamp=timestamp)
+            context = self._get_daemon_recording_context()
+            try:
+                context.stop_recording(timestamp=timestamp)
+            finally:
+                # Both run even if the notify failed.
+                self._close_local_recording_gate()
+                context.flush_source()
         except Exception:
             logger.exception(
                 "Failed to stop streams and notify daemon for recording_id=%s",
                 recording_id,
             )
+
+    def _close_local_recording_gate(self) -> None:
+        """Clear the local recording handle that gates ``log_*`` forwarding."""
+        if not self.id:
+            return
+        state = get_recording_state_manager()
+        state.recording_stopped(
+            robot_id=self.id,
+            instance=self.instance,
+            recording_id=state.get_current_recording_id(self.id, self.instance),
+        )
 
     def _register_remote_stop_handler(self) -> None:
         """Register a callback to drain streams when a remote stop arrives."""

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -65,18 +65,15 @@ class TrackedRecording(NamedTuple):
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
     """Tell the producer a source's recording has been locally auto-expired.
 
-    Calls the native ``stop_recording`` for the source so the producer flushes
-    any in-progress NUT chunk and publishes ``StopRecording``. The daemon is
-    idempotent, so a later explicit ``nc.stop_recording`` that races this is a
-    no-op. The stop boundary is wall-clock here (the expiry path has no access
-    to the recording context's tracked data-clock timestamp) — acceptable for a
-    forced 5-minute timeout. Failures are logged and swallowed: the local
-    expiry must always succeed.
+    Publishes the stop, then runs ``flush_source``, which is not part of the
+    stop and is the only thing that seals the in-progress chunk. A racing
+    explicit ``nc.stop_recording`` is a no-op, the boundary is wall-clock here,
+    and failures are swallowed: the local expiry must always succeed.
     """
     try:
-        _recording_context._load_native().stop_recording(
-            robot_id, instance, time.time_ns()
-        )
+        native = _recording_context._load_native()
+        native.stop_recording(robot_id, instance, time.time_ns())
+        native.flush_source(robot_id, instance)
     except Exception:
         logger.exception(
             "Failed to notify data bridge of recording expiry for %s:%s",

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -102,9 +102,10 @@ class RecordingContext:
         source ``(robot_id, robot_instance)``. No recording id is on the wire —
         the daemon allocates and owns recording identity.
 
-        ``timestamp`` optionally pins the recording window's lower bound (Unix
-        seconds), matching the ``log_*`` methods; when ``None`` the producer
-        stamps the publish clock now.
+        ``timestamp`` is the recording's *capture* start time (Unix seconds),
+        stored and reported as such, and returned as the marker that resolves the
+        cloud id (:meth:`get_recording_id`). It does **not** bound the recording
+        window, which the daemon takes from a publish stamp inside this call.
         """
         ensure_daemon_running()
         self.bind_source(robot_id, robot_instance)
@@ -240,9 +241,12 @@ class RecordingContext:
         """Publish one ``StopRecording`` tagged with the source.
 
         The daemon uses the publish-clock stop boundary to close the recording
-        window. ``timestamp`` optionally pins that boundary (Unix seconds),
-        matching the ``log_*`` methods; when ``None`` the producer stamps
-        wall-clock now.
+        window. ``timestamp`` is the recording's *capture* stop time and is
+        separate from that boundary, never used for window membership.
+
+        This publishes the stop only; :meth:`flush_source` seals the writer's
+        tail chunks and must be called straight after, so the caller can close
+        its own logging gate in between.
         """
         if not self._robot_id:
             return
@@ -250,6 +254,16 @@ class RecordingContext:
         _load_native().stop_recording(
             self._robot_id, self._robot_instance, timestamp_ns
         )
+
+    def flush_source(self) -> None:
+        """Run the writer's deferred tail-chunk barrier for the bound source.
+
+        Mandatory after :meth:`stop_recording` — tail chunks are sealed nowhere
+        else. No-op before a source is bound.
+        """
+        if not self._robot_id:
+            return
+        _load_native().flush_source(self._robot_id, self._robot_instance)
 
     def get_recording_id(
         self,

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -309,26 +309,19 @@ fn log_json(
     Ok(())
 }
 
-/// Drain the data publisher, publish one `StopRecording`, then flush any tail
-/// video chunks for the source before returning.
+/// Drain the data publisher, then publish one `StopRecording`.
 ///
-/// Three barriers, in order: the data publisher's queue is drained first, so
-/// the recording's joint/JSON tail is on the wire before the window's upper
-/// bound is stamped, then the stop is published, then the writer seals and
-/// announces the tail chunks. Once this returns, nothing belonging to the
-/// recording is still sitting in an in-process queue that a process exit would
-/// discard.
+/// Two barriers, in order: the data publisher's queue is drained first, so the
+/// recording's joint/JSON tail is on the wire before the window's upper bound
+/// is stamped, and only then is the stop published. The writer's tail video
+/// chunks are *not* sealed here — [`flush_source`] does that, and every caller
+/// must invoke it straight after this call.
 ///
-/// The stop is published BEFORE the writer flush barrier because it shares the
-/// calling thread's publisher with `StartRecording`, so sending it first is
-/// what guarantees the daemon sees this stop ahead of the next recording's
-/// start. Stamping the boundary early but sending after the flush let the stop
-/// reach the wire behind the following start, and the daemon then retired the
-/// wrong window and dropped both recordings' data.
-/// Late tail chunks (announced on the writer's port after this stop, by the
-/// flush barrier below) route into the just-closed window by the daemon's
-/// holdback + the `SourceFlushed` marker, so chunk-before-stop ordering is not
-/// required.
+/// The stop goes out BEFORE the writer flush barrier because it shares the
+/// calling thread's publisher with `StartRecording`: sending it first is what
+/// keeps the daemon from seeing this stop after the next recording's start.
+/// Late tail chunks still route into the just-closed window, via the daemon's
+/// holdback and the `SourceFlushed` marker.
 ///
 /// The producer stamps the window's upper bound on the publish clock here
 /// (`publish_timestamp_ns`, always wall-clock now at the send), so the whole
@@ -378,14 +371,27 @@ fn stop_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
-        // Then barrier on the writer: it drains every frame still queued for
-        // this source (FIFO), seals the tail chunks and announces them,
-        // publishes the `SourceFlushed` marker, then acks. Blocking here means
-        // `stop_recording` still returns only once those chunks are durably
-        // spooled + announced, so a process exit right after the call can't
-        // lose them. The tail chunks ride the writer's port and land after this
-        // stop; the daemon's holdback + that marker route them into the
-        // just-closed window by their in-window open timestamp.
+        // Split from [`flush_source`] so the caller can close its logging gate
+        // in between, rather than after a backlog-length barrier.
+        Ok(())
+    })
+}
+
+/// Run the writer's stop barrier for a source: drain every frame still queued
+/// for it (FIFO), seal and announce the tail chunks, publish the
+/// `SourceFlushed` marker, and drain the data publisher's queue onto the wire.
+///
+/// Mandatory after [`stop_recording`] — the tail chunks are sealed nowhere
+/// else. Blocking, so once it returns a process exit cannot lose them; the
+/// daemon's holdback and the `SourceFlushed` marker route them into the
+/// just-closed window. Idempotent.
+#[pyfunction]
+fn flush_source(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let robot_id = robot_id.to_string();
+    py.detach(|| {
         let (ack_tx, ack_rx) = std::sync::mpsc::channel();
         // Control messages bypass the frame caps, so this never blocks or stalls.
         let _ = writer_queue().push(WriterMsg::FlushSource {
@@ -398,8 +404,8 @@ fn stop_recording(
         // onto the data publisher's queue, so the ack above means spooled and
         // queued, not published. Drain once more to put them on the wire.
         flush_published_data();
-        Ok(())
-    })
+    });
+    Ok(())
 }
 
 /// Cancel a recording — drop the source's in-progress chunk state without
@@ -550,6 +556,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;
     module.add_function(wrap_pyfunction!(log_json, module)?)?;
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
+    module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -57,6 +57,7 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
 
     assert active.stop_calls == 1
     fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.flush_source.assert_called_once_with()
 
 
 def test_stop_all_streams_logs_stop_failure_and_continues() -> None:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Ensure early frames make the recording window cross process by setting a recording id prior to logging data. Daemon itself ensures genuine early frames are discarded.