### PR TITLE
perf: remove per-step device syncs from the training loop

### DIFF
--- a/neuracore/ml/config/config.yaml
+++ b/neuracore/ml/config/config.yaml
@@ -32,7 +32,7 @@ allow_duplicates: true
 resume_checkpoint_path: null  # Path to checkpoint to resume from
 
 logging_frequency: 50
-# Frequency (in steps) for host and accelerator utilisation under System/.
+# Frequency (in steps) for host and accelerator utilisation under system/.
 # Sampled far less often than the model metrics: each sample costs syscalls and
 # an NVML query, and utilisation moves slowly enough that a fine cadence buys
 # nothing. 0 disables it.

--- a/neuracore/ml/logging/cloud_training_logger.py
+++ b/neuracore/ml/logging/cloud_training_logger.py
@@ -44,6 +44,11 @@ class CloudTrainingLogger(TrainingLogger):
 
         logger.info("Cloud logger initialized.")
 
+    @property
+    def supports_histograms(self) -> bool:
+        """Histograms are not supported by the cloud metrics endpoint."""
+        return False
+
     def log_scalar(self, name: str, value: float, step: int) -> None:
         """Log a scalar metric.
 

--- a/neuracore/ml/logging/system_metrics.py
+++ b/neuracore/ml/logging/system_metrics.py
@@ -13,7 +13,7 @@ BYTES_PER_GB = 1024**3
 
 # Scalars logged under this prefix are about the machine, not the model, and
 # group separately from train/ and val/ in TensorBoard.
-SYSTEM_METRIC_PREFIX = "System"
+SYSTEM_METRIC_PREFIX = "system"
 
 
 class SystemMetricsCollector:

--- a/neuracore/ml/logging/training_logger.py
+++ b/neuracore/ml/logging/training_logger.py
@@ -13,6 +13,16 @@ logger = logging.getLogger(__name__)
 class TrainingLogger(ABC):
     """Abstract base class for training loggers."""
 
+    @property
+    def supports_histograms(self) -> bool:
+        """Whether ``log_histogram`` persists anything.
+
+        Callers use this to skip building histogram inputs when the backend
+        would discard them. For model weights and gradients that means walking
+        every parameter and copying it off the device, which is far from free.
+        """
+        return True
+
     @abstractmethod
     def log_scalar(self, name: str, value: float, step: int) -> None:
         """Log a scalar metric.

--- a/neuracore/ml/trainers/distributed_trainer.py
+++ b/neuracore/ml/trainers/distributed_trainer.py
@@ -21,6 +21,7 @@ from neuracore.ml.logging.system_metrics import (
 )
 from neuracore.ml.logging.training_logger import TrainingLogger
 from neuracore.ml.preprocessing.base import PreprocessingConfiguration
+from neuracore.ml.trainers.metric_accumulator import MetricAccumulator
 from neuracore.ml.utils.device_utils import get_default_device
 from neuracore.ml.utils.memory_monitor import MemoryMonitor, OutOfMemoryError
 from neuracore.ml.utils.preprocessing import apply_device_preprocessing
@@ -30,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 # Only update the training metadata every N steps to avoid excessive API calls
 UPDATE_TRAINING_METADATA_EVERY = 20
+
+# Checking RAM and VRAM headroom reads /proc/meminfo and the CUDA allocator,
+# which is far more often than a slow-moving quantity needs. Matches the
+# interval the dataset uses for the same check.
+CHECK_MEMORY_INTERVAL = 100
 
 
 class NestedModule(nn.Module):
@@ -134,6 +140,8 @@ class DistributedTrainer:
         self.num_epochs = num_epochs
         self.log_freq = log_freq
         self.system_log_freq = system_log_freq
