### PR TITLE
fix: cut a video chunk at the recording boundary it straddles

### DIFF
--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -290,9 +290,6 @@ class Robot:
         # wall-clock now, which is at or after this value, so notifications stay
         # orderable against it.
         start_time = timestamp if timestamp is not None else time.time()
-        # Open the local gate BEFORE announcing the window: opening it second
-        # would have the SDK silently discard in-window data. The gate is a
-        # deliberate superset, leaving the daemon to reject the early samples.
         get_recording_state_manager().recording_started(
             robot_id=self.id,
             instance=self.instance,

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -168,6 +168,9 @@ pub struct ChunkEncodeRequest {
     /// Lossy codec selection for this trace. Controls whether a lossless
     /// archive is produced and how the lossy output is encoded.
     pub codec: LossyVideoCodec,
+    /// Frames to encode from the head of `raw_nut`: the whole file unless the
+    /// dispatcher cut the chunk, and always what the sidecar is built from.
+    pub frame_count: u32,
 }
 
 /// Outcome of a successful per-chunk transcode.
@@ -536,6 +539,9 @@ impl VideoEncoder {
         let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
         let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let lossy_only = request.codec.is_lossy_only();
+        // Per-output frame cap (see [`ChunkEncodeRequest::frame_count`]), a
+        // no-op unless the dispatcher cut this chunk at a recording boundary.
+        let frame_limit = (request.frame_count > 0).then(|| request.frame_count.to_string());
         let mut command = Command::new(&self.binary);
         command
             .arg("-y")
@@ -569,8 +575,11 @@ impl VideoEncoder {
                 .arg("-crf")
                 .arg("23")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
-                .arg(&request.lossy_out);
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command.arg(&request.lossy_out);
         } else {
             // Downscale the lossy preview proxy (only) to keep this dominant
             // pass cheap at high resolution; the lossless output stays native.
@@ -595,7 +604,11 @@ impl VideoEncoder {
                 .arg("-qp")
                 .arg("23")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command
                 .arg(&request.lossy_out)
                 .arg("-map")
                 .arg("0:v")
@@ -616,8 +629,11 @@ impl VideoEncoder {
                 .arg("-qp")
                 .arg("0")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
-                .arg(&request.lossless_out);
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command.arg(&request.lossless_out);
         }
         command
             .stdin(Stdio::null())
@@ -1106,6 +1122,7 @@ mod tests {
             lossy_out: lossy.clone(),
             lossless_out: lossless.clone(),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 8,
         };
         let outcome = encoder
             .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
@@ -1172,6 +1189,7 @@ mod tests {
                     lossy_out: lossy.clone(),
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 6,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1234,6 +1252,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn frame_count_encodes_only_the_frames_the_recording_owns() {
+        // The NUT cannot be rewritten, so the cut has to reach ffmpeg — on
+        // both outputs, or an mp4 outruns the sidecar indexing it.
+        let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping frame-cap encode test.");
+            return;
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let raw = tempdir.path().join("chunk_0000.nut");
+        let lossy = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless = tempdir.path().join("chunk_0000_lossless.mp4");
+        write_synthetic_nut(&ffmpeg, &raw, 8);
+
+        VideoEncoder::new()
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 3,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("transcode");
+
+        let frame_count = |path: &Path| -> u64 {
+            let out = StdCommand::new(&ffprobe)
+                .args([
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-count_frames",
+                    "-show_entries",
+                    "stream=nb_read_frames",
+                    "-of",
+                    "default=nokey=1:noprint_wrappers=1",
+                ])
+                .arg(path)
+                .output()
+                .expect("spawn ffprobe");
+            String::from_utf8_lossy(&out.stdout).trim().parse().unwrap()
+        };
+
+        assert_eq!(frame_count(&lossy), 3, "lossy output must stop at the cut");
+        assert_eq!(
+            frame_count(&lossless),
+            3,
+            "lossless output must stop at the same cut"
+        );
+    }
+
+    #[tokio::test]
     async fn encode_chunk_lossy_only_writes_single_full_res_h264() {
         let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
         else {
@@ -1258,6 +1333,7 @@ mod tests {
                     lossy_out: lossy.clone(),
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
+                    frame_count: 6,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1344,6 +1420,7 @@ mod tests {
                     lossy_out: split_lossy.clone(),
                     lossless_out: split_lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 8,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1357,6 +1434,7 @@ mod tests {
                     lossy_out: single_lossy.clone(),
                     lossless_out: tempdir.path().join("unused_lossless.mp4"),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
+                    frame_count: 8,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1459,6 +1537,7 @@ mod tests {
                             .path()
                             .join(format!("chunk_{chunk_index:04}_lossless.mp4")),
                         codec: LossyVideoCodec::LosslessPlusPreview,
+                        frame_count: frames_per_chunk as u32,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -1558,6 +1637,7 @@ mod tests {
                         lossy_out: lossy.clone(),
                         lossless_out: lossless,
                         codec: LossyVideoCodec::LosslessPlusPreview,
+                        frame_count: 4,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -1684,6 +1764,7 @@ mod tests {
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 1,
         };
         let encoder = VideoEncoder::new();
         let error = encoder
@@ -1706,6 +1787,7 @@ mod tests {
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 1,
         };
         let encoder =
             VideoEncoder::new().with_binary("this-binary-definitely-does-not-exist-ffmpeg");

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -25,6 +25,23 @@
 //! been released; finalisation is then a single `WindowClosing` signal to each
 //! actor (no sequence counting).
 //!
+//! A video chunk is the one envelope carrying more than one datum, and the same
+//! rule decides it *per frame*: the window keeps the frames published before its
+//! stop and cuts off the rest (see [`frames_inside_window`], and
+//! `data_daemon_shared::video_boundary` for where the boundary lands and what
+//! the producer does with the other edge).
+//!
+//! **Tail video chunks** escape the holdback: the producer seals them after it
+//! published the stop, so no retention constant bounds their lateness. A stopped
+//! window waits for that producer's `SourceFlushed` marker instead, capped by
+//! [`FLUSH_MARKER_WAIT_CAP`] — leaving retention load-bearing only for windows
+//! closed without a stop, which get no marker at all.
+//!
+//! A marker speaks only for its own process, so a window must know whose markers
+//! it is owed: the producer claims the source from its logging thread
+//! ([`Envelope::VideoProducerActive`]), since its first sealed chunk would be
+//! late by exactly the backlog this exists to tolerate.
+//!
 //! Everything here is owned by one tokio task, so the window map and holdback
 //! queue need no locks — total ordering through the `select!` loop is what
 //! makes the routing decisions provable.
@@ -34,7 +51,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use data_daemon_shared::{BatchedDataItem, Envelope, FrameDtype};
+use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -283,6 +300,8 @@ enum HeldPayload {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
+        /// Per-frame publish time as ms after the chunk's open stamp
+        frame_publish_offsets_ms: Vec<u32>,
     },
     SourceFlushed {
         producer_pid: u32,
@@ -487,6 +506,7 @@ impl Dispatcher {
                 frame_timestamps_ns,
                 frame_timestamps_s,
                 dtype,
+                frame_publish_offsets_ms,
             } => {
                 let source = (robot_id, robot_instance);
                 self.touch_source(&source, recv_at);
@@ -506,6 +526,7 @@ impl Dispatcher {
                         frame_count,
                         frame_timestamps_s,
                         dtype,
+                        frame_publish_offsets_ms,
                     },
                 });
             }
@@ -1053,6 +1074,7 @@ impl Dispatcher {
                 frame_count,
                 frame_timestamps_s,
                 dtype,
+                frame_publish_offsets_ms,
             } => {
                 self.route_video(
                     &held.source,
@@ -1067,6 +1089,7 @@ impl Dispatcher {
                     frame_count,
                     frame_timestamps_s,
                     dtype,
+                    frame_publish_offsets_ms,
                 )
                 .await;
             }
@@ -1192,6 +1215,7 @@ impl Dispatcher {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
+        frame_publish_offsets_ms: Vec<u32>,
     ) {
         let recordings_root = self.actor_context.recordings_root.clone();
         // The chunk's `publish_timestamp_ns` (its open time) keys both the
@@ -1206,10 +1230,7 @@ impl Dispatcher {
             thread_id,
         );
 
-        // The whole chunk routes by its open (publish) time, which lies inside
-        // exactly one recording window — so the tail chunk of a recording is
-        // routed by a timestamp strictly before the window's stop boundary,
-        // never on it.
+        // The open stamp picks the window; the per-frame cut is below.
         let Some(entry) = self.windows.get_mut(source) else {
             remove_spool_nut(&spool_nut);
             self.note_orphan();
@@ -1221,6 +1242,35 @@ impl Dispatcher {
             return;
         };
         window.video_producers.insert(producer_pid);
+
+        // Membership by open stamp, extent by per-frame publish times.
+        let kept_frames = window.stopped_at_ns.map_or(frame_count, |stop| {
+            frames_inside_window(&frame_publish_offsets_ms, publish_ts, stop, frame_count)
+        });
+        let dropped_frames = frame_count.saturating_sub(kept_frames);
+        if kept_frames == 0 {
+            tracing::warn!(
+                recording_index = window.recording_index,
+                frame_count,
+                "video chunk has no frame published inside the window it opened \
+                 in; dropping it"
+            );
+            remove_spool_nut(&spool_nut);
+            self.note_orphan();
+            return;
+        }
+        let mut frame_timestamps_s = frame_timestamps_s;
+        if dropped_frames > 0 {
+            frame_timestamps_s.truncate(kept_frames as usize);
+            tracing::debug!(
+                recording_index = window.recording_index,
+                kept_frames,
+                dropped_frames,
+                "video chunk straddles the window's stop; keeping the frames \
+                 published before it"
+            );
+        }
+        let frame_count = kept_frames;
 
         let recording_index = window.recording_index;
         let handle = Self::ensure_actor(
@@ -1335,6 +1385,21 @@ impl Dispatcher {
         self.actor_context.trace_writer.flush().await;
         tracing::info!("dispatcher stopped");
     }
+}
+
+/// How many of a chunk's leading frames this window keeps, given the window's
+/// `stop_ns` and the chunk's `frame_publish_offsets_ms`.
+fn frames_inside_window(
+    offsets_ms: &[u32],
+    chunk_open_ns: i64,
+    stop_ns: i64,
+    frame_count: u32,
+) -> u32 {
+    if offsets_ms.is_empty() {
+        return frame_count;
+    }
+    let cut = video_boundary::frames_before_boundary(offsets_ms, chunk_open_ns, stop_ns);
+    u32::try_from(cut).unwrap_or(u32::MAX).min(frame_count)
 }
 
 fn remove_spool_nut(path: &std::path::Path) {
@@ -1731,9 +1796,54 @@ mod tests {
         );
     }
 
-    /// Announce a finished video chunk whose open time is `publish_ts`. The
-    /// caller must have spooled the matching NUT under the spool dir first.
+    #[test]
+    fn frames_inside_window_cuts_at_the_stop_boundary() {
+        // `video_boundary` tests the cut; this pins the argument order.
+        let open_ns = 1_000_000_000;
+        let stop_ns = open_ns + 25 * 1_000_000;
+        let offsets = [0, 10, 20, 30, 40];
+        assert_eq!(frames_inside_window(&offsets, open_ns, stop_ns, 5), 3);
+    }
+
+    #[test]
+    fn frames_inside_window_without_per_frame_data_takes_the_chunk_whole() {
+        // No offsets, no cut to make: the chunk routes whole.
+        assert_eq!(
+            frames_inside_window(&[], 1_000_000_000, 1_000_000_000, 7),
+            7
+        );
+    }
+
+    #[test]
+    fn frames_inside_window_clamps_to_the_announced_frame_count() {
+        // The pipeline sizes itself from `frame_count`, so the cut cannot
+        // exceed it.
+        let open_ns = 1_000_000_000;
+        let offsets = [0, 10, 20, 30];
+        assert_eq!(
+            frames_inside_window(&offsets, open_ns, open_ns + 60 * 1_000_000, 2),
+            2
+        );
+    }
+
+    /// Announce a finished single-frame chunk opened at `publish_ts`. The
+    /// caller must have spooled the matching NUT first.
     fn video_chunk(robot: &str, publish_ts: i64, thread_id: i64, producer_pid: u32) -> Envelope {
+        video_chunk_frames(robot, publish_ts, thread_id, producer_pid, &[0])
+    }
+
+    /// As [`video_chunk`], with one frame per entry in `publish_offsets_ms`.
+    fn video_chunk_frames(
+        robot: &str,
+        publish_ts: i64,
+        thread_id: i64,
+        producer_pid: u32,
+        publish_offsets_ms: &[u32],
+    ) -> Envelope {
+        let capture_stamps: Vec<i64> = publish_offsets_ms
+            .iter()
+            .map(|offset| publish_ts + i64::from(*offset) * 1_000_000)
+            .collect();
         Envelope::VideoChunkReady {
             robot_id: robot.into(),
             robot_instance: 0,
@@ -1745,10 +1855,11 @@ mod tests {
             width: 64,
             height: 64,
             byte_count: 9,
-            frame_count: 1,
-            frame_timestamps_ns: vec![publish_ts],
-            frame_timestamps_s: vec![publish_ts as f64 / 1e9],
+            frame_count: publish_offsets_ms.len() as u32,
+            frame_timestamps_s: capture_stamps.iter().map(|ns| *ns as f64 / 1e9).collect(),
+            frame_timestamps_ns: capture_stamps,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms: publish_offsets_ms.to_vec(),
         }
     }
 
@@ -1820,6 +1931,105 @@ mod tests {
         assert!(
             !spool_path.exists(),
             "the spooled NUT must be relinked out of the spool dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn straddling_video_chunk_keeps_its_in_window_prefix() {
+        // The frames published after the stop are cut off, not the chunk:
+        // dropping it loses the recording's video, keeping it whole leaves the
+        // recording holding video published after it closed.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        // The chunk opens inside the window and its frames run past the stop.
+        let stop_ns = 150 + 25 * 1_000_000;
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        dispatcher
+            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .await;
+
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        dispatcher
+            .handle_inbound(
+                video_chunk_frames("robot-1", publish_ts, thread_id, 1, &[0, 10, 20, 30, 40]),
+                opened_at,
+            )
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let entry = dispatcher.windows.get(&source).unwrap();
+        assert_eq!(
+            entry.closing[0].traces.len(),
+            1,
+            "the chunk's in-window frames must still route to a video trace"
+        );
+        assert_eq!(
+            dispatcher.orphan_drops, 0,
+            "cutting a chunk's tail is not an orphan drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn video_chunk_with_no_in_window_frame_is_dropped() {
+        // Defensive branch: an empty video trace would leave the recording
+        // advertising a video with no frames.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        let stop_ns = 150 + 25 * 1_000_000;
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        dispatcher
+            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .await;
+
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        dispatcher
+            .handle_inbound(
+                video_chunk_frames("robot-1", publish_ts, thread_id, 1, &[50, 60]),
+                opened_at,
+            )
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let entry = dispatcher.windows.get(&source).unwrap();
+        assert!(
+            entry.closing[0].traces.is_empty(),
+            "a chunk with no in-window frame must not register a video trace"
+        );
+        assert_eq!(dispatcher.orphan_drops, 1);
+        let spool_path = paths::spool_chunk_path(
+            &recordings_root,
+            "robot-1",
+            0,
+            "RGB_IMAGES",
+            Some("camera_0"),
+            publish_ts,
+            thread_id,
+        );
+        assert!(
+            !spool_path.exists(),
+            "the dropped chunk's spooled NUT must be removed"
         );
     }
 

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -694,6 +694,7 @@ impl ActorState {
             lossy_out: lossy_segment.clone(),
             lossless_out: lossless_segment.clone(),
             codec,
+            frame_count,
         };
         pending_encodes.spawn(async move {
             // Acquire a permit before relinking + encoding. Gating the relink

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -57,6 +57,7 @@ use std::sync::{Arc, Condvar, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::service_name::{MAX_VIDEO_CHUNK_FRAMES, VIDEO_SPOOL_TICKS_PER_SECOND};
+use data_daemon_shared::video_boundary::{at_or_past_boundary, publish_offset_ms};
 use data_daemon_shared::{Envelope, FrameDtype};
 
 use crate::nut_writer::{NutVideoConfig, NutWriter};
@@ -226,6 +227,9 @@ struct VideoChunkState {
     frame_timestamps_ns: Vec<i64>,
     /// Per-frame `timestamp_s` accumulator for the in-progress chunk.
     frame_timestamps_s: Vec<f64>,
+    /// Per-frame publish time as ms after `chunk_publish_ns`, which is what
+    /// lets the daemon cut this chunk at a boundary inside it.
+    frame_publish_offsets_ms: Vec<u32>,
 }
 
 /// Process-wide registry of in-progress per-`(source, sensor)` video chunk
@@ -1069,6 +1073,7 @@ fn record_video_frame(
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
+            frame_publish_offsets_ms: Vec::new(),
         }));
         registry.streams.insert(key.clone(), slot.clone());
         Some(slot)
@@ -1115,8 +1120,9 @@ fn record_video_frame(
 }
 
 /// Append one frame to the locked per-stream chunk `state`, returning every
-/// chunk announcement produced this call: a geometry-change seal and/or a
-/// size/frame-cap flush (so a single call can yield two). Pure with respect to
+/// chunk announcement produced this call: a window-boundary or geometry-change
+/// seal before the append, and/or a size/frame-cap flush after it (so a single
+/// call can yield two). Pure with respect to
 /// IPC — the caller publishes the returned envelopes outside the lock — which
 /// also makes the open/seal/roll logic unit-testable without a live daemon.
 /// Best-effort: a NUT open/write error logs and drops the frame.
@@ -1139,23 +1145,26 @@ fn append_frame_locked(
     timestamp_s: f64,
 ) -> Vec<Envelope> {
     let mut announcements: Vec<Envelope> = Vec::new();
+    // The caller publishes the collected envelopes outside the lock.
+    let seal = |state: &mut VideoChunkState, announcements: &mut Vec<Envelope>| {
+        if let Some(envelope) =
+            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
+        {
+            announcements.push(envelope);
+        }
+    };
 
-    // A recording window opened partway through the frames queued ahead of this
-    // one. Seal here, so the chunk carrying the pre-window frames is announced
-    // on its own and this frame opens a fresh chunk stamped inside the window.
-    // Without the split one chunk spans the boundary, and since the daemon
-    // routes a chunk whole by its open stamp, the pre-window stamp orphans the
-    // entire chunk — silently discarding every in-window frame in it.
-    if let Some(split_ns) = state.pending_split_ns {
-        if publish_ns >= split_ns {
-            state.pending_split_ns = None;
-            if state.nut_writer.is_some() {
-                if let Some(envelope) =
-                    flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-                {
-                    announcements.push(envelope);
-                }
-            }
+    // A window opened partway through the queued frames. Without this seal one
+    // chunk spans the boundary and its pre-window open stamp orphans every
+    // in-window frame in it. The boundary is one-shot, so the first frame to
+    // reach it consumes it whether or not a chunk was open to seal.
+    if state
+        .pending_split_ns
+        .is_some_and(|split_ns| at_or_past_boundary(split_ns, publish_ns))
+    {
+        state.pending_split_ns = None;
+        if state.nut_writer.is_some() {
+            seal(state, &mut announcements);
         }
     }
 
@@ -1181,11 +1190,7 @@ fn append_frame_locked(
             new_dtype = ?dtype,
             "video frame geometry or dtype changed mid-stream; sealing chunk and reopening"
         );
-        if let Some(envelope) =
-            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-        {
-            announcements.push(envelope);
-        }
+        seal(state, &mut announcements);
     }
     state.width = width;
     state.dtype = dtype;
@@ -1301,13 +1306,12 @@ fn append_frame_locked(
     state.frame_count = state.frame_count.saturating_add(1);
     state.frame_timestamps_ns.push(timestamp_ns);
     state.frame_timestamps_s.push(timestamp_s);
+    state
+        .frame_publish_offsets_ms
+        .push(publish_offset_ms(state.chunk_publish_ns, publish_ns));
 
     if should_flush_chunk(logical_bytes_after_write, state.frame_count) {
-        if let Some(envelope) =
-            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-        {
-            announcements.push(envelope);
-        }
+        seal(state, &mut announcements);
     }
     announcements
 }
@@ -1334,6 +1338,7 @@ fn flush_chunk_locked(
             state.frame_count = 0;
             state.frame_timestamps_ns.clear();
             state.frame_timestamps_s.clear();
+            state.frame_publish_offsets_ms.clear();
             return None;
         }
     };
@@ -1343,6 +1348,7 @@ fn flush_chunk_locked(
     let frame_count = state.frame_count;
     let frame_timestamps_ns = std::mem::take(&mut state.frame_timestamps_ns);
     let frame_timestamps_s = std::mem::take(&mut state.frame_timestamps_s);
+    let frame_publish_offsets_ms = std::mem::take(&mut state.frame_publish_offsets_ms);
 
     state.frame_count = 0;
 
@@ -1361,6 +1367,7 @@ fn flush_chunk_locked(
         frame_timestamps_ns,
         frame_timestamps_s,
         dtype: state.dtype,
+        frame_publish_offsets_ms,
     })
 }
 
@@ -1592,6 +1599,7 @@ mod tests {
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
+            frame_publish_offsets_ms: Vec::new(),
         }
     }
 
@@ -2014,6 +2022,50 @@ mod tests {
         assert_eq!(state.frame_count, 0);
         assert!(state.frame_timestamps_ns.is_empty());
         assert!(state.frame_timestamps_s.is_empty());
+        assert!(state.frame_publish_offsets_ms.is_empty());
+    }
+
+    #[test]
+    fn announcement_carries_each_frame_publish_offset_from_the_chunk_open() {
+        // The offsets carry each frame's caller-thread publish stamp, measured
+        // from the chunk's open, not the capture clock beside them.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+
+        // Publish stamps, with capture stamps on an unrelated clock.
+        for (index, capture_ns) in [10_000, 20_000, 30_000].into_iter().enumerate() {
+            append_frame_locked(
+                &mut state,
+                "r",
+                0,
+                "RGB",
+                "cam",
+                2,
+                2,
+                FrameDtype::Rgb8,
+                &frame,
+                TEST_PUBLISH_NS + index as i64 * 33_333_333,
+                capture_ns,
+                capture_ns as f64 / 1e9,
+            );
+        }
+
+        let envelope = flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal");
+        match envelope {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                frame_publish_offsets_ms,
+                ..
+            } => {
+                assert_eq!(
+                    publish_timestamp_ns, TEST_PUBLISH_NS,
+                    "the chunk's open stamp is its first frame's publish stamp"
+                );
+                assert_eq!(frame_publish_offsets_ms, vec![0, 33, 66]);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -51,6 +51,118 @@ pub mod config;
 pub mod ffmpeg;
 pub mod paths;
 
+/// Recording-window membership for the frames *inside* one video chunk.
+///
+/// A chunk is a NUT file appended to until something seals it, so frames logged
+/// either side of a boundary can share one and its open stamp speaks only for
+/// the first. Both sides of the wire divide the work by what each knows in time:
+///
+/// - The **producer** seals the open chunk before the first frame at or past a
+///   boundary, which only works at a recording's start and only in the process
+///   that called `start_recording`.
+/// - The **daemon** cuts a chunk it already holds, from the per-frame offsets
+///   this module encodes. Only this works at a stop, where a video-only process
+///   logs on until its notification arrives and the frames are already written.
+pub mod video_boundary {
+    /// Nanoseconds per millisecond, the wire resolution of a frame offset.
+    const NS_PER_MS: i64 = 1_000_000;
+
+    /// Is `frame_publish_ns` at or past the recording boundary `bound_ns`?
+    ///
+    /// Argument order is boundary first, frame second.
+    pub fn at_or_past_boundary(bound_ns: i64, frame_publish_ns: i64) -> bool {
+        frame_publish_ns >= bound_ns
+    }
+
+    /// One frame's publish time as ms after its chunk's open stamp.
+    pub fn publish_offset_ms(chunk_open_ns: i64, frame_publish_ns: i64) -> u32 {
+        let offset_ns = frame_publish_ns.saturating_sub(chunk_open_ns).max(0);
+        (offset_ns / NS_PER_MS).try_into().unwrap_or(u32::MAX)
+    }
+
+    /// The inverse of [`publish_offset_ms`], paired with it so neither can
+    /// change alone.
+    pub fn frame_publish_ns(chunk_open_ns: i64, offset_ms: u32) -> i64 {
+        chunk_open_ns.saturating_add(i64::from(offset_ms) * NS_PER_MS)
+    }
+
+    /// Leading frames published before `bound_ns`, i.e. the index of the first
+    /// that is [`at_or_past_boundary`].
+    pub fn frames_before_boundary(offsets_ms: &[u32], chunk_open_ns: i64, bound_ns: i64) -> usize {
+        offsets_ms
+            .iter()
+            .position(|offset| {
+                at_or_past_boundary(bound_ns, frame_publish_ns(chunk_open_ns, *offset))
+            })
+            .unwrap_or(offsets_ms.len())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        const CHUNK_OPEN_NS: i64 = 1_700_000_000_000_000_000;
+
+        #[test]
+        fn a_frame_on_the_bound_is_already_past_it() {
+            // The half-open convention both sides must agree on.
+            assert!(!at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 1));
+            assert!(at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS));
+            assert!(at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1));
+        }
+
+        #[test]
+        fn offsets_round_trip_at_millisecond_resolution() {
+            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS), 0);
+            assert_eq!(
+                publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1_500_000),
+                1
+            );
+            assert_eq!(
+                frame_publish_ns(CHUNK_OPEN_NS, 33),
+                CHUNK_OPEN_NS + 33_000_000
+            );
+        }
+
+        #[test]
+        fn publish_offset_saturates_at_the_chunk_open() {
+            // A backwards caller clock reads as 0 rather than wrapping.
+            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 5), 0);
+        }
+
+        #[test]
+        fn frames_before_boundary_cuts_on_the_bound() {
+            // The frames before the boundary are kept; the rest are cut.
+            let offsets = [0, 10, 20, 30, 40];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 25);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 3);
+
+            // And the bound itself is exclusive.
+            let on_boundary = frame_publish_ns(CHUNK_OPEN_NS, 20);
+            assert_eq!(
+                frames_before_boundary(&offsets, CHUNK_OPEN_NS, on_boundary),
+                2
+            );
+        }
+
+        #[test]
+        fn frames_entirely_before_the_boundary_are_all_kept() {
+            let offsets = [0, 10, 20];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 60);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 3);
+        }
+
+        #[test]
+        fn the_cut_is_a_prefix_under_disordered_stamps() {
+            // One file feeds one encode, so the first frame at or past the
+            // boundary takes its successors with it.
+            let offsets = [0, 30, 10, 20];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 25);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 1);
+        }
+    }
+}
+
 /// iceoryx2 service-name conventions shared by daemon and producer.
 pub mod service_name {
     /// Pub/sub service carrying every IPC envelope: lifecycle
@@ -76,8 +188,9 @@ pub mod service_name {
     /// Worst-case postcard size of one frame's contribution to a
     /// [`crate::Envelope::VideoChunkReady`] announcement: a `frame_timestamps_ns`
     /// element is an `i64` zigzag varint (≤10 bytes for a full-range Unix-ns
-    /// value) and a `frame_timestamps_s` element is a fixed 8-byte `f64`.
-    pub const VIDEO_CHUNK_BYTES_PER_FRAME: usize = 10 + 8;
+    /// value), a `frame_timestamps_s` element is a fixed 8-byte `f64`, and a
+    /// `frame_publish_offsets_ms` element is a `u32` varint (≤5 bytes).
+    pub const VIDEO_CHUNK_BYTES_PER_FRAME: usize = 10 + 8 + 5;
 
     /// Bytes held back from [`COMMANDS_MAX_PAYLOAD_BYTES`] for a
     /// `VideoChunkReady` envelope's fixed fields — the enum tag, source ids,
@@ -90,7 +203,8 @@ pub mod service_name {
     /// The producer seals a chunk at the **lower** of its byte threshold and
     /// this frame cap. The cap exists so a [`crate::Envelope::VideoChunkReady`]
     /// announcement always fits one [`COMMANDS_MAX_PAYLOAD_BYTES`] sample: the
-    /// per-frame `frame_timestamps_{ns,s}` vectors are the only unbounded part
+    /// per-frame `frame_timestamps_{ns,s}` and `frame_publish_offsets_ms`
+    /// vectors are the only unbounded part
     /// of the envelope, so a long recording of small frames — which never
     /// reaches the byte threshold mid-recording — would otherwise accumulate
     /// enough frames in a single chunk to overflow the slice. The announcement
@@ -428,6 +542,10 @@ pub enum Envelope {
         /// geometry change). The daemon never decodes pixels; it threads this
         /// straight into the trace's `trace.json` sidecar for depth frames.
         dtype: FrameDtype,
+        /// Per-frame publish time as ms after this chunk's own
+        /// `publish_timestamp_ns`, in arrival order. What makes chunk membership
+        /// per-frame rather than atomic; see [`video_boundary`].
+        frame_publish_offsets_ms: Vec<u32>,
     },
     /// Force the daemon to re-read its profile config immediately, rather than
     /// waiting for the config watcher's next poll. Sent by the SDK's
@@ -979,6 +1097,7 @@ mod tests {
                 7.0_f64 / 60.0_f64,
             ],
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms: vec![0, 16, 33, 50],
         };
         let bytes = original.encode().expect("encode");
         let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1011,6 +1130,7 @@ mod tests {
                 frame_timestamps_ns: vec![1_700_000_000_000_000_000],
                 frame_timestamps_s: vec![1_700_000_000.0],
                 dtype,
+                frame_publish_offsets_ms: vec![0],
             };
             let bytes = original.encode().expect("encode");
             let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1050,11 +1170,11 @@ mod tests {
 
     #[test]
     fn video_chunk_ready_worst_case_fits_commands_slice() {
-        // A 128 MiB 1080p chunk holds ~3800 frames; carry two timestamps per
-        // frame (ns + s). Even at 10_000 frames the envelope is comfortably
-        // under COMMANDS_MAX_PAYLOAD_BYTES.
+        // Two timestamps plus a publish offset per frame stays well under
+        // COMMANDS_MAX_PAYLOAD_BYTES even at an implausible frame count.
         let frame_timestamps_ns: Vec<i64> = (0..10_000).map(|i| i as i64 * 1_000_000).collect();
         let frame_timestamps_s: Vec<f64> = (0..10_000).map(|i| i as f64 * 1e-3).collect();
+        let frame_publish_offsets_ms: Vec<u32> = (0..10_000).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: 0,
@@ -1070,6 +1190,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(
@@ -1085,12 +1206,14 @@ mod tests {
         // The producer caps a chunk at MAX_VIDEO_CHUNK_FRAMES frames so its
         // announcement always fits one commands sample. Prove the cap holds at
         // the absolute worst case: every per-frame ns timestamp a full-range
-        // i64 (10-byte postcard zigzag varint) and every fixed field maxed out.
+        // i64 (10-byte postcard zigzag varint), every publish offset a
+        // full-range u32 (5-byte varint), and every fixed field maxed out.
         // Without the cap a long recording of tiny frames overflows the slice
         // and the whole recording's video announcement fails to publish.
         let count = service_name::MAX_VIDEO_CHUNK_FRAMES as usize;
         let frame_timestamps_ns: Vec<i64> = (0..count).map(|i| i64::MAX - i as i64).collect();
         let frame_timestamps_s: Vec<f64> = (0..count).map(|i| i as f64).collect();
+        let frame_publish_offsets_ms: Vec<u32> = (0..count).map(|_| u32::MAX).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: i64::MAX,
@@ -1106,6 +1229,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Chunks have offset applied making sure any chunk that overspills the recording window is split at ffmpeg encode.
