### PR TITLE
perf: precompute static dataset config instead of rebuilding per sample

### DIFF
--- a/neuracore/ml/datasets/pytorch_neuracore_dataset.py
+++ b/neuracore/ml/datasets/pytorch_neuracore_dataset.py
@@ -74,6 +74,7 @@ class PytorchNeuracoreDataset(Dataset, ABC):
             self.input_cross_embodiment_description,
             self.output_cross_embodiment_description,
         )
+        self._tensor_attribute_cache: dict[type[BatchedNCData], list[str]] = {}
 
     @abstractmethod
     def load_sample(
@@ -118,6 +119,28 @@ class PytorchNeuracoreDataset(Dataset, ABC):
             Exception: If sample loading fails after exhausting retry attempts.
         """
         pass
+
+    def _tensor_attribute_names(
+        self, item_type: type[BatchedNCData], example: BatchedNCData
+    ) -> list[str]:
+        """Return the tensor-valued attribute names for ``item_type``, cached.
+
+        Args:
+            item_type: The batched data class to inspect.
+            example: An instance of ``item_type`` to read the layout from.
+
+        Returns:
+            The names of every attribute holding a tensor.
+        """
+        cached = self._tensor_attribute_cache.get(item_type)
+        if cached is None:
+            cached = [
+                attr_name
+                for attr_name in vars(example)
+                if isinstance(getattr(example, attr_name), torch.Tensor)
+            ]
+            self._tensor_attribute_cache[item_type] = cached
+        return cached
 
     def _collate_input_outputs(
         self,
@@ -165,12 +188,13 @@ class PytorchNeuracoreDataset(Dataset, ABC):
                 # Collect all samples for this specific item across the batch
                 items_to_batch = [sample[data_type][item_idx] for sample in samples]
 
-                # Get attribute names from the first item
-                attrib_names_of_tensors = [
-                    attr_name
-                    for attr_name in vars(items_to_batch[0])
-                    if isinstance(getattr(items_to_batch[0], attr_name), torch.Tensor)
-                ]
+                # Which attributes hold tensors is a property of the type,
+                # not the instance, so discover it once instead of per item of
+                # per data type of every batch.
+                item_type = type(items_to_batch[0])
+                attrib_names_of_tensors = self._tensor_attribute_names(
+                    item_type, items_to_batch[0]
+                )
 
                 # Stack each attribute across samples
                 batched_attributes = {}
@@ -184,7 +208,7 @@ class PytorchNeuracoreDataset(Dataset, ABC):
                         batched_attributes[attr_name] = None
 
                 # Create new batched object of the same type
-                batched_item = type(items_to_batch[0])(**batched_attributes)
+                batched_item = item_type(**batched_attributes)
                 batched_data[data_type].append(batched_item)
 
         return batched_data

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -177,7 +177,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             self.synchronized_dataset
         )
 
-        self.episode_indices = self._get_episode_indices()
+        self.episode_indices, self.episode_start_offsets = self._get_episode_indices()
         self._logged_in = False
 
         # Only the worker-side half runs here. Device-side methods are applied
@@ -187,6 +187,60 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         self.output_preprocessing_config, _ = (
             output_preprocessing_config.split_by_stage()
         )
+
+        # Everything below is a pure function of the cross-embodiment
+        # descriptions, which are fixed once the dataset exists. Deriving it
+        # here keeps it out of load_sample, which runs once per sample.
+        self._max_items_per_input_type = self._get_max_items_per_data_type(
+            self.input_cross_embodiment_description
+        )
+        self._max_items_per_output_type = self._get_max_items_per_data_type(
+            self.output_cross_embodiment_description
+        )
+        # Index-ordered (index, name) pairs per robot, so projecting a sync
+        # point does not re-sort the same keys for every one of the
+        # output_prediction_horizon + 1 sync points a sample touches.
+        self._merged_ordered_items = {
+            robot_id: self._order_embodiment_items(
+                self._convert_to_embodiment_description(embodiment_union)
+            )
+            for robot_id, embodiment_union in (
+                self.merged_cross_embodiment_description.items()
+            )
+        }
+
+    @staticmethod
+    def _get_max_items_per_data_type(
+        cross_embodiment_description: CrossEmbodimentDescription,
+    ) -> dict[DataType, int]:
+        """Return the padded slot count for each data type.
+
+        The count is the highest index used for that data type across every
+        robot, plus one, so samples from different embodiments pad out to a
+        common width.
+        """
+        highest_index: dict[DataType, int] = {}
+        for data_types in cross_embodiment_description.values():
+            for data_type, indexed_names in data_types.items():
+                # Floored at 0 so a data type declared with no sensors still
+                # gets a single padded slot, matching the per-sample scan this
+                # replaces.
+                highest_index[data_type] = max(
+                    highest_index.get(data_type, 0), *indexed_names, 0
+                )
+        return {data_type: highest + 1 for data_type, highest in highest_index.items()}
+
+    @staticmethod
+    def _order_embodiment_items(
+        description: EmbodimentDescription,
+    ) -> dict[DataType, list[tuple[int, str]]]:
+        """Flatten an embodiment description into index-ordered (index, name) pairs."""
+        return {
+            data_type: [
+                (index, indexed_names[index]) for index in sorted(indexed_names)
+            ]
+            for data_type, indexed_names in description.items()
+        }
 
     def _get_num_training_observations(self) -> int:
         # The count attribute of the stats should give total number of training
@@ -233,15 +287,21 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             description_kind="Output",
         )
 
-    def _get_episode_indices(self) -> list[int]:
-        """Return a list mapping each sample index to its episode (recording) index.
+    def _get_episode_indices(self) -> tuple[list[int], list[int]]:
+        """Map each sample to its episode, and each episode to its first sample.
 
         Omit the last frame of each episode because it is not used for training.
 
         Returns:
-            A list mapping each sample index to its episode (recording) index.
+            ``(episode_indices, episode_start_offsets)`` where
+            ``episode_indices[sample_idx]`` is the recording index, and
+            ``episode_start_offsets[recording_idx]`` is the sample index that
+            recording starts at. The offsets let ``__getitem__`` recover a
+            timestep by subtraction rather than by scanning
+            ``episode_indices`` for the episode's first occurrence.
         """
-        episode_indices = []
+        episode_indices: list[int] = []
+        episode_start_offsets: list[int] = []
         for recording_idx, recording in enumerate(self.synchronized_dataset):
             # Each recording must have at least 2 timesteps because we drop the
             # last frame from training. Otherwise alignment with per-recording
@@ -252,9 +312,10 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     f"'{recording.name}' has only {len(recording)} frame(s); "
                     "need >= 2 frames to generate training samples."
                 )
