### PR TITLE
fix: let any process publish the recording stop, named by window marker

### DIFF
--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -532,7 +532,9 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
+    current_recording_id = robot.get_current_recording_id()
+    if current_recording_id is not None:
+        robot.arm_video_boundary_if_new_recording(current_recording_id)
         contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
         robot._get_daemon_recording_context().log_frame(
             camera_type.value,

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -10,6 +10,7 @@ import io
 import logging
 import os
 import tempfile
+import threading
 import time
 import uuid
 import xml.etree.ElementTree as ET
@@ -121,6 +122,11 @@ class Robot:
         )
         self._joint_group_cache: "dict[DataType, ResolvedJointGroup]" = dict()
         self._daemon_recording_context: DaemonRecordingContext | None = None
+        # Did *this* process open the daemon's window for the current recording?
+        self._owns_daemon_recording = False
+        # Guarded by `_boundary_lock` so concurrent camera threads arm once.
+        self._armed_boundary_handle: str | None = None
+        self._boundary_lock = threading.Lock()
 
         self.org_id = org_id or get_current_org()
 
@@ -308,6 +314,8 @@ class Robot:
                 dataset_name=None,
                 timestamp=timestamp,
             )
+            self._owns_daemon_recording = True
+            self._armed_boundary_handle = local_handle
         except Exception:
             # The gate is open with no window behind it.
             get_recording_state_manager().recording_stopped(
@@ -348,15 +356,10 @@ class Robot:
         recording_id: str | None,
         timestamp: float | None = None,
     ) -> None:
-        """Stop all streams and send the recording-stopped IPC message to the daemon.
+        """Stop all streams and send the recording-stopped IPC message.
 
-        The local ``log_*`` gate closes in the instant between the window
-        closing and the writer's tail-chunk barrier. Closing
-        it before the notify would silently discard data the daemon would still
-        have accepted — the window is open until it receives the stop. Closing it
-        after the barrier instead leaves it open for as long as the writer's
-        backlog takes to drain (over a second under burst logging), publishing
-        data the daemon has already stopped accepting and simply throws away.
+        Every process publishes its own stop; the daemon reconciles it
+        against the window it names rather than whichever's live.
         """
         try:
             self._stop_all_streams()
@@ -364,6 +367,7 @@ class Robot:
             try:
                 context.stop_recording(timestamp=timestamp)
             finally:
+                self._owns_daemon_recording = False
                 # Both run even if the notify failed.
                 self._close_local_recording_gate()
                 context.flush_source()
@@ -426,6 +430,21 @@ class Robot:
         return get_recording_state_manager().get_current_recording_id(
             robot_id=self.id, instance=self.instance
         )
+
+    def arm_video_boundary_if_new_recording(self, recording_id: str) -> None:
+        """Roll this process's video chunk and adopt its stop marker for *recording_id*.
+
+        A no-op in the owning process, which already has both.
+        """
+        if self._owns_daemon_recording:
+            return
+        with self._boundary_lock:
+            if self._armed_boundary_handle == recording_id:
+                return
+            self._armed_boundary_handle = recording_id
+        context = self._get_daemon_recording_context()
+        context.adopt_recording_marker(recording_id)
+        context.mark_recording_boundary()
 
     def get_cloud_recording_id(
         self, timestamp_ns: int | None = None, timeout_s: float = 30.0

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -62,7 +62,9 @@ class TrackedRecording(NamedTuple):
     start_time: float
 
 
-def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
+def _notify_data_bridge_of_expiry(
+    robot_id: str, instance: int, recording_id: str
+) -> None:
     """Tell the producer a source's recording has been locally auto-expired.
 
     Publishes the stop, then runs ``flush_source``, which is not part of the
