### PR TITLE
feat: log host and accelerator utilisation, raise dataloader workers

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -333,6 +333,7 @@ nostdin
 nprocs
 numer
 numpy
+nvml
 octomap
 offsamples
 omegaconf

--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -32,6 +32,11 @@ allow_duplicates: true
 resume_checkpoint_path: null  # Path to checkpoint to resume from
 
 logging_frequency: 50
+# Frequency (in steps) for host and accelerator utilisation under System/.
+# Sampled far less often than the model metrics: each sample costs syscalls and
+# an NVML query, and utilisation moves slowly enough that a fine cadence buys
+# nothing. 0 disables it.
+system_logging_frequency: 200
 keep_last_n_checkpoints: 2
 device: null  # e.g., "cuda:0", "mps", "cpu"
 
@@ -54,8 +59,8 @@ batch_size: "auto"
 # any later run of the same configuration. Disable to always rebuild.
 dataset_sample_cache: true
 
-num_train_workers: 2
-num_val_workers: 1
+num_train_workers: 4
+num_val_workers: 2
 
 # Maximum number of workers to use for prefetching recordings
 max_prefetch_workers: 4

--- a/neuracore/ml/logging/system_metrics.py
+++ b/neuracore/ml/logging/system_metrics.py
@@ -1,0 +1,109 @@
+"""Host and accelerator utilisation metrics for training runs."""
+
+import logging
+import shutil
+from pathlib import Path
+
+import psutil
+import torch
+
+logger = logging.getLogger(__name__)
+
+BYTES_PER_GB = 1024**3
+
+# Scalars logged under this prefix are about the machine, not the model, and
+# group separately from train/ and val/ in TensorBoard.
+SYSTEM_METRIC_PREFIX = "System"
+
+
+class SystemMetricsCollector:
+    """Samples how hard the machine is working.
+
+    Answers the question a loss curve cannot: whether a slow epoch is the model
+    or the machine. A GPU sitting at low utilisation while CPU is pinned means
+    the input pipeline is the bottleneck, not the network.
+
+    Sampling costs a few syscalls plus one NVML query, so it is meant to be
+    called every N steps rather than every step. See ``system_log_freq`` on the
+    trainer.
+    """
+
+    def __init__(self, device: torch.device, disk_path: Path | None = None) -> None:
+        """Initialize the collector.
+
+        Args:
+            device: Device being trained on. Accelerator metrics are collected
+                only when this is a CUDA device.
+            disk_path: Filesystem to report usage for. Defaults to the cache
+                directory, which is what fills up during training.
+        """
+        self.device = device
+        self.disk_path = disk_path
+        self._collect_gpu = device.type == "cuda" and torch.cuda.is_available()
+        self._utilization_available = self._collect_gpu
+        self._gpu_total_bytes = 0
+        if self._collect_gpu:
+            self._gpu_total_bytes = torch.cuda.get_device_properties(
+                device
+            ).total_memory
+        # cpu_percent reports the average since the previous call, so the first
+        # one is always 0.0. Prime it here and let the first real sample cover
+        # the interval up to it.
+        psutil.cpu_percent(interval=None)
+
+    def collect(self) -> dict[str, float]:
+        """Return the current utilisation figures.
+
+        Returns:
+            Metric name to value. Names are unprefixed; the caller adds
+            :data:`SYSTEM_METRIC_PREFIX`.
+        """
+        metrics: dict[str, float] = {
+            # Average since the previous call, so this covers the interval
+            # between samples rather than an instant.
+            "cpu_utilization_percent": psutil.cpu_percent(interval=None),
+            "ram_utilization_percent": psutil.virtual_memory().percent,
+        }
+
+        if self.disk_path is not None:
+            try:
+                usage = shutil.disk_usage(self.disk_path)
+                metrics["disk_utilization_percent"] = (
+                    usage.used / usage.total * 100 if usage.total else 0.0
+                )
+            except OSError:
+                # The path may not exist yet on a fresh machine.
+                pass
+
+        if self._collect_gpu:
+            reserved_bytes = torch.cuda.memory_reserved(self.device)
+            metrics["gpu_memory_reserved_gb"] = reserved_bytes / BYTES_PER_GB
+            if self._gpu_total_bytes:
+                metrics["gpu_memory_reserved_percent"] = (
+                    reserved_bytes / self._gpu_total_bytes * 100
+                )
+            utilization = self._gpu_utilization()
+            if utilization is not None:
+                metrics["gpu_utilization_percent"] = utilization
+
+        return metrics
+
+    def _gpu_utilization(self) -> float | None:
+        """Percent of the sample period with a kernel running, via NVML.
+
+        Returns None, and stops trying, if NVML is unavailable -- it needs
+        driver access that some container configurations do not grant, and
+        utilisation is a nice-to-have rather than something worth failing or
+        log-spamming over.
+        """
+        if not self._utilization_available:
+            return None
+        try:
+            return float(torch.cuda.utilization(self.device))
+        except Exception:
+            logger.warning(
+                "GPU utilization unavailable; omitting it from system metrics.",
+                exc_info=True,
+            )
+            self._utilization_available = False
+            return None

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -550,6 +550,7 @@ def run_training(
             output_dir=Path(cfg.local_output_dir),
             num_epochs=cfg.epochs,
             log_freq=cfg.logging_frequency,
+            system_log_freq=cfg.get("system_logging_frequency", 200),
             train_device_preprocessing=(
                 train_input_preprocessing_config.split_by_stage()[1],
                 train_output_preprocessing_config.split_by_stage()[1],

--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -12,8 +12,13 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
 
+from neuracore.core.const import DEFAULT_CACHE_DIR
 from neuracore.ml import BatchedTrainingOutputs, NeuracoreModel
 from neuracore.ml.core.ml_types import BatchedTrainingSamples
+from neuracore.ml.logging.system_metrics import (
+    SYSTEM_METRIC_PREFIX,
+    SystemMetricsCollector,
+)
 from neuracore.ml.logging.training_logger import TrainingLogger
 from neuracore.ml.preprocessing.base import PreprocessingConfiguration
 from neuracore.ml.utils.device_utils import get_default_device
@@ -61,6 +66,7 @@ class DistributedTrainer:
         output_dir: Path,
         num_epochs: int,
         log_freq: int = 50,
+        system_log_freq: int = 0,
         train_device_preprocessing: (
             tuple[PreprocessingConfiguration, PreprocessingConfiguration] | None
         ) = None,
@@ -86,6 +92,10 @@ class DistributedTrainer:
             output_dir: Directory for output files
             num_epochs: Number of epochs to train
             log_freq: Frequency to log metrics (in steps)
+            system_log_freq: Frequency to log host and accelerator utilisation
+                (in steps). 0 disables it. Sampled far less often than the
+                model metrics because each sample costs syscalls and an NVML
+                query, and utilisation moves slowly.
             train_device_preprocessing: ``(input, output)`` device-side
                 preprocessing applied to training batches once they reach the
                 device. The dataset applies the worker-side half; this is the
@@ -123,6 +133,13 @@ class DistributedTrainer:
         self.output_dir = output_dir
         self.num_epochs = num_epochs
         self.log_freq = log_freq
+        self.system_log_freq = system_log_freq
+        # Only rank 0 logs, matching _log_scalars, so only rank 0 samples.
+        self._system_metrics = (
+            SystemMetricsCollector(self.device, disk_path=DEFAULT_CACHE_DIR)
+            if system_log_freq > 0 and rank == 0
+            else None
+        )
         empty = (PreprocessingConfiguration(), PreprocessingConfiguration())
         self.train_device_preprocessing = train_device_preprocessing or empty
         self.inference_device_preprocessing = inference_device_preprocessing or empty
@@ -216,6 +233,16 @@ class DistributedTrainer:
                 )
                 self._log_gradients(self.global_train_step)
                 self._log_weights(self.global_train_step)
+
+            if (
+                self._system_metrics is not None
+                and self.global_train_step % self.system_log_freq == 0
+            ):
+                self._log_scalars(
+                    self._system_metrics.collect(),
+                    self.global_train_step,
+                    prefix=SYSTEM_METRIC_PREFIX,
+                )
             pbar.set_postfix(
                 {"loss": f"{loss.item():.4f}", "step": self.global_train_step}
             )

--- a/tests/unit/ml/logging/test_system_metrics.py
+++ b/tests/unit/ml/logging/test_system_metrics.py
@@ -1,0 +1,92 @@
+"""Tests for host and accelerator utilisation metrics."""
+
+from unittest.mock import patch
+
+import torch
+
+from neuracore.ml.logging.system_metrics import (
+    SYSTEM_METRIC_PREFIX,
+    SystemMetricsCollector,
+)
+
+
+def test_reports_host_metrics_on_any_device():
+    metrics = SystemMetricsCollector(torch.device("cpu")).collect()
+
+    assert 0.0 <= metrics["cpu_utilization_percent"] <= 100.0
+    assert 0.0 < metrics["ram_utilization_percent"] <= 100.0
+
+
+def test_omits_accelerator_metrics_without_a_gpu():
+    """A CPU or MPS run must simply not report GPU figures, not fail."""
+    metrics = SystemMetricsCollector(torch.device("cpu")).collect()
+
+    assert not any(name.startswith("gpu_") for name in metrics)
+
+
+def test_disk_usage_is_reported_for_the_given_path(tmp_path):
+    metrics = SystemMetricsCollector(torch.device("cpu"), disk_path=tmp_path).collect()
+
+    assert 0.0 <= metrics["disk_utilization_percent"] <= 100.0
+
+
+def test_disk_usage_is_omitted_when_the_path_is_unreadable(tmp_path):
+    """A missing cache directory must not take the metrics down with it."""
+    collector = SystemMetricsCollector(torch.device("cpu"), disk_path=tmp_path)
+
+    with patch(
+        "neuracore.ml.logging.system_metrics.shutil.disk_usage",
+        side_effect=OSError("gone"),
+    ):
+        metrics = collector.collect()
+
+    assert "disk_utilization_percent" not in metrics
+    assert "cpu_utilization_percent" in metrics
+
+
+def test_gpu_metrics_are_reported_when_cuda_is_present():
+    collector = SystemMetricsCollector(torch.device("cpu"))
+    # Stand in for a CUDA device without needing one.
+    collector._collect_gpu = True
+    collector._utilization_available = True
+    collector._gpu_total_bytes = 8 * 1024**3
+
+    with (
+        patch("torch.cuda.memory_reserved", return_value=2 * 1024**3),
+        patch("torch.cuda.utilization", return_value=73),
+    ):
+        metrics = collector.collect()
+
+    assert metrics["gpu_memory_reserved_gb"] == 2.0
+    assert metrics["gpu_memory_reserved_percent"] == 25.0
+    assert metrics["gpu_utilization_percent"] == 73.0
+
+
+def test_unavailable_nvml_is_tolerated_and_not_retried():
+    """Utilisation needs driver access some containers withhold.
+
+    Losing it should cost the one metric, not the run, and should not
+    re-raise and re-log on every subsequent sample.
+    """
+    collector = SystemMetricsCollector(torch.device("cpu"))
+    collector._collect_gpu = True
+    collector._utilization_available = True
+    collector._gpu_total_bytes = 0
+
+    with (
+        patch("torch.cuda.memory_reserved", return_value=0),
+        patch("torch.cuda.utilization", side_effect=RuntimeError("no NVML")) as nvml,
+    ):
+        first = collector.collect()
+        second = collector.collect()
+
+    assert "gpu_utilization_percent" not in first
+    assert "gpu_utilization_percent" not in second
+    assert nvml.call_count == 1, "a failed NVML query should not be retried"
+    # The memory figures still come through.
+    assert "gpu_memory_reserved_gb" in second
+
+
+def test_prefix_groups_separately_from_model_metrics():
+    assert SYSTEM_METRIC_PREFIX == "System"
+    assert not SYSTEM_METRIC_PREFIX.endswith("/")


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Host and accelerator utilisation is logged under a `System/` prefix, so it groups separately from `train/` and `val/`: CPU %, RAM %, disk % for the cache volume, GPU utilisation %, and GPU memory reserved (GB and %).
 - Doubled num_train_workers and num_val_workers
