### PR TITLE
perf: cache built training samples on disk across epochs and runs

### DIFF
--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -48,6 +48,12 @@ output_cross_embodiment_description: {
 # Batch size (can be "auto" for automatic tuning or an integer)
 batch_size: "auto"
 
+# Cache fully built training samples under ~/.neuracore/training/sample_cache,
+# keyed by a hash of everything that changes what a sample contains. Skips
+# frame decode and tensor construction on every epoch after the first, and on
+# any later run of the same configuration. Disable to always rebuild.
+dataset_sample_cache: true
+
 num_train_workers: 2
 num_val_workers: 1
 

--- a/neuracore/ml/datasets/batch_sample_cache.py
+++ b/neuracore/ml/datasets/batch_sample_cache.py
@@ -1,0 +1,176 @@
+"""On-disk cache of fully built training samples."""
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import torch
+from neuracore_types import CrossEmbodimentDescription
+
+from neuracore.core.const import DEFAULT_CACHE_DIR
+from neuracore.core.data.cache_manager import CacheManager
+from neuracore.ml import BatchedTrainingSamples
+from neuracore.ml.preprocessing.base import PreprocessingConfiguration
+from neuracore.ml.utils.json_serialization import to_json_serializable
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_CACHE_DIR = DEFAULT_CACHE_DIR / "sample_cache"
+
+
+class BatchSampleCache:
+    """Caches built training samples on disk, shared across epochs and runs.
+
+    Building a sample is dominated by inflating a stored frame and then
+    discarding most of it during resize, work that is identical on every epoch
+    and every run of the same configuration. Caching the finished sample skips
+    all of it.
+
+    This works best when augmentation is applied on the training device,
+    so the cache stores only the deterministic projection and preprocessing.
+    """
+
+    def __init__(
+        self,
+        synchronized_dataset_id: str,
+        input_cross_embodiment_description: CrossEmbodimentDescription,
+        output_cross_embodiment_description: CrossEmbodimentDescription,
+        output_prediction_horizon: int,
+        input_preprocessing_config: PreprocessingConfiguration,
+        output_preprocessing_config: PreprocessingConfiguration,
+        root: Path | None = None,
+    ) -> None:
+        """Initialize the cache.
+
+        Every argument feeds the key, so the call site reads as a statement of
+        what makes one cached sample interchangeable with another.
+
+        Args:
+            synchronized_dataset_id: Identifies the synchronized dataset, which
+                the server keys on the synchronization parameters.
+            input_cross_embodiment_description: Which input sensors are
+                projected in, and how they are padded.
+            output_cross_embodiment_description: The same, for outputs.
+            output_prediction_horizon: How many future steps outputs span.
+            input_preprocessing_config: Worker-side input preprocessing. Pass
+                the worker-side half only; device-side methods run after this
+                cache and cannot change what is stored.
+            output_preprocessing_config: The same, for outputs.
+            root: Directory holding every configuration's entries. Defaults to
+                the shared sample cache.
+        """
+        self.directory = (root or SAMPLE_CACHE_DIR) / self._spec_hash(
+            synchronized_dataset_id=synchronized_dataset_id,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            output_prediction_horizon=output_prediction_horizon,
+            input_preprocessing_config=input_preprocessing_config,
+            output_preprocessing_config=output_preprocessing_config,
+        )
+        self.cache_manager = CacheManager(self.directory)
+
+    @classmethod
+    def _spec_hash(
+        cls,
+        synchronized_dataset_id: str,
+        input_cross_embodiment_description: CrossEmbodimentDescription,
+        output_cross_embodiment_description: CrossEmbodimentDescription,
+        output_prediction_horizon: int,
+        input_preprocessing_config: PreprocessingConfiguration,
+        output_preprocessing_config: PreprocessingConfiguration,
+    ) -> str:
+        """Digest everything that changes what a built sample contains.
+
+        Including a field costs at worst a cache miss. Omitting one serves
+        tensors that silently disagree with the configuration, so anything
+        doubtful belongs here.
+        """
+
+        def preprocessing_spec(
+            config: PreprocessingConfiguration,
+        ) -> dict[str, list[dict[str, object]]]:
+            return {
+                data_type.value: [method.to_dict() for method in methods]
+                for data_type, methods in sorted(
+                    config.items(), key=lambda item: item[0].value
+                )
+            }
+
+        spec = {
+            "synchronized_dataset_id": synchronized_dataset_id,
+            "input_cross_embodiment_description": to_json_serializable(
+                input_cross_embodiment_description
+            ),
+            "output_cross_embodiment_description": to_json_serializable(
+                output_cross_embodiment_description
+            ),
+            "output_prediction_horizon": output_prediction_horizon,
+            "input_preprocessing": preprocessing_spec(input_preprocessing_config),
+            "output_preprocessing": preprocessing_spec(output_preprocessing_config),
+        }
+        serialized = json.dumps(
+            spec, sort_keys=True, separators=(",", ":"), default=str
+        )
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+    def _path(self, recording_id: str, timestep: int) -> Path:
+        # Sharded by recording to keep any one directory a reasonable size,
+        # mirroring the layout of the decoded frame cache.
+        return self.directory / recording_id / f"{timestep}.pt"
+
+    def load(self, recording_id: str, timestep: int) -> BatchedTrainingSamples | None:
+        """Return the cached sample, or None if absent or unreadable.
+
+        Args:
+            recording_id: Recording the sample was built from.
+            timestep: Timestep within that recording.
+
+        Returns:
+            The cached sample, or None if the caller should rebuild it.
+        """
+        path = self._path(recording_id, timestep)
+        if not path.exists():
+            return None
+        try:
+            # weights_only=False is needed to rebuild the batched pydantic
+            # types. Safe here: these files are written by this process to the
+            # local disk and are never fetched from anywhere.
+            sample = torch.load(path, weights_only=False)
+        except Exception:
+            # A truncated or stale entry must cost a rebuild, never a crash.
+            logger.warning("Discarding unreadable sample cache entry %s", path)
+            path.unlink(missing_ok=True)
+            return None
+        return cast(BatchedTrainingSamples, sample)
+
+    def store(
+        self, recording_id: str, timestep: int, sample: BatchedTrainingSamples
+    ) -> None:
+        """Write a built sample. A failure here costs a rebuild, nothing more.
+
+        Args:
+            recording_id: Recording the sample was built from.
+            timestep: Timestep within that recording.
+            sample: The built sample to store.
+        """
+        path = self._path(recording_id, timestep)
+        staging: Path | None = None
+        try:
+            self.cache_manager.ensure_space_available()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Write then rename: several workers populate this concurrently and
+            # a reader must never see a half-written entry.
+            with tempfile.NamedTemporaryFile(
+                dir=path.parent, suffix=".tmp", delete=False
+            ) as handle:
+                staging = Path(handle.name)
+                torch.save(sample, handle)
+            os.replace(staging, path)
+        except Exception:
+            logger.warning("Could not write sample cache entry %s", path, exc_info=True)
+            if staging is not None:
+                staging.unlink(missing_ok=True)

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -29,6 +29,7 @@ from neuracore.core.utils.training_input_args_validation import (
     _validate_cross_embodiment_description_against_dataset,
 )
 from neuracore.ml import BatchedTrainingSamples
+from neuracore.ml.datasets.batch_sample_cache import BatchSampleCache
 from neuracore.ml.datasets.pytorch_neuracore_dataset import PytorchNeuracoreDataset
 from neuracore.ml.preprocessing.base import PreprocessingConfiguration
 from neuracore.ml.utils.json_serialization import JsonValue, to_json_serializable
@@ -63,6 +64,7 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         input_preprocessing_config: PreprocessingConfiguration,
         output_preprocessing_config: PreprocessingConfiguration,
         output_prediction_horizon: int,
+        sample_cache: bool = True,
     ):
         """Initialize the dataset.
 
@@ -77,6 +79,8 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             output_preprocessing_config: Preprocessing configuration applied
                 to output slots.
             output_prediction_horizon: Number of future timesteps to predict.
+            sample_cache: Reuse fully built samples from an on-disk cache
+                across epochs and runs, rebuilding on a miss.
         """
         self._validate_cross_embodiment_specs(
             synchronized_dataset,
@@ -177,7 +181,14 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             self.synchronized_dataset
         )
 
