### PR TITLE
feat: expose trim_no_movement_at_start_threshold in sync APIs

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -108,6 +108,7 @@ def start_training_run(
     output_cross_embodiment_description: CrossEmbodimentDescription | None = None,
     max_delay_s: float = sys.float_info.max,
     allow_duplicates: bool = True,
+    trim_no_movement_at_start_threshold: float | None = None,
     name_auto_increment: bool = False,
     disk_size_gb: int = 500,
 ) -> dict:
@@ -125,6 +126,9 @@ def start_training_run(
         output_cross_embodiment_description: Output cross-embodiment description.
         max_delay_s: Maximum allowable delay for data synchronization (in seconds)
         allow_duplicates: Whether to allow duplicate data during synchronization
+        trim_no_movement_at_start_threshold: If set, drop frames at the start of
+            each episode while every joint position stays within this threshold
+            of its value in the first frame. None keeps every frame.
         name_auto_increment: If True and a job with this name already exists, use
             name_1, name_2, ... instead of failing or duplicating the name.
         disk_size_gb: Disk size in GB for the training VM (default: 500).
@@ -187,6 +191,7 @@ def start_training_run(
             frequency=frequency,
             max_delay_s=max_delay_s,
             allow_duplicates=allow_duplicates,
+            trim_no_movement_at_start_threshold=trim_no_movement_at_start_threshold,
             cross_embodiment_union=merge_cross_embodiment_description(
                 input_cross_embodiment_description, output_cross_embodiment_description
             ),

--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -467,6 +467,7 @@ class Dataset:
         max_delay_s: float = sys.float_info.max,
         allow_duplicates: bool = True,
         trim_start_end: bool = True,
+        trim_no_movement_at_start_threshold: float | None = None,
         cross_embodiment_union: CrossEmbodimentUnion | None = None,
     ) -> SynchronizedDatasetModel:
         """Synchronize the dataset with specified frequency and data types.
@@ -480,6 +481,10 @@ class Dataset:
             max_delay_s: Maximum allowed delay for synchronization.
             allow_duplicates: Whether duplicate points are allowed when syncing.
             trim_start_end: Whether to trim start/end during synchronization.
+            trim_no_movement_at_start_threshold: If set, drop frames at the
+                start of each episode while every joint position stays within
+                this threshold of its value in the first frame. None keeps
+                every frame.
 
         Returns:
             SynchronizedDataset instance containing synchronized data.
@@ -499,6 +504,9 @@ class Dataset:
                     max_delay_s=max_delay_s,
                     allow_duplicates=allow_duplicates,
                     trim_start_end=trim_start_end,
+                    trim_no_movement_at_start_threshold=(
+                        trim_no_movement_at_start_threshold
+                    ),
                     cross_embodiment_union=cross_embodiment_union,
                 ),
             ).model_dump(mode="json"),
@@ -534,6 +542,7 @@ class Dataset:
         max_delay_s: float = sys.float_info.max,
         allow_duplicates: bool = True,
         trim_start_end: bool = True,
+        trim_no_movement_at_start_threshold: float | None = None,
     ) -> SynchronizedDataset:
         """Synchronize the dataset with specified frequency and data types.
 
@@ -547,6 +556,10 @@ class Dataset:
             max_delay_s: Maximum allowed delay for synchronization.
             allow_duplicates: Whether duplicate points are allowed when syncing.
             trim_start_end: Whether to trim start/end during synchronization.
+            trim_no_movement_at_start_threshold: If set, drop frames at the
+                start of each episode while every joint position stays within
+                this threshold of its value in the first frame. None keeps
+                every frame.
 
         Returns:
             SynchronizedDataset instance containing synchronized data.
@@ -560,6 +573,7 @@ class Dataset:
             max_delay_s=max_delay_s,
             allow_duplicates=allow_duplicates,
             trim_start_end=trim_start_end,
+            trim_no_movement_at_start_threshold=trim_no_movement_at_start_threshold,
             cross_embodiment_union=cross_embodiment_union,
         )
 
@@ -593,6 +607,7 @@ class Dataset:
             max_delay_s=max_delay_s,
             allow_duplicates=allow_duplicates,
             trim_start_end=trim_start_end,
+            trim_no_movement_at_start_threshold=trim_no_movement_at_start_threshold,
         )
 
     def get_full_embodiment_description(self, robot_id: str) -> EmbodimentDescription:

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -83,6 +83,7 @@ class Recording:
         max_delay_s: float = sys.float_info.max,
         allow_duplicates: bool = True,
         trim_start_end: bool = True,
