### PR TITLE
fix: pass full synchronization params through to recordings

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -590,6 +590,9 @@ class Dataset:
             cross_embodiment_union=cross_embodiment_union,
             prefetch_videos=prefetch_videos,
             max_prefetch_workers=max_prefetch_workers,
+            max_delay_s=max_delay_s,
+            allow_duplicates=allow_duplicates,
+            trim_start_end=trim_start_end,
         )
 
     def get_full_embodiment_description(self, robot_id: str) -> EmbodimentDescription:

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -1,10 +1,11 @@
 """Recording class for managing synchronized data streams in a dataset."""
 
+import sys
 from typing import TYPE_CHECKING
 
 from neuracore_types import CrossEmbodimentUnion, DataType
 from neuracore_types import Recording as RecordingModel
-from neuracore_types import RecordingMetadata, RecordingStatus
+from neuracore_types import RecordingMetadata, RecordingStatus, SynchronizationDetails
 
 from neuracore.core.auth import get_auth
 from neuracore.core.config.get_current_org import get_current_org
@@ -79,6 +80,9 @@ class Recording:
         self,
         frequency: int = 0,
         cross_embodiment_union: CrossEmbodimentUnion | None = None,
+        max_delay_s: float = sys.float_info.max,
+        allow_duplicates: bool = True,
+        trim_start_end: bool = True,
     ) -> SynchronizedRecording:
         """Synchronize the episode with specified frequency and data types.
 
@@ -88,6 +92,9 @@ class Recording:
             cross_embodiment_union: Dict specifying data types and their
                 names to include in synchronization. If None, will use all
                 available data types from the dataset.
+            max_delay_s: Maximum allowed delay for synchronization.
+            allow_duplicates: Whether duplicate points are allowed when syncing.
+            trim_start_end: Whether to trim start/end during synchronization.
 
         Raises:
             SynchronizationError: If synchronization fails.
@@ -117,8 +124,13 @@ class Recording:
             recording_name=self.name,
             robot_id=self.robot_id,
             instance=self.instance,
-            frequency=frequency,
-            cross_embodiment_union=cross_embodiment_union,
+            synchronization_details=SynchronizationDetails(
+                frequency=frequency,
+                cross_embodiment_union=cross_embodiment_union,
+                max_delay_s=max_delay_s,
+                allow_duplicates=allow_duplicates,
+                trim_start_end=trim_start_end,
+            ),
         )
 
     def __iter__(self) -> None:

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -1,6 +1,7 @@
 """SynchronizedDataset class for managing synchronized datasets."""
 
 import logging
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Union, cast
@@ -12,6 +13,7 @@ from neuracore_types import (
     CrossEmbodimentUnion,
     DatasetStatisticsJob,
     DatasetStatisticsJobStatus,
+    SynchronizationDetails,
     SynchronizedDatasetStatistics,
 )
 from tqdm import tqdm
@@ -47,6 +49,9 @@ class SynchronizedDataset:
         cross_embodiment_union: CrossEmbodimentUnion | None = None,
         prefetch_videos: bool = False,
         max_prefetch_workers: int = 1,
+        max_delay_s: float = sys.float_info.max,
+        allow_duplicates: bool = True,
+        trim_start_end: bool = True,
         synced_recording_cache: dict[int, SynchronizedRecording] | None = None,
     ):
         """Initialize a dataset from server response data.
@@ -58,6 +63,11 @@ class SynchronizedDataset:
             cross_embodiment_union: Cross-embodiment union for synchronization.
             prefetch_videos: Whether to prefetch video data to cache on initialization.
             max_prefetch_workers: Number of threads to use for prefetching videos.
+            max_delay_s: Maximum allowed delay the dataset was synchronized with.
+            allow_duplicates: Whether the dataset was synchronized allowing
+                duplicate points.
+            trim_start_end: Whether the dataset was synchronized with its start
+                and end trimmed.
             synced_recording_cache: Already-fetched synced recordings keyed by
                 index, used when slicing to avoid re-fetching data the parent
                 dataset already loaded.
@@ -66,6 +76,13 @@ class SynchronizedDataset:
         self.dataset = dataset
         self.frequency = frequency
         self.cross_embodiment_union = cross_embodiment_union
+        self.synchronization_details = SynchronizationDetails(
+            frequency=frequency,
+            cross_embodiment_union=cross_embodiment_union,
+            max_delay_s=max_delay_s,
+            allow_duplicates=allow_duplicates,
+            trim_start_end=trim_start_end,
+        )
         self._prefetch_videos = prefetch_videos
         self._max_prefetch_workers = max_prefetch_workers
         self._recording_idx = 0
@@ -178,6 +195,9 @@ class SynchronizedDataset:
                 cross_embodiment_union=self.cross_embodiment_union,
                 prefetch_videos=False,  # Avoid prefetching again
                 max_prefetch_workers=self._max_prefetch_workers,