+        self._pbar_enabled = rank == 0 and not storage_handler.log_to_cloud
+        self._histograms_enabled = rank == 0 and training_logger.supports_histograms
         # Only rank 0 logs, matching _log_scalars, so only rank 0 samples.
         self._system_metrics = (
             SystemMetricsCollector(self.device, disk_path=DEFAULT_CACHE_DIR)
@@ -173,25 +181,27 @@ class DistributedTrainer:
             A dictionary of averaged metrics for the epoch
         """
         self.model.train()
-        epoch_losses: list[dict[str, float]] = []
-        epoch_metrics: list[dict[str, float]] = []
+        accumulator = MetricAccumulator()
 
         memory_monitor = MemoryMonitor(
-            max_ram_utilization=0.8, max_gpu_utilization=0.95
+            max_ram_utilization=0.8,
+            max_gpu_utilization=0.95,
+            gpu_id=self.device.index if self.device.type == "cuda" else None,
         )
 
         # Progress bar only on rank 0
         pbar = tqdm(
             self.train_loader,
             desc=f"Training Epoch {epoch}",
-            disable=self.rank != 0 or self.storage_handler.log_to_cloud,
+            disable=not self._pbar_enabled,
         )
 
         for optimizer in self.optimizers:
             optimizer.zero_grad()
 
         for batch_idx, batch in enumerate(pbar):
-            memory_monitor.check_memory()
+            if batch_idx % CHECK_MEMORY_INTERVAL == 0:
+                memory_monitor.check_memory()
 
             # Move tensors to device and format batch
             batch = batch.to(self.device)
@@ -220,7 +230,10 @@ class DistributedTrainer:
                 for scheduler in self.schedulers:
                     scheduler.step()
 
-            if self.log_freq > 0 and self.global_train_step % self.log_freq == 0:
+            is_log_step = self.log_freq > 0 and (
+                self.global_train_step % self.log_freq == 0
+            )
+            if is_log_step:
                 self._log_scalars(
                     batch_output.losses,
                     self.global_train_step,
@@ -243,12 +256,11 @@ class DistributedTrainer:
                     self.global_train_step,
                     prefix=SYSTEM_METRIC_PREFIX,
                 )
-            pbar.set_postfix(
-                {"loss": f"{loss.item():.4f}", "step": self.global_train_step}
-            )
-            epoch_losses, epoch_metrics = self._accumulate_epoch_metrics(
-                batch_output, epoch_losses, epoch_metrics
-            )
+            if self._pbar_enabled and is_log_step:
+                pbar.set_postfix(
+                    {"loss": f"{loss.item():.4f}", "step": self.global_train_step}
+                )
+            accumulator.update(batch_output)
             self.global_train_step += 1
             if (
                 self.rank == 0
@@ -264,9 +276,7 @@ class DistributedTrainer:
 
             del batch, batch_output, loss
 
-        avg_epoch_losses, avg_epoch_metrics = self._average_epoch_metrics(
-            epoch_losses, epoch_metrics, epoch
-        )
+        avg_epoch_losses, avg_epoch_metrics = accumulator.averages()
         self._log_scalars(avg_epoch_losses, epoch, prefix="train/epoch/loss")
         self._log_scalars(avg_epoch_metrics, epoch, prefix="train/epoch/metrics")
         return avg_epoch_losses
@@ -281,13 +291,12 @@ class DistributedTrainer:
             A dictionary of averaged validation metrics
         """
         self.model.train()  # Keep in train mode to get losses
-        val_losses: list[dict[str, float]] = []
-        val_metrics: list[dict[str, float]] = []
+        accumulator = MetricAccumulator()
 
         pbar = tqdm(
             self.val_loader,
             desc=f"Validation Epoch {epoch}",
-            disable=self.rank != 0 or self.storage_handler.log_to_cloud,
+            disable=not self._pbar_enabled,
         )
 
         for batch_idx, batch in enumerate(pbar):
@@ -309,14 +318,10 @@ class DistributedTrainer:
                     self.global_val_step,
                     prefix="val/step/metrics",
                 )
-            val_losses, val_metrics = self._accumulate_epoch_metrics(
-                batch_output, val_losses, val_metrics
-            )
+            accumulator.update(batch_output)
             self.global_val_step += 1
 
-        avg_losses, avg_metrics = self._average_epoch_metrics(
-            val_losses, val_metrics, epoch
-        )
+        avg_losses, avg_metrics = accumulator.averages()
         self._log_scalars(avg_losses, epoch, prefix="val/epoch/loss")
         self._log_scalars(avg_metrics, epoch, prefix="val/epoch/metrics")
         return avg_losses
@@ -383,6 +388,9 @@ class DistributedTrainer:
                 # VM/container be torn down — while the final checkpoint is
                 # still mid-upload.
                 self.storage_handler.wait_for_pending_uploads()
