### PR TITLE
perf: remove per-step syncs, load payloads lazily, cache autotune results

### DIFF
--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -519,12 +519,19 @@ class SynchronizedRecording:
                 self._delete_decoding_lock(lock_file)
 
     def _load_sync_point_payloads(
-        self, sync_point: SynchronizedPoint
+        self,
+        sync_point: SynchronizedPoint,
+        data_types: frozenset[DataType] | None = None,
     ) -> SynchronizedPoint:
         """Load lazy sensor payloads from disk cache for a sync point.
 
         Args:
             sync_point: Sync point with metadata-only camera and point cloud entries.
+            data_types: If given, only these data types are materialised and the
+                rest are dropped. Loading a camera entry means opening a decoded
+                frame off disk (and, for depth, a full PNG decode plus a 24-bit
+                unpack), so callers that only need a subset should say so rather
+                than pay for frames they will discard.
 
         Returns:
             Sync point with camera frames and point cloud arrays populated.
@@ -532,6 +539,8 @@ class SynchronizedRecording:
         # Build new data dict with loaded frames
         new_data = {}
         for data_type, data_dict in sync_point.data.items():
+            if data_types is not None and data_type not in data_types:
+                continue
             if data_type == DataType.RGB_IMAGES:
                 new_data[data_type] = self._get_frame_from_disk_cache(
                     DataType.RGB_IMAGES, data_dict
@@ -548,24 +557,55 @@ class SynchronizedRecording:
                     name: nc_data.model_copy() for name, nc_data in data_dict.items()
                 }
 
-        return SynchronizedPoint(
+        # model_construct skips validation: every value here came out of an
+        # already-validated sync point, and re-validating a smart union over
+        # every NCData subtype for each of them is not free at per-sample rates.
+        return SynchronizedPoint.model_construct(
             timestamp=sync_point.timestamp,
             robot_id=sync_point.robot_id,
             data=new_data,
         )
 
-    def _get_sync_point(self, idx: int) -> SynchronizedPoint:
+    def _get_sync_point(
+        self, idx: int, data_types: frozenset[DataType] | None = None
+    ) -> SynchronizedPoint:
         """Get synchronized data point at a specific index.
 
         Args:
             idx: Index of the sync point to retrieve.
+            data_types: Optional subset of data types to materialise. See
+                ``_load_sync_point_payloads``.
 
         Returns:
             SynchronizedPoint object containing synchronized data
                 for the specified index.
         """
         sync_point = self._episode_synced.observations[idx]
-        return self._load_sync_point_payloads(sync_point)
+        return self._load_sync_point_payloads(sync_point, data_types)
+
+    def get_range(
+        self,
+        start: int,
+        stop: int,
+        data_types: frozenset[DataType] | None = None,
+    ) -> list[SynchronizedPoint]:
+        """Get sync points in ``[start, stop)``, optionally limited to some data types.
+
+        Slice syntax cannot carry the ``data_types`` filter, so callers that
+        want to avoid decoding camera frames across a long window use this
+        instead of ``recording[start:stop]``.
+
+        Args:
+            start: First index to load, clamped to the episode bounds.
+            stop: One past the last index to load, clamped to the episode bounds.
+            data_types: Optional subset of data types to materialise.
+
+        Returns:
+            The requested sync points, in order.
+        """
+        start = max(0, min(start, len(self)))
+        stop = max(start, min(stop, len(self)))
+        return [self._get_sync_point(i, data_types) for i in range(start, stop)]
 
     def __iter__(self) -> "SynchronizedRecording":
         """Initialize iteration over the episode.

--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -52,6 +52,12 @@ output_cross_embodiment_description: {
 
 # Batch size (can be "auto" for automatic tuning or an integer)
 batch_size: "auto"
+# Autotune results are cached on disk against the model, its input shapes, and
+# the GPU. Set to true to re-probe instead of reusing a cached result.
+force_batch_size_autotune: false
+# Whether an explicitly specified batch size is probed for a GPU memory fit.
+# Skipped automatically when a cached autotune result already covers it.
+validate_batch_size: true
 
 # Cache fully built training samples under ~/.neuracore/training/sample_cache,
 # keyed by a hash of everything that changes what a sample contains. Skips

--- a/neuracore/ml/datasets/pytorch_synchronized_dataset.py
+++ b/neuracore/ml/datasets/pytorch_synchronized_dataset.py
@@ -219,6 +219,16 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
                 self.merged_cross_embodiment_description.items()
             )
         }
+        # The output window is projected onto the output description alone.
+        # Only output data types are ever read back out of it, and narrowing it
+        # is what lets the recording skip decoding camera frames across the
+        # whole prediction horizon.
+        self._output_ordered_items = {
+            robot_id: self._order_embodiment_items(description)
+            for robot_id, description in (
+                self.output_cross_embodiment_description.items()
+            )
+        }
 
         self._sample_cache = self._build_sample_cache() if sample_cache else None
 
@@ -459,18 +469,28 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         synced_recording: SynchronizedRecording,
         timestep: int,
         ordered_items: dict[DataType, list[tuple[int, str]]],
+        projected_input_sync_point: SynchronizedPoint,
     ) -> list[SynchronizedPoint]:
         """Load the superset window for all output data types.
 
-        Fetches ``[timestep, timestep + 1 + horizon]`` once so target types
-        (aligned to the input step) and non-target types (next step onward)
-        can share the same loaded sync points.
+        Covers ``[timestep, timestep + 1 + horizon]`` so target types (aligned
+        to the input step) and non-target types (next step onward) can share
+        the same loaded sync points.
+
+        Only the data types in ``ordered_items`` are materialised. Loading a
+        sync point decodes camera frames off disk, and the output window is
+        usually joints-only, so without the filter every sample would pay for
+        ``horizon + 1`` frames per camera and then discard them.
+
+        The sync point at ``timestep`` is reused from
+        ``projected_input_sync_point`` rather than being loaded a second time.
         """