+                max_delay_s=self.synchronization_details.max_delay_s,
+                allow_duplicates=self.synchronization_details.allow_duplicates,
+                trim_start_end=self.synchronization_details.trim_start_end,
                 synced_recording_cache=sliced_cache,
             )
         else:
@@ -195,8 +215,7 @@ class SynchronizedDataset:
                         dataset=self.dataset,
                         robot_id=rec.robot_id,
                         instance=rec.instance,
-                        frequency=self.frequency,
-                        cross_embodiment_union=self.cross_embodiment_union,
+                        synchronization_details=self.synchronization_details,
                         prefetch_videos=self._prefetch_videos,
                     )
                     self._synced_recording_cache[idx] = synced_recording
@@ -226,8 +245,7 @@ class SynchronizedDataset:
                     dataset=self.dataset,
                     robot_id=recording.robot_id,
                     instance=recording.instance,
-                    frequency=self.frequency,
-                    cross_embodiment_union=self.cross_embodiment_union,
+                    synchronization_details=self.synchronization_details,
                     prefetch_videos=self._prefetch_videos,
                 )
                 self._synced_recording_cache[self._recording_idx] = s

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -5,7 +5,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import time
 from collections.abc import Callable
@@ -59,8 +58,7 @@ class SynchronizedRecording:
         recording_name: str | None,
         robot_id: str,
         instance: int,
-        frequency: int = 0,
-        cross_embodiment_union: CrossEmbodimentUnion | None = None,
+        synchronization_details: SynchronizationDetails,
         prefetch_videos: bool = False,
     ):
         """Initialize episode iterator for a specific recording.
@@ -71,16 +69,16 @@ class SynchronizedRecording:
             recording_name: Recording Name string.
             robot_id: The robot that created this recording.
             instance: The instance of the robot that created this recording.
-            frequency: Frequency at which to synchronize the recording.
-            cross_embodiment_union: Union of embodiment descriptions for
-                synchronization.
+            synchronization_details: The full synchronization parameters. The
+                server keys stored synchronized data on all of them, so these
+                must match the parameters the data was synchronized with or the
+                recording is synchronized again under a different key.
             prefetch_videos: Whether to prefetch video data to cache on initialization.
         """
         self.dataset = dataset
         self.id = recording_id
         self.name = recording_name
-        self.frequency = frequency
-        self.cross_embodiment_union = cross_embodiment_union
+        self.synchronization_details = synchronization_details
         self.cache_dir: Path = dataset.cache_dir
         self.robot_id = robot_id
         self.instance = instance
@@ -105,6 +103,16 @@ class SynchronizedRecording:
             # NOTE: this is to start video prefetching frames into cache
             self._get_sync_point(0)
 