+                # Progress updates are also sent off-thread, so flush the last
+                # one rather than letting it die with the worker.
+                self.storage_handler.wait_for_pending_progress_updates()
                 # Close the logger
                 self.training_logger.close()
 
@@ -467,6 +475,8 @@ class DistributedTrainer:
         Args:
             step: Training step.
         """
+        if not self._histograms_enabled:
+            return
         model = self.get_model_without_ddp()
         for name, param in model.named_parameters():
             if param.grad is not None:
@@ -480,6 +490,8 @@ class DistributedTrainer:
         Args:
             step: Training step.
         """
+        if not self._histograms_enabled:
+            return
         model = self.get_model_without_ddp()
         for name, param in model.named_parameters():
             self.training_logger.log_histogram(f"weights/{name}", param, step)
@@ -505,71 +517,6 @@ class DistributedTrainer:
             self.training_logger.log_scalar(
                 f"{prefix}/{scalar_name}", scalar_value, step
             )
-
-    def _accumulate_epoch_metrics(
-        self,
-        batch_output: BatchedTrainingOutputs,
-        epoch_losses: list[dict[str, float]],
-        epoch_metrics: list[dict[str, float]],
-    ) -> tuple[list[dict[str, float]], list[dict[str, float]]]:
-        """Accumulate metrics for the current epoch.
-
-        Args:
-            batch_output: Outputs from the training step
-            epoch_losses: List of losses accumulated for the epoch
-            epoch_metrics: List of metrics accumulated for the epoch
-
-        Returns:
-            Updated lists of losses and metrics for the epoch
-        """
-        # Accumulate losses
-        if batch_output.losses:
-            epoch_losses.append({
-                k: v.item() if isinstance(v, torch.Tensor) else v
-                for k, v in batch_output.losses.items()
-            })
-
-        # Accumulate metrics
-        if batch_output.metrics:
-            epoch_metrics.append({
-                k: v.item() if isinstance(v, torch.Tensor) else v
-                for k, v in batch_output.metrics.items()
-            })
-
-        return epoch_losses, epoch_metrics
-
-    def _average_epoch_metrics(
-        self,
-        epoch_losses: list[dict[str, float]],
-        epoch_metrics: list[dict[str, float]],
-        epoch: int,
-    ) -> tuple[dict[str, float], dict[str, float]]:
-        """Average metrics across the epoch.
-
-        Args:
-            epoch_losses: List of losses accumulated for the epoch
-            epoch_metrics: List of metrics accumulated for the epoch
-            epoch: Current epoch number
-
-        Returns:
-            A dictionary of averaged losses and metrics for the epoch
-        """
-        avg_epoch_losses = {}
-        avg_epoch_metrics = {}
-
-        if epoch_losses:
-            for key in epoch_losses[0].keys():
-                avg_epoch_losses[key] = sum(x[key] for x in epoch_losses) / len(
-                    epoch_losses
-                )
-
-        if epoch_metrics:
-            for key in epoch_metrics[0].keys():
-                avg_epoch_metrics[key] = sum(x[key] for x in epoch_metrics) / len(
-                    epoch_metrics
-                )
-
-        return avg_epoch_losses, avg_epoch_metrics
 
 
 def setup_distributed(rank: int, world_size: int) -> None:

