### PR TITLE
fix: confine a non-owning producer to the recording it was told about

### DIFF
--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -532,7 +532,9 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
+    current_recording_id = robot.get_current_recording_id()
+    if current_recording_id is not None:
+        robot.arm_video_boundary_if_new_recording(current_recording_id)
         contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
         robot._get_daemon_recording_context().log_frame(
             camera_type.value,

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -10,6 +10,7 @@ import io
 import logging
 import os
 import tempfile
+import threading
 import time
 import uuid
 import xml.etree.ElementTree as ET
@@ -121,6 +122,11 @@ class Robot:
         )
         self._joint_group_cache: "dict[DataType, ResolvedJointGroup]" = dict()
         self._daemon_recording_context: DaemonRecordingContext | None = None
+        # Did *this* process open the daemon's window for the current recording?
+        self._owns_daemon_recording = False
+        # Guarded by `_boundary_lock` so concurrent camera threads arm once.
+        self._armed_boundary_handle: str | None = None
+        self._boundary_lock = threading.Lock()
 
         self.org_id = org_id or get_current_org()
 
@@ -308,6 +314,8 @@ class Robot:
                 dataset_name=None,
                 timestamp=timestamp,
             )
+            self._owns_daemon_recording = True
+            self._armed_boundary_handle = local_handle
         except Exception:
             # The gate is open with no window behind it.
             get_recording_state_manager().recording_stopped(
@@ -348,22 +356,20 @@ class Robot:
         recording_id: str | None,
         timestamp: float | None = None,
     ) -> None:
-        """Stop all streams and send the recording-stopped IPC message to the daemon.
+        """Stop all streams and send the recording-stopped IPC message.
 
-        The local ``log_*`` gate closes in the instant between the window
-        closing and the writer's tail-chunk barrier. Closing
-        it before the notify would silently discard data the daemon would still
-        have accepted — the window is open until it receives the stop. Closing it
-        after the barrier instead leaves it open for as long as the writer's
-        backlog takes to drain (over a second under burst logging), publishing
-        data the daemon has already stopped accepting and simply throws away.
+        Only the process that opened the window publishes the stop, since
+        ``StopRecording`` names a source. Non-owners still close their gate and
+        run their writer barrier, which seals tail chunks nothing else would.
         """
         try:
             self._stop_all_streams()
             context = self._get_daemon_recording_context()
             try:
-                context.stop_recording(timestamp=timestamp)
+                if self._owns_daemon_recording:
+                    context.stop_recording(timestamp=timestamp)
             finally:
+                self._owns_daemon_recording = False
                 # Both run even if the notify failed.
                 self._close_local_recording_gate()
                 context.flush_source()
@@ -426,6 +432,19 @@ class Robot:
         return get_recording_state_manager().get_current_recording_id(
             robot_id=self.id, instance=self.instance
         )
+
+    def arm_video_boundary_if_new_recording(self, recording_id: str) -> None:
+        """Roll this process's video chunk when it first logs into *recording_id*.
+
+        A no-op in the owning process, which armed the boundary at the start.
+        """
+        if self._owns_daemon_recording:
+            return
+        with self._boundary_lock:
+            if self._armed_boundary_handle == recording_id:
+                return
+            self._armed_boundary_handle = recording_id
+        self._get_daemon_recording_context().mark_recording_boundary()
 
     def get_cloud_recording_id(
         self, timestamp_ns: int | None = None, timeout_s: float = 30.0

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -268,9 +268,8 @@ class Robot:
 
         Args:
             dataset_id: Unique identifier of the dataset to record into.
-            timestamp: Optional capture time (Unix seconds) for the recording's
-                start, matching the ``log_*`` methods. It pins the window's
-                lower bound; the producer stamps wall-clock now when omitted.
+
+
 
         Returns:
             A local correlation handle. The daemon owns recording identity and
@@ -291,20 +290,30 @@ class Robot:
         # wall-clock now, which is at or after this value, so notifications stay
         # orderable against it.
         start_time = timestamp if timestamp is not None else time.time()
-        self._get_daemon_recording_context().start_recording(
-            robot_id=self.id,
-            robot_instance=self.instance,
-            robot_name=self.name,
-            dataset_id=dataset_id,
-            dataset_name=None,
-            timestamp=timestamp,
-        )
+        # Open the local gate BEFORE announcing the window: opening it second
+        # would have the SDK silently discard in-window data. The gate is a
+        # deliberate superset, leaving the daemon to reject the early samples.
         get_recording_state_manager().recording_started(
             robot_id=self.id,
             instance=self.instance,
             recording_id=local_handle,
             start_time=start_time,
         )
+        try:
+            self._get_daemon_recording_context().start_recording(
+                robot_id=self.id,
+                robot_instance=self.instance,
+                robot_name=self.name,
+                dataset_id=dataset_id,
+                dataset_name=None,
+                timestamp=timestamp,
+            )
+        except Exception:
+            # The gate is open with no window behind it.
+            get_recording_state_manager().recording_stopped(
+                robot_id=self.id, instance=self.instance, recording_id=local_handle
+            )
+            raise
         return local_handle
 
     def stop_recording(
@@ -321,8 +330,9 @@ class Robot:
             recording_id: Unused — the daemon stops the active recording for
                 this source. Retained for call-site compatibility.
             timestamp: Optional capture time (Unix seconds) for the recording's
-                stop, matching the ``log_*`` methods. It pins the window's upper
-                bound; the producer stamps wall-clock now when omitted.
+                stop, matching the ``log_*`` methods. It is the reported stop
+                time, not the window's upper bound, which the daemon takes from
+                the publish stamp at the send.
 
         Raises:
             RobotError: If the robot is not initialized.
@@ -330,12 +340,7 @@ class Robot:
         if not self.id:
             raise RobotError("Robot not initialized. Call init() first.")
 
-        active_handle = get_recording_state_manager().get_current_recording_id(
-            self.id, self.instance
-        )
-        get_recording_state_manager().recording_stopped(
-            robot_id=self.id, instance=self.instance, recording_id=active_handle
-        )
+        # The gate closes inside the drain, not here.
         self._drain_streams_and_notify_daemon(recording_id, timestamp=timestamp)
 
     def _drain_streams_and_notify_daemon(
@@ -343,15 +348,41 @@ class Robot:
         recording_id: str | None,
         timestamp: float | None = None,
     ) -> None:
-        """Stop all streams and send the recording-stopped IPC message to the daemon."""
+        """Stop all streams and send the recording-stopped IPC message to the daemon.
+
+        The local ``log_*`` gate closes in the instant between the window
+        closing and the writer's tail-chunk barrier. Closing
+        it before the notify would silently discard data the daemon would still
+        have accepted — the window is open until it receives the stop. Closing it
+        after the barrier instead leaves it open for as long as the writer's
+        backlog takes to drain (over a second under burst logging), publishing
+        data the daemon has already stopped accepting and simply throws away.
+        """
         try:
             self._stop_all_streams()
-            self._get_daemon_recording_context().stop_recording(timestamp=timestamp)
+            context = self._get_daemon_recording_context()
+            try:
+                context.stop_recording(timestamp=timestamp)
+            finally:
+                # Both run even if the notify failed.
+                self._close_local_recording_gate()
+                context.flush_source()
         except Exception:
             logger.exception(
                 "Failed to stop streams and notify daemon for recording_id=%s",
                 recording_id,
             )
+
+    def _close_local_recording_gate(self) -> None:
+        """Clear the local recording handle that gates ``log_*`` forwarding."""
+        if not self.id:
+            return
+        state = get_recording_state_manager()
+        state.recording_stopped(
+            robot_id=self.id,
+            instance=self.instance,
+            recording_id=state.get_current_recording_id(self.id, self.instance),
+        )
 
     def _register_remote_stop_handler(self) -> None:
         """Register a callback to drain streams when a remote stop arrives."""

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -65,18 +65,15 @@ class TrackedRecording(NamedTuple):
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
     """Tell the producer a source's recording has been locally auto-expired.
 