+    @property
+    def frequency(self) -> int:
+        """Frequency in Hz this recording was synchronized at."""
+        return self.synchronization_details.frequency
+
+    @property
+    def cross_embodiment_union(self) -> CrossEmbodimentUnion | None:
+        """Cross-embodiment union this recording was synchronized with."""
+        return self.synchronization_details.cross_embodiment_union
+
     def _get_synced_data(self) -> SynchronizedEpisodeModel:
         """Retrieve synchronized metadata for the recording.
 
@@ -120,12 +128,7 @@ class SynchronizedRecording:
             f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording",
             json=SynchronizeRecordingRequest(
                 recording_id=self.id,
-                synchronization_details=SynchronizationDetails(
-                    frequency=self.frequency,
-                    cross_embodiment_union=self.cross_embodiment_union,
-                    max_delay_s=sys.float_info.max,
-                    allow_duplicates=True,
-                ),
+                synchronization_details=self.synchronization_details,
             ).model_dump(mode="json"),
             headers=auth.get_headers(),
         )

--- a/tests/unit/core/data/test_synchronized_dataset.py
+++ b/tests/unit/core/data/test_synchronized_dataset.py
@@ -493,3 +493,78 @@ class TestSynchronizedDataset:
 
         # Should be different objects
         assert rec1 is not rec2
+
+
+class TestSynchronizationParameterPassthrough:
+    """The dataset and its recordings must synchronize with identical parameters.
+
+    The server keys stored synchronized data on every synchronization parameter,
+    so if a recording is fetched with a different set than the dataset was
+    synchronized with, it misses the stored data and is synchronized again from
+    scratch under a second key.
+    """
+
+    def _sync_details_sent_to(self, mock_requests, path: str) -> list[dict]:
+        """Collect the synchronization_details of every request to a path.
+
+        Args:
+            mock_requests: The requests_mock Mocker holding the request history.
+            path: Substring identifying the endpoint of interest.
+
+        Returns:
+            One synchronization_details payload per matching request.
+        """
+        return [
+            req.json()["synchronization_details"]
+            for req in mock_requests.request_history
+            if path in req.path and req.method == "POST"
+        ]
+
+    def test_recordings_are_fetched_with_the_datasets_sync_parameters(
+        self, mock_data_requests, tmp_path
+    ) -> None:
+        """Non-default parameters must reach the per-recording requests."""
+        dataset = nc.get_dataset(name="test_dataset")
+        dataset.cache_dir = tmp_path / "cache"
+        dataset.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        dataset.synchronize(
+            frequency=30,
+            # Deliberately non-default: these are exactly the parameters that
+            # used to be dropped between the dataset and its recordings.
+            max_delay_s=0.25,
+            allow_duplicates=False,
+            trim_start_end=False,
+        )
+
+        dataset_details = self._sync_details_sent_to(
+            mock_data_requests, "synchronize-dataset"
+        )
+        recording_details = self._sync_details_sent_to(
+            mock_data_requests, "synchronize-recording"
+        )
+
+        assert len(dataset_details) == 1
+        assert recording_details, "expected at least one per-recording sync request"
+        for sent in recording_details:
+            assert sent == dataset_details[0]
+
+    def test_sync_parameters_survive_slicing(
+        self, mock_data_requests, tmp_path
+    ) -> None:
+        """A sliced synchronized dataset keeps the original parameters."""
+        dataset = nc.get_dataset(name="test_dataset")
+        dataset.cache_dir = tmp_path / "cache"
+        dataset.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        synced = dataset.synchronize(
+            frequency=30,
+            max_delay_s=0.25,
+            allow_duplicates=False,
+            trim_start_end=False,
+        )
+        sliced = synced[0:1]
+
+        assert (
+            sliced.synchronization_details == synced.synchronization_details
+        ), "slicing must not reset the synchronization parameters"

--- a/tests/unit/core/data/test_synchronized_episode.py
+++ b/tests/unit/core/data/test_synchronized_episode.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from neuracore_types import CameraData, DataType, JointData, SynchronizedPoint
+from neuracore_types import (
+    CameraData,
+    DataType,
+    JointData,
+    SynchronizationDetails,
+    SynchronizedPoint,
+)
 from PIL import Image
 
 from neuracore.core.const import API_URL
@@ -54,8 +60,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
 
     def test_init(self, synced_recording: SynchronizedRecording, dataset_mock):
@@ -84,8 +92,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=cross_embodiment_union,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=cross_embodiment_union,
+            ),
         )
 
         assert synced.cross_embodiment_union == cross_embodiment_union
@@ -106,8 +116,10 @@ class TestSynchronizedRecording:
         fake_self = SimpleNamespace(
             id="rec-1",
             dataset=SimpleNamespace(org_id="org-1"),
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
         session = MagicMock()
         response = MagicMock()
@@ -203,8 +215,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
 
         frames = synced[0:5:2]
@@ -276,8 +290,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
 
         sync_point = cast(SynchronizedPoint, synced[0])
@@ -296,8 +312,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
             prefetch_videos=True,
         )
 
@@ -313,8 +331,10 @@ class TestSynchronizedRecording:
                 recording_name="recording1",
                 robot_id="robot1",
                 instance=1,
-                frequency=30,
-                cross_embodiment_union=None,
+                synchronization_details=SynchronizationDetails(
+                    frequency=30,
+                    cross_embodiment_union=None,
+                ),
                 prefetch_videos=True,
             )
 
@@ -357,8 +377,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
 
         with patch(
@@ -411,8 +433,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=30,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=30,
+                cross_embodiment_union=None,
+            ),
         )
 
         synced_60 = SynchronizedRecording(
@@ -421,8 +445,10 @@ class TestSynchronizedRecording:
             recording_name="recording1",
             robot_id="robot1",
             instance=1,
-            frequency=60,
-            cross_embodiment_union=None,
+            synchronization_details=SynchronizationDetails(
+                frequency=60,
+                cross_embodiment_union=None,
+            ),
         )
 
         assert synced_30.frequency == 30


### PR DESCRIPTION
### Bugfixes
 - `Dataset.synchronize()` accepted `max_delay_s`, `allow_duplicates` and `trim_start_end`, used them for the dataset-level sync, then dropped them from the `SynchronizedDataset` it returned. The server keys stored synchronized data on all five synchronization parameters, so whenever any of the three was non-default every recording missed the stored data and was synchronized again from scratch under a second key. All three are now passed through, and survive slicing.
 - `SynchronizedRecording` takes the full `SynchronizationDetails` instead of receiving `frequency`/`cross_embodiment_union` and rebuilding the rest with hardcoded values, so the parameters can no longer drift. `frequency` and `cross_embodiment_union` remain readable as properties.
 - `Recording.synchronize()` had the same gap and now accepts the same three parameters.