-        output_sync_points = cast(
-            list[SynchronizedPoint],
-            synced_recording[timestep : timestep + 1 + self.output_prediction_horizon],
+        output_sync_points = synced_recording.get_range(
+            timestep + 1,
+            timestep + 1 + self.output_prediction_horizon,
+            data_types=frozenset(ordered_items),
         )
-        return [
+        return [projected_input_sync_point] + [
             self._project_sync_point(sync_point, ordered_items)
             for sync_point in output_sync_points
         ]
@@ -545,7 +565,8 @@ class PytorchSynchronizedDataset(PytorchNeuracoreDataset):
         output_sync_points = self._load_projected_output_sync_points(
             synced_recording=synced_recording,
             timestep=timestep,
-            ordered_items=merged_ordered_items,
+            ordered_items=self._output_ordered_items[robot_id],
+            projected_input_sync_point=input_sync_point,
         )
         recording_name = getattr(synced_recording, "name", "recording")
 

--- a/neuracore/ml/logging/cloud_training_logger.py
+++ b/neuracore/ml/logging/cloud_training_logger.py
@@ -44,6 +44,11 @@ class CloudTrainingLogger(TrainingLogger):
 
         logger.info("Cloud logger initialized.")
 
+    @property
+    def supports_histograms(self) -> bool:
+        """Histograms are not supported by the cloud metrics endpoint."""
+        return False
+
     def log_scalar(self, name: str, value: float, step: int) -> None:
         """Log a scalar metric.
 

--- a/neuracore/ml/logging/training_logger.py
+++ b/neuracore/ml/logging/training_logger.py
@@ -13,6 +13,16 @@ logger = logging.getLogger(__name__)
 class TrainingLogger(ABC):
     """Abstract base class for training loggers."""
 
+    @property
+    def supports_histograms(self) -> bool:
+        """Whether ``log_histogram`` persists anything.
+
+        Callers use this to skip building histogram inputs — which for model
+        weights and gradients means walking every parameter and copying it off
+        the device — when the backend would discard them.
+        """
+        return True
+
     @abstractmethod
     def log_scalar(self, name: str, value: float, step: int) -> None:
         """Log a scalar metric.

--- a/neuracore/ml/train.py
+++ b/neuracore/ml/train.py
@@ -1,14 +1,11 @@
 """Hydra-based training script for Neuracore models."""
 
-import copy
-import gc
 import json
 import logging
 import os
 import sys
 import time
 import traceback
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -38,10 +35,6 @@ from neuracore.ml.logging.cloud_training_logger import CloudTrainingLogger
 from neuracore.ml.logging.json_line_formatter import JsonLineLogFormatter
 from neuracore.ml.logging.tensorboard_training_logger import TensorboardTrainingLogger
 from neuracore.ml.preprocessing.base import PreprocessingConfiguration
-from neuracore.ml.trainers.batch_autotuner import (
-    find_optimal_batch_size,
-    is_valid_batch_size,
-)
 from neuracore.ml.trainers.distributed_trainer import (
     DistributedTrainer,
     cleanup_distributed,
@@ -49,6 +42,7 @@ from neuracore.ml.trainers.distributed_trainer import (
 )
 from neuracore.ml.utils.algorithm_loader import AlgorithmLoader
 from neuracore.ml.utils.algorithm_storage_handler import AlgorithmStorageHandler
+from neuracore.ml.utils.batch_size import resolve_batch_size
 from neuracore.ml.utils.dataset_utils import split_train_val_datasets
 from neuracore.ml.utils.device_utils import cpu_count, get_default_device
 from neuracore.ml.utils.preprocessing import resolve_input_output_preprocessing
@@ -64,8 +58,6 @@ os.environ["PJRT_DEVICE"] = "GPU"
 
 # Configure logging
 logger = logging.getLogger(__name__)
-
-MAX_AUTOTUNE_SAMPLE_CANDIDATES = 1000
 
 
 def _resolve_recording_cache_dir(cfg: DictConfig) -> Path:
@@ -228,141 +220,6 @@ def get_model_and_algorithm_config(
     return model, algorithm_config
 
 
-def _create_model_for_batch_validation(
-    cfg: DictConfig, model_init_description: ModelInitDescription
-) -> NeuracoreModel:
-    """Create a model instance for batch size validation (called inside subprocess)."""
-    model, _ = get_model_and_algorithm_config(cfg, model_init_description)
-    return model
-
-
-def assert_valid_batch_size(
-    batch_size: int,
-    cfg: DictConfig,
-    dataset: PytorchSynchronizedDataset,
-    input_cross_embodiment_description: CrossEmbodimentDescription,
-    output_cross_embodiment_description: CrossEmbodimentDescription,
-    device: torch.device | None = None,
-) -> None:
-    """Assert that a user-selected batch size fits in GPU memory.
-
-    The check is skipped on CPU (or when CUDA is unavailable). The user-selected
-    batch size is trusted in that case.
-
-    Raises:
-        ValueError: If ``batch_size`` does not fit in GPU memory.
-    """
-    if not torch.cuda.is_available() or (
-        device is not None and "cuda" not in device.type
-    ):
-        logger.warning("Skipping batch size memory check: GPU not available.")
-        return
-
-    if device is None:
-        device = get_default_device()
-
-    logger.info(f"Validating batch size {batch_size} on {device}...")
-
-    # Avoid altering the original dataset
-    assert_dataset = copy.deepcopy(dataset)
-
-    dataset_statistics_by_role = assert_dataset.dataset_statistics
-    model_init_description = ModelInitDescription(
-        input_dataset_statistics=dataset_statistics_by_role["input"],
-        output_dataset_statistics=dataset_statistics_by_role["output"],
-        input_data_types=extract_data_types(input_cross_embodiment_description),
-        output_data_types=extract_data_types(output_cross_embodiment_description),
-        output_prediction_horizon=cfg.output_prediction_horizon,
-    )
-    model_factory = partial(
-        _create_model_for_batch_validation, cfg, model_init_description
-    )
-
-    try:
-        valid = is_valid_batch_size(
-            cfg=cfg,
-            model_factory=model_factory,
-            dataset=assert_dataset,
-            batch_size=batch_size,
-            device=device,
-        )
-    except Exception:
-        logger.error("Batch size validation failed", exc_info=True)
-        raise
-    finally:
-        del assert_dataset
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        gc.collect()
-
-    if not valid:
-        raise ValueError(
-            f"Batch size {batch_size} is not valid: it does not fit in "
-            "memory for the current algorithm, dataset, and GPU type. "
-            "Try a smaller batch size, or use batch_size='auto' to automatically "
-            "find the largest batch size that fits."
-        )
-
-    logger.info(f"Batch size {batch_size} is valid.")
-
-
-def determine_optimal_batch_size(
-    cfg: DictConfig,
-    dataset: PytorchSynchronizedDataset,
-    input_cross_embodiment_description: CrossEmbodimentDescription,
-    output_cross_embodiment_description: CrossEmbodimentDescription,
-    device: torch.device | None = None,
-) -> int:
-    """Run batch size autotuning on a single GPU and return the result."""
-    if not torch.cuda.is_available() or (
-        device is not None and "cuda" not in device.type
-    ):
-        raise ValueError("Autotuning is only supported on GPUs.")
-
-    if device is None:
-        device = get_default_device()
-
-    logger.info(f"Starting batch size autotuning on {device}...")
-
-    # Avoid altering the original dataset
-    autotuning_dataset = copy.deepcopy(dataset)
-
-    dataset_statistics_by_role = autotuning_dataset.dataset_statistics
-    model_init_description = ModelInitDescription(
-        input_dataset_statistics=dataset_statistics_by_role["input"],
-        output_dataset_statistics=dataset_statistics_by_role["output"],
-        input_data_types=extract_data_types(input_cross_embodiment_description),
-        output_data_types=extract_data_types(output_cross_embodiment_description),
-        output_prediction_horizon=cfg.output_prediction_horizon,
-    )
-    model_factory = partial(
-        _create_model_for_batch_validation, cfg, model_init_description
-    )
-
-    try:
-        optimal_batch_size = find_optimal_batch_size(
-            cfg=cfg,
-            model_factory=model_factory,
-            dataset=autotuning_dataset,
-            device=device,
-        )
-    except Exception:
-        logger.error("Batch size autotuning failed", exc_info=True)
-        raise
-    finally:
-        # Clean up
-        del autotuning_dataset
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        gc.collect()
-
-    logger.info(
-        f"Autotuning complete. Optimal batch size per GPU: {optimal_batch_size}"
-    )
-
-    return optimal_batch_size
-
-
 def run_training(
     rank: int,
     world_size: int,
@@ -392,11 +249,6 @@ def run_training(
 
     try:
         logger.info(f"Using batch size: {batch_size}")
-
-        # Merge data_types for synchronization
-        merge_cross_embodiment_description(
-            input_cross_embodiment_description, output_cross_embodiment_description
-        )
 
         # Split dataset
         dataset_size = len(dataset)
@@ -524,6 +376,7 @@ def run_training(
             output_cross_embodiment_description=output_cross_embodiment_description,
             input_preprocessing_config=inference_input_preprocessing_config,
             output_preprocessing_config=inference_output_preprocessing_config,
+            verify_job_exists=rank == 0,
         )
 
         logger.info(
@@ -758,30 +611,19 @@ def _main(cfg: DictConfig) -> None:
             sample_cache=cfg.get("dataset_sample_cache", True),
         )
 
-        # Handle batch size configuration
-        if isinstance(batch_size, str) and batch_size.lower() == "auto":
-            # Find the largest batch size that fits in RAM and GPU memory
-            optimal_batch_size = determine_optimal_batch_size(
-                cfg=cfg,
-                dataset=pytorch_dataset,
-                input_cross_embodiment_description=input_cross_embodiment_description,
-                output_cross_embodiment_description=output_cross_embodiment_description,
-                device=device,
-            )
-
-            batch_size = optimal_batch_size
-        else:
-            # Check if the specified batch size fits in RAM and GPU memory
-            assert_valid_batch_size(
-                batch_size=int(batch_size),
-                cfg=cfg,
-                dataset=pytorch_dataset,
-                input_cross_embodiment_description=input_cross_embodiment_description,
-                output_cross_embodiment_description=output_cross_embodiment_description,
-                device=device,
-            )
-
-            batch_size = int(batch_size)
+        batch_size = resolve_batch_size(
+            cfg=cfg,
+            batch_size=batch_size,
+            dataset=pytorch_dataset,
+            input_cross_embodiment_description=input_cross_embodiment_description,
+            output_cross_embodiment_description=output_cross_embodiment_description,
+            # Algorithm construction lives here, so hand it over rather than
+            # have the batch-size module import this one.
+            create_model=lambda description: get_model_and_algorithm_config(
+                cfg, description
+            )[0],
+            device=device,
+        )
 
         if world_size > 1:
             # Use multiprocessing to launch multiple processes

--- a/neuracore/ml/trainers/batch_autotuner.py
+++ b/neuracore/ml/trainers/batch_autotuner.py
@@ -14,6 +14,7 @@ from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset
 
 from neuracore.ml import BatchedTrainingOutputs, NeuracoreModel
+from neuracore.ml.core.ml_types import BatchedTrainingSamples
 from neuracore.ml.datasets.pytorch_synchronized_dataset import (
     PytorchSynchronizedDataset,
 )
@@ -267,13 +268,21 @@ def _probe_batch_size(
 
         optimizers = model.configure_optimizers()
 
+        # One real batch, reused for warmup and measurement alike.
+        probe_batch = next(iter(train_loader), None)
+        if probe_batch is None:
+            raise ValueError(
+                f"Cannot probe batch size {batch_size}: the training dataloader "
+                "yielded no batches."
+            )
+
         # Warm up first; this triggers any one-time compilation / autotuning and
         # allocates lazy optimizer state, none of which should count toward the
         # steady-state peak used for extrapolation.
         if _NUM_WARMUP_ITERATIONS > 0:
             _train_probe(
                 model,
-                train_loader,
+                probe_batch,
                 optimizers,
                 memory_monitor,
                 _NUM_WARMUP_ITERATIONS,
@@ -287,7 +296,7 @@ def _probe_batch_size(
         # no backward and no optimizer step, so its peak memory is strictly below
         # the training-step peak that sets the OOM point.
         _train_probe(
-            model, train_loader, optimizers, memory_monitor, num_iterations, device
+            model, probe_batch, optimizers, memory_monitor, num_iterations, device
         )
 
         # Reserved (not allocated) is what the caching allocator holds and what
@@ -364,45 +373,45 @@ def _probe_batch_size(
 
 def _train_probe(
     model: NeuracoreModel,
-    data_loader: DataLoader,
+    batch: BatchedTrainingSamples,
     optimizers: list[torch.optim.Optimizer],
     memory_monitor: MemoryMonitor,
     num_iterations: int,
     device: torch.device,
 ) -> None:
-    """Run a short training loop for memory profiling."""
+    """Run a short training loop against one batch, for memory profiling.
+
+    The same host-side batch is reused for every iteration. Peak memory depends
+    on batch shape, not on the values in it, and loading a fresh batch per
+    iteration would mean decoding real frames off disk — serially, since the
+    probe loader runs with no workers — several times per probe.
+    """
     model.train()
 
     for optimizer in optimizers:
         optimizer.zero_grad()
 
-    i = 0
-    while i < num_iterations:
-        for batch in data_loader:
-            memory_monitor.check_memory(log=True)
+    for _ in range(num_iterations):
+        memory_monitor.check_memory(log=True)
 
-            batch = batch.to(device)
+        device_batch = batch.to(device)
 
-            outputs: BatchedTrainingOutputs = model.training_step(batch)
-            loss = sum(outputs.losses.values()).mean()
+        outputs: BatchedTrainingOutputs = model.training_step(device_batch)
+        loss = sum(outputs.losses.values()).mean()
 
-            loss.backward()
+        loss.backward()
 
-            for optimizer in optimizers:
-                optimizer.step()
+        for optimizer in optimizers:
+            optimizer.step()
 
-            # Check again before freeing up gradients
-            memory_monitor.check_memory(log=True)
+        # Check again before freeing up gradients
+        memory_monitor.check_memory(log=True)
 
-            # Free-up GPU during validation or before next forward pass
-            for optimizer in optimizers:
-                optimizer.zero_grad()
+        # Free-up GPU during validation or before next forward pass
+        for optimizer in optimizers:
+            optimizer.zero_grad()
 
-            del batch, outputs, loss
-
-            i += 1
-            if i >= num_iterations:
-                break
+        del device_batch, outputs, loss
 
 
 class BatchSizeAutotuner:

--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 # Only update the training metadata every N steps to avoid excessive API calls
 UPDATE_TRAINING_METADATA_EVERY = 20
 
+# Checking RAM/VRAM headroom reads /proc/meminfo and the CUDA allocator, far
+# more often than a slow-moving quantity needs. Matches the interval the
+# dataset uses for the same check (see PytorchSynchronizedDataset).
+CHECK_MEMORY_INTERVAL = 100
+
 
 class NestedModule(nn.Module):
     """A special case to allow NeuracoreModel to be used in DDP."""
@@ -134,6 +139,15 @@ class DistributedTrainer:
         self.num_epochs = num_epochs
         self.log_freq = log_freq
         self.system_log_freq = system_log_freq
+        # Progress bars render only on rank 0, and never when logs are shipped
+        # to the cloud. Cached because it also decides whether the loss is
+        # worth pulling off the device to display.
+        self._pbar_enabled = rank == 0 and not storage_handler.log_to_cloud
+        # Histograms ride the same cadence as the other scalars, but are
+        # skipped when the backend discards them (CloudTrainingLogger records
+        # nothing) and on non-zero ranks, which would otherwise race each other
+        # writing into one TensorBoard directory.
+        self._histograms_enabled = rank == 0 and training_logger.supports_histograms
         # Only rank 0 logs, matching _log_scalars, so only rank 0 samples.
         self._system_metrics = (
             SystemMetricsCollector(self.device, disk_path=DEFAULT_CACHE_DIR)
@@ -173,25 +187,28 @@ class DistributedTrainer:
             A dictionary of averaged metrics for the epoch
         """
         self.model.train()
-        epoch_losses: list[dict[str, float]] = []
-        epoch_metrics: list[dict[str, float]] = []
+        accumulator = _MetricAccumulator()
 
         memory_monitor = MemoryMonitor(
-            max_ram_utilization=0.8, max_gpu_utilization=0.95
+            max_ram_utilization=0.8,
+            max_gpu_utilization=0.95,
+            # The default gpu_id=0 would have every rank watch GPU 0.
+            gpu_id=self.device.index if self.device.type == "cuda" else None,
         )
 
         # Progress bar only on rank 0
         pbar = tqdm(
             self.train_loader,
             desc=f"Training Epoch {epoch}",
-            disable=self.rank != 0 or self.storage_handler.log_to_cloud,
+            disable=not self._pbar_enabled,
         )
 
         for optimizer in self.optimizers:
             optimizer.zero_grad()
 
         for batch_idx, batch in enumerate(pbar):
-            memory_monitor.check_memory()
+            if batch_idx % CHECK_MEMORY_INTERVAL == 0:
+                memory_monitor.check_memory()
 
             # Move tensors to device and format batch
             batch = batch.to(self.device)
@@ -220,7 +237,10 @@ class DistributedTrainer:
                 for scheduler in self.schedulers:
                     scheduler.step()
 
-            if self.log_freq > 0 and self.global_train_step % self.log_freq == 0:
+            is_log_step = self.log_freq > 0 and (
+                self.global_train_step % self.log_freq == 0
+            )
+            if is_log_step:
                 self._log_scalars(
                     batch_output.losses,
                     self.global_train_step,
@@ -243,12 +263,13 @@ class DistributedTrainer:
                     self.global_train_step,
                     prefix=SYSTEM_METRIC_PREFIX,
                 )
-            pbar.set_postfix(
-                {"loss": f"{loss.item():.4f}", "step": self.global_train_step}
-            )
-            epoch_losses, epoch_metrics = self._accumulate_epoch_metrics(
-                batch_output, epoch_losses, epoch_metrics
-            )
+            # loss.item() is a device sync. Only pay for it when a human is
+            # actually watching the bar, and then only as often as we log.
+            if self._pbar_enabled and is_log_step:
+                pbar.set_postfix(
+                    {"loss": f"{loss.item():.4f}", "step": self.global_train_step}
+                )
+            accumulator.update(batch_output)
             self.global_train_step += 1
             if (
                 self.rank == 0
@@ -264,9 +285,7 @@ class DistributedTrainer:
 
             del batch, batch_output, loss
 
-        avg_epoch_losses, avg_epoch_metrics = self._average_epoch_metrics(
-            epoch_losses, epoch_metrics, epoch
-        )
+        avg_epoch_losses, avg_epoch_metrics = accumulator.averages()
         self._log_scalars(avg_epoch_losses, epoch, prefix="train/epoch/loss")
         self._log_scalars(avg_epoch_metrics, epoch, prefix="train/epoch/metrics")
         return avg_epoch_losses
@@ -281,13 +300,12 @@ class DistributedTrainer:
             A dictionary of averaged validation metrics
         """
         self.model.train()  # Keep in train mode to get losses
-        val_losses: list[dict[str, float]] = []
-        val_metrics: list[dict[str, float]] = []
+        accumulator = _MetricAccumulator()
 
         pbar = tqdm(
             self.val_loader,
             desc=f"Validation Epoch {epoch}",
-            disable=self.rank != 0 or self.storage_handler.log_to_cloud,
+            disable=not self._pbar_enabled,
         )
 
         for batch_idx, batch in enumerate(pbar):
@@ -309,14 +327,10 @@ class DistributedTrainer:
                     self.global_val_step,
                     prefix="val/step/metrics",
                 )
-            val_losses, val_metrics = self._accumulate_epoch_metrics(
-                batch_output, val_losses, val_metrics
-            )
+            accumulator.update(batch_output)
             self.global_val_step += 1
 
-        avg_losses, avg_metrics = self._average_epoch_metrics(
-            val_losses, val_metrics, epoch
-        )
+        avg_losses, avg_metrics = accumulator.averages()
         self._log_scalars(avg_losses, epoch, prefix="val/epoch/loss")
         self._log_scalars(avg_metrics, epoch, prefix="val/epoch/metrics")
         return avg_losses
@@ -383,6 +397,9 @@ class DistributedTrainer:
                 # VM/container be torn down — while the final checkpoint is
                 # still mid-upload.
                 self.storage_handler.wait_for_pending_uploads()
+                # Progress updates are sent off-thread too, so flush the last
+                # one rather than letting it die with the worker.
+                self.storage_handler.wait_for_pending_progress_updates()
                 # Close the logger
                 self.training_logger.close()
 
@@ -467,6 +484,8 @@ class DistributedTrainer:
         Args:
             step: Training step.
         """
+        if not self._histograms_enabled:
+            return
         model = self.get_model_without_ddp()
         for name, param in model.named_parameters():
             if param.grad is not None:
@@ -480,6 +499,8 @@ class DistributedTrainer:
         Args:
             step: Training step.
         """
+        if not self._histograms_enabled:
+            return
         model = self.get_model_without_ddp()
         for name, param in model.named_parameters():
             self.training_logger.log_histogram(f"weights/{name}", param, step)
@@ -506,70 +527,60 @@ class DistributedTrainer:
                 f"{prefix}/{scalar_name}", scalar_value, step
             )
 
-    def _accumulate_epoch_metrics(
-        self,
-        batch_output: BatchedTrainingOutputs,
-        epoch_losses: list[dict[str, float]],
-        epoch_metrics: list[dict[str, float]],
-    ) -> tuple[list[dict[str, float]], list[dict[str, float]]]:
-        """Accumulate metrics for the current epoch.
 
-        Args:
-            batch_output: Outputs from the training step
-            epoch_losses: List of losses accumulated for the epoch
-            epoch_metrics: List of metrics accumulated for the epoch
+class _MetricAccumulator:
+    """Running sums of per-step losses and metrics for one epoch.
 
-        Returns:
-            Updated lists of losses and metrics for the epoch
-        """
-        # Accumulate losses
+    Tensor values are summed on whichever device they arrive on and read back
+    once, when the epoch ends. Summing on the host instead would mean a
+    blocking device-to-host copy per loss and per metric on every single step.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty accumulators."""
+        self._loss_sums: dict[str, torch.Tensor | float] = {}
+        self._metric_sums: dict[str, torch.Tensor | float] = {}
+        self._loss_steps = 0
+        self._metric_steps = 0
+
+    @staticmethod
+    def _add(
+        sums: dict[str, torch.Tensor | float], values: dict[str, torch.Tensor]
+    ) -> None:
+        for key, value in values.items():
+            contribution = value.detach() if isinstance(value, torch.Tensor) else value
+            if key in sums:
+                sums[key] = sums[key] + contribution
+            else:
+                sums[key] = contribution
+
+    def update(self, batch_output: BatchedTrainingOutputs) -> None:
+        """Add one step's losses and metrics to the running totals."""
         if batch_output.losses:
-            epoch_losses.append({
-                k: v.item() if isinstance(v, torch.Tensor) else v
-                for k, v in batch_output.losses.items()
-            })
-
-        # Accumulate metrics
+            self._add(self._loss_sums, batch_output.losses)
+            self._loss_steps += 1
         if batch_output.metrics:
-            epoch_metrics.append({
-                k: v.item() if isinstance(v, torch.Tensor) else v
-                for k, v in batch_output.metrics.items()
-            })
+            self._add(self._metric_sums, batch_output.metrics)
+            self._metric_steps += 1
 
-        return epoch_losses, epoch_metrics
+    @staticmethod
+    def _finalize(
+        sums: dict[str, torch.Tensor | float], steps: int
+    ) -> dict[str, float]:
+        if steps == 0:
+            return {}
+        return {
+            key: (total.item() if isinstance(total, torch.Tensor) else float(total))
+            / steps
+            for key, total in sums.items()
+        }
 
-    def _average_epoch_metrics(
-        self,
-        epoch_losses: list[dict[str, float]],
-        epoch_metrics: list[dict[str, float]],
-        epoch: int,
-    ) -> tuple[dict[str, float], dict[str, float]]:
-        """Average metrics across the epoch.
-
-        Args:
-            epoch_losses: List of losses accumulated for the epoch
-            epoch_metrics: List of metrics accumulated for the epoch
-            epoch: Current epoch number
-
-        Returns:
-            A dictionary of averaged losses and metrics for the epoch
-        """
-        avg_epoch_losses = {}
-        avg_epoch_metrics = {}
-
-        if epoch_losses:
-            for key in epoch_losses[0].keys():
-                avg_epoch_losses[key] = sum(x[key] for x in epoch_losses) / len(
-                    epoch_losses
-                )
-
-        if epoch_metrics:
-            for key in epoch_metrics[0].keys():
-                avg_epoch_metrics[key] = sum(x[key] for x in epoch_metrics) / len(
-                    epoch_metrics
-                )
-
-        return avg_epoch_losses, avg_epoch_metrics
+    def averages(self) -> tuple[dict[str, float], dict[str, float]]:
+        """Return the epoch-averaged losses and metrics as plain floats."""
+        return (
+            self._finalize(self._loss_sums, self._loss_steps),
+            self._finalize(self._metric_sums, self._metric_steps),
+        )
 
 
 def setup_distributed(rank: int, world_size: int) -> None:

--- a/neuracore/ml/utils/batch_size.py
+++ b/neuracore/ml/utils/batch_size.py
@@ -1,0 +1,377 @@
+"""Resolving the training batch size, and caching what it costs to find.
+
+Autotuning probes several batch sizes, and every probe spawns a subprocess that
+pays a fresh CUDA context, builds the model, and runs a few training steps. The
+answer only depends on the model, the shapes it is fed, and the GPU it runs on —
+none of which change between runs of the same configuration — so it is worth
+remembering.
+"""
+
+import gc
+import hashlib
+import json
+import logging
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import torch
+from neuracore_types import CrossEmbodimentDescription, ModelInitDescription
+from omegaconf import DictConfig, OmegaConf
+
+from neuracore.core.const import DEFAULT_CACHE_DIR
+from neuracore.core.utils.embodiment_description_utils import extract_data_types
+from neuracore.ml import NeuracoreModel
+from neuracore.ml.datasets.pytorch_synchronized_dataset import (
+    PytorchSynchronizedDataset,
+)
+from neuracore.ml.trainers.batch_autotuner import (
+    find_optimal_batch_size,
+    is_valid_batch_size,
+)
+from neuracore.ml.utils.device_utils import get_default_device
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE_CACHE_DIR = DEFAULT_CACHE_DIR / "batch_size_cache"
+
+
+def _device_fingerprint(device: torch.device) -> dict[str, Any] | None:
+    """Describe the GPU well enough to know the answer does not transfer.
+
+    Returns None if the device cannot be identified, which disables caching —
+    a key that cannot distinguish two GPUs would hand back a batch size tuned
+    for the wrong one.
+    """
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return {"type": device.type}
+    try:
+        properties = torch.cuda.get_device_properties(device)
+    except (RuntimeError, AssertionError) as exc:
+        logger.warning("Could not read properties for %s: %s", device, exc)
+        return None
+    return {
+        "type": "cuda",
+        "name": properties.name,
+        "total_memory": properties.total_memory,
+    }
+
+
+def batch_size_cache_key(
+    algorithm_name: str | None,
+    algorithm_id: str | None,
+    algorithm_config: dict[str, Any],
+    model_init_description: ModelInitDescription,
+    device: torch.device,
+) -> str | None:
+    """Build a stable cache key for one autotune result, or None if not cacheable.
+
+    Anything that could change the peak memory of a training step belongs in
+    here. Getting this wrong in the conservative direction only costs a cache
+    miss; getting it wrong in the permissive direction hands back a batch size
+    that OOMs, so prefer including a field over omitting it.
+    """
+    device_fingerprint = _device_fingerprint(device)
+    if device_fingerprint is None:
+        return None
+    spec = {
+        "algorithm_name": algorithm_name,
+        "algorithm_id": algorithm_id,
+        "algorithm_config": algorithm_config,
+        "input_data_types": sorted(
+            data_type.value for data_type in model_init_description.input_data_types
+        ),
+        "output_data_types": sorted(
+            data_type.value for data_type in model_init_description.output_data_types
+        ),
+        "input_slot_counts": {
+            data_type.value: len(stats)
+            for data_type, stats in sorted(
+                model_init_description.input_dataset_statistics.items(),
+                key=lambda item: item[0].value,
+            )
+        },
+        "output_slot_counts": {
+            data_type.value: len(stats)
+            for data_type, stats in sorted(
+                model_init_description.output_dataset_statistics.items(),
+                key=lambda item: item[0].value,
+            )
+        },
+        "output_prediction_horizon": (model_init_description.output_prediction_horizon),
+        "device": device_fingerprint,
+        "torch_version": torch.__version__,
+    }
+    serialized = json.dumps(spec, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def _cache_path(cache_key: str) -> Path:
+    return BATCH_SIZE_CACHE_DIR / f"{cache_key}.json"
+
+
+def load_cached_batch_size(cache_key: str) -> int | None:
+    """Return the cached autotuned batch size for ``cache_key``, or None on a miss.
+
+    A malformed or unreadable entry is treated as a miss rather than an error:
+    the cost of recomputing is bounded, and failing a training run over a bad
+    cache file is not a good trade.
+    """
+    path = _cache_path(cache_key)
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            cached = json.load(handle)
+        batch_size = int(cached["batch_size"])
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        logger.warning("Ignoring unreadable batch size cache at %s: %s", path, exc)
+        return None
+    if batch_size <= 0:
+        logger.warning("Ignoring non-positive cached batch size at %s", path)
+        return None
+    return batch_size
+
+
+def store_cached_batch_size(cache_key: str, batch_size: int) -> None:
+    """Persist an autotuned ``batch_size`` for ``cache_key``.
+
+    Only autotune results belong here. A batch size that merely passed
+    validation is a weaker claim, and storing it would make a later
+    ``batch_size="auto"`` run return a value the autotuner never chose.
+
+    Write failures are logged and ignored — a cache that cannot be written is
+    not a reason to fail a training run.
+    """
+    path = _cache_path(cache_key)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump({"batch_size": batch_size}, handle)
+    except OSError as exc:
+        logger.warning("Could not write batch size cache to %s: %s", path, exc)
+
+
+def assert_valid_batch_size(
+    batch_size: int,
+    cfg: DictConfig,
+    dataset: PytorchSynchronizedDataset,
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+    create_model: Callable[[ModelInitDescription], NeuracoreModel],
+    device: torch.device | None = None,
+) -> None:
+    """Assert that a user-selected batch size fits in GPU memory.
+
+    The check is skipped on CPU (or when CUDA is unavailable). The user-selected
+    batch size is trusted in that case.
+
+    Raises:
+        ValueError: If ``batch_size`` does not fit in GPU memory.
+    """
+    if not torch.cuda.is_available() or (
+        device is not None and "cuda" not in device.type
+    ):
+        logger.warning("Skipping batch size memory check: GPU not available.")
+        return
+
+    if device is None:
+        device = get_default_device()
+
+    logger.info(f"Validating batch size {batch_size} on {device}...")
+
+    dataset_statistics_by_role = dataset.dataset_statistics
+    model_init_description = ModelInitDescription(
+        input_dataset_statistics=dataset_statistics_by_role["input"],
+        output_dataset_statistics=dataset_statistics_by_role["output"],
+        input_data_types=extract_data_types(input_cross_embodiment_description),
+        output_data_types=extract_data_types(output_cross_embodiment_description),
+        output_prediction_horizon=cfg.output_prediction_horizon,
+    )
+    model_factory = partial(create_model, model_init_description)
+
+    try:
+        # dataset safe to pass in here because the probe runs in a spawned subprocess,
+        # so it works on a pickled clone and cannot reach this object.
+        valid = is_valid_batch_size(
+            cfg=cfg,
+            model_factory=model_factory,
+            dataset=dataset,
+            batch_size=batch_size,
+            device=device,
+        )
+    except Exception:
+        logger.error("Batch size validation failed", exc_info=True)
+        raise
+    finally:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    if not valid:
+        raise ValueError(
+            f"Batch size {batch_size} is not valid: it does not fit in "
+            "memory for the current algorithm, dataset, and GPU type. "
+            "Try a smaller batch size, or use batch_size='auto' to automatically "
+            "find the largest batch size that fits."
+        )
+
+    logger.info(f"Batch size {batch_size} is valid.")
+
+
+def determine_optimal_batch_size(
+    cfg: DictConfig,
+    dataset: PytorchSynchronizedDataset,
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+    create_model: Callable[[ModelInitDescription], NeuracoreModel],
+    device: torch.device | None = None,
+) -> int:
+    """Run batch size autotuning on a single GPU and return the result."""
+    if not torch.cuda.is_available() or (
+        device is not None and "cuda" not in device.type
+    ):
+        raise ValueError("Autotuning is only supported on GPUs.")
+
+    if device is None:
+        device = get_default_device()
+
+    logger.info(f"Starting batch size autotuning on {device}...")
+
+    dataset_statistics_by_role = dataset.dataset_statistics
+    model_init_description = ModelInitDescription(
+        input_dataset_statistics=dataset_statistics_by_role["input"],
+        output_dataset_statistics=dataset_statistics_by_role["output"],
+        input_data_types=extract_data_types(input_cross_embodiment_description),
+        output_data_types=extract_data_types(output_cross_embodiment_description),
+        output_prediction_horizon=cfg.output_prediction_horizon,
+    )
+    model_factory = partial(create_model, model_init_description)
+
+    try:
+        # dataset safe to pass in here because the probe runs in a spawned subprocess,
+        # so it works on a pickled clone and cannot reach this object.
+        optimal_batch_size = find_optimal_batch_size(
+            cfg=cfg,
+            model_factory=model_factory,
+            dataset=dataset,
+            device=device,
+        )
+    except Exception:
+        logger.error("Batch size autotuning failed", exc_info=True)
+        raise
+    finally:
+        # Clean up
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    logger.info(
+        f"Autotuning complete. Optimal batch size per GPU: {optimal_batch_size}"
+    )
+
+    return optimal_batch_size
+
+
+def resolve_batch_size(
+    cfg: DictConfig,
+    batch_size: Any,
+    dataset: PytorchSynchronizedDataset,
+    input_cross_embodiment_description: CrossEmbodimentDescription,
+    output_cross_embodiment_description: CrossEmbodimentDescription,
+    create_model: Callable[[ModelInitDescription], NeuracoreModel],
+    device: torch.device | None,
+) -> int:
+    """Resolve the per-GPU batch size, reusing a cached probe result if possible.
+
+    ``batch_size`` is either the string ``"auto"`` or an integer. Autotuning it
+    means spawning several probe subprocesses; validating a user-supplied value
+    means spawning one. Both results are cached against the model, its input
+    shapes, and the GPU, so a repeat run of the same configuration skips
+    straight to the answer.
+
+    Args:
+        cfg: Fully resolved Hydra configuration.
+        batch_size: ``"auto"`` or an integer batch size.
+        dataset: Dataset used to build probe batches.
+        input_cross_embodiment_description: Input embodiment mapping.
+        output_cross_embodiment_description: Output embodiment mapping.
+        create_model: Builds a model from a description. Injected so this
+            module does not depend on the training entrypoint that owns
+            algorithm construction.
+        device: Device training will run on.
+
+    Returns:
+        The batch size to train with.
+    """
+    is_auto = isinstance(batch_size, str) and batch_size.lower() == "auto"
+    probe_device = device if device is not None else get_default_device()
+
+    # The cache only describes GPU memory behaviour, and neither code path
+    # probes anything off-GPU.
+    can_cache = probe_device.type == "cuda" and torch.cuda.is_available()
+    cache_key: str | None = None
+    if can_cache and not cfg.get("force_batch_size_autotune", False):
+        dataset_statistics_by_role = dataset.dataset_statistics
+        cache_key = batch_size_cache_key(
+            algorithm_name=cfg.get("algorithm_name"),
+            algorithm_id=cfg.get("algorithm_id"),
+            algorithm_config=(
+                OmegaConf.to_container(cfg.algorithm_params, resolve=True)
+                if cfg.get("algorithm_params") is not None
+                else {}
+            ),
+            model_init_description=ModelInitDescription(
+                input_dataset_statistics=dataset_statistics_by_role["input"],
+                output_dataset_statistics=dataset_statistics_by_role["output"],
+                input_data_types=extract_data_types(input_cross_embodiment_description),
+                output_data_types=extract_data_types(
+                    output_cross_embodiment_description
+                ),
+                output_prediction_horizon=cfg.output_prediction_horizon,
+            ),
+            device=probe_device,
+        )
+    cached = load_cached_batch_size(cache_key) if cache_key is not None else None
+    if cached is not None:
+        if is_auto:
+            logger.info(f"Using cached autotuned batch size: {cached}")
+            return cached
+        if int(batch_size) <= cached:
+            # The autotuner already found a larger batch size that fits on
+            # this GPU for this model, so this one fits too.
+            logger.info(
+                f"Batch size {int(batch_size)} is within the cached "
+                f"autotuned limit of {cached}; skipping validation."
+            )
+            return int(batch_size)
+
+    if not is_auto:
+        resolved = int(batch_size)
+        if cfg.get("validate_batch_size", True):
+            assert_valid_batch_size(
+                batch_size=resolved,
+                cfg=cfg,
+                dataset=dataset,
+                input_cross_embodiment_description=input_cross_embodiment_description,
+                output_cross_embodiment_description=output_cross_embodiment_description,
+                create_model=create_model,
+                device=device,
+            )
+        # Deliberately not cached: "this size fits" is a weaker claim than the
+        # autotuned optimum, and writing it here would make a later
+        # batch_size="auto" run return a value the autotuner never chose.
+        return resolved
+
+    resolved = determine_optimal_batch_size(
+        cfg=cfg,
+        dataset=dataset,
+        input_cross_embodiment_description=input_cross_embodiment_description,
+        output_cross_embodiment_description=output_cross_embodiment_description,
+        create_model=create_model,
+        device=device,
+    )
+    if cache_key is not None:
+        store_cached_batch_size(cache_key, resolved)
+    return resolved

--- a/neuracore/ml/utils/memory_monitor.py
+++ b/neuracore/ml/utils/memory_monitor.py
@@ -64,7 +64,6 @@ class MemoryMonitor:
             )
 
         if self.gpu_id is not None and torch.cuda.is_available():
-            torch.cuda.synchronize()
             gpu_mem_reserved = torch.cuda.memory_reserved(self.gpu_id) / (1024**3)
             gpu_mem_total = torch.cuda.get_device_properties(
                 self.gpu_id

--- a/neuracore/ml/utils/training_config.py
+++ b/neuracore/ml/utils/training_config.py
@@ -2,8 +2,9 @@
 
 import copy
 import re
+from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import hydra
 from names_generator import generate_name
@@ -125,13 +126,24 @@ def _normalize_algorithm_name(name: str) -> str:
     return re.sub(r"[^a-z0-9]", "", name.lower())
 
 
+@lru_cache(maxsize=None)
+def _load_packaged_config(config_path: Path) -> DictConfig:
+    """Load and cache a packaged YAML config.
+
+    The packaged configs ship with the library and cannot change while the
+    process is running, but the resolution path reads them several times per
+    run. Callers must treat the result as read-only and merge into a copy.
+    """
+    return cast(DictConfig, OmegaConf.load(config_path))
+
+
 def _load_algorithm_config_from_name(algorithm_name: str) -> DictConfig:
     """Load a packaged algorithm config from a file stem or target class name."""
     requested_name = _normalize_algorithm_name(algorithm_name)
     available_names: list[str] = []
 
     for config_path in sorted(ALGORITHM_CONFIG_DIR.glob("*.yaml")):
-        algorithm_cfg = OmegaConf.load(config_path)
+        algorithm_cfg = _load_packaged_config(config_path)
         cfg_algorithm = algorithm_cfg.get("algorithm")
         if cfg_algorithm is None or "_target_" not in cfg_algorithm:
             continue
@@ -181,7 +193,7 @@ def resolve_to_merged_config(cfg: DictConfig) -> DictConfig:
     # Merge with the default config to ensure all expected keys are present,
     # even if the user provided a custom config that may not include all the
     # default values.
-    default_cfg = OmegaConf.load(
+    default_cfg = _load_packaged_config(
         Path(__file__).resolve().parents[1] / "config" / "config.yaml"
     )
     cfg = OmegaConf.merge(default_cfg, cfg)

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -37,6 +37,7 @@ class TrainingStorageHandler(UploadStorageMixin):
         output_preprocessing_config: PreprocessingConfiguration = (
             PreprocessingConfiguration()
         ),
+        verify_job_exists: bool = True,
     ) -> None:
         """Initialize the storage handler.
 
@@ -52,6 +53,10 @@ class TrainingStorageHandler(UploadStorageMixin):
                 data.
             output_preprocessing_config: preprocessing configuration for the output
                 data.
+            verify_job_exists: Whether to confirm the training job is reachable
+                on construction. Costs one blocking request, so distributed
+                ranks other than rank 0 skip it — rank 0 has already verified
+                the same job, and only rank 0 writes to it.
         """
         self.local_dir = Path(local_dir or "./output")
         self.training_job_id = training_job_id
@@ -62,7 +67,7 @@ class TrainingStorageHandler(UploadStorageMixin):
         self.output_preprocessing_config = output_preprocessing_config
         self.log_to_cloud = self.training_job_id is not None
         self.org_id = get_current_org()
-        if self.log_to_cloud:
+        if self.log_to_cloud and verify_job_exists:
             response = self._get_request(
                 f"{API_URL}/org/{self.org_id}/training/jobs/{self.training_job_id}"
             )
@@ -80,6 +85,16 @@ class TrainingStorageHandler(UploadStorageMixin):
         self._upload_executor: ThreadPoolExecutor | None = None
         self._pending_uploads_lock = threading.Lock()
         self._pending_uploads: dict[Path, Future] = {}
+
+        # Progress updates are fire-and-forget from the training loop's point
+        # of view. They get their own worker rather than sharing the upload
+        # one, so a multi-gigabyte checkpoint upload can't leave reported
+        # progress stalled behind it.
+        self._progress_executor: ThreadPoolExecutor | None = None
+        self._progress_lock = threading.Lock()
+        self._pending_progress: tuple[int, int] | None = None
+        self._progress_future: Future | None = None
+        self._progress_worker_running = False
 
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for a file in cloud storage.
@@ -373,21 +388,81 @@ class TrainingStorageHandler(UploadStorageMixin):
                 )
 
     def update_training_progress(self, epoch: int, step: int) -> None:
-        """Update training epoch/step progress in cloud storage.
+        """Queue a training epoch/step progress update for cloud storage.
+
+        This is called from inside the training loop, so the HTTP PUT runs on
+        a background worker rather than blocking the step. Updates coalesce:
+        if a PUT is already in flight, this replaces the payload that will be
+        sent next instead of queueing another request.
 
         Args:
             epoch: Current training epoch.
             step: Current training step.
         """
-        if self.log_to_cloud:
+        if not self.log_to_cloud:
+            return
+
+        with self._progress_lock:
+            self._pending_progress = (epoch, step)
+            if self._progress_worker_running:
+                # A worker is already draining; it will observe the payload we
+                # just stored. The flag is cleared under this same lock, so a
+                # worker that has decided to exit cannot still be marked
+                # running here.
+                return
+            if self._progress_executor is None:
+                self._progress_executor = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="nc-training-progress"
+                )
+            self._progress_worker_running = True
+            self._progress_future = self._progress_executor.submit(
+                self._drain_progress_updates
+            )
+
+    def _drain_progress_updates(self) -> None:
+        """Send queued progress updates until none remain."""
+        while True:
+            with self._progress_lock:
+                pending = self._pending_progress
+                self._pending_progress = None
+                if pending is None:
+                    # Clear the flag in the same critical section that observes
+                    # the empty queue, so a concurrent enqueue either lands
+                    # before this and is drained, or sees the flag cleared and
+                    # starts a fresh worker.
+                    self._progress_worker_running = False
+                    return
+            epoch, step = pending
+            self._send_training_progress(epoch, step)
+
+    def _send_training_progress(self, epoch: int, step: int) -> None:
+        """Send a single progress update, logging rather than raising on failure."""
+        try:
             response = self._put_request(
                 f"{API_URL}/org/{self.org_id}/training/jobs/{self.training_job_id}/update",
                 json={"epoch": epoch, "step": step, "error": None},
             )
-            if response.status_code != 200:
-                logger.error(
-                    f"Failed to update training progress to cloud: {response.text}"
-                )
+        except Exception:
+            logger.error("Failed to update training progress to cloud.", exc_info=True)
+            return
+        if response.status_code != 200:
+            logger.error(
+                f"Failed to update training progress to cloud: {response.text}"
+            )
+
+    def wait_for_pending_progress_updates(self) -> None:
+        """Block until any queued progress update has been sent.
+
+        Called before the process exits so the final epoch/step reaches the
+        backend rather than dying with the worker thread.
+        """
+        with self._progress_lock:
+            future = self._progress_future
+        if future is not None:
+            try:
+                future.result()
+            except Exception:
+                logger.error("Progress update worker failed.", exc_info=True)
 
     def report_training_error(self, error: str) -> None:
         """Report a training failure to cloud storage.

--- a/tests/unit/core/data/test_synchronized_episode.py
+++ b/tests/unit/core/data/test_synchronized_episode.py
@@ -192,6 +192,51 @@ class TestSynchronizedRecording:
         assert len(frames) == 2
         assert all(isinstance(f, SynchronizedPoint) for f in frames)
 
+    def test_get_range_matches_equivalent_slice(
+        self, synced_recording: SynchronizedRecording, mock_wget_download
+    ):
+        """get_range covers the same window as the equivalent slice."""
+        assert [point.timestamp for point in synced_recording.get_range(0, 2)] == [
+            point.timestamp for point in synced_recording[0:2]
+        ]
+
+    def test_get_range_clamps_to_episode_bounds(
+        self, synced_recording: SynchronizedRecording, mock_wget_download
+    ):
+        """An over-long range truncates rather than raising, matching slicing."""
+        frames = synced_recording.get_range(1, 500)
+
+        assert len(frames) == len(synced_recording) - 1
+        assert synced_recording.get_range(500, 600) == []
+
+    def test_get_range_only_materialises_requested_data_types(
+        self, synced_recording: SynchronizedRecording, mock_wget_download
+    ):
+        """Filtered-out data types are dropped instead of being loaded.
+
+        This is what keeps a sample from decoding camera frames across the
+        whole output prediction horizon when the outputs are joints only.
+        """
+        unfiltered = synced_recording.get_range(0, 2)
+        assert any(DataType.JOINT_POSITIONS in point.data for point in unfiltered)
+
+        filtered = synced_recording.get_range(
+            0, 2, data_types=frozenset({DataType.JOINT_POSITIONS})
+        )
+
+        assert len(filtered) == len(unfiltered)
+        for point in filtered:
+            assert set(point.data) <= {DataType.JOINT_POSITIONS}
+
+    def test_get_range_with_empty_filter_loads_nothing(
+        self, synced_recording: SynchronizedRecording, mock_wget_download
+    ):
+        """An empty data type set yields sync points carrying no payloads."""
+        frames = synced_recording.get_range(0, 2, data_types=frozenset())
+
+        assert len(frames) == 2
+        assert all(point.data == {} for point in frames)
+
     def test_getitem_slice_with_step(
         self,
         dataset_mock,

--- a/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
+++ b/tests/unit/ml/datasets/test_pytorch_synchronized_dataset.py
@@ -314,16 +314,22 @@ def mock_synced_recording(
         def __len__(self):
             return len(self.sync_points)
 
-        def __getitem__(self, idx):
-            if isinstance(idx, int):
-                return self.sync_points[idx]
-            elif isinstance(idx, slice):
-                start = idx.start or 0
-                stop = idx.stop or len(self.sync_points)
-                step = idx.step or 1
-                return self.sync_points[start:stop:step]
-            else:
-                raise TypeError(f"Invalid index type: {type(idx)}")
+        def _get_sync_point(self, idx, data_types=None):
+            # Override the payload-loading seam rather than __getitem__, so the
+            # real indexing and range logic (including the data_types filter
+            # used by get_range) is exercised.
+            sync_point = self.sync_points[idx]
+            if data_types is None:
+                return sync_point
+            return SynchronizedPoint.model_construct(
+                timestamp=sync_point.timestamp,
+                robot_id=sync_point.robot_id,
+                data={
+                    data_type: values
+                    for data_type, values in sync_point.data.items()
+                    if data_type in data_types
+                },
+            )
 
         def __iter__(self):
             return iter(self.sync_points)
@@ -522,16 +528,22 @@ def mock_synced_recording_with_depth(
         def __len__(self):
             return len(self.sync_points)
 
-        def __getitem__(self, idx):
-            if isinstance(idx, int):
-                return self.sync_points[idx]
-            elif isinstance(idx, slice):
-                start = idx.start or 0
-                stop = idx.stop or len(self.sync_points)
-                step = idx.step or 1
-                return self.sync_points[start:stop:step]
-            else:
-                raise TypeError(f"Invalid index type: {type(idx)}")
+        def _get_sync_point(self, idx, data_types=None):
+            # Override the payload-loading seam rather than __getitem__, so the
+            # real indexing and range logic (including the data_types filter
+            # used by get_range) is exercised.
+            sync_point = self.sync_points[idx]
+            if data_types is None:
+                return sync_point
+            return SynchronizedPoint.model_construct(
+                timestamp=sync_point.timestamp,
+                robot_id=sync_point.robot_id,
+                data={
+                    data_type: values
+                    for data_type, values in sync_point.data.items()
+                    if data_type in data_types
+                },
+            )
 
         def __iter__(self):
             return iter(self.sync_points)
@@ -1136,15 +1148,22 @@ class TestOutputTimestepAlignment:
             def __len__(self) -> int:
                 return len(self.sync_points)
 
-            def __getitem__(self, idx):
-                if isinstance(idx, int):
-                    return self.sync_points[idx]
-                if isinstance(idx, slice):
-                    start = idx.start or 0
-                    stop = idx.stop or len(self.sync_points)
-                    step = idx.step or 1
-                    return self.sync_points[start:stop:step]
-                raise TypeError(f"Invalid index type: {type(idx)}")
+            def _get_sync_point(self, idx, data_types=None):
+                # Override the payload-loading seam rather than __getitem__, so the
+                # real indexing and range logic (including the data_types filter
+                # used by get_range) is exercised.
+                sync_point = self.sync_points[idx]
+                if data_types is None:
+                    return sync_point
+                return SynchronizedPoint.model_construct(
+                    timestamp=sync_point.timestamp,
+                    robot_id=sync_point.robot_id,
+                    data={
+                        data_type: values
+                        for data_type, values in sync_point.data.items()
+                        if data_type in data_types
+                    },
+                )
 
         return TimestepRecording()
 

--- a/tests/unit/ml/test_batch_autotuner.py
+++ b/tests/unit/ml/test_batch_autotuner.py
@@ -395,7 +395,10 @@ def test_probe_batch_size_returns_false_on_torch_cuda_oom():
 
     with (
         patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
-        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.DataLoader",
+            return_value=[MagicMock()],
+        ),
         patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
         patch("torch.cuda.reset_peak_memory_stats"),
         patch("torch.cuda.max_memory_allocated", return_value=0),
@@ -422,7 +425,10 @@ def test_probe_batch_size_raises_on_non_oom_runtime_error():
 
     with (
         patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
-        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.DataLoader",
+            return_value=[MagicMock()],
+        ),
         patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
         patch("torch.cuda.reset_peak_memory_stats"),
         patch("torch.cuda.is_available", return_value=False),
@@ -446,7 +452,10 @@ def test_probe_batch_size_raises_on_generic_exception():
 
     with (
         patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
-        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.DataLoader",
+            return_value=[MagicMock()],
+        ),
         patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
         patch("torch.cuda.reset_peak_memory_stats"),
         patch("torch.cuda.is_available", return_value=False),
@@ -471,7 +480,10 @@ def test_probe_batch_size_gives_actionable_error_on_batchnorm_single_sample():
 
     with (
         patch("neuracore.ml.trainers.batch_autotuner.MemoryMonitor"),
-        patch("neuracore.ml.trainers.batch_autotuner.DataLoader"),
+        patch(
+            "neuracore.ml.trainers.batch_autotuner.DataLoader",
+            return_value=[MagicMock()],
+        ),
         patch("neuracore.ml.trainers.batch_autotuner._train_probe") as mock_train_probe,
         patch("torch.cuda.reset_peak_memory_stats"),
         patch("torch.cuda.is_available", return_value=False),

--- a/tests/unit/ml/test_train.py
+++ b/tests/unit/ml/test_train.py
@@ -37,14 +37,16 @@ from neuracore.ml.datasets.pytorch_synchronized_dataset import (
 from neuracore.ml.train import (
     _resolve_recording_cache_dir,
     _serialize_cross_embodiment_description,
-    assert_valid_batch_size,
-    determine_optimal_batch_size,
     get_model_and_algorithm_config,
     main,
     run_training,
     setup_logging,
 )
 from neuracore.ml.trainers.batch_autotuner import find_optimal_batch_size
+from neuracore.ml.utils.batch_size import (
+    assert_valid_batch_size,
+    determine_optimal_batch_size,
+)
 from neuracore.ml.utils.preprocessing import (
     resolve_input_output_preprocessing,
     resolve_preprocessing_config,
@@ -177,6 +179,9 @@ class MainTestSetup:
         self.mock_synchronized_dataset = Mock()
         self.mock_pytorch_dataset = Mock(spec=PytorchSynchronizedDataset)
         self.mock_pytorch_dataset.cross_embodiment_description = Mock()
+        # Read when building the batch-size cache key, so it has to be a real
+        # mapping rather than a bare Mock.
+        self.mock_pytorch_dataset.dataset_statistics = {"input": {}, "output": {}}
         self.mock_pytorch_dataset.__len__ = Mock(return_value=100)
         self.mock_pytorch_dataset.load_sample = Mock(return_value=Mock())
         self.mock_pytorch_dataset.__getitem__ = Mock(
@@ -258,10 +263,23 @@ class MainTestSetup:
         )
         self.mock_assert_valid_batch_size = Mock()
         self.monkeypatch.setattr(
-            "neuracore.ml.train.assert_valid_batch_size",
+            "neuracore.ml.utils.batch_size.assert_valid_batch_size",
             self.mock_assert_valid_batch_size,
         )
         self.monkeypatch.setattr("torch.cuda.device_count", self.mock_cuda_device_count)
+        # Keep the on-disk batch-size cache out of unit tests: a real hit would
+        # short-circuit the autotune and validate paths these tests assert on,
+        # and a real write would leak into the developer's home directory.
+        self.mock_load_cached_batch_size = Mock(return_value=None)
+        self.mock_store_cached_batch_size = Mock()
+        self.monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.load_cached_batch_size",
+            self.mock_load_cached_batch_size,
+        )
+        self.monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.store_cached_batch_size",
+            self.mock_store_cached_batch_size,
+        )
         self.monkeypatch.setattr(
             "neuracore.ml.train.AlgorithmStorageHandler",
             self.mock_storage_handler_class,
@@ -293,7 +311,7 @@ class MainTestSetup:
         if include_determine_optimal_batch_size:
             self.mock_determine_optimal_batch_size = Mock()
             self.monkeypatch.setattr(
-                "neuracore.ml.train.determine_optimal_batch_size",
+                "neuracore.ml.utils.batch_size.determine_optimal_batch_size",
                 self.mock_determine_optimal_batch_size,
             )
 
@@ -1121,9 +1139,11 @@ class TestDetermineOptimalBatchSize:
             return_value=(mock_model_class(model_init_description), {})
         )
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
         monkeypatch.setattr(
-            "neuracore.ml.train.find_optimal_batch_size", mock_find_optimal
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.find_optimal_batch_size", mock_find_optimal
         )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
@@ -1135,6 +1155,7 @@ class TestDetermineOptimalBatchSize:
             mock_dataset,
             mock_cfg_batch_size.input_cross_embodiment_description,
             mock_cfg_batch_size.output_cross_embodiment_description,
+            Mock(),  # create_model: never called, probes are patched
         )
 
         assert result == 16
@@ -1149,7 +1170,9 @@ class TestDetermineOptimalBatchSize:
         monkeypatch,
     ):
         mock_get_device = Mock(return_value=torch.device("cpu"))
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
         monkeypatch.setattr("torch.cuda.is_available", lambda: False)
 
         with pytest.raises(ValueError, match="Autotuning is only supported on GPUs"):
@@ -1158,6 +1181,7 @@ class TestDetermineOptimalBatchSize:
                 mock_dataset,
                 mock_cfg_batch_size.input_cross_embodiment_description,
                 mock_cfg_batch_size.output_cross_embodiment_description,
+                Mock(),  # create_model: never called, probes are patched
             )
 
     @pytest.mark.skipif(SKIP_TEST, reason="Skipping test in CI environment")
@@ -1175,7 +1199,7 @@ class TestDetermineOptimalBatchSize:
         )
 
         monkeypatch.setattr(
-            "neuracore.ml.train.find_optimal_batch_size", mock_find_optimal
+            "neuracore.ml.utils.batch_size.find_optimal_batch_size", mock_find_optimal
         )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
@@ -1188,6 +1212,7 @@ class TestDetermineOptimalBatchSize:
             mock_dataset,
             mock_cfg_batch_size.input_cross_embodiment_description,
             mock_cfg_batch_size.output_cross_embodiment_description,
+            Mock(),  # create_model: never called, probes are patched
             device=device,
         )
 
@@ -1223,9 +1248,11 @@ class TestDetermineOptimalBatchSize:
             cleanup_called["cuda_empty_cache"] = True
             return original_cuda_empty_cache()
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
         monkeypatch.setattr(
-            "neuracore.ml.train.find_optimal_batch_size", mock_find_optimal
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.find_optimal_batch_size", mock_find_optimal
         )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
@@ -1239,6 +1266,7 @@ class TestDetermineOptimalBatchSize:
             mock_dataset,
             mock_cfg_batch_size.input_cross_embodiment_description,
             mock_cfg_batch_size.output_cross_embodiment_description,
+            Mock(),  # create_model: never called, probes are patched
         )
 
         assert result == 16
@@ -1260,9 +1288,11 @@ class TestDetermineOptimalBatchSize:
             return_value=(mock_model_class(model_init_description), {})
         )
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
         monkeypatch.setattr(
-            "neuracore.ml.train.find_optimal_batch_size", mock_find_optimal
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.find_optimal_batch_size", mock_find_optimal
         )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
@@ -1274,6 +1304,7 @@ class TestDetermineOptimalBatchSize:
             mock_dataset,
             mock_cfg_batch_size.input_cross_embodiment_description,
             mock_cfg_batch_size.output_cross_embodiment_description,
+            Mock(),  # create_model: never called, probes are patched
         )
 
         assert result == 16
@@ -1295,6 +1326,7 @@ class TestDetermineOptimalBatchSize:
                 mock_dataset,
                 mock_cfg_batch_size.input_cross_embodiment_description,
                 mock_cfg_batch_size.output_cross_embodiment_description,
+                Mock(),  # create_model: never called, probes are patched
                 device=device,
             )
 
@@ -1317,8 +1349,12 @@ class TestAssertValidBatchSize:
             return_value=(mock_model_class(model_init_description), {})
         )
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
-        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.is_valid_batch_size", mock_is_valid
+        )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
         )
@@ -1334,6 +1370,7 @@ class TestAssertValidBatchSize:
             output_cross_embodiment_description=(
                 mock_cfg_batch_size.output_cross_embodiment_description
             ),
+            create_model=Mock(),  # never called: the check exits before probing
         )
 
         assert result is None