--- a/neuracore/ml/trainers/metric_accumulator.py
+++ b/neuracore/ml/trainers/metric_accumulator.py
@@ -1,0 +1,75 @@
+"""Accumulation of per-step losses and metrics over a training epoch."""
+
+import torch
+
+from neuracore.ml import BatchedTrainingOutputs
+
+
+class MetricAccumulator:
+    """Running sums of per-step losses and metrics for one epoch.
+
+    Tensor values are summed on whichever device they arrive on and read back
+    once, when the epoch ends. Summing on the host instead would mean a
+    blocking device-to-host copy per loss and per metric on every single step,
+    which serialises the training loop against the accelerator.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty accumulators."""
+        self._loss_sums: dict[str, torch.Tensor | float] = {}
+        self._metric_sums: dict[str, torch.Tensor | float] = {}
+        self._loss_steps = 0
+        self._metric_steps = 0
+
+    @staticmethod
+    def _add(
+        sums: dict[str, torch.Tensor | float], values: dict[str, torch.Tensor]
+    ) -> None:
+        """Fold one step's values into the running totals.
+
+        Detaches first: these are held for a whole epoch, and keeping them
+        attached would pin every step's autograd graph alive with them.
+        """
+        for key, value in values.items():
+            contribution = value.detach() if isinstance(value, torch.Tensor) else value
+            sums[key] = sums[key] + contribution if key in sums else contribution
+
+    def update(self, batch_output: BatchedTrainingOutputs) -> None:
+        """Add one step's losses and metrics to the running totals.
+
+        Args:
+            batch_output: Outputs from a single training or validation step.
+        """
+        if batch_output.losses:
+            self._add(self._loss_sums, batch_output.losses)
+            self._loss_steps += 1
+        if batch_output.metrics:
+            self._add(self._metric_sums, batch_output.metrics)
+            self._metric_steps += 1
+
+    @staticmethod
+    def _finalize(
+        sums: dict[str, torch.Tensor | float], steps: int
+    ) -> dict[str, float]:
+        """Divide the totals through and bring them back to the host."""
+        if steps == 0:
+            return {}
+        return {
+            key: (total.item() if isinstance(total, torch.Tensor) else float(total))
+            / steps
+            for key, total in sums.items()
+        }
+
+    def averages(self) -> tuple[dict[str, float], dict[str, float]]:
+        """Return the epoch-averaged losses and metrics as plain floats.
+
+        This is the only point at which values cross back from the device, so
+        it belongs at an epoch boundary rather than inside the step loop.
+
+        Returns:
+            ``(losses, metrics)``, each empty if nothing was accumulated.
+        """
+        return (
+            self._finalize(self._loss_sums, self._loss_steps),
+            self._finalize(self._metric_sums, self._metric_steps),
+        )

--- a/neuracore/ml/utils/memory_monitor.py
+++ b/neuracore/ml/utils/memory_monitor.py
@@ -64,7 +64,6 @@ class MemoryMonitor:
             )
 
         if self.gpu_id is not None and torch.cuda.is_available():
-            torch.cuda.synchronize()
             gpu_mem_reserved = torch.cuda.memory_reserved(self.gpu_id) / (1024**3)
             gpu_mem_total = torch.cuda.get_device_properties(
                 self.gpu_id

--- a/neuracore/ml/utils/training_storage_handler.py
+++ b/neuracore/ml/utils/training_storage_handler.py
@@ -81,6 +81,16 @@ class TrainingStorageHandler(UploadStorageMixin):
         self._pending_uploads_lock = threading.Lock()
         self._pending_uploads: dict[Path, Future] = {}
 
+        # Progress updates are fire-and-forget from the training loop's point
+        # of view. They get their own worker rather than sharing the upload
+        # one, so a multi-gigabyte checkpoint upload cannot leave reported
+        # progress stalled behind it.
+        self._progress_executor: ThreadPoolExecutor | None = None
+        self._progress_lock = threading.Lock()
+        self._pending_progress: tuple[int, int] | None = None
+        self._progress_future: Future | None = None
+        self._progress_worker_running = False
+
     def _get_upload_url(self, filepath: str, content_type: str) -> str:
         """Get a signed upload URL for a file in cloud storage.
 
@@ -373,21 +383,79 @@ class TrainingStorageHandler(UploadStorageMixin):
                 )
 
     def update_training_progress(self, epoch: int, step: int) -> None:
-        """Update training epoch/step progress in cloud storage.
+        """Queue a training epoch/step progress update for cloud storage.
+
+        Called from inside the training loop, so the HTTP PUT runs on a
+        background worker rather than blocking the step. Updates coalesce: if a
+        request is already in flight this replaces the payload that will be
+        sent next, instead of queueing another.
 
         Args:
             epoch: Current training epoch.
             step: Current training step.
         """
-        if self.log_to_cloud:
+        if not self.log_to_cloud:
+            return
+
+        with self._progress_lock:
+            self._pending_progress = (epoch, step)
+            if self._progress_worker_running:
+                # A worker is already draining and will observe what was just
+                # stored. The flag is cleared under this same lock, so a worker
+                # that has decided to exit cannot still be marked as running.
+                return
+            if self._progress_executor is None:
+                self._progress_executor = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="nc-training-progress"
+                )
+            self._progress_worker_running = True
+            self._progress_future = self._progress_executor.submit(
+                self._drain_progress_updates
+            )
+
+    def _drain_progress_updates(self) -> None:
+        """Send queued progress updates until none remain."""
+        while True:
+            with self._progress_lock:
+                pending = self._pending_progress
+                self._pending_progress = None
+                if pending is None:
+                    # Cleared in the same critical section that observes the
+                    # empty queue, so a concurrent enqueue either lands before
+                    # this and gets drained, or sees the flag cleared and
+                    # starts a fresh worker.
+                    self._progress_worker_running = False
+                    return
+            self._send_training_progress(*pending)
+
+    def _send_training_progress(self, epoch: int, step: int) -> None:
+        """Send one progress update, logging rather than raising on failure."""
+        try:
             response = self._put_request(
                 f"{API_URL}/org/{self.org_id}/training/jobs/{self.training_job_id}/update",
                 json={"epoch": epoch, "step": step, "error": None},
             )