@@ -72,7 +74,10 @@ def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
     """
     try:
         native = _recording_context._load_native()
-        native.stop_recording(robot_id, instance, time.time_ns())
+        # A short timeout: this runs on the shared SSE event loop, so a slow
+        # or absent daemon must not stall every other instance's stream.
+        window_marker_ns = native.resolve_window_marker(recording_id, 1.0)
+        native.stop_recording(robot_id, instance, time.time_ns(), window_marker_ns)
         native.flush_source(robot_id, instance)
     except Exception:
         logger.exception(
@@ -292,7 +297,7 @@ class RecordingStateManager(BaseSSEConsumer):
                 )
                 self._expired_recording_ids.add(recording_id)
                 self.recording_stopped(robot_id, instance, recording_id)
-                _notify_data_bridge_of_expiry(robot_id, instance)
+                _notify_data_bridge_of_expiry(robot_id, instance, recording_id)
 
         loop = get_running_loop()
 

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -57,11 +57,13 @@ class RecordingContext:
     A *thin shipper* bridge: ``start_recording`` / ``log_joints`` / ``log_frame``
     / ``log_json`` / ``stop_recording`` / ``cancel_recording`` forward straight
     through to ``_data_bridge`` over iceoryx2, tagged only with the **source**
-    ``(robot_id, robot_instance)``. The daemon owns all recording identity —
-    there is no recording id on the wire, so this class carries none. Routing
-    is by a producer-stamped *publish* timestamp (wall clock), decoupled from
-    the data's own capture timestamp, so the daemon partitions recordings by
+    ``(robot_id, robot_instance)``. The daemon owns all recording identity — no
+    recording id travels on the data-plane envelopes. Routing is by a
+    producer-stamped *publish* timestamp (wall clock), decoupled from the
+    data's own capture timestamp, so the daemon partitions recordings by
     when data was published rather than what clock it carries.
+    ``stop_recording`` is the exception: it carries the window's start
+    marker so any process may call it.
     """
 
     def __init__(self) -> None:
@@ -251,9 +253,27 @@ class RecordingContext:
         if not self._robot_id:
             return
         timestamp_ns = int(timestamp * 1_000_000_000) if timestamp is not None else None
+        window_marker_ns = self._recording_marker_ns or None
         _load_native().stop_recording(
-            self._robot_id, self._robot_instance, timestamp_ns
+            self._robot_id, self._robot_instance, timestamp_ns, window_marker_ns
         )