+            episode_start_offsets.append(len(episode_indices))
             episode_indices.extend([recording_idx] * (len(recording) - 1))
 
-        return episode_indices
+        return episode_indices, episode_start_offsets
 
     def _convert_to_embodiment_description(
         self, value: EmbodimentUnion
@@ -301,33 +362,39 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         return embodiment_description
 
     @staticmethod
-    def _project_sync_point_to_embodiment_description(
+    def _project_sync_point(
         sync_point: SynchronizedPoint,
-        embodiment_description: EmbodimentDescription,
+        ordered_items: dict[DataType, list[tuple[int, str]]],
     ) -> SynchronizedPoint:
         """Project a sync point onto the requested spec in deterministic order.
 
         Extra data types or sensor names in the source sync point are ignored.
         Missing required data types or sensor names raise a ValueError.
+
+        Args:
+            sync_point: The sync point to project.
+            ordered_items: Index-ordered ``{data_type: [(index, name), ...]}``
+                built once at construction, so this does not re-sort the same
+                keys for every sync point of every sample.
         """
         projected_data: dict[DataType, dict[str, object]] = {}
 
-        for data_type, indexed_names in embodiment_description.items():
+        for data_type, indexed_names in ordered_items.items():
             source_data_for_type = sync_point.data.get(data_type)
             if source_data_for_type is None:
                 raise ValueError(
                     f"SynchronizedPoint is missing required data type: {data_type}"
                 )
 
-            projected_data[data_type] = {}
-            for index in sorted(indexed_names):
-                name = indexed_names[index]
+            projected_for_type: dict[str, object] = {}
+            for _, name in indexed_names:
                 if name not in source_data_for_type:
                     raise ValueError(
                         "SynchronizedPoint is missing required sensor name "
                         f"'{name}' for data type {data_type}"
                     )
-                projected_data[data_type][name] = source_data_for_type[name]
+                projected_for_type[name] = source_data_for_type[name]
+            projected_data[data_type] = projected_for_type
 
         return SynchronizedPoint.model_construct(
             timestamp=sync_point.timestamp,
@@ -344,7 +411,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         self,
         synced_recording: SynchronizedRecording,
         timestep: int,
-        embodiment_description: EmbodimentDescription,
+        ordered_items: dict[DataType, list[tuple[int, str]]],
     ) -> list[SynchronizedPoint]:
         """Load the superset window for all output data types.
 
@@ -357,9 +424,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             synced_recording[timestep : timestep + 1 + self.output_prediction_horizon],
         )
         return [
-            self._project_sync_point_to_embodiment_description(
-                sync_point, embodiment_description
-            )
+            self._project_sync_point(sync_point, ordered_items)
             for sync_point in output_sync_points
         ]
 
@@ -417,20 +482,15 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         # Order the SynchronizedPoints to the merged embodiment description.
         robot_id = synced_recording.robot_id
 
-        robot_embodiment_union: EmbodimentUnion = (
-            self.merged_cross_embodiment_description[robot_id]
-        )
-        robot_merged_embodiment_description: EmbodimentDescription = (
-            self._convert_to_embodiment_description(robot_embodiment_union)
-        )
-        input_sync_point = self._project_sync_point_to_embodiment_description(
-            input_sync_point, robot_merged_embodiment_description
+        merged_ordered_items = self._merged_ordered_items[robot_id]
+        input_sync_point = self._project_sync_point(
+            input_sync_point, merged_ordered_items
         )
 
         output_sync_points = self._load_projected_output_sync_points(
             synced_recording=synced_recording,
             timestep=timestep,
-            embodiment_description=robot_merged_embodiment_description,
+            ordered_items=merged_ordered_items,
         )
         recording_name = getattr(synced_recording, "name", "recording")
 
@@ -442,17 +502,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             batched_nc_data_class = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type]
             inputs[data_type] = []
 
-            max_items_trained_on = 0
-            # Iterate through all robots and find the max index for this data
-            # type across all robots to determine padding length.
-            for other_robot_id in self.input_cross_embodiment_description:
-                for index in self.input_cross_embodiment_description[other_robot_id][
-                    data_type
-                ].keys():
-                    if index > max_items_trained_on:
-                        max_items_trained_on = index
-
-            max_items_trained_on += 1
+            max_items_trained_on = self._max_items_per_input_type[data_type]
             input_mask_values: list[float] = [0.0] * max_items_trained_on
             for index in range(max_items_trained_on):
                 name = self.input_cross_embodiment_description[robot_id][data_type].get(
@@ -488,17 +538,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             batched_nc_data_class = DATA_TYPE_TO_BATCHED_NC_DATA_CLASS[data_type]
             outputs[data_type] = []
 
-            max_items_trained_on = 0
-            # Iterate through all robots and find the max index for this data
-            # type across all robots to determine padding length.
-            for other_robot_id in self.output_cross_embodiment_description:
-                for index in self.output_cross_embodiment_description[other_robot_id][
-                    data_type
-                ].keys():
-                    if index > max_items_trained_on:
-                        max_items_trained_on = index
-
-            max_items_trained_on += 1
+            max_items_trained_on = self._max_items_per_output_type[data_type]
             aligned_output_sync_points = self._output_sync_points_for_data_type(
                 output_sync_points,
                 data_type,
@@ -577,7 +617,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             )
 
         episode_idx = self.episode_indices[idx]
-        timestep = idx - self.episode_indices.index(episode_idx)
+        timestep = idx - self.episode_start_offsets[episode_idx]
         return self.load_sample(episode_idx, timestep)
 
     @property

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -1514,6 +1514,91 @@ class TestPerformanceAndOptimization:
         assert all(idx == 0 for idx in dataset.episode_indices[:9])
         assert all(idx == 1 for idx in dataset.episode_indices[9:18])
 
+        # Offsets must agree with a scan for the episode's first occurrence,
+        # which is what they replace in __getitem__.
+        assert dataset.episode_start_offsets == [0, 9, 18, 27, 36]
+        for episode_idx, offset in enumerate(dataset.episode_start_offsets):
+            assert dataset.episode_indices.index(episode_idx) == offset
+
+    @patch("neuracore.login")
+    def test_precomputed_padding_widths_match_a_per_sample_scan(
+        self, mock_login, mock_synchronized_dataset
+    ):
+        """Padding widths are derived once; they must match the old scan.
+
+        The width is the highest index used for a data type across every
+        robot, plus one, so mixed-embodiment batches pad to a common size.
+        """
+        input_description: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3),
+                DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 2),
+            }
+        }
+        output_description: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                    DataType.JOINT_TARGET_POSITIONS, 3
+                )
+            }
+        }
+
+        dataset = PytorchSynchronizedDataset(
+            synchronized_dataset=mock_synchronized_dataset,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
+            output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
+        )
+
+        def scan(description, data_type):
+            widest = 0
+            for robot in description:
+                for index in description[robot][data_type]:
+                    widest = max(widest, index)
+            return widest + 1
+
+        for data_type in input_description[ROBOT_ID]:
+            assert dataset._max_items_per_input_type[data_type] == scan(
+                input_description, data_type
+            )
+        for data_type in output_description[ROBOT_ID]:
+            assert dataset._max_items_per_output_type[data_type] == scan(
+                output_description, data_type
+            )
+
+    @patch("neuracore.login")
+    def test_precomputed_ordering_is_index_sorted(
+        self, mock_login, mock_synchronized_dataset
+    ):
+        """Projection order is fixed at construction, not re-sorted per sample."""
+        input_description: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_POSITIONS: _indexed_names(DataType.JOINT_POSITIONS, 3)
+            }
+        }
+        output_description: CrossEmbodimentDescription = {
+            ROBOT_ID: {
+                DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                    DataType.JOINT_TARGET_POSITIONS, 3
+                )
+            }
+        }
+
+        dataset = PytorchSynchronizedDataset(
+            synchronized_dataset=mock_synchronized_dataset,
+            input_cross_embodiment_description=input_description,
+            output_cross_embodiment_description=output_description,
+            output_prediction_horizon=3,
+            input_preprocessing_config=_default_preprocessing_config(),
+            output_preprocessing_config=_default_preprocessing_config(),
+        )
+
+        for ordered in dataset._merged_ordered_items[ROBOT_ID].values():
+            indices = [index for index, _ in ordered]
+            assert indices == sorted(indices)
+
 
 class TestIntegrationWithPyTorchDataLoader:
     """Integration tests with PyTorch DataLoader."""


### PR DESCRIPTION
### Features
 - `load_sample` no longer rebuilds config that cannot change once the dataset exists. Padding widths, the indexed embodiment mapping and its sort order are derived once in `__init__`.
 - `__getitem__` recovers a timestep from a precomputed per-episode start offset rather than scanning `episode_indices` for the episode's first occurrence, which was O(N) per access and so O(N^2) per epoch.
 - `collate_fn` caches which attributes hold tensors per type, instead of re-deriving it by reflection for every item of every data type of every batch.