@@ -1357,8 +1394,12 @@ class TestAssertValidBatchSize:
             return_value=(mock_model_class(model_init_description), {})
         )
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
-        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.is_valid_batch_size", mock_is_valid
+        )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
         )
@@ -1384,7 +1425,9 @@ class TestAssertValidBatchSize:
     ):
         """On CPU the memory check must be skipped without raising."""
         mock_is_valid = Mock()
-        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.is_valid_batch_size", mock_is_valid
+        )
         monkeypatch.setattr("torch.cuda.is_available", lambda: False)
 
         result = assert_valid_batch_size(
@@ -1397,6 +1440,7 @@ class TestAssertValidBatchSize:
             output_cross_embodiment_description=(
                 mock_cfg_batch_size.output_cross_embodiment_description
             ),
+            create_model=Mock(),  # never called: the check exits before probing
         )
 
         assert result is None
@@ -1407,7 +1451,9 @@ class TestAssertValidBatchSize:
     ):
         """Explicit CPU device should also skip the memory check."""
         mock_is_valid = Mock()
-        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.is_valid_batch_size", mock_is_valid
+        )
         monkeypatch.setattr("torch.cuda.is_available", lambda: True)
 
         result = assert_valid_batch_size(
@@ -1420,6 +1466,7 @@ class TestAssertValidBatchSize:
             output_cross_embodiment_description=(
                 mock_cfg_batch_size.output_cross_embodiment_description
             ),
+            create_model=Mock(),  # never called: the check exits before probing
             device=torch.device("cpu"),
         )
 