-    Calls the native ``stop_recording`` for the source so the producer flushes
-    any in-progress NUT chunk and publishes ``StopRecording``. The daemon is
-    idempotent, so a later explicit ``nc.stop_recording`` that races this is a
-    no-op. The stop boundary is wall-clock here (the expiry path has no access
-    to the recording context's tracked data-clock timestamp) — acceptable for a
-    forced 5-minute timeout. Failures are logged and swallowed: the local
-    expiry must always succeed.
+    Publishes the stop, then runs ``flush_source``, which is not part of the
+    stop and is the only thing that seals the in-progress chunk. A racing
+    explicit ``nc.stop_recording`` is a no-op, the boundary is wall-clock here,
+    and failures are swallowed: the local expiry must always succeed.
     """
     try:
-        _recording_context._load_native().stop_recording(
-            robot_id, instance, time.time_ns()
-        )
+        native = _recording_context._load_native()
+        native.stop_recording(robot_id, instance, time.time_ns())
+        native.flush_source(robot_id, instance)
     except Exception:
         logger.exception(
             "Failed to notify data bridge of recording expiry for %s:%s",

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -102,9 +102,10 @@ class RecordingContext:
         source ``(robot_id, robot_instance)``. No recording id is on the wire —
         the daemon allocates and owns recording identity.
 
-        ``timestamp`` optionally pins the recording window's lower bound (Unix
-        seconds), matching the ``log_*`` methods; when ``None`` the producer
-        stamps the publish clock now.
+        ``timestamp`` is the recording's *capture* start time (Unix seconds),
+        stored and reported as such, and returned as the marker that resolves the
+        cloud id (:meth:`get_recording_id`). It does **not** bound the recording
+        window, which the daemon takes from a publish stamp inside this call.
         """
         ensure_daemon_running()
         self.bind_source(robot_id, robot_instance)
@@ -240,9 +241,12 @@ class RecordingContext:
         """Publish one ``StopRecording`` tagged with the source.
 
         The daemon uses the publish-clock stop boundary to close the recording
-        window. ``timestamp`` optionally pins that boundary (Unix seconds),
-        matching the ``log_*`` methods; when ``None`` the producer stamps
-        wall-clock now.
+        window. ``timestamp`` is the recording's *capture* stop time and is
+        separate from that boundary, never used for window membership.
+
+        This publishes the stop only; :meth:`flush_source` seals the writer's
+        tail chunks and must be called straight after, so the caller can close
+        its own logging gate in between.
         """
         if not self._robot_id:
             return
@@ -250,6 +254,16 @@ class RecordingContext:
         _load_native().stop_recording(
             self._robot_id, self._robot_instance, timestamp_ns
         )
+
+    def flush_source(self) -> None:
+        """Run the writer's deferred tail-chunk barrier for the bound source.
+
+        Mandatory after :meth:`stop_recording` — tail chunks are sealed nowhere
+        else. No-op before a source is bound.
+        """
+        if not self._robot_id:
+            return
+        _load_native().flush_source(self._robot_id, self._robot_instance)
 
     def get_recording_id(
         self,

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -255,6 +255,12 @@ class RecordingContext:
             self._robot_id, self._robot_instance, timestamp_ns
         )
 
+    def mark_recording_boundary(self) -> None:
+        """Arm the writer's boundary split for a process that did not start it."""
+        if not self._robot_id:
+            return
+        _load_native().mark_recording_boundary(self._robot_id, self._robot_instance)
+
     def flush_source(self) -> None:
         """Run the writer's deferred tail-chunk barrier for the bound source.
 

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -167,6 +167,9 @@ pub struct ChunkEncodeRequest {
     /// Lossy codec selection for this trace. Controls whether a lossless
     /// archive is produced and how the lossy output is encoded.
     pub codec: LossyVideoCodec,
+    /// Frames to encode from the head of `raw_nut`: the whole file unless the
+    /// dispatcher cut the chunk, and always what the sidecar is built from.
+    pub frame_count: u32,
 }
 
 /// Outcome of a successful per-chunk transcode.
@@ -528,6 +531,9 @@ impl VideoEncoder {
         let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
         let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let lossy_only = request.codec.is_lossy_only();
+        // Per-output frame cap (see [`ChunkEncodeRequest::frame_count`]), a
+        // no-op unless the dispatcher cut this chunk at a recording boundary.
+        let frame_limit = (request.frame_count > 0).then(|| request.frame_count.to_string());
         let mut command = Command::new(&self.binary);
         command
             .arg("-y")
@@ -561,8 +567,11 @@ impl VideoEncoder {
                 .arg("-crf")
                 .arg("23")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
-                .arg(&request.lossy_out);
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command.arg(&request.lossy_out);
         } else {
             // Downscale the lossy preview proxy (only) to keep this dominant
             // pass cheap at high resolution; the lossless output stays native.
@@ -587,7 +596,11 @@ impl VideoEncoder {
                 .arg("-qp")
                 .arg("23")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command
                 .arg(&request.lossy_out)
                 .arg("-map")
                 .arg("0:v")
@@ -608,8 +621,11 @@ impl VideoEncoder {
                 .arg("-qp")
                 .arg("0")
                 .arg("-video_track_timescale")
-                .arg(&track_timescale)
-                .arg(&request.lossless_out);
+                .arg(&track_timescale);
+            if let Some(limit) = frame_limit.as_deref() {
+                command.arg("-frames:v").arg(limit);
+            }
+            command.arg(&request.lossless_out);
         }
         command
             .stdin(Stdio::null())
@@ -1093,6 +1109,7 @@ mod tests {
             lossy_out: lossy.clone(),
             lossless_out: lossless.clone(),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 8,
         };
         let outcome = encoder
             .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
@@ -1159,6 +1176,7 @@ mod tests {
                     lossy_out: lossy.clone(),
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 6,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1221,6 +1239,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn frame_count_encodes_only_the_frames_the_recording_owns() {
+        // The NUT cannot be rewritten, so the cut has to reach ffmpeg — on
+        // both outputs, or an mp4 outruns the sidecar indexing it.
+        let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping frame-cap encode test.");
+            return;
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let raw = tempdir.path().join("chunk_0000.nut");
+        let lossy = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless = tempdir.path().join("chunk_0000_lossless.mp4");
+        write_synthetic_nut(&ffmpeg, &raw, 8);
+
+        VideoEncoder::new()
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 3,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("transcode");
+
+        let frame_count = |path: &Path| -> u64 {
+            let out = StdCommand::new(&ffprobe)
+                .args([
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-count_frames",
+                    "-show_entries",
+                    "stream=nb_read_frames",
+                    "-of",
+                    "default=nokey=1:noprint_wrappers=1",
+                ])
+                .arg(path)
+                .output()
+                .expect("spawn ffprobe");
+            String::from_utf8_lossy(&out.stdout).trim().parse().unwrap()
+        };
+
+        assert_eq!(frame_count(&lossy), 3, "lossy output must stop at the cut");
+        assert_eq!(
+            frame_count(&lossless),
+            3,
+            "lossless output must stop at the same cut"
+        );
+    }
+
+    #[tokio::test]
     async fn encode_chunk_lossy_only_writes_single_full_res_h264() {
         let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
         else {
@@ -1245,6 +1320,7 @@ mod tests {
                     lossy_out: lossy.clone(),
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
+                    frame_count: 6,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1331,6 +1407,7 @@ mod tests {
                     lossy_out: split_lossy.clone(),
                     lossless_out: split_lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 8,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1344,6 +1421,7 @@ mod tests {
                     lossy_out: single_lossy.clone(),
                     lossless_out: tempdir.path().join("unused_lossless.mp4"),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
+                    frame_count: 8,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1446,6 +1524,7 @@ mod tests {
                             .path()
                             .join(format!("chunk_{chunk_index:04}_lossless.mp4")),
                         codec: LossyVideoCodec::LosslessPlusPreview,
+                        frame_count: frames_per_chunk as u32,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -1545,6 +1624,7 @@ mod tests {
                         lossy_out: lossy.clone(),
                         lossless_out: lossless,
                         codec: LossyVideoCodec::LosslessPlusPreview,
+                        frame_count: 4,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -1671,6 +1751,7 @@ mod tests {
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 1,
         };
         let encoder = VideoEncoder::new();
         let error = encoder
@@ -1693,6 +1774,7 @@ mod tests {
             lossy_out: tempdir.path().join("lossy.mp4"),
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
+            frame_count: 1,
         };
         let encoder =
             VideoEncoder::new().with_binary("this-binary-definitely-does-not-exist-ffmpeg");

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -48,15 +48,18 @@ use crate::state::{DaemonEvent, NewRecording, SqliteStateStore, StateStore};
 use crate::storage::paths;
 
 /// Default holdback: each data envelope waits this long after daemon receipt
-/// before it is routed. Tunable via `NCD_HOLDBACK_MS`. A generous default is
-/// safe — joint/scalar data is sparse, so even a 1 s holdback retains only a
-/// few thousand small envelopes per source. Completeness (catching a datum
-/// whose publisher was preempted between capture and publish) scales directly
-/// with this value.
+/// before it is routed. Tunable via `NCD_HOLDBACK_MS`.
+///
+/// Lifecycle is applied on arrival while data is held, so a `StartRecording`
+/// racing its own data still opens the window first.
 const DEFAULT_HOLDBACK_MS: u64 = 500;
 
 /// Environment override for the holdback, in milliseconds.
 const HOLDBACK_ENV: &str = "NCD_HOLDBACK_MS";
+
+/// Hard bound on how long a stopped window waits for its producer's
+/// [`Envelope::SourceFlushed`] marker before being evicted anyway.
+const FLUSH_MARKER_WAIT_CAP: Duration = Duration::from_secs(30);
 
 /// A source silent (no data, no lifecycle) for this long has its open window
 /// force-closed as a crash backstop, so a producer that died without a Stop
@@ -180,6 +183,12 @@ struct ActiveWindow {
     stopped_at_ns: Option<i64>,
     /// Daemon clock at which the window closed — drives the eviction deadline.
     stop_recv_at: Option<Instant>,
+    /// Closed by a `StopRecording`, so its producer still owes a
+    /// [`Envelope::SourceFlushed`] marker.
+    awaiting_flush: bool,
+    /// Set when that marker has been released from the holdback queue, i.e.
+    /// every tail chunk it was ordered behind has already routed.
+    flushed: bool,
     /// Per-trace actors spawned within this window.
     traces: HashMap<TraceKey, TraceHandle>,
 }
@@ -188,6 +197,17 @@ impl ActiveWindow {
     /// Does this window's `[started_at_ns, stopped_at_ns)` contain `ts`?
     fn contains(&self, ts: i64) -> bool {
         ts >= self.started_at_ns && self.stopped_at_ns.is_none_or(|stop| ts < stop)
+    }
+
+    /// Time elapsed since stop once this window may be evicted: retention has
+    /// passed *and* either every owed flush marker is in or
+    /// [`FLUSH_MARKER_WAIT_CAP`] has expired. `None` while it must be kept.
+    fn eviction_elapsed(&self, now: Instant, retention: Duration) -> Option<Duration> {
+        let since_stop = self.stop_recv_at.map(|at| now.duration_since(at))?;
+        let retained = since_stop >= retention;
+        let flush_settled =
+            !self.awaiting_flush || self.flushed || since_stop >= FLUSH_MARKER_WAIT_CAP;
+        (retained && flush_settled).then_some(since_stop)
     }
 }
 
@@ -200,6 +220,17 @@ struct WindowsForSource {
     /// Daemon clock of the last envelope seen for this source — drives the
     /// idle reaper.
     last_seen: Option<Instant>,
+}
+
+impl WindowsForSource {
+    /// Nothing live, nothing retained, quiet past `IDLE_REAP`: droppable.
+    fn is_empty(&self, now: Instant) -> bool {
+        self.live.is_none()
+            && self.closing.is_empty()
+            && self
+                .last_seen
+                .is_none_or(|at| now.duration_since(at) >= IDLE_REAP)
+    }
 }
 
 /// One held data envelope awaiting its holdback release.
@@ -238,6 +269,8 @@ enum HeldPayload {
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
     },
+    /// End-of-tail marker for a source's stopped window.
+    SourceFlushed,
 }
 
 /// The dispatcher's task-local state.
@@ -455,6 +488,20 @@ impl Dispatcher {
                     },
                 });
             }
+            Envelope::SourceFlushed {
+                robot_id,
+                robot_instance,
+                publish_timestamp_ns,
+            } => {
+                let source = (robot_id, robot_instance);
+                self.touch_source(&source, recv_at);
+                self.held.push_back(Held {
+                    source,
+                    release_at: recv_at + self.holdback,
+                    publish_timestamp_ns,
+                    payload: HeldPayload::SourceFlushed,
+                });
+            }
             Envelope::RefreshConfig {} => self.handle_refresh_config().await,
         }
     }
@@ -484,10 +531,7 @@ impl Dispatcher {
     }
 
     fn touch_source(&mut self, source: &Source, recv_at: Instant) {
-        // Hot path: every inbound `Data` / `BatchedData` / `VideoChunkReady`
-        // envelope touches its source. The common case is an existing window, so
-        // probe with `get_mut` (no allocation) and only clone the `(String, i64)`
-        // key on the rare first-insert.
+        // Hot path: probe with `get_mut` and only clone the key on insert.
         if let Some(window) = self.windows.get_mut(source) {
             window.last_seen = Some(recv_at);
         } else {
@@ -566,6 +610,8 @@ impl Dispatcher {
             started_at_ns: publish_timestamp_ns,
             stopped_at_ns: None,
             stop_recv_at: None,
+            awaiting_flush: false,
+            flushed: false,
             traces: HashMap::new(),
         });
 
@@ -624,6 +670,7 @@ impl Dispatcher {
             // time.
             window.stopped_at_ns = Some(publish_timestamp_ns);
             window.stop_recv_at = Some(recv_at);
+            window.awaiting_flush = true;
             let recording_index = window.recording_index;
             entry.closing.push(window);
             // Persist `stopped_at` before publishing the event: the cloud
@@ -657,8 +704,11 @@ impl Dispatcher {
             // keeping the boundary at the successor start mis-routes nothing.
             //
             // Refresh the closing-retention deadline so the extra late tail data
-            // this delayed stop implies still has a window to land in.
+            // this delayed stop implies still has a window to land in, and wait
+            // on this stop's flush marker for the same reason.
             window.stop_recv_at = Some(recv_at);
+            window.awaiting_flush = true;
+            window.flushed = false;
             tracing::warn!(
                 robot_id = source.0,
                 recording_index,
@@ -778,51 +828,9 @@ impl Dispatcher {
     /// window scans, so throttled to [`HOUSEKEEP_INTERVAL`] by the caller rather
     /// than run per inbound envelope.
     async fn housekeep(&mut self, now: Instant) {
-        // 2. Window evictions: a closing window is retained for 2·HOLDBACK
-        //    after its stop, by which point all in-window data has released.
         let retention = self.holdback * 2;
-        let mut closing_actors: Vec<TraceHandle> = Vec::new();
-        let mut empty_sources: Vec<Source> = Vec::new();
-        for (source, entry) in self.windows.iter_mut() {
-            entry.closing.retain_mut(|window| {
-                let evict = window
-                    .stop_recv_at
-                    .is_some_and(|at| now.duration_since(at) >= retention);
-                if evict {
-                    let elapsed = window
-                        .stop_recv_at
-                        .map(|at| now.duration_since(at))
-                        .unwrap_or_default();
-                    crate::perf_events::emit(
-                        "holdback",
-                        "completed",
-                        Some(window.recording_index),
-                        None,
-                        Some(elapsed),
-                        serde_json::json!({
-                            "trace_actor_count": window.traces.len(),
-                            "configured_retention_ms": retention.as_secs_f64() * 1_000.0,
-                        }),
-                    );
-                    for (_, handle) in window.traces.drain() {
-                        closing_actors.push(handle);
-                    }
-                    false
-                } else {
-                    true
-                }
-            });
-            if entry.live.is_none()
-                && entry.closing.is_empty()
-                && entry
-                    .last_seen
-                    .is_none_or(|at| now.duration_since(at) >= IDLE_REAP)
-            {
-                empty_sources.push(source.clone());
-            }
-        }
-        // Send WindowClosing to every actor of an evicted window. Their senders
-        // drop after, so each actor finalises and exits.
+        let (closing_actors, empty_sources) = self.evict_closing_windows(now, retention);
+
         for handle in closing_actors {
             let _ = handle.sender.send(TraceActorMessage::WindowClosing).await;
         }
@@ -830,9 +838,71 @@ impl Dispatcher {
             self.windows.remove(&source);
         }
 
-        // 3. Idle reaper: force-close a live window whose source has gone
-        //    silent (producer crashed without a Stop).
+        // Idle reaper: force-close a live window whose source has gone
+        // silent (producer crashed without a Stop).
         self.reap_idle(now).await;
+    }
+
+    /// Evict every closing window past retention and collect the sources left
+    /// with nothing to track. Returns the evicted windows' trace actors, still
+    /// owed a `WindowClosing`, and the now-empty source keys.
+    fn evict_closing_windows(
+        &mut self,
+        now: Instant,
+        retention: Duration,
+    ) -> (Vec<TraceHandle>, Vec<Source>) {
+        let mut closing_actors: Vec<TraceHandle> = Vec::new();
+        let mut empty_sources: Vec<Source> = Vec::new();
+        for (source, entry) in self.windows.iter_mut() {
+            entry.closing.retain_mut(|window| {
+                let Some(elapsed) = window.eviction_elapsed(now, retention) else {
+                    return true;
+                };
+                Self::finish_eviction(source, window, elapsed, retention, &mut closing_actors);
+                false
+            });
+            if entry.is_empty(now) {
+                empty_sources.push(source.clone());
+            }
+        }
+        (closing_actors, empty_sources)
+    }
+
+    /// Emit one evicted window's completion event and drain its trace actors
+    /// into `closing_actors`.
+    fn finish_eviction(
+        source: &Source,
+        window: &mut ActiveWindow,
+        elapsed: Duration,
+        retention: Duration,
+        closing_actors: &mut Vec<TraceHandle>,
+    ) {
+        if window.awaiting_flush && !window.flushed {
+            tracing::warn!(
+                recording_index = window.recording_index,
+                robot_id = source.0,
+                elapsed_s = elapsed.as_secs_f64(),
+                "no producer flush marker before the cap; retiring the \
+                 window anyway — any tail video chunk still in flight \
+                 will be dropped as an orphan"
+            );
+        }
+        crate::perf_events::emit(
+            "holdback",
+            "completed",
+            Some(window.recording_index),
+            None,
+            Some(elapsed),
+            serde_json::json!({
+                "trace_actor_count": window.traces.len(),
+                "configured_retention_ms": retention.as_secs_f64() * 1_000.0,
+                "awaited_flush_marker": window.awaiting_flush,
+                "flush_marker_seen": window.flushed,
+            }),
+        );
+        for (_, handle) in window.traces.drain() {
+            closing_actors.push(handle);
+        }
     }
 
     /// Force-close any live window whose source has been silent past
@@ -954,7 +1024,28 @@ impl Dispatcher {
                 )
                 .await;
             }
+            HeldPayload::SourceFlushed => self.mark_source_flushed(&held.source),
         }
+    }
+
+    /// Record that a source's flush barrier has drained, releasing the oldest
+    /// closing window still waiting on one for eviction.
+    fn mark_source_flushed(&mut self, source: &Source) {
+        let Some(entry) = self.windows.get_mut(source) else {
+            return;
+        };
+        let Some(window) = entry
+            .closing
+            .iter_mut()
+            .find(|window| window.awaiting_flush && !window.flushed)
+        else {
+            return;
+        };
+        window.flushed = true;
+        tracing::debug!(
+            recording_index = window.recording_index,
+            "producer flush barrier drained; window may retire"
+        );
     }
 
     /// Find the window for `source` containing `ts`. Closing windows are
@@ -1245,6 +1336,14 @@ mod tests {
             robot_instance: 0,
             publish_timestamp_ns,
             timestamp_ns: publish_timestamp_ns,
+        }
+    }
+
+    fn source_flushed(robot: &str, publish_timestamp_ns: i64) -> Envelope {
+        Envelope::SourceFlushed {
+            robot_id: robot.into(),
+            robot_instance: 0,
+            publish_timestamp_ns,
         }
     }
 
@@ -1886,6 +1985,9 @@ mod tests {
         // A closing window is retained for 2·holdback (so its in-window data has
         // released) and then evicted; without this the window map — and the
         // actor handles it holds — leak for the daemon's lifetime.
+        //
+        // Retention is the floor, not the whole gate: the flush marker is
+        // settled first so the deadline itself is what is tested.
         fast_holdback();
         let (store, dir) = open_store().await;
         let context = test_context(dir.path().join("recordings"), store.clone());
@@ -1905,6 +2007,12 @@ mod tests {
             1,
             "the stopped window is retained as closing"
         );
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 900), stopped_at)
+            .await;
+        dispatcher
+            .release_due_holdback(stopped_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
 
         // Just past the 2·holdback retention window.
         let retention = dispatcher.holdback * 2;
@@ -1916,5 +2024,127 @@ mod tests {
             .get(&source)
             .map_or(0, |entry| entry.closing.len());
         assert_eq!(closing, 0, "a closing window past 2·holdback is evicted");
+    }
+
+    #[tokio::test]
+    async fn housekeep_holds_a_stopped_window_until_the_flush_marker() {
+        // The stop is published before the writer's flush barrier, so the tail
+        // chunks it seals arrive after their own stop by an unbounded backlog.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        let stopped_at = opened_at + Duration::from_millis(1);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        // Well past the retention deadline.
+        let past_retention = stopped_at + dispatcher.holdback * 2 + Duration::from_millis(1);
+        dispatcher.housekeep(past_retention).await;
+        assert_eq!(
+            dispatcher.windows.get(&source).unwrap().closing.len(),
+            1,
+            "a stopped window still owed a flush marker outlives the retention deadline"
+        );
+
+        // The barrier drains and announces its marker.
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 900), past_retention)
+            .await;
+        let released_at = past_retention + dispatcher.holdback + Duration::from_millis(1);
+        dispatcher.release_due_holdback(released_at).await;
+        dispatcher.housekeep(released_at).await;
+
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "the window retires once the marker has released"
+        );
+    }
+
+    #[tokio::test]
+    async fn housekeep_evicts_a_stopped_window_when_the_flush_marker_never_comes() {
+        // The marker is best-effort: a producer that never sends one must not
+        // pin the window open forever.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        let stopped_at = opened_at + Duration::from_millis(1);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        let at_cap = stopped_at + FLUSH_MARKER_WAIT_CAP + Duration::from_millis(1);
+        dispatcher.housekeep(at_cap).await;
+
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "a marker that never arrives is capped, not waited on forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn tail_video_chunk_announced_past_the_retention_deadline_still_routes() {
+        // A burst producer is still draining when `stop_recording` returns, so
+        // its in-window tail chunk is announced past the retention deadline;
+        // without the marker gating eviction it is orphan-dropped.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let (tx, handle) = spawn(store.clone(), context.clone(), shutdown_rx);
+
+        let (publish_ts, thread_id) = (150, 7); // opened inside window [100, 200)
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+
+        tx.send(start("robot-1", 100)).await.unwrap();
+        tx.send(stop("robot-1", 200)).await.unwrap();
+
+        // Stand in for a slow flush barrier, well past the retention.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        tx.send(video_chunk("robot-1", publish_ts, thread_id))
+            .await
+            .unwrap();
+        tx.send(source_flushed("robot-1", 500)).await.unwrap();
+
+        drop(tx);
+        timeout(Duration::from_secs(10), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 1);
+        let traces = store
+            .list_traces_for_recording(recordings[0].recording_index)
+            .await
+            .unwrap();
+        assert!(
+            traces
+                .iter()
+                .any(|trace| trace.data_type.as_deref() == Some("RGB_IMAGES")),
+            "a tail chunk announced after the retention deadline must still route"
+        );
     }
 }

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -25,6 +25,23 @@
 //! been released; finalisation is then a single `WindowClosing` signal to each
 //! actor (no sequence counting).
 //!
+//! A video chunk is the one envelope carrying more than one datum, and the same
+//! rule decides it *per frame*: the window keeps the frames published before its
+//! stop and cuts off the rest (see [`frames_inside_window`], and
+//! `data_daemon_shared::video_boundary` for where the boundary lands and what
+//! the producer does with the other edge).
+//!
+//! **Tail video chunks** escape the holdback: the producer seals them after it
+//! published the stop, so no retention constant bounds their lateness. A stopped
+//! window waits for that producer's `SourceFlushed` marker instead, capped by
+//! [`FLUSH_MARKER_WAIT_CAP`] — leaving retention load-bearing only for windows
+//! closed without a stop, which get no marker at all.
+//!
+//! A marker speaks only for its own process, so a window must know whose markers
+//! it is owed: the producer claims the source from its logging thread
+//! ([`Envelope::VideoProducerActive`]), since its first sealed chunk would be
+//! late by exactly the backlog this exists to tolerate.
+//!
 //! Everything here is owned by one tokio task, so the window map and holdback
 //! queue need no locks — total ordering through the `select!` loop is what
 //! makes the routing decisions provable.
@@ -34,7 +51,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use data_daemon_shared::{BatchedDataItem, Envelope, FrameDtype};
+use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -283,6 +300,8 @@ enum HeldPayload {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
+        /// Per-frame publish time as ms after the chunk's open stamp
+        frame_publish_offsets_ms: Vec<u32>,
     },
     SourceFlushed {
         producer_pid: u32,
@@ -487,6 +506,7 @@ impl Dispatcher {
                 frame_timestamps_ns,
                 frame_timestamps_s,
                 dtype,
+                frame_publish_offsets_ms,
             } => {
                 let source = (robot_id, robot_instance);
                 self.touch_source(&source, recv_at);
@@ -506,6 +526,7 @@ impl Dispatcher {
                         frame_count,
                         frame_timestamps_s,
                         dtype,
+                        frame_publish_offsets_ms,
                     },
                 });
             }
@@ -1053,6 +1074,7 @@ impl Dispatcher {
                 frame_count,
                 frame_timestamps_s,
                 dtype,
+                frame_publish_offsets_ms,
             } => {
                 self.route_video(
                     &held.source,
@@ -1067,6 +1089,7 @@ impl Dispatcher {
                     frame_count,
                     frame_timestamps_s,
                     dtype,
+                    frame_publish_offsets_ms,
                 )
                 .await;
             }
@@ -1192,6 +1215,7 @@ impl Dispatcher {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
+        frame_publish_offsets_ms: Vec<u32>,
     ) {
         let recordings_root = self.actor_context.recordings_root.clone();
         // The chunk's `publish_timestamp_ns` (its open time) keys both the
@@ -1206,10 +1230,7 @@ impl Dispatcher {
             thread_id,
         );
 
-        // The whole chunk routes by its open (publish) time, which lies inside
-        // exactly one recording window — so the tail chunk of a recording is
-        // routed by a timestamp strictly before the window's stop boundary,
-        // never on it.
+        // The open stamp picks the window; the per-frame cut is below.
         let Some(entry) = self.windows.get_mut(source) else {
             remove_spool_nut(&spool_nut);
             self.note_orphan();
@@ -1221,6 +1242,35 @@ impl Dispatcher {
             return;
         };
         window.video_producers.insert(producer_pid);
+
+        // Membership by open stamp, extent by per-frame publish times.
+        let kept_frames = window.stopped_at_ns.map_or(frame_count, |stop| {
+            frames_inside_window(&frame_publish_offsets_ms, publish_ts, stop, frame_count)
+        });
+        let dropped_frames = frame_count.saturating_sub(kept_frames);
+        if kept_frames == 0 {
+            tracing::warn!(
+                recording_index = window.recording_index,
+                frame_count,
+                "video chunk has no frame published inside the window it opened \
+                 in; dropping it"
+            );
+            remove_spool_nut(&spool_nut);
+            self.note_orphan();
+            return;
+        }
+        let mut frame_timestamps_s = frame_timestamps_s;
+        if dropped_frames > 0 {
+            frame_timestamps_s.truncate(kept_frames as usize);
+            tracing::debug!(
+                recording_index = window.recording_index,
+                kept_frames,
+                dropped_frames,
+                "video chunk straddles the window's stop; keeping the frames \
+                 published before it"
+            );
+        }
+        let frame_count = kept_frames;
 
         let recording_index = window.recording_index;
         let handle = Self::ensure_actor(
@@ -1335,6 +1385,21 @@ impl Dispatcher {
         self.actor_context.trace_writer.flush().await;
         tracing::info!("dispatcher stopped");
     }
+}
+
+/// How many of a chunk's leading frames this window keeps, given the window's
+/// `stop_ns` and the chunk's `frame_publish_offsets_ms`.
+fn frames_inside_window(
+    offsets_ms: &[u32],
+    chunk_open_ns: i64,
+    stop_ns: i64,
+    frame_count: u32,
+) -> u32 {
+    if offsets_ms.is_empty() {
+        return frame_count;
+    }
+    let cut = video_boundary::frames_before_boundary(offsets_ms, chunk_open_ns, stop_ns);
+    u32::try_from(cut).unwrap_or(u32::MAX).min(frame_count)
 }
 
 fn remove_spool_nut(path: &std::path::Path) {
@@ -1731,9 +1796,54 @@ mod tests {
         );
     }
 
-    /// Announce a finished video chunk whose open time is `publish_ts`. The
-    /// caller must have spooled the matching NUT under the spool dir first.
+    #[test]
+    fn frames_inside_window_cuts_at_the_stop_boundary() {
+        // `video_boundary` tests the cut; this pins the argument order.
+        let open_ns = 1_000_000_000;
+        let stop_ns = open_ns + 25 * 1_000_000;
+        let offsets = [0, 10, 20, 30, 40];
+        assert_eq!(frames_inside_window(&offsets, open_ns, stop_ns, 5), 3);
+    }
+
+    #[test]
+    fn frames_inside_window_without_per_frame_data_takes_the_chunk_whole() {
+        // No offsets, no cut to make: the chunk routes whole.
+        assert_eq!(
+            frames_inside_window(&[], 1_000_000_000, 1_000_000_000, 7),
+            7
+        );
+    }
+
+    #[test]
+    fn frames_inside_window_clamps_to_the_announced_frame_count() {
+        // The pipeline sizes itself from `frame_count`, so the cut cannot
+        // exceed it.
+        let open_ns = 1_000_000_000;
+        let offsets = [0, 10, 20, 30];
+        assert_eq!(
+            frames_inside_window(&offsets, open_ns, open_ns + 60 * 1_000_000, 2),
+            2
+        );
+    }
+
+    /// Announce a finished single-frame chunk opened at `publish_ts`. The
+    /// caller must have spooled the matching NUT first.
     fn video_chunk(robot: &str, publish_ts: i64, thread_id: i64, producer_pid: u32) -> Envelope {
+        video_chunk_frames(robot, publish_ts, thread_id, producer_pid, &[0])
+    }
+
+    /// As [`video_chunk`], with one frame per entry in `publish_offsets_ms`.
+    fn video_chunk_frames(
+        robot: &str,
+        publish_ts: i64,
+        thread_id: i64,
+        producer_pid: u32,
+        publish_offsets_ms: &[u32],
+    ) -> Envelope {
+        let capture_stamps: Vec<i64> = publish_offsets_ms
+            .iter()
+            .map(|offset| publish_ts + i64::from(*offset) * 1_000_000)
+            .collect();
         Envelope::VideoChunkReady {
             robot_id: robot.into(),
             robot_instance: 0,
@@ -1745,10 +1855,11 @@ mod tests {
             width: 64,
             height: 64,
             byte_count: 9,
-            frame_count: 1,
-            frame_timestamps_ns: vec![publish_ts],
-            frame_timestamps_s: vec![publish_ts as f64 / 1e9],
+            frame_count: publish_offsets_ms.len() as u32,
+            frame_timestamps_s: capture_stamps.iter().map(|ns| *ns as f64 / 1e9).collect(),
+            frame_timestamps_ns: capture_stamps,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms: publish_offsets_ms.to_vec(),
         }
     }
 
@@ -1820,6 +1931,105 @@ mod tests {
         assert!(
             !spool_path.exists(),
             "the spooled NUT must be relinked out of the spool dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn straddling_video_chunk_keeps_its_in_window_prefix() {
+        // The frames published after the stop are cut off, not the chunk:
+        // dropping it loses the recording's video, keeping it whole leaves the
+        // recording holding video published after it closed.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        // The chunk opens inside the window and its frames run past the stop.
+        let stop_ns = 150 + 25 * 1_000_000;
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        dispatcher
+            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .await;
+
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        dispatcher
+            .handle_inbound(
+                video_chunk_frames("robot-1", publish_ts, thread_id, 1, &[0, 10, 20, 30, 40]),
+                opened_at,
+            )
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let entry = dispatcher.windows.get(&source).unwrap();
+        assert_eq!(
+            entry.closing[0].traces.len(),
+            1,
+            "the chunk's in-window frames must still route to a video trace"
+        );
+        assert_eq!(
+            dispatcher.orphan_drops, 0,
+            "cutting a chunk's tail is not an orphan drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn video_chunk_with_no_in_window_frame_is_dropped() {
+        // Defensive branch: an empty video trace would leave the recording
+        // advertising a video with no frames.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        let stop_ns = 150 + 25 * 1_000_000;
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        dispatcher
+            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .await;
+
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        dispatcher
+            .handle_inbound(
+                video_chunk_frames("robot-1", publish_ts, thread_id, 1, &[50, 60]),
+                opened_at,
+            )
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let entry = dispatcher.windows.get(&source).unwrap();
+        assert!(
+            entry.closing[0].traces.is_empty(),
+            "a chunk with no in-window frame must not register a video trace"
+        );
+        assert_eq!(dispatcher.orphan_drops, 1);
+        let spool_path = paths::spool_chunk_path(
+            &recordings_root,
+            "robot-1",
+            0,
+            "RGB_IMAGES",
+            Some("camera_0"),
+            publish_ts,
+            thread_id,
+        );
+        assert!(
+            !spool_path.exists(),
+            "the dropped chunk's spooled NUT must be removed"
         );
     }
 

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -29,7 +29,7 @@
 //! queue need no locks — total ordering through the `select!` loop is what
 //! makes the routing decisions provable.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -186,9 +186,16 @@ struct ActiveWindow {
     /// Closed by a `StopRecording`, so its producer still owes a
     /// [`Envelope::SourceFlushed`] marker.
     awaiting_flush: bool,
-    /// Set when that marker has been released from the holdback queue, i.e.
-    /// every tail chunk it was ordered behind has already routed.
-    flushed: bool,
+    /// OS process ids that have video in this window; it is not flushed until
+    /// every one of them also appears in `flushed_producers`.
+    ///
+    /// Needs both populating envelopes: a [`Envelope::VideoChunkReady`] arrives
+    /// only once a chunk has sealed, while a [`Envelope::VideoProducerActive`]
+    /// claim lands inside the window even when that first chunk will not.
+    video_producers: HashSet<u32>,
+    /// OS process ids whose `SourceFlushed` marker has left the holdback queue,
+    /// so every tail chunk ordered behind it has routed.
+    flushed_producers: HashSet<u32>,
     /// Per-trace actors spawned within this window.
     traces: HashMap<TraceKey, TraceHandle>,
 }
@@ -205,9 +212,16 @@ impl ActiveWindow {
     fn eviction_elapsed(&self, now: Instant, retention: Duration) -> Option<Duration> {
         let since_stop = self.stop_recv_at.map(|at| now.duration_since(at))?;
         let retained = since_stop >= retention;
-        let flush_settled =
-            !self.awaiting_flush || self.flushed || since_stop >= FLUSH_MARKER_WAIT_CAP;
+        let flush_settled = !self.awaiting_flush
+            || self.flush_markers_settled()
+            || since_stop >= FLUSH_MARKER_WAIT_CAP;
         (retained && flush_settled).then_some(since_stop)
+    }
+
+    /// True once every producer with video here has sent its flush marker.
+    fn flush_markers_settled(&self) -> bool {
+        !self.flushed_producers.is_empty()
+            && self.video_producers.is_subset(&self.flushed_producers)
     }
 }
 
@@ -262,6 +276,7 @@ enum HeldPayload {
         data_type: String,
         sensor_name: Option<String>,
         thread_id: i64,
+        producer_pid: u32,
         width: u32,
         height: u32,
         byte_count: u64,
@@ -269,8 +284,12 @@ enum HeldPayload {
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
     },
-    /// End-of-tail marker for a source's stopped window.
-    SourceFlushed,
+    SourceFlushed {
+        producer_pid: u32,
+    },
+    VideoProducerActive {
+        producer_pid: u32,
+    },
 }
 
 /// The dispatcher's task-local state.
@@ -460,6 +479,7 @@ impl Dispatcher {
                 sensor_name,
                 publish_timestamp_ns,
                 thread_id,
+                producer_pid,
                 width,
                 height,
                 byte_count,
@@ -479,6 +499,7 @@ impl Dispatcher {
                         data_type,
                         sensor_name,
                         thread_id,
+                        producer_pid,
                         width,
                         height,
                         byte_count,
@@ -492,6 +513,7 @@ impl Dispatcher {
                 robot_id,
                 robot_instance,
                 publish_timestamp_ns,
+                producer_pid,
             } => {
                 let source = (robot_id, robot_instance);
                 self.touch_source(&source, recv_at);
@@ -499,7 +521,24 @@ impl Dispatcher {
                     source,
                     release_at: recv_at + self.holdback,
                     publish_timestamp_ns,
-                    payload: HeldPayload::SourceFlushed,
+                    payload: HeldPayload::SourceFlushed { producer_pid },
+                });
+            }
+            Envelope::VideoProducerActive {
+                robot_id,
+                robot_instance,
+                publish_timestamp_ns,
+                producer_pid,
+            } => {
+                let source = (robot_id, robot_instance);
+                self.touch_source(&source, recv_at);
+                // Held for the same reason data is: the claim rides the
+                // producer's port, `StartRecording` the calling thread's.
+                self.held.push_back(Held {
+                    source,
+                    release_at: recv_at + self.holdback,
+                    publish_timestamp_ns,
+                    payload: HeldPayload::VideoProducerActive { producer_pid },
                 });
             }
             Envelope::RefreshConfig {} => self.handle_refresh_config().await,
@@ -611,7 +650,8 @@ impl Dispatcher {
             stopped_at_ns: None,
             stop_recv_at: None,
             awaiting_flush: false,
-            flushed: false,
+            video_producers: HashSet::new(),
+            flushed_producers: HashSet::new(),
             traces: HashMap::new(),
         });
 
@@ -708,7 +748,7 @@ impl Dispatcher {
             // on this stop's flush marker for the same reason.
             window.stop_recv_at = Some(recv_at);
             window.awaiting_flush = true;
-            window.flushed = false;
+            window.flushed_producers.clear();
             tracing::warn!(
                 robot_id = source.0,
                 recording_index,
@@ -877,11 +917,15 @@ impl Dispatcher {
         retention: Duration,
         closing_actors: &mut Vec<TraceHandle>,
     ) {
-        if window.awaiting_flush && !window.flushed {
+        if window.awaiting_flush && !window.flush_markers_settled() {
             tracing::warn!(
                 recording_index = window.recording_index,
                 robot_id = source.0,
                 elapsed_s = elapsed.as_secs_f64(),
+                outstanding_producers = window
+                    .video_producers
+                    .difference(&window.flushed_producers)
+                    .count(),
                 "no producer flush marker before the cap; retiring the \
                  window anyway — any tail video chunk still in flight \
                  will be dropped as an orphan"
@@ -897,7 +941,7 @@ impl Dispatcher {
                 "trace_actor_count": window.traces.len(),
                 "configured_retention_ms": retention.as_secs_f64() * 1_000.0,
                 "awaited_flush_marker": window.awaiting_flush,
-                "flush_marker_seen": window.flushed,
+                "flush_marker_seen": window.flush_markers_settled(),
             }),
         );
         for (_, handle) in window.traces.drain() {
@@ -1002,6 +1046,7 @@ impl Dispatcher {
                 data_type,
                 sensor_name,
                 thread_id,
+                producer_pid,
                 width,
                 height,
                 byte_count,
@@ -1015,6 +1060,7 @@ impl Dispatcher {
                     data_type,
                     sensor_name,
                     thread_id,
+                    producer_pid,
                     width,
                     height,
                     byte_count,
@@ -1024,27 +1070,51 @@ impl Dispatcher {
                 )
                 .await;
             }
-            HeldPayload::SourceFlushed => self.mark_source_flushed(&held.source),
+            HeldPayload::SourceFlushed { producer_pid } => {
+                self.mark_source_flushed(&held.source, producer_pid)
+            }
+            HeldPayload::VideoProducerActive { producer_pid } => {
+                self.note_video_producer(&held.source, publish_ts, producer_pid)
+            }
         }
     }
 
-    /// Record that a source's flush barrier has drained, releasing the oldest
-    /// closing window still waiting on one for eviction.
-    fn mark_source_flushed(&mut self, source: &Source) {
+    /// Attribute the window containing `publish_ts` to `producer_pid`, before
+    /// any of its video has sealed into a chunk.
+    fn note_video_producer(&mut self, source: &Source, publish_ts: i64, producer_pid: u32) {
         let Some(entry) = self.windows.get_mut(source) else {
             return;
         };
-        let Some(window) = entry
-            .closing
-            .iter_mut()
-            .find(|window| window.awaiting_flush && !window.flushed)
-        else {
+        let Some(window) = Self::window_for_mut(entry, publish_ts) else {
             return;
         };
-        window.flushed = true;
+        if window.video_producers.insert(producer_pid) {
+            tracing::debug!(
+                recording_index = window.recording_index,
+                producer_pid,
+                "producer claimed video for window; its own flush marker is now \
+                 required before the window can retire"
+            );
+        }
+    }
+
+    /// Credit one producer's drained flush barrier to the oldest closing window
+    /// still owed a marker from that `producer_pid`.
+    fn mark_source_flushed(&mut self, source: &Source, producer_pid: u32) {
+        let Some(entry) = self.windows.get_mut(source) else {
+            return;
+        };
+        let Some(window) = entry.closing.iter_mut().find(|window| {
+            window.awaiting_flush && !window.flushed_producers.contains(&producer_pid)
+        }) else {
+            return;
+        };
+        window.flushed_producers.insert(producer_pid);
         tracing::debug!(
             recording_index = window.recording_index,
-            "producer flush barrier drained; window may retire"
+            producer_pid,
+            "producer flush barrier drained; window may retire once every \
+             video-contributing producer has reported"
         );
     }
 
@@ -1115,6 +1185,7 @@ impl Dispatcher {
         data_type: String,
         sensor_name: Option<String>,
         thread_id: i64,
+        producer_pid: u32,
         width: u32,
         height: u32,
         byte_count: u64,
@@ -1149,6 +1220,7 @@ impl Dispatcher {
             self.note_orphan();
             return;
         };
+        window.video_producers.insert(producer_pid);
 
         let recording_index = window.recording_index;
         let handle = Self::ensure_actor(
@@ -1339,11 +1411,14 @@ mod tests {
         }
     }
 
-    fn source_flushed(robot: &str, publish_timestamp_ns: i64) -> Envelope {
+    /// The producer's end-of-barrier marker: no more tail chunks are coming for
+    /// this source's just-stopped window.
+    fn source_flushed(robot: &str, publish_timestamp_ns: i64, producer_pid: u32) -> Envelope {
         Envelope::SourceFlushed {
             robot_id: robot.into(),
             robot_instance: 0,
             publish_timestamp_ns,
+            producer_pid,
         }
     }
 
@@ -1658,7 +1733,7 @@ mod tests {
 
     /// Announce a finished video chunk whose open time is `publish_ts`. The
     /// caller must have spooled the matching NUT under the spool dir first.
-    fn video_chunk(robot: &str, publish_ts: i64, thread_id: i64) -> Envelope {
+    fn video_chunk(robot: &str, publish_ts: i64, thread_id: i64, producer_pid: u32) -> Envelope {
         Envelope::VideoChunkReady {
             robot_id: robot.into(),
             robot_instance: 0,
@@ -1666,6 +1741,7 @@ mod tests {
             sensor_name: Some("camera_0".into()),
             publish_timestamp_ns: publish_ts,
             thread_id,
+            producer_pid,
             width: 64,
             height: 64,
             byte_count: 9,
@@ -1710,7 +1786,7 @@ mod tests {
 
         // Window [100, 200); the chunk (open ts 150) is announced before stop.
         tx.send(start("robot-1", 100)).await.unwrap();
-        tx.send(video_chunk("robot-1", publish_ts, thread_id))
+        tx.send(video_chunk("robot-1", publish_ts, thread_id, 1))
             .await
             .unwrap();
         tx.send(stop("robot-1", 200)).await.unwrap();
@@ -1764,7 +1840,7 @@ mod tests {
 
         tx.send(start("robot-1", 100)).await.unwrap();
         tx.send(stop("robot-1", 200)).await.unwrap();
-        tx.send(video_chunk("robot-1", publish_ts, thread_id))
+        tx.send(video_chunk("robot-1", publish_ts, thread_id, 1))
             .await
             .unwrap();
 
@@ -2008,7 +2084,7 @@ mod tests {
             "the stopped window is retained as closing"
         );
         dispatcher
-            .handle_inbound(source_flushed("robot-1", 900), stopped_at)
+            .handle_inbound(source_flushed("robot-1", 900, 1), stopped_at)
             .await;
         dispatcher
             .release_due_holdback(stopped_at + dispatcher.holdback + Duration::from_millis(1))
@@ -2056,7 +2132,7 @@ mod tests {
 
         // The barrier drains and announces its marker.
         dispatcher
-            .handle_inbound(source_flushed("robot-1", 900), past_retention)
+            .handle_inbound(source_flushed("robot-1", 900, 1), past_retention)
             .await;
         let released_at = past_retention + dispatcher.holdback + Duration::from_millis(1);
         dispatcher.release_due_holdback(released_at).await;
@@ -2104,6 +2180,189 @@ mod tests {
         );
     }
 
+    /// A producer's claim that it is logging video, before any chunk sealed.
+    fn video_producer_active(robot: &str, publish_ts: i64, producer_pid: u32) -> Envelope {
+        Envelope::VideoProducerActive {
+            robot_id: robot.into(),
+            robot_instance: 0,
+            publish_timestamp_ns: publish_ts,
+            producer_pid,
+        }
+    }
+
+    #[tokio::test]
+    async fn video_claim_holds_the_window_for_a_producer_whose_chunk_has_not_sealed() {
+        // In real arrival order: the lifecycle process's instant marker is
+        // processed while the camera process is still deep in its backlog, so
+        // chunk-driven attribution is empty and the window would retire on a
+        // marker vouching for nothing. The claim is what holds it.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+
+        // The camera process claims the source as it logs, before any chunk.
+        dispatcher
+            .handle_inbound(video_producer_active("robot-1", 150, 1), opened_at)
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let stopped_at = opened_at + Duration::from_millis(2);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        // The lifecycle process owns no video, so its marker lands at once.
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 300, 2), stopped_at)
+            .await;
+        let retention = dispatcher.holdback * 2;
+        let past_retention = stopped_at + retention + Duration::from_millis(1);
+        dispatcher.release_due_holdback(past_retention).await;
+        dispatcher.housekeep(past_retention).await;
+        assert_eq!(
+            dispatcher.windows.get(&source).unwrap().closing.len(),
+            1,
+            "a claim from a producer that has not announced a chunk yet must \
+             still hold the window against another producer's marker"
+        );
+
+        // Its chunk is announced long past retention and must still route.
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        let drained_at = past_retention + Duration::from_millis(1);
+        dispatcher
+            .handle_inbound(video_chunk("robot-1", publish_ts, thread_id, 1), drained_at)
+            .await;
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 400, 1), drained_at)
+            .await;
+        let released_at = drained_at + dispatcher.holdback + Duration::from_millis(1);
+        dispatcher.release_due_holdback(released_at).await;
+        assert_eq!(
+            dispatcher.orphan_drops, 0,
+            "the tail chunk must route into the window the claim held open"
+        );
+
+        // The claim delays eviction, it does not deadlock it.
+        dispatcher.housekeep(released_at).await;
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "the window retires once the claiming producer's own marker arrives"
+        );
+    }
+
+    #[tokio::test]
+    async fn video_claim_outside_every_window_is_dropped_without_counting_an_orphan() {
+        // Routine, not data loss: it must not inflate the orphan counter.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, opened_at)
+            .await;
+
+        // Published after the stop: past every window's upper bound.
+        dispatcher
+            .handle_inbound(video_producer_active("robot-1", 250, 1), opened_at)
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        assert_eq!(dispatcher.orphan_drops, 0);
+        let window = &dispatcher.windows.get(&source).unwrap().closing[0];
+        assert!(
+            window.video_producers.is_empty(),
+            "a claim outside the window must not make the window wait on that \
+             producer's marker"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_flushed_from_one_producer_must_not_vouch_for_another_producers_chunk() {
+        // `SourceFlushed` is per-process, so a video-less process's marker says
+        // nothing about a camera process's still-open barrier. Retiring on the
+        // first marker from any producer orphans the camera's tail chunk.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let recordings_root = dir.path().join("recordings");
+        let context = test_context(recordings_root.clone(), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let opened_at = Instant::now();
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .await;
+
+        // Producer A seals a chunk mid-recording, so the window knows of it.
+        let (publish_ts, thread_id) = (150, 7);
+        spool_placeholder_nut(&recordings_root, publish_ts, thread_id);
+        dispatcher
+            .handle_inbound(video_chunk("robot-1", publish_ts, thread_id, 1), opened_at)
+            .await;
+        dispatcher
+            .release_due_holdback(opened_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let stopped_at = opened_at + Duration::from_millis(2);
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .await;
+
+        // Producer B owns no video, so its marker lands immediately.
+        dispatcher
+            .handle_inbound(source_flushed("robot-1", 300, 2), stopped_at)
+            .await;
+        dispatcher
+            .release_due_holdback(stopped_at + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        // Well past retention, but producer A has not sent its marker.
+        let retention = dispatcher.holdback * 2;
+        let past_retention = stopped_at + retention + Duration::from_millis(1);
+        dispatcher.housekeep(past_retention).await;
+        assert_eq!(
+            dispatcher.windows.get(&source).unwrap().closing.len(),
+            1,
+            "producer B's marker must not vouch for producer A's still-open \
+             flush barrier"
+        );
+
+        // Producer A's barrier never drains, so the cap has to release it.
+        let at_cap = stopped_at + FLUSH_MARKER_WAIT_CAP + Duration::from_millis(1);
+        dispatcher.housekeep(at_cap).await;
+        let closing = dispatcher
+            .windows
+            .get(&source)
+            .map_or(0, |entry| entry.closing.len());
+        assert_eq!(
+            closing, 0,
+            "an unmatched producer still gives way to the cap"
+        );
+    }
+
     #[tokio::test]
     async fn tail_video_chunk_announced_past_the_retention_deadline_still_routes() {
         // A burst producer is still draining when `stop_recording` returns, so
@@ -2124,10 +2383,10 @@ mod tests {
 
         // Stand in for a slow flush barrier, well past the retention.
         tokio::time::sleep(Duration::from_millis(400)).await;
-        tx.send(video_chunk("robot-1", publish_ts, thread_id))
+        tx.send(video_chunk("robot-1", publish_ts, thread_id, 1))
             .await
             .unwrap();
-        tx.send(source_flushed("robot-1", 500)).await.unwrap();
+        tx.send(source_flushed("robot-1", 500, 1)).await.unwrap();
 
         drop(tx);
         timeout(Duration::from_secs(10), handle.shutdown())

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -947,7 +947,7 @@ impl ActorState {
     }
 
     async fn finalise_writer(
-        &self,
+        &mut self,
         writer: TraceWriterKind,
         context: &Arc<TraceActorContext>,
     ) -> Result<u64, FrameAppendError> {
@@ -1003,6 +1003,13 @@ impl ActorState {
                     let completed = result.outcome?;
                     completed_chunks.insert(result.chunk_index, completed);
                 }
+                // Restate the frame count from the finished chunk set rather
+                // than trusting the running total. That total is only bumped by
+                // `drain_completed_encodes.
+                self.frame_count = completed_chunks
+                    .values()
+                    .map(|chunk| chunk.frame_count as u64)
+                    .sum();
                 crate::perf_events::emit(
                     "video_encoding",
                     "completed",
@@ -1499,6 +1506,11 @@ mod tests {
             .expect("trace exists");
         assert_eq!(trace.write_status, TraceWriteStatus::Written);
         assert!(trace.total_bytes > 0);
+        assert_eq!(
+            state.frame_count, 8,
+            "finalised frame count must cover every chunk, not just those \
+             drained before close"
+        );
 
         // RGB metadata entries must stay exactly as before: no `dtype` field.
         let sidecar: Value = serde_json::from_slice(

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -694,6 +694,7 @@ impl ActorState {
             lossy_out: lossy_segment.clone(),
             lossless_out: lossless_segment.clone(),
             codec,
+            frame_count,
         };
         pending_encodes.spawn(async move {
             // Acquire a permit before relinking + encoding. Gating the relink

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -1003,9 +1003,8 @@ impl ActorState {
                     let completed = result.outcome?;
                     completed_chunks.insert(result.chunk_index, completed);
                 }
-                // Restate the frame count from the finished chunk set rather
-                // than trusting the running total. That total is only bumped by
-                // `drain_completed_encodes.
+                // The running total is only bumped by `drain_completed_encodes`,
+                // which misses encodes that finish here, at window close.
                 self.frame_count = completed_chunks
                     .values()
                     .map(|chunk| chunk.frame_count as u64)

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -317,16 +317,11 @@ fn log_json(
 /// chunks are *not* sealed here — [`flush_source`] does that, and every caller
 /// must invoke it straight after this call.
 ///
-/// The stop is published BEFORE the writer flush barrier because it shares the
-/// calling thread's publisher with `StartRecording`, so sending it first is
-/// what guarantees the daemon sees this stop ahead of the next recording's
-/// start. Stamping the boundary early but sending after the flush let the stop
-/// reach the wire behind the following start, and the daemon then retired the
-/// wrong window and dropped both recordings' data.
-/// Late tail chunks (announced on the writer's port after this stop, by the
-/// flush barrier below) route into the just-closed window by the daemon's
-/// holdback + the `SourceFlushed` marker, so chunk-before-stop ordering is not
-/// required.
+/// The stop goes out BEFORE the writer flush barrier because it shares the
+/// calling thread's publisher with `StartRecording`: sending it first is what
+/// keeps the daemon from seeing this stop after the next recording's start.
+/// Late tail chunks still route into the just-closed window, via the daemon's
+/// holdback and the `SourceFlushed` marker.
 ///
 /// The producer stamps the window's upper bound on the publish clock here
 /// (`publish_timestamp_ns`, always wall-clock now at the send), so the whole
@@ -376,14 +371,27 @@ fn stop_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
-        // Then barrier on the writer: it drains every frame still queued for
-        // this source (FIFO), seals the tail chunks and announces them,
-        // publishes the `SourceFlushed` marker, then acks. Blocking here means
-        // `stop_recording` still returns only once those chunks are durably
-        // spooled + announced, so a process exit right after the call can't
-        // lose them. The tail chunks ride the writer's port and land after this
-        // stop; the daemon's holdback + that marker route them into the
-        // just-closed window by their in-window open timestamp.
+        // Split from [`flush_source`] so the caller can close its logging gate
+        // in between, rather than after a backlog-length barrier.
+        Ok(())
+    })
+}
+
+/// Run the writer's stop barrier for a source: drain every frame still queued
+/// for it (FIFO), seal and announce the tail chunks, publish the
+/// `SourceFlushed` marker, and drain the data publisher's queue onto the wire.
+///
+/// Mandatory after [`stop_recording`] — the tail chunks are sealed nowhere
+/// else. Blocking, so once it returns a process exit cannot lose them; the
+/// daemon's holdback and the `SourceFlushed` marker route them into the
+/// just-closed window. Idempotent.
+#[pyfunction]
+fn flush_source(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let robot_id = robot_id.to_string();
+    py.detach(|| {
         let (ack_tx, ack_rx) = std::sync::mpsc::channel();
         // Control messages bypass the frame caps, so this never blocks or stalls.
         let _ = writer_queue().push(WriterMsg::FlushSource {
@@ -396,8 +404,8 @@ fn stop_recording(
         // onto the data publisher's queue, so the ack above means spooled and
         // queued, not published. Drain once more to put them on the wire.
         flush_published_data();
-        Ok(())
-    })
+    });
+    Ok(())
 }
 
 /// Cancel a recording — drop the source's in-progress chunk state without
@@ -548,6 +556,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;
     module.add_function(wrap_pyfunction!(log_json, module)?)?;
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
+    module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -95,7 +95,7 @@ fn start_recording(
         // (publish clock when omitted). Decoupled from the window boundary.
         let capture_timestamp_ns = timestamp_ns.unwrap_or(publish_timestamp_ns);
         publish(&Envelope::StartRecording {
-            robot_id,
+            robot_id: robot_id.clone(),
             robot_instance,
             robot_name,
             dataset_id,
@@ -103,6 +103,12 @@ fn start_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // Tell the writer where the window opened, so no chunk spans it.
+        let _ = writer_queue().push(WriterMsg::Boundary {
+            robot_id,
+            robot_instance,
+            publish_ns: publish_timestamp_ns,
+        });
         Ok(capture_timestamp_ns)
     })
 }
@@ -229,6 +235,9 @@ fn log_frame(
         width,
         height,
         dtype: frame_dtype,
+        // Stamped on the caller's thread while the owning recording is open,
+        // not on the writer thread, which may reach the frame after the stop.
+        publish_ns: now_ns(),
         timestamp_ns,
         timestamp_s: resolved_timestamp_s,
         data,
@@ -297,26 +306,24 @@ fn log_json(
     Ok(())
 }
 
-/// Drain the data publisher, publish one `StopRecording`, then flush any tail
-/// video chunks for the source before returning.
+/// Drain the data publisher, then publish one `StopRecording`.
 ///
-/// Three barriers, in order: the data publisher's queue is drained first (so
-/// the recording's joint/JSON tail is on the wire before the window's upper
-/// bound is stamped), then the stop is published, then the writer is flushed
-/// and its chunk announcements drained. Together these make the call's
-/// post-condition uniform across every data path — once `stop_recording`
-/// returns, nothing belonging to the recording is still sitting in an
-/// in-process queue that a subsequent process exit would discard.
+/// Two barriers, in order: the data publisher's queue is drained first, so the
+/// recording's joint/JSON tail is on the wire before the window's upper bound
+/// is stamped, and only then is the stop published. The writer's tail video
+/// chunks are *not* sealed here — [`flush_source`] does that, and every caller
+/// must invoke it straight after this call.
 ///
-/// The stop is published BEFORE the writer flush barrier:
-/// it shares the calling thread's publisher with `StartRecording`, so sending
-/// it first guarantees the daemon sees this stop ahead of the next recording's
-/// start. Stamping the boundary early but sending only after a slow flush
-/// (~19 ms observed) let the stop reach the wire after the following start —
-/// the daemon then retired the wrong window and dropped both recordings' data.
-/// Late tail chunks (announced on the writer's port after this stop) route
-/// into the just-closed window by the daemon's holdback + closing-window
-/// retention, so chunk-before-stop ordering is not required.
+/// The stop is published BEFORE the writer flush barrier because it shares the
+/// calling thread's publisher with `StartRecording`, so sending it first is
+/// what guarantees the daemon sees this stop ahead of the next recording's
+/// start. Stamping the boundary early but sending after the flush let the stop
+/// reach the wire behind the following start, and the daemon then retired the
+/// wrong window and dropped both recordings' data.
+/// Late tail chunks (announced on the writer's port after this stop, by the
+/// flush barrier below) route into the just-closed window by the daemon's
+/// holdback + the `SourceFlushed` marker, so chunk-before-stop ordering is not
+/// required.
 ///
 /// The producer stamps the window's upper bound on the publish clock here
 /// (`publish_timestamp_ns`, always wall-clock now at the send), so the whole
@@ -367,13 +374,13 @@ fn stop_recording(
             timestamp_ns: capture_timestamp_ns,
         })?;
         // Then barrier on the writer: it drains every frame still queued for
-        // this source (FIFO), seals the tail chunks and announces them, then
-        // acks. Blocking here means `stop_recording` still returns only once
-        // those chunks are durably spooled + announced, so a process exit right
-        // after the call can't lose them. The tail chunks ride the writer's
-        // port and land after this stop; the daemon's holdback + closing-window
-        // retention route them into the just-closed window by their in-window
-        // open timestamp.
+        // this source (FIFO), seals the tail chunks and announces them,
+        // publishes the `SourceFlushed` marker, then acks. Blocking here means
+        // `stop_recording` still returns only once those chunks are durably
+        // spooled + announced, so a process exit right after the call can't
+        // lose them. The tail chunks ride the writer's port and land after this
+        // stop; the daemon's holdback + that marker route them into the
+        // just-closed window by their in-window open timestamp.
         let (ack_tx, ack_rx) = std::sync::mpsc::channel();
         // Control messages bypass the frame caps, so this never blocks or stalls.
         let _ = writer_queue().push(WriterMsg::FlushSource {

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -60,7 +60,7 @@ use crate::query::{
     daemon_version as daemon_version_impl, resolve_recording_id,
     wait_until_ready as wait_until_ready_impl,
 };
-use crate::writer::{writer_queue, FrameJob, WriterMsg};
+use crate::writer::{note_video_activity, writer_queue, FrameJob, WriterMsg};
 
 /// Announce that a recording has started for a source. Fire-and-forget: the
 /// daemon opens a window and owns all recording identity.
@@ -248,13 +248,16 @@ fn log_frame(
     // GIL would stall every Python thread in the process. A frame that cannot be
     // admitted before the spool-stall window elapses surfaces as an error rather
     // than being silently dropped, so the caller learns the daemon has stalled.
-    py.detach(move || writer_queue().push(WriterMsg::Frame(job)))
-        .map_err(|_| {
-            PyRuntimeError::new_err(
-                "video logging stalled: the data daemon is not draining the spool \
-                 backlog (frame rejected after 1s of backpressure)",
-            )
-        })?;
+    py.detach(move || {
+        note_video_activity(&job.robot_id, job.robot_instance, job.publish_ns);
+        writer_queue().push(WriterMsg::Frame(job))
+    })
+    .map_err(|_| {
+        PyRuntimeError::new_err(
+            "video logging stalled: the data daemon is not draining the spool \
+             backlog (frame rejected after 1s of backpressure)",
+        )
+    })?;
     Ok(())
 }
 

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -377,6 +377,24 @@ fn stop_recording(
     })
 }
 
+/// Arm a window-boundary split for a source without publishing a recording
+/// lifecycle event.
+#[pyfunction]
+fn mark_recording_boundary(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let robot_id = robot_id.to_string();
+    py.detach(|| {
+        let _ = writer_queue().push(WriterMsg::Boundary {
+            robot_id,
+            robot_instance,
+            publish_ns: now_ns(),
+        });
+    });
+    Ok(())
+}
+
 /// Run the writer's stop barrier for a source: drain every frame still queued
 /// for it (FIFO), seal and announce the tail chunks, publish the
 /// `SourceFlushed` marker, and drain the data publisher's queue onto the wire.
@@ -556,6 +574,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;
     module.add_function(wrap_pyfunction!(log_json, module)?)?;
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
+    module.add_function(wrap_pyfunction!(mark_recording_boundary, module)?)?;
     module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -36,6 +36,11 @@
 //! an [`Envelope::SourceFlushed`] marker on the same publisher port, and the
 //! daemon retires the window on that rather than on a timer.
 //!
+//! The marker speaks only for *this* process, and a source can be logged from
+//! several at once, so the daemon has to hear this process owes one before the
+//! first chunk seals — which is as late as the backlog is deep. Hence the claim
+//! comes off the logging thread, not the writer: see [`note_video_activity`].
+//!
 //! ## Fork safety
 //!
 //! The process-wide [`VIDEO_CHUNKS`] registry stores the owning PID and wipes
@@ -124,6 +129,14 @@ const SYNTH_PTS_STEP_MAX_US: u64 = 100_000;
 /// longer than any healthy transcode stall, yet short enough that the caller
 /// learns promptly instead of silently losing frames.
 const FRAME_ADMISSION_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Minimum publish-clock gap between two [`Envelope::VideoProducerActive`]
+/// claims for one source (see [`note_video_activity`]).
+///
+/// Bounded above by the daemon's window retention, so a claim always reaches
+/// its window before eviction, and below by IPC cost: one extra `commands`
+/// sample per source per interval.
+const VIDEO_CLAIM_INTERVAL_NS: i64 = 100_000_000;
 
 /// Resolve the producer's spool-backlog cap (bytes) from the daemon profile
 /// config (`spool_limit`: `NCD_SPOOL_LIMIT` → active profile → default).
@@ -225,6 +238,8 @@ struct VideoChunkRegistry {
     streams: HashMap<String, VideoChunkSlot>,
     /// Latest recording-window boundary seen per source prefix.
     boundaries: HashMap<String, i64>,
+    /// Last claim published per source prefix — the rate limiter's only state.
+    claims: HashMap<String, i64>,
 }
 
 static VIDEO_CHUNKS: LazyLock<Mutex<VideoChunkRegistry>> = LazyLock::new(|| {
@@ -232,6 +247,7 @@ static VIDEO_CHUNKS: LazyLock<Mutex<VideoChunkRegistry>> = LazyLock::new(|| {
         owner_pid: 0,
         streams: HashMap::new(),
         boundaries: HashMap::new(),
+        claims: HashMap::new(),
     })
 });
 
@@ -248,6 +264,8 @@ fn with_video_registry<R>(operation: impl FnOnce(&mut VideoChunkRegistry) -> R) 
     if registry.owner_pid != pid {
         registry.streams.clear();
         registry.boundaries.clear();
+        // A forked child is a different pid, so it owes its own claim.
+        registry.claims.clear();
         registry.owner_pid = pid;
     }
     operation(&mut registry)
@@ -1335,6 +1353,7 @@ fn flush_chunk_locked(
         sensor_name: Some(sensor_name.to_string()),
         publish_timestamp_ns,
         thread_id,
+        producer_pid: std::process::id(),
         width: state.width,
         height: state.height,
         byte_count,
@@ -1406,6 +1425,50 @@ fn announce_source_flushed(robot_id: &str, robot_instance: i64) {
         robot_id: robot_id.to_string(),
         robot_instance,
         publish_timestamp_ns: now_ns(),
+        producer_pid: std::process::id(),
+    }));
+}
+
+/// Should a source whose last claim was published at `last_claim_ns` claim
+/// again for a frame published at `publish_ns`?
+///
+/// The first frame always claims; after that the gap must reach
+/// [`VIDEO_CLAIM_INTERVAL_NS`] on the *publish* clock. A frame stamped behind
+/// the last claim (a regressed producer clock) claims again.
+fn should_claim_video(last_claim_ns: Option<i64>, publish_ns: i64) -> bool {
+    match last_claim_ns {
+        None => true,
+        Some(last) => publish_ns < last || publish_ns - last >= VIDEO_CLAIM_INTERVAL_NS,
+    }
+}
+
+/// Announce that this process is logging video for a source, rate-limited to
+/// one claim per [`VIDEO_CLAIM_INTERVAL_NS`].
+///
+/// Called from `log_frame` on the **logging** thread — deliberately not from
+/// the writer thread or the chunk seal, both of which are as late as the
+/// backlog is deep. The logging thread is inside the recording by construction,
+/// which is what makes the daemon's per-producer marker matching sound.
+///
+/// Best-effort: a dropped claim leaves the daemon with the chunk-driven
+/// attribution it had before.
+pub(crate) fn note_video_activity(robot_id: &str, robot_instance: i64, publish_ns: i64) {
+    let prefix = source_prefix(robot_id, robot_instance);
+    let claim = with_video_registry(|registry| {
+        if !should_claim_video(registry.claims.get(&prefix).copied(), publish_ns) {
+            return false;
+        }
+        registry.claims.insert(prefix, publish_ns);
+        true
+    });
+    if !claim {
+        return;
+    }
+    let _ = publisher_tx().send(PublishMsg::Announce(Envelope::VideoProducerActive {
+        robot_id: robot_id.to_string(),
+        robot_instance,
+        publish_timestamp_ns: publish_ns,
+        producer_pid: std::process::id(),
     }));
 }
 
@@ -1438,6 +1501,36 @@ mod tests {
         assert!(!should_flush_chunk(
             CHUNK_FLUSH_BYTES - 1,
             MAX_VIDEO_CHUNK_FRAMES - 1
+        ));
+    }
+
+    #[test]
+    fn first_frame_of_a_source_always_claims_it() {
+        // A short recording may have no second interval, so the first frame
+        // must not be rate limited.
+        assert!(should_claim_video(None, TEST_PUBLISH_NS));
+    }
+
+    #[test]
+    fn claims_are_rate_limited_to_one_per_interval() {
+        let last = TEST_PUBLISH_NS;
+        assert!(!should_claim_video(Some(last), last));
+        assert!(!should_claim_video(
+            Some(last),
+            last + VIDEO_CLAIM_INTERVAL_NS - 1
+        ));
+        assert!(should_claim_video(
+            Some(last),
+            last + VIDEO_CLAIM_INTERVAL_NS
+        ));
+    }
+
+    #[test]
+    fn a_regressed_publish_clock_claims_again() {
+        // Silence until the clock catches up leaves windows unclaimed.
+        assert!(should_claim_video(
+            Some(TEST_PUBLISH_NS),
+            TEST_PUBLISH_NS - 1
         ));
     }
 

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -27,9 +27,14 @@
 //! publishing `CancelRecording`, so no tail chunk is ever announced after the
 //! daemon tears the window down. Chunk-before-stop ordering is not a same-port
 //! guarantee here but is safe anyway: the daemon holds every `VideoChunkReady`
-//! back (`NCD_HOLDBACK_MS`, default 500 ms) and retains a just-closed window,
-//! so a tail chunk announced just after the stop still routes into the
-//! (closing) window by its in-window open timestamp.
+//! back (`NCD_HOLDBACK_MS`, default 500 ms), so a tail chunk announced just
+//! after the stop still routes into the (closing) window by its in-window open
+//! timestamp — but how long the daemon must then keep that closing window
+//! around is not something it can work out: the barrier lasts as long as this
+//! writer's backlog, which under burst logging runs well past any fixed
+//! retention. So it says so outright — after the last tail chunk it announces
+//! an [`Envelope::SourceFlushed`] marker on the same publisher port, and the
+//! daemon retires the window on that rather than on a timer.
 //!
 //! ## Fork safety
 //!
@@ -177,6 +182,12 @@ struct VideoChunkState {
     /// path. Re-stamped on every chunk open, so each chunk is named uniquely
     /// and no two recordings collide on a filename. `0` between chunks.
     chunk_publish_ns: i64,
+    /// Previous chunk's `chunk_publish_ns`, so the next open can be forced
+    /// strictly above it. `0` before the first chunk.
+    last_chunk_publish_ns: i64,
+    /// A recording-window boundary this stream has yet to cross: the first
+    /// frame to reach it seals the open chunk, so none spans the boundary.
+    pending_split_ns: Option<i64>,
     /// OS thread id (`gettid`) of the thread that opened the in-progress chunk.
     chunk_thread_id: i64,
     /// Frames already written into the in-progress chunk.
@@ -212,30 +223,39 @@ type VideoChunkSlot = Arc<Mutex<VideoChunkState>>;
 struct VideoChunkRegistry {
     owner_pid: u32,
     streams: HashMap<String, VideoChunkSlot>,
+    /// Latest recording-window boundary seen per source prefix.
+    boundaries: HashMap<String, i64>,
 }
 
 static VIDEO_CHUNKS: LazyLock<Mutex<VideoChunkRegistry>> = LazyLock::new(|| {
     Mutex::new(VideoChunkRegistry {
         owner_pid: 0,
         streams: HashMap::new(),
+        boundaries: HashMap::new(),
     })
 });
 
-/// Lock the video chunk registry and run `operation` against its streams map.
+/// Lock the video chunk registry and run `operation` against it.
 ///
 /// Heals on fork: when the stored `owner_pid` no longer matches the current
-/// process the map was inherited from a pre-fork parent, so it is cleared
+/// process the state was inherited from a pre-fork parent, so it is cleared
 /// before use.
-fn with_video_chunks<R>(operation: impl FnOnce(&mut HashMap<String, VideoChunkSlot>) -> R) -> R {
+fn with_video_registry<R>(operation: impl FnOnce(&mut VideoChunkRegistry) -> R) -> R {
     let mut registry = VIDEO_CHUNKS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let pid = std::process::id();
     if registry.owner_pid != pid {
         registry.streams.clear();
+        registry.boundaries.clear();
         registry.owner_pid = pid;
     }
-    operation(&mut registry.streams)
+    operation(&mut registry)
+}
+
+/// Lock the video chunk registry and run `operation` against its streams map.
+fn with_video_chunks<R>(operation: impl FnOnce(&mut HashMap<String, VideoChunkSlot>) -> R) -> R {
+    with_video_registry(|registry| operation(&mut registry.streams))
 }
 
 /// One frame handed to the background writer. Owns its raw sample bytes
@@ -252,6 +272,8 @@ pub(crate) struct FrameJob {
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) dtype: FrameDtype,
+    /// Stamped on the *calling* thread when `log_frame` accepted the frame.
+    pub(crate) publish_ns: i64,
     pub(crate) timestamp_ns: i64,
     pub(crate) timestamp_s: f64,
     pub(crate) data: Vec<u8>,
@@ -277,6 +299,12 @@ pub(crate) enum WriterMsg {
         robot_id: String,
         robot_instance: i64,
         ack: Sender<()>,
+    },
+    /// A window opened at `publish_ns`; no chunk may straddle it.
+    Boundary {
+        robot_id: String,
+        robot_instance: i64,
+        publish_ns: i64,
     },
 }
 
@@ -800,6 +828,7 @@ fn write_pending_frame(pending: PendingFrame, png: Vec<u8>) {
         pending.job.height,
         pending.job.dtype,
         &png,
+        pending.job.publish_ns,
         pending.job.timestamp_ns,
         pending.job.timestamp_s,
     ) {
@@ -878,6 +907,7 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
                 if let Err(error) = flush_source_chunks(&robot_id, robot_instance) {
                     tracing::warn!(%error, "failed to flush tail video chunks on stop");
                 }
+                announce_source_flushed(&robot_id, robot_instance);
                 let _ = ack.send(());
             }
             Some(WriterMsg::DropSource {
@@ -897,6 +927,13 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
                 });
                 let _ = ack.send(());
             }
+            Some(WriterMsg::Boundary {
+                robot_id,
+                robot_instance,
+                publish_ns,
+            }) => {
+                arm_boundary_split(&robot_id, robot_instance, publish_ns);
+            }
             // pop_timeout elapsed with no message: fall through to the rescan.
             None => {}
         }
@@ -912,31 +949,10 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
     }
 }
 
-/// A chunk-open timestamp that is strictly increasing within this process.
-///
-/// The spool filename is `chunk_{publish_ns}_{thread_id}.nut`. All video chunks
-/// are now opened by the single background writer thread, so they share one
-/// `thread_id` and uniqueness rests entirely on `publish_ns`. `now_ns()` reads
-/// `CLOCK_REALTIME`, whose granularity can repeat across two opens issued back
-/// to back, which would collide two cameras' chunk files. Bumping past the last
-/// value returned keeps every chunk's name distinct while staying within the
-/// recording window (the window spans seconds; a few ns of skew is irrelevant
-/// to membership). Only the writer thread calls this, but the atomic keeps it
-/// correct regardless.
-fn next_chunk_open_ns() -> i64 {
-    use std::sync::atomic::{AtomicI64, Ordering};
-    static LAST: AtomicI64 = AtomicI64::new(0);
-    let mut candidate = now_ns();
-    loop {
-        let last = LAST.load(Ordering::Relaxed);
-        if candidate <= last {
-            candidate = last + 1;
-        }
-        match LAST.compare_exchange_weak(last, candidate, Ordering::Relaxed, Ordering::Relaxed) {
-            Ok(_) => return candidate,
-            Err(_) => candidate = now_ns(),
-        }
-    }
+/// The chunk-open timestamp for a chunk whose first frame published at
+/// `frame_publish_ns`, kept strictly increasing within its stream.
+fn next_chunk_open_ns(last_chunk_publish_ns: i64, frame_publish_ns: i64) -> i64 {
+    frame_publish_ns.max(last_chunk_publish_ns.saturating_add(1))
 }
 
 /// OS thread id of the calling thread. Used to disambiguate a video chunk's
@@ -996,6 +1012,7 @@ fn record_video_frame(
     height: u32,
     dtype: FrameDtype,
     png_payload: &[u8],
+    publish_ns: i64,
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Result<(), ProducerError> {
@@ -1007,11 +1024,16 @@ fn record_video_frame(
     // at high frame rates. The recordings root is pre-validated on the GIL in
     // `log_frame`, so `spool_dir` only returns `None` on a genuine
     // misconfiguration — drop the frame (never panic on the writer thread).
-    let slot: VideoChunkSlot = match with_video_chunks(|streams| {
-        if let Some(slot) = streams.get(&key) {
+    let slot: VideoChunkSlot = match with_video_registry(|registry| {
+        if let Some(slot) = registry.streams.get(&key) {
             return Some(slot.clone());
         }
         let spool = spool_dir(robot_id, robot_instance, data_type, sensor_name)?;
+        // This stream is new, but its first frames may predate the window.
+        let pending_split_ns = registry
+            .boundaries
+            .get(&source_prefix(robot_id, robot_instance))
+            .copied();
         let slot = Arc::new(Mutex::new(VideoChunkState {
             width,
             height,
@@ -1019,6 +1041,8 @@ fn record_video_frame(
             spool_dir: spool,
             nut_writer: None,
             chunk_publish_ns: 0,
+            last_chunk_publish_ns: 0,
+            pending_split_ns,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1028,7 +1052,7 @@ fn record_video_frame(
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }));
-        streams.insert(key.clone(), slot.clone());
+        registry.streams.insert(key.clone(), slot.clone());
         Some(slot)
     }) {
         Some(slot) => slot,
@@ -1057,6 +1081,7 @@ fn record_video_frame(
             height,
             dtype,
             png_payload,
+            publish_ns,
             timestamp_ns,
             timestamp_s,
         )
@@ -1091,10 +1116,30 @@ fn append_frame_locked(
     height: u32,
     dtype: FrameDtype,
     png_payload: &[u8],
+    publish_ns: i64,
     timestamp_ns: i64,
     timestamp_s: f64,
 ) -> Vec<Envelope> {
     let mut announcements: Vec<Envelope> = Vec::new();
+
+    // A recording window opened partway through the frames queued ahead of this
+    // one. Seal here, so the chunk carrying the pre-window frames is announced
+    // on its own and this frame opens a fresh chunk stamped inside the window.
+    // Without the split one chunk spans the boundary, and since the daemon
+    // routes a chunk whole by its open stamp, the pre-window stamp orphans the
+    // entire chunk — silently discarding every in-window frame in it.
+    if let Some(split_ns) = state.pending_split_ns {
+        if publish_ns >= split_ns {
+            state.pending_split_ns = None;
+            if state.nut_writer.is_some() {
+                if let Some(envelope) =
+                    flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
+                {
+                    announcements.push(envelope);
+                }
+            }
+        }
+    }
 
     // A mid-stream resolution *or dtype* change can't share a chunk with the
     // prior state: the NUT header advertises the opening frame's size, and a
@@ -1187,11 +1232,14 @@ fn append_frame_locked(
     }
 
     if state.nut_writer.is_none() {
-        // Stamp the chunk's identity at open: its `publish_timestamp_ns`
-        // (this instant — inside the active recording window) plus the
-        // opening thread's id. These name the spool file and ride the
+        // The chunk's identity: publish stamp plus opening thread id, which
+        // name the spool file and ride the
         // announcement so the daemon can both route and locate the chunk.
-        state.chunk_publish_ns = next_chunk_open_ns();
+        //
+        // The stamp is the OPENING FRAME's publish time, taken back on the
+        // caller's thread (see `FrameJob::publish_ns`) — not this instant.
+        state.chunk_publish_ns = next_chunk_open_ns(state.last_chunk_publish_ns, publish_ns);
+        state.last_chunk_publish_ns = state.chunk_publish_ns;
         state.chunk_thread_id = current_thread_id();
         let chunk_path = state.spool_dir.join(spool_chunk_filename(
             state.chunk_publish_ns,
@@ -1297,6 +1345,25 @@ fn flush_chunk_locked(
     })
 }
 
+/// Arm a pending window-boundary split on every stream of a source.
+fn arm_boundary_split(robot_id: &str, robot_instance: i64, publish_ns: i64) {
+    let prefix = source_prefix(robot_id, robot_instance);
+    let slots: Vec<VideoChunkSlot> = with_video_registry(|registry| {
+        // Recorded per source, so a not-yet-created stream still picks it up.
+        registry.boundaries.insert(prefix.clone(), publish_ns);
+        registry
+            .streams
+            .iter()
+            .filter(|(key, _)| key.starts_with(&prefix))
+            .map(|(_, slot)| slot.clone())
+            .collect()
+    });
+    for slot in slots {
+        let mut state = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending_split_ns = Some(publish_ns);
+    }
+}
+
 /// Flush and remove every open video chunk for a source. Each flushed chunk is
 /// announced so the daemon can route it before the `StopRecording` lands.
 fn flush_source_chunks(robot_id: &str, robot_instance: i64) -> Result<(), ProducerError> {
@@ -1332,9 +1399,21 @@ fn flush_source_chunks(robot_id: &str, robot_instance: i64) -> Result<(), Produc
     Ok(())
 }
 
+/// Announce that the source's flush barrier is complete — no further tail
+/// chunks are coming for its just-stopped recording.
+fn announce_source_flushed(robot_id: &str, robot_instance: i64) {
+    let _ = publisher_tx().send(PublishMsg::Announce(Envelope::SourceFlushed {
+        robot_id: robot_id.to_string(),
+        robot_instance,
+        publish_timestamp_ns: now_ns(),
+    }));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_PUBLISH_NS: i64 = 1_700_000_000_000_000_000;
 
     #[test]
     fn flushes_when_byte_threshold_reached() {
@@ -1410,6 +1489,8 @@ mod tests {
             spool_dir,
             nut_writer: None,
             chunk_publish_ns: 0,
+            last_chunk_publish_ns: 0,
+            pending_split_ns: None,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1419,6 +1500,171 @@ mod tests {
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
         }
+    }
+
+    #[test]
+    fn chunk_is_stamped_from_its_opening_frame_not_the_writer_clock() {
+        // `publish_ns` is stamped on the caller's thread while the recording is
+        // open. Taking the writer's "now" instead would stamp the chunk outside
+        // the window and orphan every frame in it.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+
+        // The writer is far behind, so `now_ns()` is necessarily much larger.
+        let logged_at = now_ns() - 1_000_000_000;
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            logged_at,
+            1_000,
+            0.0,
+        );
+
+        assert_eq!(
+            state.chunk_publish_ns, logged_at,
+            "the chunk carries its opening frame's publish time verbatim"
+        );
+        match flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal") {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                ..
+            } => assert_eq!(
+                publish_timestamp_ns, logged_at,
+                "and announces it, so the daemon routes by when the frame was logged"
+            ),
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_window_boundary_splits_the_chunk_it_would_have_spanned() {
+        // Frames logged either side of `start_recording` can sit in the queue
+        // together, and a chunk spanning the boundary is orphaned whole.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+        let boundary = TEST_PUBLISH_NS;
+
+        // A frame logged before the window opened.
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            boundary - 1_000_000,
+            1_000,
+            0.0,
+        );
+        let pre_window_stamp = state.chunk_publish_ns;
+        state.pending_split_ns = Some(boundary);
+
+        // The first frame at/after the boundary must seal that chunk first.
+        let sealed = append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            boundary,
+            2_000,
+            0.001,
+        );
+
+        assert_eq!(
+            sealed.len(),
+            1,
+            "crossing the boundary seals the open chunk"
+        );
+        match &sealed[0] {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                frame_count,
+                ..
+            } => {
+                assert_eq!(
+                    *publish_timestamp_ns, pre_window_stamp,
+                    "the sealed chunk keeps its pre-window stamp, so the daemon \
+                     orphans only the frames that really are pre-window"
+                );
+                assert_eq!(*frame_count, 1);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
+        assert_eq!(
+            state.chunk_publish_ns, boundary,
+            "and the replacement chunk opens inside the window"
+        );
+        assert!(
+            state.pending_split_ns.is_none(),
+            "a boundary is applied exactly once"
+        );
+    }
+
+    #[test]
+    fn consecutive_chunks_of_a_stream_never_share_an_open_stamp() {
+        // The spool filename carries the publish stamp and thread id, so two
+        // chunks sharing a stamp would collide under a coarse clock tick.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+        let repeated = TEST_PUBLISH_NS;
+
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            repeated,
+            1_000,
+            0.0,
+        );
+        let first = state.chunk_publish_ns;
+        flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal");
+
+        append_frame_locked(
+            &mut state,
+            "r",
+            0,
+            "RGB",
+            "cam",
+            2,
+            2,
+            FrameDtype::Rgb8,
+            &frame,
+            repeated,
+            2_000,
+            0.001,
+        );
+        let second = state.chunk_publish_ns;
+
+        assert_eq!(first, repeated, "the first chunk takes the frame's stamp");
+        assert!(
+            second > first,
+            "a repeated publish stamp is bumped past the previous chunk's \
+             ({second} must exceed {first})"
+        );
     }
 
     #[test]
@@ -1441,6 +1687,7 @@ mod tests {
             2,
             FrameDtype::Rgb8,
             &frame_2x2,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1463,6 +1710,7 @@ mod tests {
             4,
             FrameDtype::Rgb8,
             &frame_4x4,
+            TEST_PUBLISH_NS,
             2_000,
             0.001,
         );
@@ -1517,6 +1765,7 @@ mod tests {
             2,
             FrameDtype::DepthF16,
             &png_payload,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1535,6 +1784,7 @@ mod tests {
             2,
             FrameDtype::DepthF32,
             &png_payload,
+            TEST_PUBLISH_NS,
             2_000,
             0.001,
         );
@@ -1581,6 +1831,7 @@ mod tests {
             2,
             FrameDtype::DepthF32,
             &frame,
+            TEST_PUBLISH_NS,
             1_000,
             0.0,
         );
@@ -1630,6 +1881,7 @@ mod tests {
                 2,
                 FrameDtype::Rgb8,
                 &frame,
+                TEST_PUBLISH_NS,
                 timestamp_ns,
                 timestamp_s,
             );
@@ -1703,6 +1955,7 @@ mod tests {
                 2,
                 FrameDtype::Rgb8,
                 &frame,
+                TEST_PUBLISH_NS,
                 timestamp_ns,
                 0.0,
             );
@@ -1728,6 +1981,7 @@ mod tests {
             width: 0,
             height: 0,
             dtype: FrameDtype::Rgb8,
+            publish_ns: TEST_PUBLISH_NS,
             timestamp_ns: 0,
             timestamp_s: 0.0,
             data: vec![0u8; bytes],
@@ -1861,6 +2115,7 @@ mod tests {
             4096,
             FrameDtype::Rgb8,
             &[0u8; 4],
+            TEST_PUBLISH_NS + timestamp_us * 1_000,
             timestamp_us * 1_000,
             timestamp_us as f64 / 1e6,
         )

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -57,6 +57,7 @@ use std::sync::{Arc, Condvar, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::service_name::{MAX_VIDEO_CHUNK_FRAMES, VIDEO_SPOOL_TICKS_PER_SECOND};
+use data_daemon_shared::video_boundary::{at_or_past_boundary, publish_offset_ms};
 use data_daemon_shared::{Envelope, FrameDtype};
 
 use crate::nut_writer::{NutVideoConfig, NutWriter};
@@ -226,6 +227,9 @@ struct VideoChunkState {
     frame_timestamps_ns: Vec<i64>,
     /// Per-frame `timestamp_s` accumulator for the in-progress chunk.
     frame_timestamps_s: Vec<f64>,
+    /// Per-frame publish time as ms after `chunk_publish_ns`, which is what
+    /// lets the daemon cut this chunk at a boundary inside it.
+    frame_publish_offsets_ms: Vec<u32>,
 }
 
 /// Process-wide registry of in-progress per-`(source, sensor)` video chunk
@@ -1069,6 +1073,7 @@ fn record_video_frame(
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
+            frame_publish_offsets_ms: Vec::new(),
         }));
         registry.streams.insert(key.clone(), slot.clone());
         Some(slot)
@@ -1115,8 +1120,9 @@ fn record_video_frame(
 }
 
 /// Append one frame to the locked per-stream chunk `state`, returning every
-/// chunk announcement produced this call: a geometry-change seal and/or a
-/// size/frame-cap flush (so a single call can yield two). Pure with respect to
+/// chunk announcement produced this call: a window-boundary or geometry-change
+/// seal before the append, and/or a size/frame-cap flush after it (so a single
+/// call can yield two). Pure with respect to
 /// IPC — the caller publishes the returned envelopes outside the lock — which
 /// also makes the open/seal/roll logic unit-testable without a live daemon.
 /// Best-effort: a NUT open/write error logs and drops the frame.
@@ -1139,23 +1145,26 @@ fn append_frame_locked(
     timestamp_s: f64,
 ) -> Vec<Envelope> {
     let mut announcements: Vec<Envelope> = Vec::new();
+    // The caller publishes the collected envelopes outside the lock.
+    let seal = |state: &mut VideoChunkState, announcements: &mut Vec<Envelope>| {
+        if let Some(envelope) =
+            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
+        {
+            announcements.push(envelope);
+        }
+    };
 
-    // A recording window opened partway through the frames queued ahead of this
-    // one. Seal here, so the chunk carrying the pre-window frames is announced
-    // on its own and this frame opens a fresh chunk stamped inside the window.
-    // Without the split one chunk spans the boundary, and since the daemon
-    // routes a chunk whole by its open stamp, the pre-window stamp orphans the
-    // entire chunk — silently discarding every in-window frame in it.
-    if let Some(split_ns) = state.pending_split_ns {
-        if publish_ns >= split_ns {
-            state.pending_split_ns = None;
-            if state.nut_writer.is_some() {
-                if let Some(envelope) =
-                    flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-                {
-                    announcements.push(envelope);
-                }
-            }
+    // A window opened partway through the queued frames. Without this seal one
+    // chunk spans the boundary and its pre-window open stamp orphans every
+    // in-window frame in it. The boundary is one-shot, so the first frame to
+    // reach it consumes it whether or not a chunk was open to seal.
+    if state
+        .pending_split_ns
+        .is_some_and(|split_ns| at_or_past_boundary(split_ns, publish_ns))
+    {
+        state.pending_split_ns = None;
+        if state.nut_writer.is_some() {
+            seal(state, &mut announcements);
         }
     }
 
@@ -1181,11 +1190,7 @@ fn append_frame_locked(
             new_dtype = ?dtype,
             "video frame geometry or dtype changed mid-stream; sealing chunk and reopening"
         );
-        if let Some(envelope) =
-            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-        {
-            announcements.push(envelope);
-        }
+        seal(state, &mut announcements);
     }
     state.width = width;
     state.dtype = dtype;
@@ -1301,13 +1306,12 @@ fn append_frame_locked(
     state.frame_count = state.frame_count.saturating_add(1);
     state.frame_timestamps_ns.push(timestamp_ns);
     state.frame_timestamps_s.push(timestamp_s);
+    state
+        .frame_publish_offsets_ms
+        .push(publish_offset_ms(state.chunk_publish_ns, publish_ns));
 
     if should_flush_chunk(logical_bytes_after_write, state.frame_count) {
-        if let Some(envelope) =
-            flush_chunk_locked(robot_id, robot_instance, data_type, sensor_name, state)
-        {
-            announcements.push(envelope);
-        }
+        seal(state, &mut announcements);
     }
     announcements
 }
@@ -1334,6 +1338,7 @@ fn flush_chunk_locked(
             state.frame_count = 0;
             state.frame_timestamps_ns.clear();
             state.frame_timestamps_s.clear();
+            state.frame_publish_offsets_ms.clear();
             return None;
         }
     };
@@ -1343,6 +1348,7 @@ fn flush_chunk_locked(
     let frame_count = state.frame_count;
     let frame_timestamps_ns = std::mem::take(&mut state.frame_timestamps_ns);
     let frame_timestamps_s = std::mem::take(&mut state.frame_timestamps_s);
+    let frame_publish_offsets_ms = std::mem::take(&mut state.frame_publish_offsets_ms);
 
     state.frame_count = 0;
 
@@ -1361,6 +1367,7 @@ fn flush_chunk_locked(
         frame_timestamps_ns,
         frame_timestamps_s,
         dtype: state.dtype,
+        frame_publish_offsets_ms,
     })
 }
 
@@ -1592,6 +1599,7 @@ mod tests {
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
+            frame_publish_offsets_ms: Vec::new(),
         }
     }
 
@@ -2014,6 +2022,50 @@ mod tests {
         assert_eq!(state.frame_count, 0);
         assert!(state.frame_timestamps_ns.is_empty());
         assert!(state.frame_timestamps_s.is_empty());
+        assert!(state.frame_publish_offsets_ms.is_empty());
+    }
+
+    #[test]
+    fn announcement_carries_each_frame_publish_offset_from_the_chunk_open() {
+        // The offsets carry each frame's caller-thread publish stamp, measured
+        // from the chunk's open, not the capture clock beside them.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
+        let frame = vec![0u8; 2 * 2 * 3];
+
+        // Publish stamps, with capture stamps on an unrelated clock.
+        for (index, capture_ns) in [10_000, 20_000, 30_000].into_iter().enumerate() {
+            append_frame_locked(
+                &mut state,
+                "r",
+                0,
+                "RGB",
+                "cam",
+                2,
+                2,
+                FrameDtype::Rgb8,
+                &frame,
+                TEST_PUBLISH_NS + index as i64 * 33_333_333,
+                capture_ns,
+                capture_ns as f64 / 1e9,
+            );
+        }
+
+        let envelope = flush_chunk_locked("r", 0, "RGB", "cam", &mut state).expect("seal");
+        match envelope {
+            Envelope::VideoChunkReady {
+                publish_timestamp_ns,
+                frame_publish_offsets_ms,
+                ..
+            } => {
+                assert_eq!(
+                    publish_timestamp_ns, TEST_PUBLISH_NS,
+                    "the chunk's open stamp is its first frame's publish stamp"
+                );
+                assert_eq!(frame_publish_offsets_ms, vec![0, 33, 66]);
+            }
+            other => panic!("expected VideoChunkReady, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -85,11 +85,7 @@ pub mod video_boundary {
 
     /// Leading frames published before `bound_ns`, i.e. the index of the first
     /// that is [`at_or_past_boundary`].
-    pub fn frames_before_boundary(
-        offsets_ms: &[u32],
-        chunk_open_ns: i64,
-        bound_ns: i64,
-    ) -> usize {
+    pub fn frames_before_boundary(offsets_ms: &[u32], chunk_open_ns: i64, bound_ns: i64) -> usize {
         offsets_ms
             .iter()
             .position(|offset| {

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -409,8 +409,8 @@ pub enum Envelope {
         /// Number of frames packed into this chunk.
         frame_count: u32,
         /// Per-frame capture time in nanoseconds since the Unix epoch, in
-        /// arrival order. Length equals `frame_count`. Used to bucket the
-        /// chunk's frames against the source's active-window map.
+        /// arrival order. Length equals `frame_count`. Capture-clock content for
+        /// the trace sidecar; routing uses `frame_publish_offsets_ms`.
         frame_timestamps_ns: Vec<i64>,
         /// Per-frame `timestamp_s` (Unix seconds, f64) in arrival order.
         /// Length equals `frame_count`; values round-trip bit-exact through
@@ -430,6 +430,18 @@ pub enum Envelope {
     /// recording window; the dispatcher handles it by refreshing the in-memory
     /// config (see `cloud::config_watcher`).
     RefreshConfig {},
+    /// End-of-stream marker for a just-stopped window's late data.
+    ///
+    /// Published on the same port as the chunk announcements, so it is ordered
+    /// strictly behind every chunk it vouches for and the dispatcher can evict
+    /// the closing window with no timing assumption.
+    SourceFlushed {
+        robot_id: String,
+        robot_instance: i64,
+        /// Publish time at the marker's send. Diagnostic only: deliberately
+        /// not used for window membership.
+        publish_timestamp_ns: i64,
+    },
 }
 
 /// Original pixel/sample representation of one video-family frame.
@@ -515,6 +527,7 @@ impl Envelope {
             Envelope::BatchedData { .. } => "batched_data",
             Envelope::VideoChunkReady { .. } => "video_chunk_ready",
             Envelope::RefreshConfig {} => "refresh_config",
+            Envelope::SourceFlushed { .. } => "source_flushed",
         }
     }
 

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -400,6 +400,10 @@ pub enum Envelope {
         /// chunk. Disambiguates the spool filename across threads and is a
         /// useful breadcrumb when inspecting the spool directory.
         thread_id: i64,
+        /// OS process id of the producer that sealed this chunk, matched
+        /// against [`Envelope::SourceFlushed`]'s `producer_pid` so one process's
+        /// marker never vouches for another's pending video.
+        producer_pid: u32,
         /// Frame width in pixels (constant across a trace).
         width: u32,
         /// Frame height in pixels (constant across a trace).
@@ -441,6 +445,20 @@ pub enum Envelope {
         /// Publish time at the marker's send. Diagnostic only: deliberately
         /// not used for window membership.
         publish_timestamp_ns: i64,
+        /// OS process id of the producer whose barrier this reports on.
+        producer_pid: u32,
+    },
+    /// Producer asserts that it is currently logging video for a source —
+    /// published *before* any of that video has been sealed into a chunk.
+    VideoProducerActive {
+        robot_id: String,
+        robot_instance: i64,
+        /// Publish time of the frame that triggered the claim, stamped on the
+        /// logging thread, so it is the window-membership key here too.
+        publish_timestamp_ns: i64,
+        /// OS process id of the claiming producer, the same identity
+        /// [`Envelope::SourceFlushed`] reports under.
+        producer_pid: u32,
     },
 }
 
@@ -528,6 +546,7 @@ impl Envelope {
             Envelope::VideoChunkReady { .. } => "video_chunk_ready",
             Envelope::RefreshConfig {} => "refresh_config",
             Envelope::SourceFlushed { .. } => "source_flushed",
+            Envelope::VideoProducerActive { .. } => "video_producer_active",
         }
     }
 
@@ -918,6 +937,19 @@ mod tests {
     }
 
     #[test]
+    fn video_producer_active_round_trips() {
+        let claim = Envelope::VideoProducerActive {
+            robot_id: "robot-1".into(),
+            robot_instance: 3,
+            publish_timestamp_ns: 1_700_000_000_000_000_000,
+            producer_pid: 4242,
+        };
+        let bytes = claim.encode().expect("encode");
+        assert_eq!(claim, Envelope::decode(&bytes).expect("decode"));
+        assert_eq!(claim.kind(), "video_producer_active");
+    }
+
+    #[test]
     fn video_chunk_ready_round_trips() {
         let original = Envelope::VideoChunkReady {
             robot_id: "robot-1".into(),
@@ -926,6 +958,7 @@ mod tests {
             sensor_name: Some("camera_right".into()),
             publish_timestamp_ns: 1_700_000_000_000_000_000,
             thread_id: 4242,
+            producer_pid: 99,
             width: 1920,
             height: 1080,
             byte_count: 128 * 1024 * 1024,
@@ -967,6 +1000,7 @@ mod tests {
                 sensor_name: Some("depth_camera".into()),
                 publish_timestamp_ns: 1_700_000_000_000_000_000,
                 thread_id: 7,
+                producer_pid: 99,
                 width: 128,
                 height: 128,
                 byte_count: 4096,
@@ -1025,6 +1059,7 @@ mod tests {
             sensor_name: Some("camera_right".into()),
             publish_timestamp_ns: 1_700_000_000_000_000_000,
             thread_id: 42,
+            producer_pid: 99,
             width: 1920,
             height: 1080,
             byte_count: 128 * 1024 * 1024,
@@ -1060,6 +1095,7 @@ mod tests {
             sensor_name: Some("camera_with_a_deliberately_long_sensor_label".into()),
             publish_timestamp_ns: i64::MAX,
             thread_id: i64::MAX,
+            producer_pid: u32::MAX,
             width: u32::MAX,
             height: u32::MAX,
             byte_count: u64::MAX,

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -48,6 +48,122 @@ use thiserror::Error;
 pub mod config;
 pub mod paths;
 
+/// Recording-window membership for the frames *inside* one video chunk.
+///
+/// A chunk is a NUT file appended to until something seals it, so frames logged
+/// either side of a boundary can share one and its open stamp speaks only for
+/// the first. Both sides of the wire divide the work by what each knows in time:
+///
+/// - The **producer** seals the open chunk before the first frame at or past a
+///   boundary, which only works at a recording's start and only in the process
+///   that called `start_recording`.
+/// - The **daemon** cuts a chunk it already holds, from the per-frame offsets
+///   this module encodes. Only this works at a stop, where a video-only process
+///   logs on until its notification arrives and the frames are already written.
+pub mod video_boundary {
+    /// Nanoseconds per millisecond, the wire resolution of a frame offset.
+    const NS_PER_MS: i64 = 1_000_000;
+
+    /// Is `frame_publish_ns` at or past the recording boundary `bound_ns`?
+    ///
+    /// Argument order is boundary first, frame second.
+    pub fn at_or_past_boundary(bound_ns: i64, frame_publish_ns: i64) -> bool {
+        frame_publish_ns >= bound_ns
+    }
+
+    /// One frame's publish time as ms after its chunk's open stamp.
+    pub fn publish_offset_ms(chunk_open_ns: i64, frame_publish_ns: i64) -> u32 {
+        let offset_ns = frame_publish_ns.saturating_sub(chunk_open_ns).max(0);
+        (offset_ns / NS_PER_MS).try_into().unwrap_or(u32::MAX)
+    }
+
+    /// The inverse of [`publish_offset_ms`], paired with it so neither can
+    /// change alone.
+    pub fn frame_publish_ns(chunk_open_ns: i64, offset_ms: u32) -> i64 {
+        chunk_open_ns.saturating_add(i64::from(offset_ms) * NS_PER_MS)
+    }
+
+    /// Leading frames published before `bound_ns`, i.e. the index of the first
+    /// that is [`at_or_past_boundary`].
+    pub fn frames_before_boundary(
+        offsets_ms: &[u32],
+        chunk_open_ns: i64,
+        bound_ns: i64,
+    ) -> usize {
+        offsets_ms
+            .iter()
+            .position(|offset| {
+                at_or_past_boundary(bound_ns, frame_publish_ns(chunk_open_ns, *offset))
+            })
+            .unwrap_or(offsets_ms.len())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        const CHUNK_OPEN_NS: i64 = 1_700_000_000_000_000_000;
+
+        #[test]
+        fn a_frame_on_the_bound_is_already_past_it() {
+            // The half-open convention both sides must agree on.
+            assert!(!at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 1));
+            assert!(at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS));
+            assert!(at_or_past_boundary(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1));
+        }
+
+        #[test]
+        fn offsets_round_trip_at_millisecond_resolution() {
+            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS), 0);
+            assert_eq!(
+                publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1_500_000),
+                1
+            );
+            assert_eq!(
+                frame_publish_ns(CHUNK_OPEN_NS, 33),
+                CHUNK_OPEN_NS + 33_000_000
+            );
+        }
+
+        #[test]
+        fn publish_offset_saturates_at_the_chunk_open() {
+            // A backwards caller clock reads as 0 rather than wrapping.
+            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 5), 0);
+        }
+
+        #[test]
+        fn frames_before_boundary_cuts_on_the_bound() {
+            // The frames before the boundary are kept; the rest are cut.
+            let offsets = [0, 10, 20, 30, 40];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 25);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 3);
+
+            // And the bound itself is exclusive.
+            let on_boundary = frame_publish_ns(CHUNK_OPEN_NS, 20);
+            assert_eq!(
+                frames_before_boundary(&offsets, CHUNK_OPEN_NS, on_boundary),
+                2
+            );
+        }
+
+        #[test]
+        fn frames_entirely_before_the_boundary_are_all_kept() {
+            let offsets = [0, 10, 20];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 60);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 3);
+        }
+
+        #[test]
+        fn the_cut_is_a_prefix_under_disordered_stamps() {
+            // One file feeds one encode, so the first frame at or past the
+            // boundary takes its successors with it.
+            let offsets = [0, 30, 10, 20];
+            let bound = frame_publish_ns(CHUNK_OPEN_NS, 25);
+            assert_eq!(frames_before_boundary(&offsets, CHUNK_OPEN_NS, bound), 1);
+        }
+    }
+}
+
 /// iceoryx2 service-name conventions shared by daemon and producer.
 pub mod service_name {
     /// Pub/sub service carrying every IPC envelope: lifecycle
@@ -73,8 +189,9 @@ pub mod service_name {
     /// Worst-case postcard size of one frame's contribution to a
     /// [`crate::Envelope::VideoChunkReady`] announcement: a `frame_timestamps_ns`
     /// element is an `i64` zigzag varint (≤10 bytes for a full-range Unix-ns
-    /// value) and a `frame_timestamps_s` element is a fixed 8-byte `f64`.
-    pub const VIDEO_CHUNK_BYTES_PER_FRAME: usize = 10 + 8;
+    /// value), a `frame_timestamps_s` element is a fixed 8-byte `f64`, and a
+    /// `frame_publish_offsets_ms` element is a `u32` varint (≤5 bytes).
+    pub const VIDEO_CHUNK_BYTES_PER_FRAME: usize = 10 + 8 + 5;
 
     /// Bytes held back from [`COMMANDS_MAX_PAYLOAD_BYTES`] for a
     /// `VideoChunkReady` envelope's fixed fields — the enum tag, source ids,
@@ -87,7 +204,8 @@ pub mod service_name {
     /// The producer seals a chunk at the **lower** of its byte threshold and
     /// this frame cap. The cap exists so a [`crate::Envelope::VideoChunkReady`]
     /// announcement always fits one [`COMMANDS_MAX_PAYLOAD_BYTES`] sample: the
-    /// per-frame `frame_timestamps_{ns,s}` vectors are the only unbounded part
+    /// per-frame `frame_timestamps_{ns,s}` and `frame_publish_offsets_ms`
+    /// vectors are the only unbounded part
     /// of the envelope, so a long recording of small frames — which never
     /// reaches the byte threshold mid-recording — would otherwise accumulate
     /// enough frames in a single chunk to overflow the slice. The announcement
@@ -425,6 +543,10 @@ pub enum Envelope {
         /// geometry change). The daemon never decodes pixels; it threads this
         /// straight into the trace's `trace.json` sidecar for depth frames.
         dtype: FrameDtype,
+        /// Per-frame publish time as ms after this chunk's own
+        /// `publish_timestamp_ns`, in arrival order. What makes chunk membership
+        /// per-frame rather than atomic; see [`video_boundary`].
+        frame_publish_offsets_ms: Vec<u32>,
     },
     /// Force the daemon to re-read its profile config immediately, rather than
     /// waiting for the config watcher's next poll. Sent by the SDK's
@@ -976,6 +1098,7 @@ mod tests {
                 7.0_f64 / 60.0_f64,
             ],
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms: vec![0, 16, 33, 50],
         };
         let bytes = original.encode().expect("encode");
         let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1008,6 +1131,7 @@ mod tests {
                 frame_timestamps_ns: vec![1_700_000_000_000_000_000],
                 frame_timestamps_s: vec![1_700_000_000.0],
                 dtype,
+                frame_publish_offsets_ms: vec![0],
             };
             let bytes = original.encode().expect("encode");
             let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1047,11 +1171,11 @@ mod tests {
 
     #[test]
     fn video_chunk_ready_worst_case_fits_commands_slice() {
-        // A 128 MiB 1080p chunk holds ~3800 frames; carry two timestamps per
-        // frame (ns + s). Even at 10_000 frames the envelope is comfortably
-        // under COMMANDS_MAX_PAYLOAD_BYTES.
+        // Two timestamps plus a publish offset per frame stays well under
+        // COMMANDS_MAX_PAYLOAD_BYTES even at an implausible frame count.
         let frame_timestamps_ns: Vec<i64> = (0..10_000).map(|i| i as i64 * 1_000_000).collect();
         let frame_timestamps_s: Vec<f64> = (0..10_000).map(|i| i as f64 * 1e-3).collect();
+        let frame_publish_offsets_ms: Vec<u32> = (0..10_000).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: 0,
@@ -1067,6 +1191,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(
@@ -1082,12 +1207,14 @@ mod tests {
         // The producer caps a chunk at MAX_VIDEO_CHUNK_FRAMES frames so its
         // announcement always fits one commands sample. Prove the cap holds at
         // the absolute worst case: every per-frame ns timestamp a full-range
-        // i64 (10-byte postcard zigzag varint) and every fixed field maxed out.
+        // i64 (10-byte postcard zigzag varint), every publish offset a
+        // full-range u32 (5-byte varint), and every fixed field maxed out.
         // Without the cap a long recording of tiny frames overflows the slice
         // and the whole recording's video announcement fails to publish.
         let count = service_name::MAX_VIDEO_CHUNK_FRAMES as usize;
         let frame_timestamps_ns: Vec<i64> = (0..count).map(|i| i64::MAX - i as i64).collect();
         let frame_timestamps_s: Vec<f64> = (0..count).map(|i| i as f64).collect();
+        let frame_publish_offsets_ms: Vec<u32> = (0..count).map(|_| u32::MAX).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: i64::MAX,
@@ -1103,6 +1230,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
+            frame_publish_offsets_ms,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -23,17 +23,8 @@ class _FailingStopStream(_ActiveStream):
         raise RuntimeError("stop failed")
 
 
-def test_web_stop_drains_streams_and_notifies_daemon() -> None:
-    """Callback registered at connect time must drain streams and notify the daemon."""
-    robot = Robot("robot", instance=0, org_id="org-1")
-    robot.id = "robot-id-1"
-
-    active = _ActiveStream()
-    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
-
-    fake_daemon = MagicMock()
-    robot._daemon_recording_context = fake_daemon
-
+def _remote_stop_callback(robot: Robot) -> object:
+    """Register the connect-time handler and hand back the callback it stored."""
     captured: dict[str, object] = {}
 
     class _FakeManager:
@@ -53,10 +44,44 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
 
     callback = captured["callback"]
     assert callable(callback)
-    callback("rec-abc")
+    return callback
+
+
+def test_web_stop_drains_streams_and_notifies_daemon() -> None:
+    """Callback registered at connect time must drain streams and notify the daemon."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+    # This process opened the window, so it is the one that closes it.
+    robot._owns_daemon_recording = True
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    _remote_stop_callback(robot)("rec-abc")
 
     assert active.stop_calls == 1
     fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.flush_source.assert_called_once_with()
+
+
+def test_web_stop_in_a_non_owning_process_flushes_without_publishing_a_stop() -> None:
+    """A process that never started the recording must not publish its stop."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    _remote_stop_callback(robot)("rec-abc")
+
+    assert active.stop_calls == 1
+    fake_daemon.stop_recording.assert_not_called()
     fake_daemon.flush_source.assert_called_once_with()
 
 

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -57,6 +57,7 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
 
     assert active.stop_calls == 1
     fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.flush_source.assert_called_once_with()
 
 
 def test_stop_all_streams_logs_stop_failure_and_continues() -> None:


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Function for non owning video producers to mark the boundary window for their source. **Caveat** Process owning start recording call must call stop.