-        self.episode_indices, self.episode_start_offsets = self._get_episode_indices()
+        (
+            self.episode_indices,
+            self.episode_start_offsets,
+            # Keys the sample cache: an episode index is a position in a
+            # server-ordered list and can point at a different recording once
+            # the dataset changes, where an id cannot.
+            self._episode_recording_ids,
+        ) = self._get_sample_to_episode_mapping()
         self._logged_in = False
 
         # Only the worker-side half runs here. Device-side methods are applied
@@ -208,6 +219,36 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                 self.merged_cross_embodiment_description.items()
             )
         }
+
+        self._sample_cache = self._build_sample_cache() if sample_cache else None
+
+    def rebuild_sample_cache(self) -> None:
+        """Re-key the sample cache against the current preprocessing.
+
+        Call after swapping a preprocessing configuration on an existing
+        dataset, so entries are stored under a key describing what is actually
+        being built rather than what the dataset was constructed with.
+        """
+        if self._sample_cache is not None:
+            self._sample_cache = self._build_sample_cache()
+
+    def _build_sample_cache(self) -> BatchSampleCache:
+        """Create the cache for the currently configured preprocessing."""
+        cache = BatchSampleCache(
+            synchronized_dataset_id=self.synchronized_dataset.id,
+            input_cross_embodiment_description=(
+                self.input_cross_embodiment_description
+            ),
+            output_cross_embodiment_description=(
+                self.output_cross_embodiment_description
+            ),
+            output_prediction_horizon=self.output_prediction_horizon,
+            # Worker-side halves only; the dataset already discarded the rest.
+            input_preprocessing_config=self.input_preprocessing_config,
+            output_preprocessing_config=self.output_preprocessing_config,
+        )
+        logger.info("Caching built samples under %s", cache.directory)
+        return cache
 
     @staticmethod
     def _get_max_items_per_data_type(
@@ -287,21 +328,26 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             description_kind="Output",
         )
 
