### PR TITLE
perf: run image augmentation on the training device, not the dataloader

### DIFF
--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -65,6 +65,12 @@ trim_no_movement_at_start_threshold: null
 # for images, we must have a resize step to reshape all images from different sources to the same size.
 # train_preprocessing is used on the training split (may include augmentations).
 # inference_preprocessing is used for validation and packaged into the model archive.
+#
+# ORDERING: methods do not necessarily run in the order listed here. Each method
+# declares, via its `on_cpu` attribute, whether it runs per sample in a
+# DataLoader worker or per batch once the batch is on the training device, and
+# every worker-side method runs before every device-side one. Relative order is
+# preserved within each of those two groups.
 train_preprocessing:
   input:
     RGB_IMAGES:

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -180,8 +180,13 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         self.episode_indices = self._get_episode_indices()
         self._logged_in = False
 
-        self.input_preprocessing_config = input_preprocessing_config
-        self.output_preprocessing_config = output_preprocessing_config
+        # Only the worker-side half runs here. Device-side methods are applied
+        # by the trainer once the batch is on the accelerator, where they run
+        # batched rather than once per frame on a contended worker CPU.
+        self.input_preprocessing_config, _ = input_preprocessing_config.split_by_stage()
+        self.output_preprocessing_config, _ = (
+            output_preprocessing_config.split_by_stage()
+        )
 
     def _get_num_training_observations(self) -> int:
         # The count attribute of the stats should give total number of training

--- a/neuracore/ml/preprocessing/base.py
+++ b/neuracore/ml/preprocessing/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from neuracore_types import DataType
 
@@ -14,6 +14,17 @@ if TYPE_CHECKING:
 
 class PreprocessingMethod(ABC):
     """Base interface for preprocessing implementations."""
+
+    # Where in the pipeline this method runs.
+    #
+    # True runs it in the dataset, per sample, inside a DataLoader worker.
+    #
+    # False runs it in the trainer, per batch, once the batch has reached the
+    # training device.
+    # A method that opts out must handle a batched input: it sees a whole
+    # batch rather than one sample, so anything random has to draw per sample
+    # explicitly or the entire batch gets one draw.
+    on_cpu: ClassVar[bool] = True
 
     @staticmethod
     @abstractmethod
@@ -51,6 +62,27 @@ class PreprocessingMethod(ABC):
 
 class PreprocessingConfiguration(dict[DataType, list[PreprocessingMethod]]):
     """Runtime preprocessing pipeline keyed by data type."""
+
+    def split_by_stage(
+        self,
+    ) -> tuple[PreprocessingConfiguration, PreprocessingConfiguration]:
+        """Partition into the worker-side and device-side halves.
+
+        Order within each data type is preserved. Interleaving methods of
+        different stages reorders them relative to each other, so a pipeline
+        that depends on strict ordering should keep its methods on one side.
+
+        Returns:
+            ``(on_cpu, on_device)``, each omitting data types left with
+            nothing to do.
+        """
+        on_cpu = PreprocessingConfiguration()
+        on_device = PreprocessingConfiguration()
+        for data_type, methods in self.items():
+            for method in methods:
+                target = on_cpu if method.on_cpu else on_device
+                target.setdefault(data_type, []).append(method)
+        return on_cpu, on_device
 
     def __str__(self) -> str:
         """Return a human-readable representation of the preprocessing pipeline."""

--- a/neuracore/ml/preprocessing/methods/color_jitter.py
+++ b/neuracore/ml/preprocessing/methods/color_jitter.py
@@ -13,7 +13,22 @@ class ColorJitter(PreprocessingMethod):
 
     Expects float frames in ``[0, 255]`` (as produced by ``BatchedRGBData``),
     applies torchvision color jitter in ``[0, 1]``, then scales back.