@@ -1455,8 +1502,12 @@ class TestAssertValidBatchSize:
             cleanup_call_counts["cuda_empty_cache"] += 1
             return original_cuda_empty_cache()
 
-        monkeypatch.setattr("neuracore.ml.train.get_default_device", mock_get_device)
-        monkeypatch.setattr("neuracore.ml.train.is_valid_batch_size", mock_is_valid)
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.get_default_device", mock_get_device
+        )
+        monkeypatch.setattr(
+            "neuracore.ml.utils.batch_size.is_valid_batch_size", mock_is_valid
+        )
         monkeypatch.setattr(
             "neuracore.ml.train.get_model_and_algorithm_config", mock_get_model_config
         )
@@ -1476,6 +1527,7 @@ class TestAssertValidBatchSize:
             output_cross_embodiment_description=(
                 mock_cfg_batch_size.output_cross_embodiment_description
             ),
+            create_model=Mock(),  # never called: the check exits before probing
         )
 
         assert cleanup_call_counts["gc_collect"] == 1

--- a/tests/unit/ml/utils/test_training_storage_handler.py
+++ b/tests/unit/ml/utils/test_training_storage_handler.py
@@ -551,6 +551,7 @@ class TestUpdateTrainingProgress:
         requests_mock.put(f"{BASE_JOB_URL}/update", status_code=200)
 
         handler.update_training_progress(epoch=3, step=150)