-    def _get_episode_indices(self) -> tuple[list[int], list[int]]:
-        """Map each sample to its episode, and each episode to its first sample.
+    def _get_sample_to_episode_mapping(self) -> tuple[list[int], list[int], list[str]]:
+        """Map each sample index to its episode index, start offset, and recording ID.
 
         Omit the last frame of each episode because it is not used for training.
 
         Returns:
-            ``(episode_indices, episode_start_offsets)`` where
-            ``episode_indices[sample_idx]`` is the recording index, and
-            ``episode_start_offsets[recording_idx]`` is the sample index that
-            recording starts at. The offsets let ``__getitem__`` recover a
-            timestep by subtraction rather than by scanning
-            ``episode_indices`` for the episode's first occurrence.
+            ``(episode_indices, episode_start_offsets, episode_recording_ids)``
+            where ``episode_indices[sample_idx]`` is the episode index,
+            ``episode_start_offsets[episode_idx]`` is the sample index that
+            episode starts at, and ``episode_recording_ids[episode_idx]``
+            is its id. The offsets let ``__getitem__`` recover a timestep by
+            subtraction rather than by scanning ``episode_indices`` for the
+            episode's first occurrence. The ids let the sample cache be keyed
+            without a recording lookup; they are gathered here because
+            iterating the synchronized dataset is not guaranteed to be
+            restartable, so it must be walked exactly once.
         """
         episode_indices: list[int] = []
         episode_start_offsets: list[int] = []
+        episode_recording_ids: list[str] = []
         for recording_idx, recording in enumerate(self.synchronized_dataset):
             # Each recording must have at least 2 timesteps because we drop the
             # last frame from training. Otherwise alignment with per-recording
@@ -313,9 +359,10 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                     "need >= 2 frames to generate training samples."
                 )
             episode_start_offsets.append(len(episode_indices))
+            episode_recording_ids.append(recording.id)
             episode_indices.extend([recording_idx] * (len(recording) - 1))
 
-        return episode_indices, episode_start_offsets
+        return episode_indices, episode_start_offsets, episode_recording_ids
 
     def _convert_to_embodiment_description(
         self, value: EmbodimentUnion
@@ -471,6 +518,14 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
             self._mem_check_counter = 0
         self._mem_check_counter += 1
 
+        # Check for a cached sample first, keyed by recording id and timestep.
+        if self._sample_cache is not None and timestep is not None:
+            cached = self._sample_cache.load(
+                self._episode_recording_ids[episode_idx], timestep
+            )
+            if cached is not None:
+                return cached
+
         synced_recording = self.synchronized_dataset[episode_idx]
         synced_recording = cast(SynchronizedRecording, synced_recording)
         episode_length = len(synced_recording)
@@ -581,13 +636,16 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                 output_mask_values, dtype=torch.float32
             )
 
-        return TrainingSample(
+        sample = TrainingSample(
             inputs=inputs,
             inputs_mask=inputs_mask,
             outputs=outputs,
             outputs_mask=outputs_mask,
             batch_size=1,
         )
+        if self._sample_cache is not None:
+            self._sample_cache.store(synced_recording.id, timestep, sample)
+        return sample
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset.

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -754,6 +754,7 @@ def _main(cfg: DictConfig) -> None:
             output_prediction_horizon=cfg.output_prediction_horizon,
             input_preprocessing_config=train_input_preprocessing_config,
             output_preprocessing_config=train_output_preprocessing_config,
+            sample_cache=cfg.get("dataset_sample_cache", True),
         )
 
         # Handle batch size configuration

--- a/neuracore/ml/utils/dataset_utils.py
+++ b/neuracore/ml/utils/dataset_utils.py
@@ -60,6 +60,10 @@ def split_train_val_datasets(
     val_base.output_preprocessing_config = (
         inference_output_preprocessing_config.split_by_stage()[0]
     )
+    # The shallow copy would otherwise share a cache keyed on the train
+    # pipeline while storing samples built with the inference one. Re-key it
+    # against the preprocessing just assigned above.
+    val_base.rebuild_sample_cache()
     val_dataset = Subset(val_base, val_dataset.indices)
 
     return train_dataset, val_dataset

--- a/tests/unit/ml/conftest.py
+++ b/tests/unit/ml/conftest.py
@@ -22,6 +22,8 @@ from neuracore_types import (
     SynchronizedPoint,
 )
 
+from neuracore.ml.datasets import batch_sample_cache
+
 REMOTE_TIMESTAMP = 1234567890.0
 REMOTE_JOINT_NAMES = ("joint1", "joint2")
 REMOTE_CAMERA_NAME = "top_camera"
@@ -70,6 +72,21 @@ def remote_sync_point(*payloads: RemoteData) -> SynchronizedPoint:
     for payload in payloads:
         data.update(payload)
     return SynchronizedPoint(timestamp=REMOTE_TIMESTAMP, data=data)
+
+
+@pytest.fixture(autouse=True)
+def isolate_sample_cache(tmp_path_factory, monkeypatch):
+    """Keep the built-sample cache out of the developer's real cache directory.
+
+    The dataset enables the cache by default, so any test that constructs one
+    would otherwise read and write ``~/.neuracore/training/sample_cache``,
+    leaking entries between tests and onto the machine running them.
+    """
+    monkeypatch.setattr(
+        batch_sample_cache,
+        "SAMPLE_CACHE_DIR",
+        tmp_path_factory.mktemp("sample_cache"),
+    )
 
 
 @pytest.fixture

--- a/tests/unit/ml/datasets/test_batch_sample_cache.py
+++ b/tests/unit/ml/datasets/test_batch_sample_cache.py
@@ -1,0 +1,116 @@
+"""Tests for the on-disk cache of built training samples."""
+
+import torch
+from neuracore_types import BatchedRGBData, DataType
+
+from neuracore.ml.core.ml_types import BatchedTrainingSamples
+from neuracore.ml.datasets.batch_sample_cache import BatchSampleCache
+from neuracore.ml.preprocessing.base import PreprocessingConfiguration
+from neuracore.ml.preprocessing.methods.resize_pad import ResizePad
+
+ROBOT = "robot-1"
+
+
+def _description(slots: int = 2) -> dict:
+    return {ROBOT: {DataType.RGB_IMAGES: {i: f"cam_{i}" for i in range(slots)}}}
+
+
+def _sample(value: float = 1.0) -> BatchedTrainingSamples:
+    return BatchedTrainingSamples(
+        inputs={
+            DataType.RGB_IMAGES: [
+                BatchedRGBData(
+                    frame=torch.full((1, 1, 3, 8, 8), value),
+                    extrinsics=torch.zeros((1, 1, 4, 4)),
+                    intrinsics=torch.zeros((1, 1, 3, 3)),
+                )
+            ]
+        },
+        inputs_mask={DataType.RGB_IMAGES: torch.ones(1, 1)},
+        outputs={},
+        outputs_mask={},
+        batch_size=1,
+    )
+
+
+def _cache(tmp_path, horizon: int = 3, resize=(224, 224), slots: int = 2):
+    return BatchSampleCache(
+        synchronized_dataset_id="sync-1",
+        input_cross_embodiment_description=_description(slots),
+        output_cross_embodiment_description=_description(slots),
+        output_prediction_horizon=horizon,
+        input_preprocessing_config=PreprocessingConfiguration(
+            {DataType.RGB_IMAGES: [ResizePad(size=resize)]}
+        ),
+        output_preprocessing_config=PreprocessingConfiguration(),
+        root=tmp_path,
+    )
+
+
+def test_round_trip_returns_an_equal_sample(tmp_path):
+    cache = _cache(tmp_path)
+    original = _sample(value=7.0)
+
+    cache.store("rec-1", 4, original)
+    restored = cache.load("rec-1", 4)
+
+    assert restored is not None
+    assert torch.equal(
+        restored.inputs[DataType.RGB_IMAGES][0].frame,
+        original.inputs[DataType.RGB_IMAGES][0].frame,
+    )
+    assert restored.batch_size == original.batch_size
+
+
+def test_miss_returns_none(tmp_path):
+    assert _cache(tmp_path).load("rec-1", 4) is None
+
+
+def test_entries_are_keyed_by_recording_and_timestep(tmp_path):
+    """Two samples must not collide, including across recordings."""
+    cache = _cache(tmp_path)
+    cache.store("rec-1", 0, _sample(value=1.0))
+    cache.store("rec-1", 1, _sample(value=2.0))
+    cache.store("rec-2", 0, _sample(value=3.0))
+
+    def first_pixel(recording_id, timestep):
+        sample = cache.load(recording_id, timestep)
+        return float(sample.inputs[DataType.RGB_IMAGES][0].frame.flatten()[0])
+
+    assert first_pixel("rec-1", 0) == 1.0
+    assert first_pixel("rec-1", 1) == 2.0
+    assert first_pixel("rec-2", 0) == 3.0
+
+
+def test_unreadable_entry_is_discarded_rather_than_raising(tmp_path):
+    """A truncated entry costs a rebuild, never a crash."""
+    cache = _cache(tmp_path)
+    cache.store("rec-1", 4, _sample())
+    entry = next(cache.directory.rglob("*.pt"))
+    entry.write_bytes(b"not a torch file")
+
+    assert cache.load("rec-1", 4) is None
+    assert not entry.exists(), "a bad entry should be removed, not left to fail again"
+
+
+def test_store_leaves_no_partial_files(tmp_path):
+    cache = _cache(tmp_path)
+    cache.store("rec-1", 4, _sample())
+
+    assert list(cache.directory.rglob("*.tmp")) == []
+
+
+def test_key_changes_with_anything_that_shapes_a_sample(tmp_path):
+    """Stale entries must not survive a configuration change."""
+    baseline = _cache(tmp_path).directory
+
+    assert _cache(tmp_path, horizon=5).directory != baseline
+    assert _cache(tmp_path, resize=(128, 128)).directory != baseline
+    assert _cache(tmp_path, slots=3).directory != baseline
+    assert _cache(tmp_path).directory == baseline, "identical config must be stable"
+
+
+def test_key_ignores_the_root_directory(tmp_path):
+    """Moving the cache elsewhere must not invalidate its entries."""
+    other = tmp_path / "elsewhere"
+    assert _cache(tmp_path).directory.name == _cache(other).directory.name

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -23,6 +23,7 @@ from neuracore.core.utils.embodiment_description_utils import (
     merge_cross_embodiment_description,
 )
 from neuracore.ml import BatchedTrainingSamples
+from neuracore.ml.datasets import batch_sample_cache
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
     _cacheable_cross_embodiment_description,
@@ -308,6 +309,7 @@ def mock_synced_recording(
         def __init__(self):
             self.sync_points = sync_points
             self.robot_id = ROBOT_ID
+            self.id = "mock_recording"
 
         def __len__(self):
             return len(self.sync_points)
@@ -515,6 +517,7 @@ def mock_synced_recording_with_depth(
         def __init__(self):
             self.sync_points = sync_points
             self.robot_id = ROBOT_ID
+            self.id = "mock_recording"
 
         def __len__(self):
             return len(self.sync_points)
@@ -1127,6 +1130,7 @@ class TestOutputTimestepAlignment:
             def __init__(self) -> None:
                 self.sync_points = sync_points
                 self.robot_id = ROBOT_ID
+                self.id = "timestep_recording_id"
                 self.name = "timestep_recording"
 
             def __len__(self) -> int:
@@ -1185,6 +1189,11 @@ class TestOutputTimestepAlignment:
 
             def __getitem__(self, idx: int) -> SynchronizedRecording:
                 return recording
+
+            def __iter__(self):
+                # Explicit, rather than inheriting an implementation that walks
+                # internals this mock does not set up.
+                return iter([recording])
 
         return TimestepSynchronizedDataset()
 
@@ -1780,3 +1789,90 @@ class TestDatasetStatistics:
         assert cache_path.exists()
 
         assert cache_path.exists()
+
+
+class TestSampleCache:
+    """Tests for the on-disk cache of fully built samples."""
+
+    @staticmethod
+    def _dataset(mock_synchronized_dataset, horizon=3, resize=(224, 224)):
+        return PytorchSynchronizedDataset(
+            synchronized_dataset=mock_synchronized_dataset,
+            input_cross_embodiment_description={
+                ROBOT_ID: {
+                    DataType.JOINT_POSITIONS: _indexed_names(
+                        DataType.JOINT_POSITIONS, 3
+                    ),
+                    DataType.RGB_IMAGES: _indexed_names(DataType.RGB_IMAGES, 3),
+                }
+            },
+            output_cross_embodiment_description={
+                ROBOT_ID: {
+                    DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                        DataType.JOINT_TARGET_POSITIONS, 3
+                    )
+                }
+            },
+            output_prediction_horizon=horizon,
+            input_preprocessing_config=PreprocessingConfiguration({
+                DataType.RGB_IMAGES: [ResizePad(size=resize)],
+                DataType.DEPTH_IMAGES: [ResizePad(size=resize)],
+            }),
+            output_preprocessing_config=_default_preprocessing_config(),
+            sample_cache=True,
+        )
+
+    def test_cache_can_be_turned_off(self, mock_synchronized_dataset):
+        """Caching is on by default; opting out must leave no cache at all."""
+
+        def build(sample_cache):
+            return PytorchSynchronizedDataset(
+                synchronized_dataset=mock_synchronized_dataset,
+                input_cross_embodiment_description={
+                    ROBOT_ID: {
+                        DataType.JOINT_POSITIONS: _indexed_names(
+                            DataType.JOINT_POSITIONS, 3
+                        )
+                    }
+                },
+                output_cross_embodiment_description={
+                    ROBOT_ID: {
+                        DataType.JOINT_TARGET_POSITIONS: _indexed_names(
+                            DataType.JOINT_TARGET_POSITIONS, 3
+                        )
+                    }
+                },
+                output_prediction_horizon=3,
+                input_preprocessing_config=_default_preprocessing_config(),
+                output_preprocessing_config=_default_preprocessing_config(),
+                sample_cache=sample_cache,
+            )
+
+        assert build(sample_cache=True)._sample_cache is not None
+        assert build(sample_cache=False)._sample_cache is None
+
+    @patch("neuracore.login")
+    def test_hit_matches_a_rebuild_and_skips_the_recording(
+        self, mock_login, mock_synchronized_dataset, tmp_path
+    ):
+        """A hit must return the same tensors without touching the recording."""
+        with patch.object(batch_sample_cache, "SAMPLE_CACHE_DIR", tmp_path):
+            dataset = self._dataset(mock_synchronized_dataset)
+            with patch.object(dataset, "_memory_monitor"):
+                built = dataset[4]
+                # Any read of the recording now would mean the cache was missed.
+                with patch.object(dataset, "synchronized_dataset") as untouchable:
+                    untouchable.__getitem__.side_effect = AssertionError(
+                        "recording read on a cache hit"
+                    )
+                    cached = dataset[4]
+
+        for data_type, items in built.inputs.items():
+            for original, restored in zip(items, cached.inputs[data_type]):
+                for name, value in vars(original).items():
+                    if isinstance(value, torch.Tensor):
+                        assert torch.equal(value, getattr(restored, name))
+        assert torch.equal(
+            built.inputs_mask[DataType.RGB_IMAGES],
+            cached.inputs_mask[DataType.RGB_IMAGES],
+        )


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Fully built training samples are cached under `~/.neuracore/training/sample_cache/<hash>/<recording_id>/<timestep>.pt`, skipping frame decode and tensor construction on every epoch after the  first and on any later run of the same configuration. Controlled by
   `dataset_sample_cache`.
 - Reads happen before the recording is touched, keyed on a recording id resolved at construction, so a hit is one file read.
 
### Measurement
 - 24.44 ms/sample cold (build and store) against 0.67 ms/sample warm: 36.6x.
 - The first epoch is slower by the cost of writing entries; it pays back within the next epoch.