+
+    Jitter is uniform across the batch. ``T.ColorJitter`` draws one factor set
+    per call and applies it to whatever it is handed, so running per batch on
+    the device means every sample in that batch shares a colour transform,
+    where running per sample on a worker CPU gave each its own. That is a
+    deliberate trade: the augmentation still varies from batch to batch, and
+    keeping torchvision's implementation is worth more than the extra
+    within-batch variation would be. Per-sample factors would mean
+    reimplementing all four adjustments with broadcasting, including a batched
+    RGB/HSV conversion for hue, since torchvision exposes no batched-factor
+    path.
     """
+
+    # Batched on the device it costs one pass over the batch rather
+    # than one pass per frame on a contended worker CPU.
+    on_cpu = False
 
     def __init__(
         self,
@@ -62,5 +77,5 @@ class ColorJitter(PreprocessingMethod):
             )
 
         jittered = self._jitter(data.frame / 255.0)
-        data.frame = (jittered * 255.0).clamp(0.0, 255.0)
+        data.frame = (jittered * 255.0).clamp(0.0, 255.0).contiguous()
         return data

--- a/neuracore/ml/preprocessing/methods/gaussian_noise.py
+++ b/neuracore/ml/preprocessing/methods/gaussian_noise.py
@@ -14,6 +14,9 @@ class GaussianNoise(PreprocessingMethod):
     Noise ``std`` is in pixel units for float frames in ``[0, 255]``.
     """
 