-            if response.status_code != 200:
-                logger.error(
-                    f"Failed to update training progress to cloud: {response.text}"
-                )
+        except Exception:
+            logger.error("Failed to update training progress to cloud.", exc_info=True)
+            return
+        if response.status_code != 200:
+            logger.error(
+                f"Failed to update training progress to cloud: {response.text}"
+            )
+
+    def wait_for_pending_progress_updates(self) -> None:
+        """Block until any queued progress update has been sent.
+
+        Called before the process exits so the final epoch and step reach the
+        backend rather than dying with the worker thread.
+        """
+        with self._progress_lock:
+            future = self._progress_future
+        if future is not None:
+            try:
+                future.result()
+            except Exception:
+                logger.error("Progress update worker failed.", exc_info=True)
 
     def report_training_error(self, error: str) -> None:
         """Report a training failure to cloud storage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ml = [
     "hydra-core>=1.3.0",
     "tensorboard>=2",
     "names-generator>=0.2.0",
+    "nvidia-ml-py"
 ]
 dev = [
     "pytest>=6.2.5",

--- a/tests/unit/ml/logging/test_system_metrics.py
+++ b/tests/unit/ml/logging/test_system_metrics.py
@@ -88,5 +88,8 @@ def test_unavailable_nvml_is_tolerated_and_not_retried():
 
 
 def test_prefix_groups_separately_from_model_metrics():
-    assert SYSTEM_METRIC_PREFIX == "System"
+    """These are machine metrics, so they must not land under train/ or val/."""
+    assert SYSTEM_METRIC_PREFIX
+    assert SYSTEM_METRIC_PREFIX not in ("train", "val")
+    # _log_scalars joins with a slash, so carrying one here would double it.
     assert not SYSTEM_METRIC_PREFIX.endswith("/")

--- a/tests/unit/ml/trainers/test_histogram_gating.py
+++ b/tests/unit/ml/trainers/test_histogram_gating.py
@@ -1,0 +1,84 @@
+"""Tests for when weight and gradient histograms are collected."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+from neuracore.ml.trainers.distributed_trainer import DistributedTrainer
+
+
+def _trainer(tmp_path: Path, **kwargs) -> DistributedTrainer:
+    model = nn.Linear(2, 2)
+    model.configure_optimizers = lambda: [torch.optim.SGD(model.parameters(), lr=0.1)]
+    model.configure_schedulers = lambda optimizers, steps: []
+
+    storage_handler = MagicMock()
+    storage_handler.log_to_cloud = kwargs.pop("log_to_cloud", False)
+    training_logger = MagicMock()
+    training_logger.supports_histograms = kwargs.pop("supports_histograms", True)
+
+    loader = MagicMock()
+    loader.__len__ = lambda _self: 10
+    loader.batch_size = 4
+
+    return DistributedTrainer(
+        model=model,
+        train_loader=loader,
+        val_loader=loader,
+        training_logger=training_logger,
+        storage_handler=storage_handler,
+        output_dir=tmp_path,
+        num_epochs=1,
+        device=torch.device("cpu"),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected, reason",
+    [
+        ({}, True, "collected alongside the other step metrics by default"),
+        (
+            {"supports_histograms": False},
+            False,
+            "backend discards them, so building them is pure waste",
+        ),
+        (
+            {"rank": 1},
+            False,
+            "non-zero ranks would race into one TensorBoard directory",
+        ),
+    ],
+)
+def test_histograms_are_only_collected_when_they_are_wanted(
+    tmp_path, kwargs, expected, reason
+):
+    assert _trainer(tmp_path, **kwargs)._histograms_enabled is expected, reason
+
+
+def test_disabled_histograms_do_not_walk_the_model(tmp_path):
+    """The cost is iterating every parameter, so the guard must precede it."""
+    trainer = _trainer(tmp_path, supports_histograms=False)
+
+    trainer._log_gradients(step=0)
+    trainer._log_weights(step=0)
+
+    trainer.training_logger.log_histogram.assert_not_called()
+
+
+def test_enabled_histograms_reach_the_logger(tmp_path):
+    trainer = _trainer(tmp_path)
+
+    trainer._log_weights(step=0)
+
+    assert trainer.training_logger.log_histogram.called
+
+
+def test_progress_bar_is_off_when_logs_go_to_the_cloud(tmp_path):
+    """Nobody reads the bar on a cloud run, and rendering it costs a sync."""
+    assert _trainer(tmp_path, log_to_cloud=True)._pbar_enabled is False
+    assert _trainer(tmp_path, log_to_cloud=False)._pbar_enabled is True
+    assert _trainer(tmp_path, rank=1)._pbar_enabled is False

