### PR TITLE
fix: strip data type prefix from remote sync point keys

### DIFF
--- a/.github/workflows/integration-ml-multi-node-policy-inference-prod.yaml
+++ b/.github/workflows/integration-ml-multi-node-policy-inference-prod.yaml
@@ -1,0 +1,16 @@
+name: Integration ML - Multi-Node Policy Inference (Production)
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: NeuracoreAI/shared-workflows/.github/workflows/integration-ml-test.yaml@main
+    with:
+      environment: production
+      test-path: tests/integration/ml/test_multi_node_policy_inference.py
+      extras: dev,ml
+      lfs: false
+    secrets: inherit

--- a/.github/workflows/integration-ml-multi-node-policy-inference-staging.yaml
+++ b/.github/workflows/integration-ml-multi-node-policy-inference-staging.yaml
@@ -1,0 +1,16 @@
+name: Integration ML - Multi-Node Policy Inference (Staging)
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: NeuracoreAI/shared-workflows/.github/workflows/integration-ml-test.yaml@main
+    with:
+      environment: staging
+      test-path: tests/integration/ml/test_multi_node_policy_inference.py
+      extras: dev,ml
+      lfs: false
+    secrets: inherit

--- a/neuracore/core/streaming/p2p/consumer/sync_point_parser.py
+++ b/neuracore/core/streaming/p2p/consumer/sync_point_parser.py
@@ -32,12 +32,16 @@ def parse_sync_point(
     """
     try:
         data_type: DataType = track_details.data_type
-        label: str = track_details.label
 
         # Get the appropriate data class from the mapping
         data_class: type[NCData] | None = DATA_TYPE_TO_NC_DATA_CLASS.get(data_type)
         if data_class is None:
             raise ValueError(f"Unsupported track data_type: {data_type}")
+
+        # Providers label JSON tracks "{DATA_TYPE}:{sensor_name}".
+        # Local streams are keyed by the bare sensor name, so strip the
+        # prefix to keep remote and local sync points addressable the same way.
+        label: str = track_details.label.removeprefix(f"{data_type.value}:")
 
         # Parse the JSON data using the appropriate class
         data: NCData = data_class.model_validate_json(message_data)

--- a/tests/integration/ml/test_multi_node_policy_inference.py
+++ b/tests/integration/ml/test_multi_node_policy_inference.py
@@ -1,0 +1,433 @@
+"""Peer-to-peer multi-node policy inference.
+
+A robot instance can be driven by several processes at once. Here one node
+logs joint positions, a second logs camera frames, and the main process — which
+logs nothing at all — runs the policy. `get_latest_sync_point` merges what every
+remote node provides into the sync point `Policy.predict()` consumes, so a
+successful prediction is only possible if the peer-to-peer transport delivered
+both modalities.
+"""
+
+import logging
+import multiprocessing
+import random
+import time
+import traceback
+from collections.abc import Generator
+from copy import deepcopy
+from multiprocessing.synchronize import Event
+from pathlib import Path
+
+import numpy as np
+import pytest
+from neuracore_types import (
+    BatchedJointData,
+    CrossEmbodimentDescription,
+    DataType,
+    EmbodimentDescription,
+    ModelInitDescription,
+)
+from ordered_set import OrderedSet
+
+import neuracore as nc
+from neuracore.core.endpoint import Policy
+from neuracore.ml.algorithms.cnnmlp.cnnmlp import CNNMLP
+from neuracore.ml.datasets.pytorch_dummy_dataset import (
+    MAX_LEN_PER_DATA_TYPE,
+    PytorchDummyDataset,
+)
+from neuracore.ml.preprocessing.base import PreprocessingConfiguration
+from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
+from neuracore.ml.utils.device_utils import get_default_device
+from neuracore.ml.utils.nc_archive import create_nc_archive
+from tests.integration.ml.shared.utils import unique_name
+from tests.integration.platform.data_daemon.shared.test_infrastructure import (
+    delete_cloud_robot,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+DEVICE = get_default_device()
+INPUT_DATA_TYPES = OrderedSet([DataType.JOINT_POSITIONS, DataType.RGB_IMAGES])
+OUTPUT_DATA_TYPES = OrderedSet([DataType.JOINT_TARGET_POSITIONS])
+
+
+def _indexed_names(data_type: DataType) -> dict[int, str]:
+    return {
+        index: f"{data_type.value}_{index}" for index in range(MAX_LEN_PER_DATA_TYPE)
+    }
+
+
+INPUT_EMBODIMENT_DESCRIPTION: EmbodimentDescription = {
+    data_type: _indexed_names(data_type) for data_type in INPUT_DATA_TYPES
+}
+OUTPUT_EMBODIMENT_DESCRIPTION: EmbodimentDescription = {
+    data_type: _indexed_names(data_type) for data_type in OUTPUT_DATA_TYPES
+}
+
+JOINT_NAMES = tuple(INPUT_EMBODIMENT_DESCRIPTION[DataType.JOINT_POSITIONS].values())
+CAMERA_NAMES = tuple(INPUT_EMBODIMENT_DESCRIPTION[DataType.RGB_IMAGES].values())
+
+ROBOT_INSTANCE = 0
+ROBOT_NAME_PREFIX = "multinode_policy_robot"
+
+FRAME_SHAPE = (64, 64, 3)
+NODE_READY_TIMEOUT_S = 180
+NODE_CONNECT_TIMEOUT_S = 180
+NODE_CONNECT_POLL_S = 1.0
+NODE_JOIN_TIMEOUT_S = 15
+PREDICT_TIMEOUT_S = 60
+
+DUMMY_DATASET_SAMPLES = 5
+TRAIN_BATCH_SIZE = 2
+
+
+def _joint_positions() -> dict[str, float]:
+    """Distinct per-joint values so the merge can be checked name by name."""
+    return {name: 0.1 * (index + 1) for index, name in enumerate(JOINT_NAMES)}
+
+
+def _camera_frames() -> dict[str, np.ndarray]:
+    """Distinct per-camera frames, each with an identifying corner pixel."""
+    frames = {}
+    for index, name in enumerate(CAMERA_NAMES):
+        frame = np.full(FRAME_SHAPE, 40 * (index + 1), dtype=np.uint8)
+        frame[0, 0] = [255, index, 0]
+        frames[name] = frame
+    return frames
+
+
+def _build_cnnmlp_archive(output_dir: Path) -> Path:
+    """Train a CNNMLP for one step and save it as an .nc.zip archive.
+
+    Mirrors the archive-export path in ``neuracore.ml.utils.validate``.
+
+    Args:
+        output_dir: Directory the archive is written into.
+
+    Returns:
+        Path to the written ``model.nc.zip``.
+    """
+    input_cross_embodiment_description: CrossEmbodimentDescription = {
+        "robot_1": dict(INPUT_EMBODIMENT_DESCRIPTION)
+    }
+    output_cross_embodiment_description: CrossEmbodimentDescription = {
+        "robot_1": dict(OUTPUT_EMBODIMENT_DESCRIPTION)
+    }
+    dataset = PytorchDummyDataset(
+        input_cross_embodiment_description=input_cross_embodiment_description,
+        output_cross_embodiment_description=output_cross_embodiment_description,
+        num_samples=DUMMY_DATASET_SAMPLES,
+    )
+    model_init_description = ModelInitDescription(
+        input_data_types=INPUT_DATA_TYPES,
+        output_data_types=OUTPUT_DATA_TYPES,
+        input_dataset_statistics={
+            data_type: deepcopy(dataset.dataset_statistics["input"][data_type])
+            for data_type in INPUT_DATA_TYPES
+        },
+        output_dataset_statistics={
+            data_type: deepcopy(dataset.dataset_statistics["output"][data_type])
+            for data_type in OUTPUT_DATA_TYPES
+        },
+        output_prediction_horizon=dataset.output_prediction_horizon,
+    )
+
+    model = CNNMLP(model_init_description=model_init_description).to(DEVICE)
+    logger.info(
+        f"Built CNNMLP with {sum(p.numel() for p in model.parameters()):,} parameters"
+    )
+
+    # PolicyInference rejects an archive with no input preprocessing config.
+    preprocessing_config = PreprocessingConfiguration({
+        DataType.RGB_IMAGES: [ResizePad(size=(224, 224))],
+    })
+    archive_path = create_nc_archive(
+        model,
+        output_dir,
+        {},
+        input_cross_embodiment_description,
+        output_cross_embodiment_description,
+        preprocessing_config,
+        preprocessing_config,
+    )
+    logger.info(f"Saved model archive to {archive_path}")
+    return archive_path
+
+
+def _joint_node_worker(
+    robot_name: str,
+    instance: int,
+    joint_positions: dict[str, float],
+    ready_event: Event,
+    stop_event: Event,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    """Remote node A: logs joint positions and nothing else."""
+    import neuracore as nc_remote
+
+    try:
+        nc_remote.login()
+        nc_remote.connect_robot(robot_name, instance=instance, overwrite=False)
+        nc_remote.log_joint_positions(
+            joint_positions, robot_name=robot_name, instance=instance
+        )
+        result_queue.put({"ok": True, "node": "joints"})
+        ready_event.set()
+        stop_event.wait()
+    except BaseException:
+        result_queue.put({
+            "ok": False,
+            "node": "joints",
+            "traceback": traceback.format_exc(),
+        })
+        ready_event.set()
+
+
+def _camera_node_worker(
+    robot_name: str,
+    instance: int,
+    frames: dict[str, np.ndarray],
+    ready_event: Event,
+    stop_event: Event,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    """Remote node B: logs camera frames and nothing else."""
+    import neuracore as nc_remote
+
+    try:
+        nc_remote.login()
+        nc_remote.connect_robot(robot_name, instance=instance, overwrite=False)
+        for name, frame in frames.items():
+            nc_remote.log_rgb(
+                name=name, rgb=frame, robot_name=robot_name, instance=instance
+            )
+        result_queue.put({"ok": True, "node": "camera"})
+        ready_event.set()
+        stop_event.wait()
+    except BaseException:
+        result_queue.put({
+            "ok": False,
+            "node": "camera",
+            "traceback": traceback.format_exc(),
+        })
+        ready_event.set()
+
+
+def _wait_for_remote_nodes(
+    robot_name: str, instance: int, num_remote_nodes: int
+) -> None:
+    """Block until the expected remote nodes have delivered data."""
+    deadline = time.time() + NODE_CONNECT_TIMEOUT_S
+    while not nc.check_remote_nodes_connected(
+        num_remote_nodes=num_remote_nodes, robot_name=robot_name, instance=instance
+    ):
+        assert time.time() < deadline, (
+            f"Timed out after {NODE_CONNECT_TIMEOUT_S}s waiting for "
+            f"{num_remote_nodes} remote node(s) to connect"
+        )
+        time.sleep(NODE_CONNECT_POLL_S)
+
+
+def _assert_no_worker_failures(result_queue: multiprocessing.Queue) -> None:
+    """Fail with the child traceback if either logger node errored."""
+    failures = []
+    while not result_queue.empty():
+        result = result_queue.get_nowait()
+        if not result["ok"]:
+            failures.append(f"[{result['node']}] {result['traceback']}")
+    assert not failures, "Logger node failure(s):\n" + "\n".join(failures)
+
+
+def _run_policy_inference_multi_node(
+    policy: Policy,
+    *,
+    robot_name: str,
+    instance: int,
+    joint_positions: dict[str, float],
+    frames: dict[str, np.ndarray],
+    output_data_types: list[DataType],
+) -> None:
+    """Predict in this process off data logged by two other processes."""
+    context = multiprocessing.get_context("spawn")
+    joint_ready = context.Event()
+    camera_ready = context.Event()
+    stop_event = context.Event()
+    result_queue = context.Queue()
+    processes: list[multiprocessing.process.BaseProcess] = []
+
+    try:
+        # This process contributes nothing, so anything the merged sync point
+        # holds later can only have arrived over the peer-to-peer transport.
+        local_sync_point = nc.get_latest_sync_point(
+            robot_name=robot_name, instance=instance, include_remote=False
+        )
+        assert not local_sync_point.data, (
+            "Expected the predicting process to log nothing, but its local sync "
+            f"point already holds: {list(local_sync_point.data)}"
+        )
+
+        processes = [
+            context.Process(
+                target=_joint_node_worker,
+                name="joint-node",
+                args=(
+                    robot_name,
+                    instance,
+                    joint_positions,
+                    joint_ready,
+                    stop_event,
+                    result_queue,
+                ),
+            ),
+            context.Process(
+                target=_camera_node_worker,
+                name="camera-node",
+                args=(
+                    robot_name,
+                    instance,
+                    frames,
+                    camera_ready,
+                    stop_event,
+                    result_queue,
+                ),
+            ),
+        ]
+        for process in processes:
+            process.start()
+
+        assert joint_ready.wait(
+            timeout=NODE_READY_TIMEOUT_S
+        ), "Joint node did not signal readiness in time"
+        assert camera_ready.wait(
+            timeout=NODE_READY_TIMEOUT_S
+        ), "Camera node did not signal readiness in time"
+        _assert_no_worker_failures(result_queue)
+        logger.info("Both logger nodes are ready")
+
+        _wait_for_remote_nodes(robot_name, instance, num_remote_nodes=2)
+        logger.info("Both remote nodes are connected")
+
+        sync_point = nc.get_latest_sync_point(
+            robot_name=robot_name, instance=instance, include_remote=True
+        )
+        assert DataType.JOINT_POSITIONS in sync_point.data, (
+            "Joint positions from the joint node not found, got: "
+            f"{list(sync_point.data)}"
+        )
+        assert (
+            DataType.RGB_IMAGES in sync_point.data
+        ), f"RGB images from the camera node not found, got: {list(sync_point.data)}"
+        for name, value in joint_positions.items():
+            assert name in sync_point[DataType.JOINT_POSITIONS], (
+                f"Joint {name!r} missing from merged sync point, got: "
+                f"{sorted(sync_point[DataType.JOINT_POSITIONS])}"
+            )
+            assert sync_point[DataType.JOINT_POSITIONS][name].value == pytest.approx(
+                value
+            )
+        for name, frame in frames.items():
+            assert name in sync_point[DataType.RGB_IMAGES], (
+                f"Camera {name!r} missing from merged sync point, got: "
+                f"{sorted(sync_point[DataType.RGB_IMAGES])}"
+            )
+            # Frames cross the wire as lossless PNG data URIs.
+            np.testing.assert_array_equal(
+                sync_point[DataType.RGB_IMAGES][name].frame, frame
+            )
+        logger.info("Merged sync point holds both remote nodes' data")
+
+        predictions = policy.predict(timeout=PREDICT_TIMEOUT_S)
+        for data_type in output_data_types:
+            assert data_type in predictions, (
+                f"Expected {data_type.value} in policy output, got: "
+                f"{[key.value for key in predictions]}"
+            )
+            for name, prediction in predictions[data_type].items():
+                assert isinstance(
+                    prediction, BatchedJointData
+                ), f"Expected BatchedJointData for {name!r}, got {type(prediction)}"
+                assert (
+                    prediction.value.shape[0] == 1
+                ), f"Expected a batch of 1 for {name!r}, got {prediction.value.shape}"
+        logger.info(
+            f"Multi-node inference passed — output keys: "
+            f"{[key.value for key in predictions]}"
+        )
+    finally:
+        stop_event.set()
+        for process in processes:
+            process.join(timeout=NODE_JOIN_TIMEOUT_S)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        _assert_no_worker_failures(result_queue)
+        policy.disconnect()
+
+
+@pytest.fixture(scope="module")
+def cnnmlp_archive(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the CNNMLP archive once and share it across the tests."""
+    return _build_cnnmlp_archive(tmp_path_factory.mktemp("cnnmlp_archive"))
+
+
+@pytest.fixture
+def robot_name() -> Generator[str, None, None]:
+    """A freshly registered robot per test, deleted on teardown.
+
+    A unique name guarantees the predicting process starts with empty local
+    streams and keeps concurrent runs on a shared org from interfering.
+    """
+    nc.login()
+    name = unique_name(prefix=ROBOT_NAME_PREFIX)
+    nc.connect_robot(name, instance=ROBOT_INSTANCE, overwrite=False)
+    try:
+        yield name
+    finally:
+        delete_cloud_robot(name)
+
+
+class TestMultiNodePolicyInference:
+    """Predict off remote-node data through each locally loaded policy."""
+
+    def test_direct_policy_multi_node_inference(
+        self, cnnmlp_archive: Path, robot_name: str
+    ) -> None:
+        policy = nc.policy(
+            input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+            output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+            model_file=str(cnnmlp_archive),
+            device=str(DEVICE),
+        )
+        _run_policy_inference_multi_node(
+            policy,
+            robot_name=robot_name,
+            instance=ROBOT_INSTANCE,
+            joint_positions=_joint_positions(),
+            frames=_camera_frames(),
+            output_data_types=list(OUTPUT_DATA_TYPES),
+        )
+        logger.info("[PASSED] Direct policy multi-node inference")
+
+    def test_local_server_policy_multi_node_inference(
+        self, cnnmlp_archive: Path, robot_name: str
+    ) -> None:
+        policy = nc.policy_local_server(
+            input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
+            output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
+            model_file=str(cnnmlp_archive),
+            device=str(DEVICE),
+            port=random.randint(10000, 20000),
+        )
+        _run_policy_inference_multi_node(
+            policy,
+            robot_name=robot_name,
+            instance=ROBOT_INSTANCE,
+            joint_positions=_joint_positions(),
+            frames=_camera_frames(),
+            output_data_types=list(OUTPUT_DATA_TYPES),
+        )
+        logger.info("[PASSED] Local server policy multi-node inference")

--- a/tests/unit/ml/conftest.py
+++ b/tests/unit/ml/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures for the ML unit tests.
+
+Multi-node (peer-to-peer) prediction: a robot instance can be driven by several
+processes at once — one node logs joints, another logs camera frames, and a
+third runs the policy. ``get_latest_sync_point`` merges the local process's
+streams with what the remote nodes provide, and ``Policy.predict(sync_point=None)``
+calls it. The helpers below stub that remote-node seam so the merge-into-predict
+path can be exercised without a real WebRTC connection.
+"""
+
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from neuracore_types import (
+    DataType,
+    JointData,
+    NCData,
+    ParallelGripperOpenAmountData,
+    RGBCameraData,
+    SynchronizedPoint,
+)
+
+REMOTE_TIMESTAMP = 1234567890.0
+REMOTE_JOINT_NAMES = ("joint1", "joint2")
+REMOTE_CAMERA_NAME = "top_camera"
+REMOTE_GRIPPER_NAMES = ("left_arm", "right_arm")
+REMOTE_FRAME = np.full((8, 8, 3), 7, dtype=np.uint8)
+
+RemoteData = dict[DataType, dict[str, NCData]]
+
+
+def remote_joint_data() -> RemoteData:
+    """The payload a joints-only remote node contributes."""
+    return {
+        DataType.JOINT_POSITIONS: {
+            name: JointData(timestamp=REMOTE_TIMESTAMP, value=0.5)
+            for name in REMOTE_JOINT_NAMES
+        }
+    }
+
+
+def remote_camera_data() -> RemoteData:
+    """The payload a camera-only remote node contributes."""
+    return {
+        DataType.RGB_IMAGES: {
+            REMOTE_CAMERA_NAME: RGBCameraData(
+                timestamp=REMOTE_TIMESTAMP, frame=REMOTE_FRAME
+            )
+        }
+    }
+
+
+def remote_gripper_data() -> RemoteData:
+    """The payload a gripper-only remote node contributes."""
+    return {
+        DataType.PARALLEL_GRIPPER_OPEN_AMOUNTS: {
+            name: ParallelGripperOpenAmountData(
+                timestamp=REMOTE_TIMESTAMP, open_amount=0.5
+            )
+            for name in REMOTE_GRIPPER_NAMES
+        }
+    }
+
+
+def remote_sync_point(*payloads: RemoteData) -> SynchronizedPoint:
+    """Combine the payloads of several remote nodes into one sync point."""
+    data: RemoteData = {}
+    for payload in payloads:
+        data.update(payload)
+    return SynchronizedPoint(timestamp=REMOTE_TIMESTAMP, data=data)
+
+
+@pytest.fixture
+def patch_remote_node_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[..., SimpleNamespace]:
+    """Return a callable that stubs the remote-node seam.
+
+    The returned callable takes a zero-argument factory — rather than a fixed
+    sync point — so a test can vary what the remote nodes deliver between
+    successive ``_predict`` attempts.
+
+    Pass ``consume_enabled=False`` to leave live-data consumption switched off,
+    which is the negative control: the stub consumer is installed but should
+    never be reached.
+
+    The stub consumer is returned so tests can assert on how it was used.
+    """
+
+    def patch(
+        get_remote_data: Callable[[], SynchronizedPoint],
+        *,
+        consume_enabled: bool = True,
+    ) -> SimpleNamespace:
+        consumer = SimpleNamespace(
+            calls=0,
+            num_remote_nodes=lambda: 1,
+            all_remote_nodes_connected=lambda: True,
+        )
+
+        def get_latest_data() -> SynchronizedPoint:
+            consumer.calls += 1
+            return get_remote_data()
+
+        consumer.get_latest_data = get_latest_data
+
+        if consume_enabled:
+            # The unit suite globally disables live data (see
+            # tests/unit/conftest.py) and EnabledManager.disable() is one-way,
+            # so the getter itself is stubbed rather than the manager it
+            # returns.
+            monkeypatch.setattr(
+                "neuracore.core.get_latest_sync_point."
+                "get_consume_live_data_enabled_manager",
+                lambda: SimpleNamespace(is_disabled=lambda: False),
+            )
+        # Both get_latest_sync_point and check_remote_nodes_connected read this
+        # name out of the same module, so patching here covers both.
+        monkeypatch.setattr(
+            "neuracore.core.get_latest_sync_point.get_org_nodes_manager",
+            lambda org_id: SimpleNamespace(
+                get_robot_consumer=lambda robot_id, robot_instance: consumer
+            ),
+        )
+        return consumer
+
+    return patch

--- a/tests/unit/ml/test_direct_policy_endpoint.py
+++ b/tests/unit/ml/test_direct_policy_endpoint.py
@@ -22,13 +22,35 @@ import neuracore as nc
 import neuracore.api.endpoints as endpoints
 from neuracore.core.const import API_URL
 from neuracore.core.endpoint import DirectPolicy
-from neuracore.core.exceptions import RobotError
+from neuracore.core.exceptions import InsufficientSynchronizedPointError, RobotError
 from tests.unit.conftest import TEST_API_KEY
+from tests.unit.ml.conftest import (
+    REMOTE_CAMERA_NAME,
+    REMOTE_FRAME,
+    REMOTE_JOINT_NAMES,
+    remote_camera_data,
+    remote_joint_data,
+    remote_sync_point,
+)
 
 TEST_ROBOT_ID = "test_robot"
 TEST_ROBOT_PAYLOAD = {"robot_id": "mock_robot_id", "has_urdf": True}
 TRAIN_RUN_NAME = "test_run"
 TRAIN_JOB_ID = "job_123"
+
+
+def _indexed_names(*names: str) -> dict[int, str]:
+    """Return explicitly indexed names for embodiment descriptions."""
+    return {index: name for index, name in enumerate(names)}
+
+
+MULTI_NODE_INPUT_EMBODIMENT_DESCRIPTION = {
+    DataType.JOINT_POSITIONS: _indexed_names(*REMOTE_JOINT_NAMES),
+    DataType.RGB_IMAGES: _indexed_names(REMOTE_CAMERA_NAME),
+}
+MULTI_NODE_OUTPUT_EMBODIMENT_DESCRIPTION = {
+    DataType.JOINT_TARGET_POSITIONS: _indexed_names(*REMOTE_JOINT_NAMES),
+}
 
 
 def _ordered_names(names_or_mapping):
@@ -43,11 +65,6 @@ def _ordered_names(names_or_mapping):
     return list(names_or_mapping)
 
 
-def _indexed_names(*names: str) -> dict[int, str]:
-    """Return explicitly indexed names for embodiment descriptions."""
-    return {index: name for index, name in enumerate(names)}
-
-
 def _mock_policy_output(output_embodiment_description):
     """Build a named policy output from an embodiment description."""
     output = {}
@@ -57,6 +74,25 @@ def _mock_policy_output(output_embodiment_description):
             for name in _ordered_names(names_or_mapping)
         }
     return output
+
+
+def _build_multi_node_policy(mock_policy_inference_class, mock_model_path):
+    """Build a DirectPolicy over a mocked PolicyInference for the multi-node tests."""
+    mock_policy = MagicMock()
+    mock_policy.input_embodiment_description = MULTI_NODE_INPUT_EMBODIMENT_DESCRIPTION
+    mock_policy.output_embodiment_description = MULTI_NODE_OUTPUT_EMBODIMENT_DESCRIPTION
+    mock_policy.return_value = _mock_policy_output(
+        MULTI_NODE_OUTPUT_EMBODIMENT_DESCRIPTION
+    )
+    mock_policy_inference_class.return_value = mock_policy
+
+    policy = DirectPolicy(
+        input_embodiment_description=MULTI_NODE_INPUT_EMBODIMENT_DESCRIPTION,
+        output_embodiment_description=MULTI_NODE_OUTPUT_EMBODIMENT_DESCRIPTION,
+        model_path=mock_model_path,
+        org_id="test_org",
+    )
+    return policy, mock_policy
 
 
 def test_resolve_robot_id_returns_explicit_robot_id(monkeypatch):
@@ -907,3 +943,138 @@ def test_connect_direct_policy_with_model_file(
 
     called_sync_point = mock_policy.call_args[0][0]
     assert set(called_sync_point.data.keys()) == {DataType.JOINT_POSITIONS}
+
+
+@patch("neuracore.ml.utils.policy_inference.PolicyInference")
+def test_predict_merges_remote_node_data_into_sync_point(
+    mock_policy_inference_class,
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    patch_remote_node_data,
+    mock_model_path,
+):
+    """Joints logged in this process merge with a camera logged on another node."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    patch_remote_node_data(lambda: remote_sync_point(remote_camera_data()))
+    policy, mock_policy = _build_multi_node_policy(
+        mock_policy_inference_class, mock_model_path
+    )
+
+    nc.log_joint_positions(positions={name: 0.5 for name in REMOTE_JOINT_NAMES})
+    policy.predict()
+
+    called_sync_point = mock_policy.call_args[0][0]
+    assert set(called_sync_point.data) == {
+        DataType.JOINT_POSITIONS,
+        DataType.RGB_IMAGES,
+    }
+    assert set(called_sync_point.data[DataType.JOINT_POSITIONS]) == set(
+        REMOTE_JOINT_NAMES
+    )
+    np.testing.assert_array_equal(
+        called_sync_point.data[DataType.RGB_IMAGES][REMOTE_CAMERA_NAME].frame,
+        REMOTE_FRAME,
+    )
+
+
+@patch("neuracore.ml.utils.policy_inference.PolicyInference")
+def test_predict_uses_only_remote_node_data_when_nothing_logged_locally(
+    mock_policy_inference_class,
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    patch_remote_node_data,
+    mock_model_path,
+):
+    """The predicting process may contribute nothing and still get a full input."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    patch_remote_node_data(
+        lambda: remote_sync_point(remote_joint_data(), remote_camera_data())
+    )
+    policy, mock_policy = _build_multi_node_policy(
+        mock_policy_inference_class, mock_model_path
+    )
+
+    policy.predict()
+
+    called_sync_point = mock_policy.call_args[0][0]
+    assert set(called_sync_point.data) == set(
+        MULTI_NODE_INPUT_EMBODIMENT_DESCRIPTION.keys()
+    )
+    assert set(called_sync_point.data[DataType.JOINT_POSITIONS]) == set(
+        REMOTE_JOINT_NAMES
+    )
+    assert REMOTE_CAMERA_NAME in called_sync_point.data[DataType.RGB_IMAGES]
+
+
+@patch("neuracore.ml.utils.policy_inference.PolicyInference")
+def test_predict_retries_until_remote_node_data_arrives(
+    mock_policy_inference_class,
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    patch_remote_node_data,
+    monkeypatch,
+    mock_model_path,
+):
+    """predict() keeps retrying while a remote node is still connecting."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+
+    attempts = {"count": 0}
+
+    def get_remote_data() -> SynchronizedPoint:
+        # The camera node only starts delivering frames on the third attempt.
+        attempts["count"] += 1
+        payloads = [remote_joint_data()]
+        if attempts["count"] >= 3:
+            payloads.append(remote_camera_data())
+        return remote_sync_point(*payloads)
+
+    patch_remote_node_data(get_remote_data)
+    policy, mock_policy = _build_multi_node_policy(
+        mock_policy_inference_class, mock_model_path
+    )
+
+    def predict_impl(sync_point):
+        if DataType.RGB_IMAGES not in sync_point.data:
+            raise InsufficientSynchronizedPointError("no camera data yet")
+        return _mock_policy_output(MULTI_NODE_OUTPUT_EMBODIMENT_DESCRIPTION)
+
+    mock_policy.side_effect = predict_impl
+    monkeypatch.setattr("neuracore.core.endpoint.time.sleep", lambda _seconds: None)
+
+    predictions = policy.predict(timeout=5)
+
+    assert DataType.JOINT_TARGET_POSITIONS in predictions
+    assert mock_policy.call_count == 3
+
+
+@patch("neuracore.ml.utils.policy_inference.PolicyInference")
+def test_predict_ignores_remote_node_data_when_consume_live_data_disabled(
+    mock_policy_inference_class,
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    patch_remote_node_data,
+    mock_model_path,
+):
+    """With live data consumption off, remote nodes are never consulted."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    consumer = patch_remote_node_data(
+        lambda: remote_sync_point(remote_camera_data()), consume_enabled=False
+    )
+    policy, mock_policy = _build_multi_node_policy(
+        mock_policy_inference_class, mock_model_path
+    )
+
+    nc.log_joint_positions(positions={name: 0.5 for name in REMOTE_JOINT_NAMES})
+    policy.predict()
+
+    assert consumer.calls == 0
+    called_sync_point = mock_policy.call_args[0][0]
+    assert set(called_sync_point.data) == {DataType.JOINT_POSITIONS}

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -16,7 +16,16 @@ import neuracore as nc
 from neuracore.core.const import API_URL
 from neuracore.core.endpoint import EndpointError, Policy
 from neuracore.core.exceptions import InsufficientSynchronizedPointError
+from neuracore.core.utils.image_string_encoder import ImageStringEncoder
 from tests.unit.conftest import TEST_API_KEY
+from tests.unit.ml.conftest import (
+    REMOTE_CAMERA_NAME,
+    REMOTE_FRAME,
+    REMOTE_GRIPPER_NAMES,
+    remote_camera_data,
+    remote_gripper_data,
+    remote_sync_point,
+)
 
 B = 1
 PREDICTION_HORIZON = 3
@@ -1010,3 +1019,50 @@ def test_connect_local_endpoint_invalid_args(
             input_embodiment_description=INPUT_EMBODIMENT_DESCRIPTION,
             output_embodiment_description=OUTPUT_EMBODIMENT_DESCRIPTION,
         )
+
+
+def test_remote_endpoint_sends_remote_node_data_in_predict_request(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mocked_org_id,
+    patch_remote_node_data,
+):
+    """Data logged on other nodes must survive serialization onto the wire."""
+    _login_and_connect_robot(mock_auth_requests, mocked_org_id)
+    patch_remote_node_data(
+        lambda: remote_sync_point(remote_camera_data(), remote_gripper_data())
+    )
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/models/endpoints/test_endpoint_id/predict",
+        json=FAKE_PREDICTED_DATA_JSON,
+        status_code=200,
+    )
+    endpoint = _connect_test_remote_endpoint(mock_auth_requests, mocked_org_id)
+
+    # Only the joints come from this process; the camera and grippers are
+    # contributed by other nodes.
+    nc.log_joint_positions(positions={"joint1": 0.5, "joint2": 0.5, "joint3": 0.5})
+
+    _assert_joint_prediction_matches_expected(endpoint.predict())
+
+    request_body = mock_auth_requests.request_history[-1].json()
+    assert set(request_body["data"]) == {
+        "JOINT_POSITIONS",
+        "RGB_IMAGES",
+        "PARALLEL_GRIPPER_OPEN_AMOUNTS",
+    }
+    assert set(request_body["data"]["JOINT_POSITIONS"]) == {
+        "joint1",
+        "joint2",
+        "joint3",
+    }
+    assert set(request_body["data"]["PARALLEL_GRIPPER_OPEN_AMOUNTS"]) == set(
+        REMOTE_GRIPPER_NAMES
+    )
+    # Frames are transmitted as PNG data URIs, not raw arrays.
+    encoded_frame = request_body["data"]["RGB_IMAGES"][REMOTE_CAMERA_NAME]["frame"]
+    assert encoded_frame.startswith("data:image/png;base64,")
+    np.testing.assert_array_equal(
+        ImageStringEncoder.decode_image(encoded_frame), REMOTE_FRAME
+    )


### PR DESCRIPTION
### Features
 - New integration test covering multi-node policy inference. Nightly workflows running it against staging and production.

### Bugfixes
 - Remote sync point keys no longer carry a data type prefix. Providers label JSON tracks `"{DATA_TYPE}:{sensor_name}"`, but `get_latest_sync_point` keys local streams by the bare sensor name, so data logged on a remote node arrived as `JOINT_POSITIONS:joint_0` and could never match an embodiment description. This affected every JSON data type (joints, grippers, poses, language, custom 1d, point clouds); cameras were unaffected.