+        trim_no_movement_at_start_threshold: float | None = None,
     ) -> SynchronizedRecording:
         """Synchronize the episode with specified frequency and data types.
 
@@ -95,6 +96,10 @@ class Recording:
             max_delay_s: Maximum allowed delay for synchronization.
             allow_duplicates: Whether duplicate points are allowed when syncing.
             trim_start_end: Whether to trim start/end during synchronization.
+            trim_no_movement_at_start_threshold: If set, drop frames at the
+                start of the episode while every joint position stays within
+                this threshold of its value in the first frame. None keeps
+                every frame.
 
         Raises:
             SynchronizationError: If synchronization fails.
@@ -130,6 +135,9 @@ class Recording:
                 max_delay_s=max_delay_s,
                 allow_duplicates=allow_duplicates,
                 trim_start_end=trim_start_end,
+                trim_no_movement_at_start_threshold=(
+                    trim_no_movement_at_start_threshold
+                ),
             ),
         )
 

--- a/neuracore/core/data/synced_dataset.py
+++ b/neuracore/core/data/synced_dataset.py
@@ -52,6 +52,7 @@ class SynchronizedDataset:
         max_delay_s: float = sys.float_info.max,
         allow_duplicates: bool = True,
         trim_start_end: bool = True,
+        trim_no_movement_at_start_threshold: float | None = None,
         synced_recording_cache: dict[int, SynchronizedRecording] | None = None,
     ):
         """Initialize a dataset from server response data.
@@ -68,6 +69,9 @@ class SynchronizedDataset:
                 duplicate points.
             trim_start_end: Whether the dataset was synchronized with its start
                 and end trimmed.
+            trim_no_movement_at_start_threshold: The joint movement threshold
+                the dataset was synchronized with, below which leading frames
+                were dropped, or None if no such trimming was applied.
             synced_recording_cache: Already-fetched synced recordings keyed by
                 index, used when slicing to avoid re-fetching data the parent
                 dataset already loaded.
@@ -82,6 +86,7 @@ class SynchronizedDataset:
             max_delay_s=max_delay_s,
             allow_duplicates=allow_duplicates,
             trim_start_end=trim_start_end,
+            trim_no_movement_at_start_threshold=(trim_no_movement_at_start_threshold),
         )
         self._prefetch_videos = prefetch_videos
         self._max_prefetch_workers = max_prefetch_workers
@@ -198,6 +203,9 @@ class SynchronizedDataset:
                 max_delay_s=self.synchronization_details.max_delay_s,
                 allow_duplicates=self.synchronization_details.allow_duplicates,
                 trim_start_end=self.synchronization_details.trim_start_end,
+                trim_no_movement_at_start_threshold=(
+                    self.synchronization_details.trim_no_movement_at_start_threshold
+                ),
                 synced_recording_cache=sliced_cache,
             )
         else:

--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -57,6 +57,10 @@ max_prefetch_workers: 4
 max_delay_s: null
 trim_start_end: true
 
+# If set, drop frames at the start of each episode while every joint position
+# stays within this threshold of its value in the first frame.
+trim_no_movement_at_start_threshold: null
+
 # Dict[str, Dict[DataType, List[MethodConfig]]], e.g.:
 # for images, we must have a resize step to reshape all images from different sources to the same size.
 # train_preprocessing is used on the training split (may include augmentations).

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -154,6 +154,9 @@ def _save_local_training_metadata(
                 else getattr(cfg, "max_delay_s")
             ),
             "trim_start_end": getattr(cfg, "trim_start_end", True),
+            "trim_no_movement_at_start_threshold": getattr(
+                cfg, "trim_no_movement_at_start_threshold", None
+            ),
             "cross_embodiment_union": _serialize_cross_embodiment_union(
                 cross_embodiment_union
             ),
@@ -694,6 +697,9 @@ def _main(cfg: DictConfig) -> None:
             ),
             allow_duplicates=cfg.allow_duplicates,
             trim_start_end=cfg.trim_start_end,
+            trim_no_movement_at_start_threshold=getattr(
+                cfg, "trim_no_movement_at_start_threshold", None
+            ),
         )
 
         # Check if distributed training is enabled and multiple GPUs are available


### PR DESCRIPTION
### Features
 - Adds `trim_no_movement_at_start_threshold` to `Dataset.synchronize`, `Recording.synchronize`, `SynchronizedDataset`, and `nc.start_training_run`. Defaults to `None`, which preserves existing behaviour.
 - Adds the matching Hydra key to the training config (`trim_no_movement_at_start_threshold: null`) and plumbs it through `neuracore.ml.train`.

### Bugfixes
 - None

### Items
 - None

### Related PRs
 - neuracore_types: https://github.com/NeuracoreAI/neuracore_types/pull/112
 - neuracore_backend: https://github.com/NeuracoreAI/neuracore_backend/pull/528
 - neuracore_frontend: https://github.com/NeuracoreAI/neuracore_frontend/pull/438

Merge `neuracore_types` first; the others depend on the new field.