--- a/tests/unit/ml/trainers/test_metric_accumulator.py
+++ b/tests/unit/ml/trainers/test_metric_accumulator.py
@@ -1,0 +1,70 @@
+"""Tests for epoch metric accumulation."""
+
+import torch
+
+from neuracore.ml import BatchedTrainingOutputs
+from neuracore.ml.trainers.metric_accumulator import MetricAccumulator
+
+
+def test_averages_losses_and_metrics_over_the_epoch():
+    accumulator = MetricAccumulator()
+    for step in range(4):
+        accumulator.update(
+            BatchedTrainingOutputs(
+                losses={"l1": torch.tensor(float(step)), "l2": torch.tensor(2.0)},
+                metrics={"m": torch.tensor(float(step) * 3)},
+            )
+        )
+
+    losses, metrics = accumulator.averages()
+
+    assert losses == {"l1": 1.5, "l2": 2.0}
+    assert metrics == {"m": 4.5}
+
+
+def test_empty_accumulator_yields_nothing():
+    assert MetricAccumulator().averages() == ({}, {})
+
+
+def test_values_are_summed_without_leaving_the_device():
+    """The point of this class is avoiding a device sync on every step.
+
+    Reading a tensor back with .item() per loss per step is what it replaces,
+    so the running totals must stay tensors until the epoch ends.
+    """
+    accumulator = MetricAccumulator()
+    accumulator.update(
+        BatchedTrainingOutputs(losses={"l": torch.tensor(1.0)}, metrics={})
+    )
+    accumulator.update(
+        BatchedTrainingOutputs(losses={"l": torch.tensor(3.0)}, metrics={})
+    )
+
+    assert isinstance(accumulator._loss_sums["l"], torch.Tensor)
+    assert accumulator.averages()[0] == {"l": 2.0}
+
+
+def test_accumulated_tensors_are_detached():
+    """Holding graph-attached tensors for a whole epoch would leak the graph."""
+    accumulator = MetricAccumulator()
+    weight = torch.tensor(2.0, requires_grad=True)
+
+    accumulator.update(BatchedTrainingOutputs(losses={"l": weight * 3}, metrics={}))
+
+    assert not accumulator._loss_sums["l"].requires_grad
+
+
+def test_metrics_are_counted_independently_of_losses():
+    """A model that reports losses but no metrics must still average cleanly."""
+    accumulator = MetricAccumulator()
+    accumulator.update(
+        BatchedTrainingOutputs(losses={"l": torch.tensor(4.0)}, metrics={})
+    )
+    accumulator.update(
+        BatchedTrainingOutputs(losses={"l": torch.tensor(2.0)}, metrics={})
+    )
+
+    losses, metrics = accumulator.averages()
+
+    assert losses == {"l": 3.0}
+    assert metrics == {}