+        handler.wait_for_pending_progress_updates()
 
         put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
         assert len(put_requests) == 1
@@ -562,14 +563,47 @@ class TestUpdateTrainingProgress:
         matcher = requests_mock.put(f"{BASE_JOB_URL}/update", status_code=401)
 
         handler.update_training_progress(epoch=3, step=150)
+        handler.wait_for_pending_progress_updates()
 
         assert matcher.call_count == 1
         assert not login.called
 
     def test_makes_no_http_request_without_job_id(self, local_handler, requests_mock):
         local_handler.update_training_progress(epoch=1, step=1)
+        local_handler.wait_for_pending_progress_updates()
 
         assert len(requests_mock.request_history) == 0
+
+    def test_coalesces_updates_queued_while_one_is_in_flight(
+        self, handler, requests_mock
+    ):
+        """A backlog of stale progress must not build up behind a slow endpoint.
+
+        The first PUT is held until further updates have been queued, so the
+        worker is guaranteed to still be busy when they arrive. Only the newest
+        of those should be sent afterwards.
+        """
+        first_put_started = threading.Event()
+        release_first_put = threading.Event()
+
+        def _blocking_response(request, context):
+            if not first_put_started.is_set():
+                first_put_started.set()
+                release_first_put.wait(timeout=5)
+            context.status_code = 200
+            return ""
+
+        requests_mock.put(f"{BASE_JOB_URL}/update", text=_blocking_response)
+
+        handler.update_training_progress(epoch=1, step=10)
+        assert first_put_started.wait(timeout=5)
+        handler.update_training_progress(epoch=1, step=20)
+        handler.update_training_progress(epoch=1, step=30)
+        release_first_put.set()
+        handler.wait_for_pending_progress_updates()
+
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert [r.json()["step"] for r in put_requests] == [10, 30]
 
 
 class TestReportTrainingError:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Autotune results are cached on disk against the model, its input shapes and the GPU, so a repeat launch of the same configuration skips probing entirely. 
 - Batch size resolution moved out of `train.py` into  `neuracore/ml/utils/batch_size.py` alongside its cache.

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Per-step device synchronisations removed from the training loop:
   - `MemoryMonitor` no longer calls `torch.cuda.synchronize()`. `memory_reserved()` reads host-side allocator bookkeeping, so the barrier bought nothing while serialising every step. 
   - Losses and metrics accumulate on-device and are read back once per epoch, replacing a blocking `.item()` per loss and per metric per step.
   - The progress-bar `loss.item()` ran unconditionally, including on cloud runs where the bar is disabled. It now runs only when the bar is visible.
 - Histograms are rank-guarded and skipped when the backend discards them. `CloudTrainingLogger` records nothing, so cloud runs were walking every parameter twice per log step to hand it to a no-op.
 - The training-progress PUT no longer blocks the training thread; updates coalesce onto a background worker and are flushed at shutdown.
 - Sync point payloads load lazily. The output window is projected onto the output description alone and reuses the already-loaded input timestep, so a  joints-only output no longer decodes a camera frame per horizon step and discards it.
 - Autotune probes reuse one batch instead of loading three serially; the two defensive `deepcopy` calls on the dataset are gone (probes run in spawned  subprocesses, so the parent is already isolated by pickling); packaged YAML  loads are memoised; only rank 0 verifies the training job exists.