+    # randn_like over a full frame is expensive; far cheaper batched on the device
+    on_cpu = False
+
     def __init__(
         self,
         std: float = 5.0,

--- a/neuracore/ml/preprocessing/methods/resize_pad.py
+++ b/neuracore/ml/preprocessing/methods/resize_pad.py
@@ -15,6 +15,10 @@ class ResizePad(PreprocessingMethod):
     padded with zeros to get the output to the target size (height, width).
     """
 
+    # Has to run before collation: recordings differ in source resolution, and
+    # a batch cannot be stacked until every frame is the same size.
+    on_cpu = True
+
     def __init__(self, size: list[int] | tuple[int, int] = (224, 224)) -> None:
         """Initialize resize target as (height, width)."""
         self.size = size

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -372,6 +372,8 @@ def run_training(
     output_cross_embodiment_description: CrossEmbodimentDescription,
     inference_input_preprocessing_config: PreprocessingConfiguration,
     inference_output_preprocessing_config: PreprocessingConfiguration,
+    train_input_preprocessing_config: PreprocessingConfiguration,
+    train_output_preprocessing_config: PreprocessingConfiguration,
     dataset: PytorchSynchronizedDataset,
     device: torch.device | None = None,
 ) -> None:
@@ -548,6 +550,14 @@ def run_training(
             output_dir=Path(cfg.local_output_dir),
             num_epochs=cfg.epochs,
             log_freq=cfg.logging_frequency,
+            train_device_preprocessing=(
+                train_input_preprocessing_config.split_by_stage()[1],
+                train_output_preprocessing_config.split_by_stage()[1],
+            ),
+            inference_device_preprocessing=(
+                inference_input_preprocessing_config.split_by_stage()[1],
+                inference_output_preprocessing_config.split_by_stage()[1],
+            ),
             keep_last_n_checkpoints=cfg.keep_last_n_checkpoints,
             clip_grad_norm=algorithm_config.get("clip_grad_norm", None),
             rank=rank,
@@ -783,6 +793,8 @@ def _main(cfg: DictConfig) -> None:
                     output_cross_embodiment_description,
                     inference_input_preprocessing_config,
                     inference_output_preprocessing_config,
+                    train_input_preprocessing_config,
+                    train_output_preprocessing_config,
                     pytorch_dataset,
                     device,
                 ),
@@ -800,6 +812,8 @@ def _main(cfg: DictConfig) -> None:
                 output_cross_embodiment_description,
                 inference_input_preprocessing_config,
                 inference_output_preprocessing_config,
+                train_input_preprocessing_config,
+                train_output_preprocessing_config,
                 pytorch_dataset,
                 device,
             )

--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -15,8 +15,10 @@ from tqdm import tqdm
 from neuracore.ml import BatchedTrainingOutputs, NeuracoreModel
 from neuracore.ml.core.ml_types import BatchedTrainingSamples
 from neuracore.ml.logging.training_logger import TrainingLogger
+from neuracore.ml.preprocessing.base import PreprocessingConfiguration
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.memory_monitor import MemoryMonitor, OutOfMemoryError
+from neuracore.ml.utils.preprocessing import apply_device_preprocessing
 from neuracore.ml.utils.training_storage_handler import TrainingStorageHandler
 
 logger = logging.getLogger(__name__)
@@ -59,6 +61,12 @@ class DistributedTrainer:
         output_dir: Path,
         num_epochs: int,
         log_freq: int = 50,
+        train_device_preprocessing: (
+            tuple[PreprocessingConfiguration, PreprocessingConfiguration] | None
+        ) = None,
+        inference_device_preprocessing: (
+            tuple[PreprocessingConfiguration, PreprocessingConfiguration] | None
+        ) = None,
         save_freq: int = 1,
         save_checkpoints: bool = True,
         keep_last_n_checkpoints: int = 5,
@@ -78,6 +86,12 @@ class DistributedTrainer:
             output_dir: Directory for output files
             num_epochs: Number of epochs to train
             log_freq: Frequency to log metrics (in steps)
+            train_device_preprocessing: ``(input, output)`` device-side
+                preprocessing applied to training batches once they reach the
+                device. The dataset applies the worker-side half; this is the
+                rest.
+            inference_device_preprocessing: The same, for validation batches,
+                which use the inference pipeline rather than the training one.
             save_freq: Frequency to save checkpoints (in epochs)
             save_checkpoints: Whether to save checkpoints
             keep_last_n_checkpoints: Number of checkpoints to keep
@@ -109,6 +123,9 @@ class DistributedTrainer:
         self.output_dir = output_dir
         self.num_epochs = num_epochs
         self.log_freq = log_freq
+        empty = (PreprocessingConfiguration(), PreprocessingConfiguration())
+        self.train_device_preprocessing = train_device_preprocessing or empty
+        self.inference_device_preprocessing = inference_device_preprocessing or empty
         self.save_freq = save_freq
         self.save_checkpoints = save_checkpoints
         self.keep_last_n_checkpoints = keep_last_n_checkpoints
@@ -161,6 +178,7 @@ class DistributedTrainer:
 
             # Move tensors to device and format batch
             batch = batch.to(self.device)
+            apply_device_preprocessing(batch, *self.train_device_preprocessing)
 
             # Forward pass
             if self.world_size > 1:
@@ -247,6 +265,7 @@ class DistributedTrainer:
 
         for batch_idx, batch in enumerate(pbar):
             batch = batch.to(self.device)
+            apply_device_preprocessing(batch, *self.inference_device_preprocessing)
 
             # Forward pass
             if self.world_size > 1:

--- a/neuracore/ml/utils/dataset_utils.py
+++ b/neuracore/ml/utils/dataset_utils.py
@@ -52,8 +52,14 @@ def split_train_val_datasets(
 
     # Both subsets share the train-configured dataset; give val its own copy.
     val_base = copy(dataset)
-    val_base.input_preprocessing_config = inference_input_preprocessing_config
-    val_base.output_preprocessing_config = inference_output_preprocessing_config
+    # Worker-side half only, matching what the dataset constructor keeps. The
+    # trainer applies the device-side half of the inference pipeline.
+    val_base.input_preprocessing_config = (
+        inference_input_preprocessing_config.split_by_stage()[0]
+    )
+    val_base.output_preprocessing_config = (
+        inference_output_preprocessing_config.split_by_stage()[0]
+    )
     val_dataset = Subset(val_base, val_dataset.indices)
 
     return train_dataset, val_dataset

--- a/neuracore/ml/utils/preprocessing.py
+++ b/neuracore/ml/utils/preprocessing.py
@@ -10,6 +10,8 @@ from omegaconf import DictConfig, OmegaConf
 if TYPE_CHECKING:
     from neuracore_types import BatchedNCData
 
+    from neuracore.ml.core.ml_types import BatchedTrainingSamples
+
 from neuracore.ml.preprocessing.base import (
     PreprocessingConfiguration,
     PreprocessingMethod,
@@ -119,3 +121,32 @@ def apply_preprocessing_methods(
     for method in methods:
         batched_data = method(batched_data)
     return batched_data
+
+
+def apply_device_preprocessing(
+    batch: BatchedTrainingSamples,
+    input_config: PreprocessingConfiguration,
+    output_config: PreprocessingConfiguration,
+) -> None:
+    """Apply device-side preprocessing to a batch already on the device.
+
+    Mutates ``batch`` in place: each method transforms an item and returns it,
+    and the batch's per-slot lists are rebuilt from the results.
+
+    Args:
+        batch: Batch whose tensors are already on the target device.
+        input_config: Device-side methods for input slots.
+        output_config: Device-side methods for output slots.
+    """
+    for role_data, role_config in (
+        (batch.inputs, input_config),
+        (batch.outputs, output_config),
+    ):
+        for data_type, methods in role_config.items():
+            items = role_data.get(data_type)
+            if not items:
+                continue
+            role_data[data_type] = [
+                apply_preprocessing_methods(batched_data=item, methods=methods)
+                for item in items
+            ]

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -63,10 +63,10 @@ def _full_embodiment_description() -> dict[DataType, dict[int, str]]:
 
 
 def _default_preprocessing_config() -> PreprocessingConfiguration:
-    return {
+    return PreprocessingConfiguration({
         DataType.RGB_IMAGES: [ResizePad(size=(224, 224))],
         DataType.DEPTH_IMAGES: [ResizePad(size=(224, 224))],
-    }
+    })
 
 
 NON_TARGET_OUTPUT_DATA_TYPES = tuple(
@@ -977,10 +977,10 @@ class TestDataLoading:
         }
         RGB_TEST_SHAPE = (123, 456)
         DEPTH_TEST_SHAPE = (789, 101)
-        input_preprocessing_config = {
+        input_preprocessing_config = PreprocessingConfiguration({
             DataType.RGB_IMAGES: [ResizePad(size=RGB_TEST_SHAPE)],
             DataType.DEPTH_IMAGES: [ResizePad(size=DEPTH_TEST_SHAPE)],
-        }
+        })
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset_with_depth,
             input_cross_embodiment_description=input_description,
@@ -1021,10 +1021,10 @@ class TestDataLoading:
         }
         RGB_TEST_SHAPE = (160, 200)
         DEPTH_TEST_SHAPE = (180, 220)
-        output_preprocessing_config = {
+        output_preprocessing_config = PreprocessingConfiguration({
             DataType.RGB_IMAGES: [ResizePad(size=RGB_TEST_SHAPE)],
             DataType.DEPTH_IMAGES: [ResizePad(size=DEPTH_TEST_SHAPE)],
-        }
+        })
         dataset = PytorchSynchronizedDataset(
             synchronized_dataset=mock_synchronized_dataset_with_depth,
             input_cross_embodiment_description=input_description,
@@ -1209,7 +1209,7 @@ class TestOutputTimestepAlignment:
             output_cross_embodiment_description=output_description,
             output_prediction_horizon=1,
             input_preprocessing_config=_default_preprocessing_config(),
-            output_preprocessing_config={},
+            output_preprocessing_config=PreprocessingConfiguration(),
         )
 
         with patch.object(dataset, "_memory_monitor") as mock_monitor:
@@ -1274,7 +1274,7 @@ class TestOutputTimestepAlignment:
             output_cross_embodiment_description=output_description,
             output_prediction_horizon=1,
             input_preprocessing_config=_default_preprocessing_config(),
-            output_preprocessing_config={},
+            output_preprocessing_config=PreprocessingConfiguration(),
         )
 
         timestep = 4

--- a/tests/unit/ml/preprocessing/test_apply_preprocessing_configs.py
+++ b/tests/unit/ml/preprocessing/test_apply_preprocessing_configs.py
@@ -2,8 +2,13 @@ import pytest
 import torch
 from neuracore_types import BatchedNCData, BatchedRGBData, DataType
 
-from neuracore.ml.preprocessing.base import PreprocessingMethod
+from neuracore.ml.core.ml_types import BatchedTrainingSamples
+from neuracore.ml.preprocessing.base import (
+    PreprocessingConfiguration,
+    PreprocessingMethod,
+)
 from neuracore.ml.utils.preprocessing import (
+    apply_device_preprocessing,
     apply_preprocessing_methods,
     validate_preprocessing_configuration,
 )
@@ -55,3 +60,86 @@ def test_apply_methods_for_data_type_executes_handlers_in_order():
 
     assert isinstance(result, BatchedRGBData)
     assert call_order == ["first", "second"]
+
+
+class _StagedStep(_RecordStep):
+    """Records its label, and reports whichever stage it was built for."""
+
+    def __init__(self, call_order: list[str], label: str, on_cpu: bool) -> None:
+        super().__init__(call_order, label)
+        self.on_cpu = on_cpu
+
+
+def test_split_by_stage_partitions_and_preserves_order():
+    order: list[str] = []
+    config = PreprocessingConfiguration({
+        DataType.RGB_IMAGES: [
+            _StagedStep(order, "resize", on_cpu=True),
+            _StagedStep(order, "jitter", on_cpu=False),
+            _StagedStep(order, "noise", on_cpu=False),
+        ]
+    })
+
+    on_cpu, on_device = config.split_by_stage()
+
+    assert [m._label for m in on_cpu[DataType.RGB_IMAGES]] == ["resize"]
+    assert [m._label for m in on_device[DataType.RGB_IMAGES]] == ["jitter", "noise"]
+
+
+def test_split_by_stage_omits_data_types_with_nothing_to_do():
+    order: list[str] = []
+    config = PreprocessingConfiguration({
+        DataType.RGB_IMAGES: [_StagedStep(order, "jitter", on_cpu=False)],
+        DataType.DEPTH_IMAGES: [_StagedStep(order, "resize", on_cpu=True)],
+    })
+
+    on_cpu, on_device = config.split_by_stage()
+
+    assert DataType.RGB_IMAGES not in on_cpu
+    assert DataType.DEPTH_IMAGES not in on_device
+
+
+def test_methods_run_on_the_worker_unless_they_opt_out():
+    """The safe default: a method with no opinion runs where it always did."""
+    assert _RecordStep(call_order=[], label="x").on_cpu is True
+
+
+def test_apply_device_preprocessing_transforms_inputs_and_outputs():
+    order: list[str] = []
+    batch = BatchedTrainingSamples(
+        inputs={DataType.RGB_IMAGES: [_sample_rgb()]},
+        inputs_mask={DataType.RGB_IMAGES: torch.ones(1, 1)},
+        outputs={DataType.RGB_IMAGES: [_sample_rgb()]},
+        outputs_mask={DataType.RGB_IMAGES: torch.ones(1, 1)},
+        batch_size=1,
+    )
+
+    apply_device_preprocessing(
+        batch,
+        PreprocessingConfiguration(
+            {DataType.RGB_IMAGES: [_StagedStep(order, "in", on_cpu=False)]}
+        ),
+        PreprocessingConfiguration(
+            {DataType.RGB_IMAGES: [_StagedStep(order, "out", on_cpu=False)]}
+        ),
+    )
+
+    assert order == ["in", "out"]
+
+
+def test_apply_device_preprocessing_skips_absent_data_types():
+    """A configured data type the batch does not carry is simply not applied."""
+    order: list[str] = []
+    batch = BatchedTrainingSamples(
+        inputs={}, inputs_mask={}, outputs={}, outputs_mask={}, batch_size=1
+    )
+
+    apply_device_preprocessing(
+        batch,
+        PreprocessingConfiguration(
+            {DataType.RGB_IMAGES: [_StagedStep(order, "in", on_cpu=False)]}
+        ),
+        PreprocessingConfiguration(),
+    )
+
+    assert order == []

--- a/tests/unit/ml/preprocessing/test_color_jitter.py
+++ b/tests/unit/ml/preprocessing/test_color_jitter.py
@@ -41,3 +41,42 @@ def test_color_jitter_rejects_non_rgb():
     )
     with pytest.raises(TypeError, match="Unsupported batched data type"):
         ColorJitter()(depth)
+
+
+def test_color_jitter_is_uniform_across_the_batch():
+    """Pins the documented trade-off rather than treating it as a defect.
+
+    T.ColorJitter draws one factor set per call, so running it per batch on
+    the device gives every sample in that batch the same colour transform.
+    Augmentation still varies batch to batch. Change this test only alongside
+    a deliberate decision to reintroduce per-sample factors.
+    """
+    torch.manual_seed(0)
+    identical = BatchedRGBData(
+        frame=torch.full((4, 1, 3, 16, 16), 128.0, dtype=torch.float32),
+        extrinsics=torch.zeros((4, 1, 4, 4), dtype=torch.float32),
+        intrinsics=torch.zeros((4, 1, 3, 3), dtype=torch.float32),
+    )
+
+    out = ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4, hue=0.1)(identical)
+
+    assert all(torch.equal(out.frame[0], out.frame[i]) for i in range(4))
+
+
+def test_color_jitter_returns_contiguous_frames():
+    """The hue path returns a non-contiguous view; encoders flatten with .view.
+
+    Collation used to mask this by re-materialising the tensor with torch.cat,
+    but this runs after collation now.
+    """
+    torch.manual_seed(0)
+    data = _rgb()
+    assert data.frame.is_contiguous(), "fixture should start contiguous"
+
+    out = ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.05)(data)
+
+    assert out.frame.is_contiguous()
+
+
+def test_color_jitter_runs_on_the_device_stage():
+    assert ColorJitter().on_cpu is False

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -389,6 +389,10 @@ class RunTrainingTestSetup:
         inference_input, inference_output = resolve_input_output_preprocessing(
             cfg.inference_preprocessing, role_name="inference_preprocessing"
         )
+        train_input, train_output = resolve_input_output_preprocessing(
+            cfg.get("train_preprocessing", cfg.inference_preprocessing),
+            role_name="train_preprocessing",
+        )
         return run_training(
             self.rank,
             self.world_size,
@@ -398,6 +402,8 @@ class RunTrainingTestSetup:
             cfg.output_cross_embodiment_description,
             inference_input,
             inference_output,
+            train_input,
+            train_output,
             dataset,
         )
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - `PreprocessingMethod` gains an `on_cpu` flag. `True` (the default) keeps a method in the dataset, per sample, inside a DataLoader worker; `False` runs it in the trainer, per batch, once the batch is on the training device.
 - `ColorJitter` and `GaussianNoise` opt out and now run batched on the device. `ResizePad` stays on the worker: it must precede collation, since recordings differ in resolution and a batch cannot be stacked until frames match.

### Trade-off
 - `T.ColorJitter` draws one factor set per call, so per batch on the device every sample in a batch shares a colour transform where per sample it got its own. Accepted deliberately: augmentation still varies batch to batch, and per-sample factors would mean reimplementing all four adjustments with broadcasting, including a batched RGB/HSV conversion for hue. 