+
+    def adopt_recording_marker(self, recording_id: str, timeout_s: float = 5.0) -> None:
+        """Resolve and adopt the marker of a recording this context didn't open.
+
+        No-op if the daemon doesn't resolve one within ``timeout_s``.
+        """
+        if not self._robot_id:
+            return
+        marker_ns = _load_native().resolve_window_marker(recording_id, timeout_s)
+        if marker_ns is not None:
+            self._recording_marker_ns = marker_ns
+
+    def mark_recording_boundary(self) -> None:
+        """Arm the writer's boundary split for a process that did not start it."""
+        if not self._robot_id:
+            return
+        _load_native().mark_recording_boundary(self._robot_id, self._robot_instance)
 
     def flush_source(self) -> None:
         """Run the writer's deferred tail-chunk barrier for the bound source.

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use data_daemon_shared::{
     Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, VersionReply,
-    VersionRequest,
+    VersionRequest, WindowMarkerQuery, WindowMarkerReply,
 };
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
@@ -77,6 +77,7 @@ pub async fn run(
         recording_ids = data_daemon_shared::service_name::RECORDING_IDS,
         health = data_daemon_shared::service_name::HEALTH,
         version = data_daemon_shared::service_name::VERSION,
+        window_markers = data_daemon_shared::service_name::WINDOW_MARKERS,
         "ipc listener started"
     );
 
@@ -129,6 +130,12 @@ pub async fn run(
         // borrow makes this future `!Send`, which is fine: `run` is awaited
         // inline under `block_on`, never `tokio::spawn`'d.
         serve_recording_id_queries(transport.recording_id_server(), &store).await;
+
+        // -- Answer window-marker queries -----------------------------------
+        // A non-owning producer resolves the marker it needs to name a
+        // `StopRecording`'s window from the daemon's own store, same as the
+        // recording-id queries above.
+        serve_window_marker_queries(transport.window_marker_server(), &store).await;
 
         // -- Yield / shutdown ---------------------------------------------------
         // Poll fast while data is flowing; relax once the bus has been empty
@@ -294,6 +301,58 @@ async fn serve_recording_id_queries(
                 Err(error) => tracing::warn!(%error, "failed to loan recording-id reply sample"),
             },
             Err(error) => tracing::warn!(%error, "failed to encode recording-id reply"),
+        }
+    }
+}
+
+/// Drain every pending window-marker query, answering each from the daemon's
+/// own store. Mirrors [`serve_recording_id_queries`], reversed (cloud id →
+/// marker rather than marker → cloud id).
+async fn serve_window_marker_queries(
+    server: &Server<ipc::Service, [u8], (), [u8], ()>,
+    store: &Arc<SqliteStateStore>,
+) {
+    loop {
+        let active = match server.receive() {
+            Ok(Some(active)) => active,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(%error, "window-marker server receive failed");
+                return;
+            }
+        };
+
+        let query = match WindowMarkerQuery::decode(active.payload()) {
+            Ok(query) => query,
+            Err(error) => {
+                tracing::warn!(%error, "dropping malformed window-marker query");
+                continue;
+            }
+        };
+
+        let window_marker_ns = match store
+            .resolve_marker_for_recording_id(&query.recording_id)
+            .await
+        {
+            Ok(window_marker_ns) => window_marker_ns,
+            Err(error) => {
+                tracing::warn!(%error, recording_id = query.recording_id, "window-marker lookup failed");
+                None
+            }
+        };
+
+        let reply = WindowMarkerReply { window_marker_ns };
+        match reply.encode() {
+            Ok(bytes) => match active.loan_slice_uninit(bytes.len()) {
+                Ok(response) => {
+                    let response = response.write_from_slice(&bytes);
+                    if let Err(error) = response.send() {
+                        tracing::warn!(%error, "failed to send window-marker reply");
+                    }
+                }
+                Err(error) => tracing::warn!(%error, "failed to loan window-marker reply sample"),
+            },
+            Err(error) => tracing::warn!(%error, "failed to encode window-marker reply"),
         }
     }
 }

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -14,7 +14,8 @@ use data_daemon_shared::service_name::{
     COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
     MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
-    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
+    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES, WINDOW_MARKERS,
+    WINDOW_MARKER_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
 use iceoryx2::port::server::Server;
@@ -106,6 +107,11 @@ pub struct IpcTransport {
     version_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the version server.
     _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response server on `neuracore/data_daemon/window_markers` that
+    /// answers a non-owning producer's window-marker lookups.
+    window_marker_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the window-marker server.
+    _window_marker_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
 }
 
 impl IpcTransport {
@@ -135,6 +141,8 @@ impl IpcTransport {
             open_query_server(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
         let (version_service, version_server) =
             open_query_server(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
+        let (window_marker_service, window_marker_server) =
+            open_query_server(&node, WINDOW_MARKERS, WINDOW_MARKER_MAX_PAYLOAD_BYTES)?;
 
         Ok(IpcTransport {
             _node: node,
@@ -146,6 +154,8 @@ impl IpcTransport {
             _health_service: health_service,
             version_server,
             _version_service: version_service,
+            window_marker_server,
+            _window_marker_service: window_marker_service,
         })
     }
 
@@ -167,6 +177,11 @@ impl IpcTransport {
     /// Borrow the `version` request-response server port.
     pub fn version_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
         &self.version_server
+    }
+
+    /// Borrow the `window_markers` request-response server port.
+    pub fn window_marker_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.window_marker_server
     }
 }
 

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -193,6 +193,9 @@ struct TraceHandle {
 /// the producer published, which is exactly "which recording was active then".
 struct ActiveWindow {
     recording_index: i64,
+    /// The window's own start capture marker (`StartRecording`'s
+    /// `timestamp_ns`).
+    capture_marker_ns: i64,
     /// Inclusive lower bound — the lifecycle publish time of the start.
     started_at_ns: i64,
     /// Exclusive upper bound — the lifecycle publish time of the stop. `None`
@@ -426,11 +429,13 @@ impl Dispatcher {
                 robot_instance,
                 publish_timestamp_ns,
                 timestamp_ns,
+                window_marker_ns,
             } => {
                 self.handle_stop(
                     (robot_id, robot_instance),
                     publish_timestamp_ns,
                     timestamp_ns,
+                    window_marker_ns,
                     recv_at,
                 )
                 .await;
@@ -667,6 +672,7 @@ impl Dispatcher {
         }
         entry.live = Some(ActiveWindow {
             recording_index,
+            capture_marker_ns: timestamp_ns,
             started_at_ns: publish_timestamp_ns,
             stopped_at_ns: None,
             stop_recv_at: None,
@@ -703,6 +709,7 @@ impl Dispatcher {
         source: Source,
         publish_timestamp_ns: i64,
         timestamp_ns: i64,
+        window_marker_ns: Option<i64>,
         recv_at: Instant,
     ) {
         let Some(entry) = self.windows.get_mut(&source) else {
@@ -711,17 +718,22 @@ impl Dispatcher {
         };
         entry.last_seen = Some(recv_at);
 
-        // A stop whose publish time falls inside the live window closes the live
-        // recording normally. A stop that predates the live window is a delayed
+        // A stop naming a marker identifies its window by that marker alone,
+        // regardless of whether the stop's publish time happens to fall inside
+        // some other window.
+        let window_matches = |window: &ActiveWindow| match window_marker_ns {
+            Some(token) => token == window.capture_marker_ns,
+            None => window.contains(publish_timestamp_ns),
+        };
+
+        // A stop matching the live window closes it normally. A stop matching
+        // no live window (predates it / names a different one) is a delayed
         // stop for a recording `handle_start` already retired (an inverted
-        // start/stop pair) — it is matched against the closing windows instead.
-        // Both paths converge on the shared post-persist tail below, so a
-        // retired recording also becomes notifiable (fires `RecordingStopped`).
-        let recording_index = if entry
-            .live
-            .as_ref()
-            .is_some_and(|window| window.contains(publish_timestamp_ns))
-        {
+        // start/stop pair, or a slow non-owner) — matched against the closing
+        // windows instead. Both paths converge on the shared post-persist tail
+        // below, so a retired recording also becomes notifiable (fires
+        // `RecordingStopped`).
+        let recording_index = if entry.live.as_ref().is_some_and(&window_matches) {
             let mut window = entry
                 .live
                 .take()
@@ -746,11 +758,7 @@ impl Dispatcher {
                 return;
             }
             recording_index
-        } else if let Some(position) = entry
-            .closing
-            .iter()
-            .rposition(|window| window.contains(publish_timestamp_ns))
-        {
+        } else if let Some(position) = entry.closing.iter().rposition(window_matches) {
             let window = &mut entry.closing[position];
             let recording_index = window.recording_index;
             // Deliberately DO NOT narrow the window's in-memory `stopped_at_ns`
@@ -770,30 +778,45 @@ impl Dispatcher {
             window.stop_recv_at = Some(recv_at);
             window.awaiting_flush = true;
             window.flushed_producers.clear();
-            tracing::warn!(
-                robot_id = source.0,
-                recording_index,
-                "stop arrived after a later recording started; refining the retired recording's stop"
-            );
-            // Refine the row's `stop_timestamp_ns` (→ backend `end_time`) to
-            // this true capture stop. `handle_start` already marked the row with
-            // the successor start's time, and `mark_recording_stopped` is
-            // COALESCE-idempotent, so a plain re-mark would no-op — a forced
-            // overwrite is required, and correct because `stop < successor
-            // start`.
-            if let Err(error) = self
-                .store
-                .refine_recording_stop(recording_index, timestamp_ns)
-                .await
-            {
-                tracing::warn!(%error, recording_index, "failed to refine retired recording stop");
-                return;
+            // A marker match can land here from a stop that is simply late;
+            // only refine the stop time if it's actually earlier than what's
+            // already recorded.
+            let refines_stop = window
+                .stopped_at_ns
+                .is_none_or(|stop| publish_timestamp_ns < stop);
+            if refines_stop {
+                tracing::warn!(
+                    robot_id = source.0,
+                    recording_index,
+                    "stop arrived after a later recording started; refining the retired recording's stop"
+                );
+                // Refine the row's `stop_timestamp_ns` (→ backend `end_time`) to
+                // this true capture stop. `handle_start` already marked the row with
+                // the successor start's time, and `mark_recording_stopped` is
+                // COALESCE-idempotent, so a plain re-mark would no-op — a forced
+                // overwrite is required, and correct because `stop < successor
+                // start`.
+                if let Err(error) = self
+                    .store
+                    .refine_recording_stop(recording_index, timestamp_ns)
+                    .await
+                {
+                    tracing::warn!(%error, recording_index, "failed to refine retired recording stop");
+                    return;
+                }
+            } else {
+                tracing::debug!(
+                    robot_id = source.0,
+                    recording_index,
+                    "late stop matched a retired window by marker but carries no new stop time; retention bumped only"
+                );
             }
             recording_index
         } else {
             tracing::debug!(
                 robot_id = source.0,
                 publish_timestamp_ns,
+                window_marker_ns,
                 "stop does not belong to any retained recording window; ignoring"
             );
             return;
@@ -1468,11 +1491,22 @@ mod tests {
     }
 
     fn stop(robot: &str, publish_timestamp_ns: i64) -> Envelope {
+        stop_with_marker(robot, publish_timestamp_ns, None)
+    }
+
+    /// As [`stop`], naming the window it means via `window_marker_ns` — what a
+    /// non-owning process sends once it has resolved one.
+    fn stop_with_marker(
+        robot: &str,
+        publish_timestamp_ns: i64,
+        window_marker_ns: Option<i64>,
+    ) -> Envelope {
         Envelope::StopRecording {
             robot_id: robot.into(),
             robot_instance: 0,
             publish_timestamp_ns,
             timestamp_ns: publish_timestamp_ns,
+            window_marker_ns,
         }
     }
 
@@ -1796,6 +1830,76 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn late_marked_stop_names_its_own_window_not_whatever_is_live() {
+        // Unlike the inversion above, this late stop's publish time does NOT
+        // predate the next recording's start — it arrives well *inside* B's
+        // live window, exactly as a non-owning process's SSE-driven stop for A
+        // would if delayed past B's start. A time-only match would wrongly
+        // close B here; naming A's marker must route it to the already-closed
+        // A instead and leave B running.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let (tx, handle) = spawn(store.clone(), context.clone(), shutdown_rx);
+
+        tx.send(start("robot-1", 100)).await.unwrap(); // A, marker=100
+        tx.send(stop_with_marker("robot-1", 150, Some(100)))
+            .await
+            .unwrap(); // A's own, on-time stop
+        tx.send(start("robot-1", 200)).await.unwrap(); // B, marker=200
+        tx.send(datum("robot-1", 210, 1)).await.unwrap();
+        // A's late, non-owner stop: publish time 250 is inside B's live range.
+        tx.send(stop_with_marker("robot-1", 250, Some(100)))
+            .await
+            .unwrap();
+        tx.send(datum("robot-1", 260, 2)).await.unwrap();
+        tx.send(stop_with_marker("robot-1", 300, Some(200)))
+            .await
+            .unwrap(); // B's own stop
+
+        drop(tx);
+        timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 2);
+        let recording_a = &recordings[0];
+        let recording_b = &recordings[1];
+
+        assert_eq!(
+            recording_a.stop_timestamp_ns,
+            Some(150),
+            "A's late, marker-matched stop must not overwrite its true (earlier) stop time"
+        );
+        assert_eq!(
+            recording_b.stop_timestamp_ns,
+            Some(300),
+            "B must close only on its own stop, not the late stop meant for A"
+        );
+
+        let b_traces = store
+            .list_traces_for_recording(recording_b.recording_index)
+            .await
+            .unwrap();
+        assert_eq!(
+            b_traces.len(),
+            1,
+            "B keeps both its data points (ts=210 and ts=260), not orphaned by an early close"
+        );
+        let b_dir = TracePath::new(
+            recording_b.recording_index.to_string(),
+            "joints",
+            b_traces[0].trace_id.clone(),
+        )
+        .directory(context.recordings_root.as_path());
+        let b: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(b_dir.join("trace.json")).unwrap()).unwrap();
+        assert_eq!(b, serde_json::json!([{"i": 1}, {"i": 2}]));
+    }
+
     #[test]
     fn frames_inside_window_cuts_at_the_stop_boundary() {
         // `video_boundary` tests the cut; this pins the argument order.
@@ -1953,7 +2057,7 @@ mod tests {
             .handle_start(source.clone(), None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .handle_stop(source.clone(), stop_ns, stop_ns, None, opened_at)
             .await;
 
         let (publish_ts, thread_id) = (150, 7);
@@ -1997,7 +2101,7 @@ mod tests {
             .handle_start(source.clone(), None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .handle_stop(source.clone(), stop_ns, stop_ns, None, opened_at)
             .await;
 
         let (publish_ts, thread_id) = (150, 7);
@@ -2286,7 +2390,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
         assert_eq!(
             dispatcher.windows.get(&source).unwrap().closing.len(),
@@ -2328,7 +2432,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // Well past the retention deadline.
@@ -2374,7 +2478,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         let at_cap = stopped_at + FLUSH_MARKER_WAIT_CAP + Duration::from_millis(1);
@@ -2428,7 +2532,7 @@ mod tests {
 
         let stopped_at = opened_at + Duration::from_millis(2);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // The lifecycle process owns no video, so its marker lands at once.
@@ -2489,7 +2593,7 @@ mod tests {
             .handle_start(source.clone(), None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), 200, 200, opened_at)
+            .handle_stop(source.clone(), 200, 200, None, opened_at)
             .await;
 
         // Published after the stop: past every window's upper bound.
@@ -2538,7 +2642,7 @@ mod tests {
 
         let stopped_at = opened_at + Duration::from_millis(2);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // Producer B owns no video, so its marker lands immediately.

--- a/rust/data_daemon/src/state/store.rs
+++ b/rust/data_daemon/src/state/store.rs
@@ -303,6 +303,13 @@ pub trait StateStore: Send + Sync {
         start_timestamp_ns: i64,
     ) -> Result<Option<String>, StateStoreError>;
 
+    /// Resolve the start capture marker (`start_timestamp_ns`) of the
+    /// recording identified by its cloud `recording_id`.
+    async fn resolve_marker_for_recording_id(
+        &self,
+        recording_id: &str,
+    ) -> Result<Option<i64>, StateStoreError>;
+
     /// Atomically transition `progress_reported` for `recording_id`.
     ///
     /// `expected` is the status the caller observed before the request — if
@@ -1318,6 +1325,21 @@ impl StateStore for SqliteStateStore {
         // Outer `Option` = row present; inner = the nullable column. A matching
         // row whose cloud id has not been minted yet flattens to `None`.
         Ok(recording_id.flatten())
+    }
+
+    async fn resolve_marker_for_recording_id(
+        &self,
+        recording_id: &str,
+    ) -> Result<Option<i64>, StateStoreError> {
+        let marker = sqlx::query_scalar::<_, i64>(
+            "SELECT start_timestamp_ns FROM recordings \
+              WHERE recording_id = ?1 AND cancelled_at IS NULL \
+           ORDER BY recording_index DESC LIMIT 1",
+        )
+        .bind(recording_id)
+        .fetch_optional(&self.read_pool)
+        .await?;
+        Ok(marker)
     }
 
     async fn mark_recording_stop_notified(

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -48,7 +48,7 @@ mod publisher;
 mod query;
 mod writer;
 
-use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery};
+use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery, WindowMarkerQuery};
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -57,7 +57,7 @@ use crate::publisher::{
     flush_published_data, now_ns, publish, publisher_tx, ProducerError, PublishMsg,
 };
 use crate::query::{
-    daemon_version as daemon_version_impl, resolve_recording_id,
+    daemon_version as daemon_version_impl, resolve_recording_id, resolve_window_marker_ns,
     wait_until_ready as wait_until_ready_impl,
 };
 use crate::writer::{note_video_activity, writer_queue, FrameJob, WriterMsg};
@@ -330,13 +330,17 @@ fn log_json(
 /// supplied, else the publish time) is separate — it is stored as
 /// `stop_timestamp_ns` and POSTed as the backend `end_time`, never used for
 /// window membership.
+///
+/// `window_marker_ns` names the window this stop is meant for (the start's
+/// own capture marker), so any process may call this.
 #[pyfunction]
-#[pyo3(signature = (robot_id, robot_instance, timestamp_ns = None))]
+#[pyo3(signature = (robot_id, robot_instance, timestamp_ns = None, window_marker_ns = None))]
 fn stop_recording(
     py: Python<'_>,
     robot_id: &str,
     robot_instance: i64,
     timestamp_ns: Option<i64>,
+    window_marker_ns: Option<i64>,
 ) -> PyResult<()> {
     if robot_id.is_empty() {
         return Err(PyValueError::new_err("robot_id must not be empty"));
@@ -370,11 +374,30 @@ fn stop_recording(
             robot_instance,
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
+            window_marker_ns,
         })?;
         // Split from [`flush_source`] so the caller can close its logging gate
         // in between, rather than after a backlog-length barrier.
         Ok(())
     })
+}
+
+/// Arm a window-boundary split for a source without publishing a recording
+/// lifecycle event.
+#[pyfunction]
+fn mark_recording_boundary(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let robot_id = robot_id.to_string();
+    py.detach(|| {
+        let _ = writer_queue().push(WriterMsg::Boundary {
+            robot_id,
+            robot_instance,
+            publish_ns: now_ns(),
+        });
+    });
+    Ok(())
 }
 
 /// Run the writer's stop barrier for a source: drain every frame still queued
@@ -515,6 +538,28 @@ fn get_recording_id(
     })
 }
 
+/// Resolve a recording's start capture marker from its cloud `recording_id`,
+/// blocking with the GIL released until it is available or `timeout_s`
+/// elapses. The marker is meant for `stop_recording`'s `window_marker_ns`.
+#[pyfunction]
+#[pyo3(signature = (recording_id, timeout_s))]
+fn resolve_window_marker(
+    py: Python<'_>,
+    recording_id: &str,
+    timeout_s: f64,
+) -> PyResult<Option<i64>> {
+    if recording_id.is_empty() {
+        return Err(PyValueError::new_err("recording_id must not be empty"));
+    }
+    let query = WindowMarkerQuery {
+        recording_id: recording_id.to_string(),
+    };
+    let request_bytes = query.encode().map_err(ProducerError::from)?;
+    py.detach(|| -> PyResult<Option<i64>> {
+        Ok(resolve_window_marker_ns(&request_bytes, timeout_s)?)
+    })
+}
+
 /// Wait until the Rust daemon answers a side-effect-free IPC health probe.
 #[pyfunction]
 #[pyo3(signature = (timeout_s))]
@@ -556,9 +601,11 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;
     module.add_function(wrap_pyfunction!(log_json, module)?)?;
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
+    module.add_function(wrap_pyfunction!(mark_recording_boundary, module)?)?;
     module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
+    module.add_function(wrap_pyfunction!(resolve_window_marker, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(daemon_version, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -46,7 +46,7 @@ use data_daemon_shared::service_name::{
     LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE, MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE,
     MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION,
-    VERSION_MAX_PAYLOAD_BYTES,
+    VERSION_MAX_PAYLOAD_BYTES, WINDOW_MARKERS, WINDOW_MARKER_MAX_PAYLOAD_BYTES,
 };
 use data_daemon_shared::{BatchedDataItem, Envelope};
 use iceoryx2::node::{Node, NodeBuilder};
@@ -117,6 +117,12 @@ pub(crate) struct ProducerState {
     _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
     /// Request-response client used to read the running daemon's build version.
     pub(crate) version_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the window-marker client so port
+    /// discovery doesn't race the handle going out of scope.
+    _window_marker_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response client used by a non-owning producer to resolve a
+    /// window's start capture marker from its cloud `recording_id`.
+    pub(crate) window_marker_client: Client<ipc::Service, [u8], (), [u8], ()>,
 }
 
 /// Work item for the publisher thread.
@@ -378,6 +384,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         open_query_client(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
     let (version_service, version_client) =
         open_query_client(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
+    let (window_marker_service, window_marker_client) =
+        open_query_client(&node, WINDOW_MARKERS, WINDOW_MARKER_MAX_PAYLOAD_BYTES)?;
 
     Ok(ProducerState {
         _node: node,
@@ -389,6 +397,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         health_client,
         _version_service: version_service,
         version_client,
+        _window_marker_service: window_marker_service,
+        window_marker_client,
     })
 }
 

--- a/rust/data_daemon_bridge/src/query.rs
+++ b/rust/data_daemon_bridge/src/query.rs
@@ -8,7 +8,7 @@
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::{
-    HealthReply, HealthRequest, RecordingIdReply, VersionReply, VersionRequest,
+    HealthReply, HealthRequest, RecordingIdReply, VersionReply, VersionRequest, WindowMarkerReply,
 };
 
 use crate::publisher::{now_ns, with_producer, ProducerError, ProducerState};
@@ -202,6 +202,62 @@ fn resolve_recording_id_once(
                 // deadline, matching this function's documented `Ok(None)`
                 // contract (it is a receive failure, not a send failure).
                 tracing::debug!(%error, "recording-id receive failed; treating as no reply");
+                return Ok(None);
+            }
+        }
+        if Instant::now() >= response_deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(RECORDING_ID_RECEIVE_POLL);
+    }
+}
+
+/// Block (with the GIL released by the caller) until the window-marker query
+/// is answered or `timeout_s` elapses. Returns `None` on timeout / when no daemon is
+/// answering / when the recording is unknown, all of which the caller treats
+/// the same way: publish the stop with no marker.
+pub(crate) fn resolve_window_marker_ns(
+    request_bytes: &[u8],
+    timeout_s: f64,
+) -> Result<Option<i64>, ProducerError> {
+    let deadline = Instant::now() + bounded_timeout(timeout_s);
+    loop {
+        let resolved = with_producer(|state| resolve_window_marker_once(state, request_bytes))?;
+        if resolved.is_some() {
+            return Ok(resolved);
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(RECORDING_ID_POLL_INTERVAL);
+    }
+}
+
+/// Send one window-marker request and wait briefly for the daemon's reply.
+/// See [`resolve_recording_id_once`].
+fn resolve_window_marker_once(
+    state: &ProducerState,
+    request_bytes: &[u8],
+) -> Result<Option<i64>, ProducerError> {
+    let request = state
+        .window_marker_client
+        .loan_slice_uninit(request_bytes.len())
+        .map_err(|error| ProducerError::Loan(error.to_string()))?;
+    let request = request.write_from_slice(request_bytes);
+    let pending = request
+        .send()
+        .map_err(|error| ProducerError::Send(error.to_string()))?;
+
+    let response_deadline = Instant::now() + RECORDING_ID_RESPONSE_WAIT;
+    loop {
+        match pending.receive() {
+            Ok(Some(response)) => {
+                let reply = WindowMarkerReply::decode(response.payload())?;
+                return Ok(reply.window_marker_ns);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(%error, "window-marker receive failed; treating as no reply");
                 return Ok(None);
             }
         }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -85,11 +85,7 @@ pub mod video_boundary {
 
     /// Leading frames published before `bound_ns`, i.e. the index of the first
     /// that is [`at_or_past_boundary`].
-    pub fn frames_before_boundary(
-        offsets_ms: &[u32],
-        chunk_open_ns: i64,
-        bound_ns: i64,
-    ) -> usize {
+    pub fn frames_before_boundary(offsets_ms: &[u32], chunk_open_ns: i64, bound_ns: i64) -> usize {
         offsets_ms
             .iter()
             .position(|offset| {
@@ -349,6 +345,17 @@ pub mod service_name {
 
     /// Maximum number of concurrent request-response servers. The daemon opens exactly one.
     pub const MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE: usize = 1;
+
+    /// Request-response service a non-owning producer uses to resolve the
+    /// capture marker (see [`crate::Envelope::StartRecording::timestamp_ns`])
+    /// of the window behind a cloud `recording_id` it only learned about over
+    /// SSE.
+    pub const WINDOW_MARKERS: &str = "neuracore/data_daemon/window_markers";
+
+    /// Maximum size of a single `window_markers` service sample. Both the
+    /// request and the reply are a UUID string plus one integer; 4 KiB is
+    /// generous.
+    pub const WINDOW_MARKER_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
 }
 
 /// A single message exchanged between the producer and the daemon.
@@ -402,6 +409,10 @@ pub enum Envelope {
         /// the row's `stop_timestamp_ns` and POSTed to the backend as
         /// `end_time`; never used for routing.
         timestamp_ns: i64,
+        /// The window's own start capture marker, when the sender knows it —
+        /// names which window this stop means instead of matching by time
+        /// range alone. `None` falls back to matching by time range.
+        window_marker_ns: Option<i64>,
     },
     /// Producer cancels the source's active recording — the daemon drops every
     /// in-flight per-trace actor, deletes the on-disk artefacts, marks the
@@ -732,6 +743,44 @@ pub struct RecordingIdReply {
     pub recording_id: Option<String>,
 }
 
+/// Request sent on [`service_name::WINDOW_MARKERS`] to resolve a window's
+/// start capture marker from its cloud `recording_id` — the reverse of
+/// [`RecordingIdQuery`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowMarkerQuery {
+    pub recording_id: String,
+}
+
+/// Reply to a [`WindowMarkerQuery`]. `None` when no such recording exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowMarkerReply {
+    pub window_marker_ns: Option<i64>,
+}
+
+impl WindowMarkerQuery {
+    /// Encode as a postcard byte vector for a `window_markers` service request sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `window_markers` service request sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl WindowMarkerReply {
+    /// Encode as a postcard byte vector for a `window_markers` service response sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `window_markers` service response sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
 /// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HealthRequest {
@@ -1035,6 +1084,7 @@ mod tests {
             robot_instance: 2,
             publish_timestamp_ns: 1_700_000_000_000_000_000,
             timestamp_ns: 1_700_000_000_000_000_000,
+            window_marker_ns: Some(1_700_000_000_000_000_000),
         };
         let bytes = stop.encode().expect("encode");
         assert_eq!(stop, Envelope::decode(&bytes).expect("decode"));

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -23,17 +23,8 @@ class _FailingStopStream(_ActiveStream):
         raise RuntimeError("stop failed")
 
 
-def test_web_stop_drains_streams_and_notifies_daemon() -> None:
-    """Callback registered at connect time must drain streams and notify the daemon."""
-    robot = Robot("robot", instance=0, org_id="org-1")
-    robot.id = "robot-id-1"
-
-    active = _ActiveStream()
-    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
-
-    fake_daemon = MagicMock()
-    robot._daemon_recording_context = fake_daemon
-
+def _remote_stop_callback(robot: Robot) -> object:
+    """Register the connect-time handler and hand back the callback it stored."""
     captured: dict[str, object] = {}
 
     class _FakeManager:
@@ -53,7 +44,46 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
 
     callback = captured["callback"]
     assert callable(callback)
-    callback("rec-abc")
+    return callback
+
+
+def test_web_stop_drains_streams_and_notifies_daemon() -> None:
+    """Callback registered at connect time must drain streams and notify the daemon."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+    # This process opened the window, so it is the one that closes it.
+    robot._owns_daemon_recording = True
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    _remote_stop_callback(robot)("rec-abc")
+
+    assert active.stop_calls == 1
+    fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.flush_source.assert_called_once_with()
+
+
+def test_web_stop_in_a_non_owning_process_also_publishes_a_stop() -> None:
+    """A process that never started the recording still publishes its stop.
+
+    The daemon holds the window state and reconciles whichever
+    ``StopRecording`` it receives against it, so the SDK does not restrict who
+    may send one.
+    """
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    _remote_stop_callback(robot)("rec-abc")
 
     assert active.stop_calls == 1
     fake_daemon.stop_recording.assert_called_once_with(timestamp=None)


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Pass window markers on IPC so daemon can resolve recording window across all participating processes

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>