### PR TITLE
fix: batch size validation improvements

### DIFF
--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -38,6 +38,12 @@ _NUM_WARMUP_ITERATIONS = 1
 # this factor and re-probed until it fits -- a cheap alternative to bisection.
 _DOWNSCALE_FACTOR = 0.9
 
+# Validation reuses the autotuner's own headroom (budget * safety) so a manually
+# set batch size is accepted only if it leaves the same margin an auto-selected
+# one would.
+_VALIDATION_MAX_GPU_UTILIZATION = 0.9
+_VALIDATION_SAFETY_FACTOR = 0.6
+
 
 @dataclass
 class BatchProbeResult:
@@ -417,7 +423,7 @@ class BatchSizeAutotuner:
         min_batch_size: int = 2,
         max_batch_size: int = 512,
         num_iterations: int = 2,
-        safety_factor: float = 0.7,
+        safety_factor: float = 0.6,
     ):
         """Initialize the batch size auto-tuner.
 
@@ -836,6 +842,35 @@ def find_optimal_batch_size(
     return optimal_batch_size
 
 
+def _fits_within_budget(
+    result: BatchProbeResult,
+    max_gpu_utilization: float,
+    safety_factor: float,
+) -> bool:
+    """Return True if the probe fitted within budget * safety.
+
+    A probe that merely avoided OOM is not enough to call a batch size valid:
+    real training allocates memory a short, single-process probe never does (DDP
+    gradient buckets / NCCL buffers, allocator fragmentation over a full epoch,
+    grad-clipping and scheduler temporaries). Apply the same budget * safety
+    threshold the autotuner uses so a manually set batch is accepted only if it
+    would survive as an auto-selected one.
+
+    Args:
+        result: The probe result to judge.
+        max_gpu_utilization: Fraction of VRAM treated as the usable budget.
+        safety_factor: Extra headroom multiplier applied on top of the budget.
+
+    Returns:
+        True if the probe fitted and its peak reserved memory is within
+        total * max_gpu_utilization * safety_factor.
+    """
+    if not result.fitted:
+        return False
+    budget_bytes = result.total_bytes * max_gpu_utilization * safety_factor
+    return result.peak_reserved_bytes <= budget_bytes
+
+
 def is_valid_batch_size(
     cfg: DictConfig,
     model_factory: Callable[[], NeuracoreModel],
@@ -843,7 +878,12 @@ def is_valid_batch_size(
     batch_size: int,
     device: torch.device,
 ) -> bool:
-    """Check whether a specific batch size fits in RAM and GPU memory."""
+    """Check whether a specific batch size fits in RAM and GPU memory.
+
+    A batch is valid only if the probe both fits and leaves headroom (budget *
+    safety); a batch that fits at the razor's edge is rejected, because real
+    training adds overhead the probe does not measure and would then OOM.
+    """
     train_dataset, _ = _split_train_val_dataset(cfg, dataset)
 
     if batch_size > len(train_dataset):
@@ -872,9 +912,12 @@ def is_valid_batch_size(
         },
     )
 
-    valid = validator.test_batch_size(batch_size)
-
-    return valid
+    result = validator.probe_batch_size(batch_size)
+    return _fits_within_budget(
+        result,
+        max_gpu_utilization=_VALIDATION_MAX_GPU_UTILIZATION,
+        safety_factor=_VALIDATION_SAFETY_FACTOR,
+    )
 
 
 def _split_train_val_dataset(

--- a/tests/unit/ml/test_batch_autotuner.py
+++ b/tests/unit/ml/test_batch_autotuner.py
@@ -19,6 +19,7 @@ from neuracore.ml.trainers.batch_autotuner import (
     BatchSizeValidator,
     _BatchSizeEstimationError,
     _estimate_max_batch_size,
+    _fits_within_budget,
     _probe_batch_size,
     find_optimal_batch_size,
     is_valid_batch_size,
@@ -578,9 +579,11 @@ def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
             side_effect=fake_split_train_val,
         ),
         patch(
-            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.test_batch_size",
-            return_value=True,
-        ) as mock_test_batch_size,
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.probe_batch_size",
+            return_value=BatchProbeResult(
+                fitted=True, peak_reserved_bytes=1 * GB, total_bytes=100 * GB
+            ),
+        ) as mock_probe_batch_size,
     ):
         result = is_valid_batch_size(
             cfg=cfg,
@@ -591,7 +594,176 @@ def test_is_valid_batch_size_clamps_when_exceeding_train_dataset_size():
         )
 
     assert result is True
-    mock_test_batch_size.assert_called_once_with(80)
+    mock_probe_batch_size.assert_called_once_with(80)
+
+
+def test_is_valid_batch_size_rejects_batch_that_fits_without_headroom():
+    """A batch that fits the probe but exceeds budget * safety is INVALID.
+
+    This is the regression guard: previously any batch that merely avoided OOM in
+    the short probe passed validation and then OOM'd once real training added
+    DDP/fragmentation overhead. It must now be rejected for lack of headroom.
+    """
+    cfg = OmegaConf.create({
+        "validation_split": 0.2,
+        "seed": 42,
+        "num_train_workers": 0,
+        "num_val_workers": 0,
+    })
+
+    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
+    mock_dataset.__len__ = Mock(return_value=100)
+    mock_dataset.collate_fn = lambda x: x
+
+    device = torch.device("cuda:0")
+    model_factory = functools.partial(DummyModel, device=device)
+
+    def fake_split_train_val(dataset, train_size, val_size, seed, **kwargs):
+        return (DummyDataset(train_size), DummyDataset(val_size))
+
+    # Fits (no OOM) but peak reserved is 92% of total -- above the 0.9 * 0.7 =
+    # 63% budget * safety threshold, so it leaves no headroom for real training.
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.resolve_input_output_preprocessing",
+            return_value=({}, {}),
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.split_train_val_datasets",
+            side_effect=fake_split_train_val,
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.probe_batch_size",
+            return_value=BatchProbeResult(
+                fitted=True, peak_reserved_bytes=92 * GB, total_bytes=100 * GB
+            ),
+        ),
+    ):
+        result = is_valid_batch_size(
+            cfg=cfg,
+            model_factory=model_factory,
+            dataset=mock_dataset,
+            batch_size=64,
+            device=device,
+        )
+
+    assert result is False
+
+
+def test_is_valid_batch_size_accepts_batch_within_headroom():
+    """A batch whose peak reserved is within budget * safety is valid."""
+    cfg = OmegaConf.create({
+        "validation_split": 0.2,
+        "seed": 42,
+        "num_train_workers": 0,
+        "num_val_workers": 0,
+    })
+
+    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
+    mock_dataset.__len__ = Mock(return_value=100)
+    mock_dataset.collate_fn = lambda x: x
+
+    device = torch.device("cuda:0")
+    model_factory = functools.partial(DummyModel, device=device)
+
+    def fake_split_train_val(dataset, train_size, val_size, seed, **kwargs):
+        return (DummyDataset(train_size), DummyDataset(val_size))
+
+    # Fits at 50% of total, comfortably under the 63% budget * safety threshold.
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.resolve_input_output_preprocessing",
+            return_value=({}, {}),
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.split_train_val_datasets",
+            side_effect=fake_split_train_val,
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.probe_batch_size",
+            return_value=BatchProbeResult(
+                fitted=True, peak_reserved_bytes=50 * GB, total_bytes=100 * GB
+            ),
+        ),
+    ):
+        result = is_valid_batch_size(
+            cfg=cfg,
+            model_factory=model_factory,
+            dataset=mock_dataset,
+            batch_size=64,
+            device=device,
+        )
+
+    assert result is True
+
+
+def test_is_valid_batch_size_rejects_when_probe_ooms():
+    """A probe that OOMs (fitted=False) is invalid regardless of memory fields."""
+    cfg = OmegaConf.create({
+        "validation_split": 0.2,
+        "seed": 42,
+        "num_train_workers": 0,
+        "num_val_workers": 0,
+    })
+
+    mock_dataset = Mock(spec=PytorchSynchronizedDataset)
+    mock_dataset.__len__ = Mock(return_value=100)
+    mock_dataset.collate_fn = lambda x: x
+
+    device = torch.device("cuda:0")
+    model_factory = functools.partial(DummyModel, device=device)
+
+    def fake_split_train_val(dataset, train_size, val_size, seed, **kwargs):
+        return (DummyDataset(train_size), DummyDataset(val_size))
+
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.resolve_input_output_preprocessing",
+            return_value=({}, {}),
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.split_train_val_datasets",
+            side_effect=fake_split_train_val,
+        ),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.BatchSizeValidator.probe_batch_size",
+            return_value=BatchProbeResult(fitted=False),
+        ),
+    ):
+        result = is_valid_batch_size(
+            cfg=cfg,
+            model_factory=model_factory,
+            dataset=mock_dataset,
+            batch_size=64,
+            device=device,
+        )
+
+    assert result is False
+
+
+def test_fits_within_budget_true_when_under_threshold():
+    """peak 60GB <= 100GB * 0.9 * 0.7 = 63GB -> fits with headroom."""
+    result = BatchProbeResult(
+        fitted=True, peak_reserved_bytes=60 * GB, total_bytes=100 * GB
+    )
+    assert _fits_within_budget(result, max_gpu_utilization=0.9, safety_factor=0.7)
+
+
+def test_fits_within_budget_false_when_over_threshold():
+    """peak 70GB > 63GB budget * safety -> no headroom, not valid."""
+    result = BatchProbeResult(
+        fitted=True, peak_reserved_bytes=70 * GB, total_bytes=100 * GB
+    )
+    assert not _fits_within_budget(result, max_gpu_utilization=0.9, safety_factor=0.7)
+
+
+def test_fits_within_budget_false_when_not_fitted():
+    """An OOM'd probe is never within budget."""
+    result = BatchProbeResult(fitted=False)
+    assert not _fits_within_budget(result, max_gpu_utilization=0.9, safety_factor=0.7)
 
 
 def test_batch_probe_result_defaults():


### PR DESCRIPTION
### Bugfixes
 - Currently, batch size auto validation applies a safety factor fraction to the batch size that barely fits in memory. Sometimes auto batch size validation still results in subsequent OOM issues since this safety factor is eyeballed and not deterministic. This PR makes the safety factor more conservative until a more robust validation flow can be implemented.
 - Manually set batch sizes would not apply the safety factor as above, and would validate any batch size that barely fit in memory, without considering the additional memory overhead of other utilities that would be spun up during actual training, resulting in false positives. This PR 

### Items
 - [NCRL-711](https://neuracore.atlassian.net/browse/NCRL-711)