--- a/tests/unit/ml/utils/test_training_storage_handler.py
+++ b/tests/unit/ml/utils/test_training_storage_handler.py
@@ -551,6 +551,7 @@ class TestUpdateTrainingProgress:
         requests_mock.put(f"{BASE_JOB_URL}/update", status_code=200)
 
         handler.update_training_progress(epoch=3, step=150)
+        handler.wait_for_pending_progress_updates()
 
         put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
         assert len(put_requests) == 1
@@ -562,14 +563,54 @@ class TestUpdateTrainingProgress:
         matcher = requests_mock.put(f"{BASE_JOB_URL}/update", status_code=401)
 
         handler.update_training_progress(epoch=3, step=150)
+        handler.wait_for_pending_progress_updates()
 
         assert matcher.call_count == 1
         assert not login.called
 
     def test_makes_no_http_request_without_job_id(self, local_handler, requests_mock):
         local_handler.update_training_progress(epoch=1, step=1)
+        local_handler.wait_for_pending_progress_updates()
 
         assert len(requests_mock.request_history) == 0
+
+    def test_coalesces_updates_queued_while_one_is_in_flight(
+        self, handler, requests_mock
+    ):
+        """A backlog of stale progress must not build up behind a slow endpoint.
+
+        The first request is held until further updates have been queued, so
+        the worker is guaranteed to still be busy when they arrive. Only the
+        newest of those should be sent afterwards.
+        """
+        first_put_started = threading.Event()
+        release_first_put = threading.Event()
+
+        def _blocking_response(request, context):
+            if not first_put_started.is_set():
+                first_put_started.set()
+                release_first_put.wait(timeout=5)
+            context.status_code = 200
+            return ""
+
+        requests_mock.put(f"{BASE_JOB_URL}/update", text=_blocking_response)
+
+        handler.update_training_progress(epoch=1, step=10)
+        assert first_put_started.wait(timeout=5)
+        handler.update_training_progress(epoch=1, step=20)
+        handler.update_training_progress(epoch=1, step=30)
+        release_first_put.set()
+        handler.wait_for_pending_progress_updates()
+
+        put_requests = [r for r in requests_mock.request_history if r.method == "PUT"]
+        assert [r.json()["step"] for r in put_requests] == [10, 30]
+
+    def test_a_failing_update_does_not_propagate(self, handler, requests_mock):
+        """Progress reporting is best-effort; it must not fail a training run."""
+        requests_mock.put(f"{BASE_JOB_URL}/update", exc=ConnectionError("down"))
+
+        handler.update_training_progress(epoch=3, step=150)
+        handler.wait_for_pending_progress_updates()
 
 
 class TestReportTrainingError:


### PR DESCRIPTION
### Bugfixes / Features
<!-- Please explain any existing functionality improved/changed -->
 - Dropped a full device barrier from every training step. `MemoryMonitor.check_memory` called `torch.cuda.synchronize()` before reading `memory_reserved()`, which is host-side allocator bookkeeping and
   accurate without one. 
 - `MemoryMonitor` defaults to `gpu_id=0`, so on multi-GPU every rank was watching GPU 0's memory instead of its own. It now takes the rank's device.
 - Removed the per-step device-to-host syncs. Losses and metrics accumulate on device via `MetricAccumulator` and are read back once per epoch, replacing an `.item()` per loss and per metric per step. This also drops two unbounded per-step lists that were held for a whole epoch.
 - `pbar.set_postfix` called `loss.item()` unconditionally, including on cloud runs where the bar is disabled and nobody sees the result. It is now gated on the bar being visible and on it being a logging step.
 - Weight and gradient histograms are skipped when the backend discards them (`CloudTrainingLogger.log_histogram` is a no-op, so cloud runs walked every parameter twice per logging step for nothing) and on non-zero ranks, which were racing into one TensorBoard directory. `_log_scalars` was already  rank-guarded; these two were not. 
 - Training progress updates no longer block the training loop on an HTTPS PUT. They run on their own worker with coalescing, so a slow endpoint costs staleness rather than a backlog, and are flushed before the process exits.
