### PR TITLE
test: bound the trailing RGB gap at the recording stop boundary

### DIFF
--- a/tests/integration/platform/data_daemon/shared/disk_helpers.py
+++ b/tests/integration/platform/data_daemon/shared/disk_helpers.py
@@ -19,6 +19,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     FRAME_COLOR_CHANNELS,
     FRAME_GRID_SIZE,
     LOSSLESS_CONTENT_BYTES_PER_PIXEL,
+    TRAILING_RGB_GAP_FRAME_TOLERANCE,
 )
 from tests.integration.platform.data_daemon.shared.test_case.frame_source import (
     frame_code_base,
@@ -256,6 +257,36 @@ def _assert_timestamps_match(
         durations[f"{recording_id}:{trace_key}"] = timestamps[-1] - timestamps[0]
 
 
+def _assert_no_trailing_rgb_gap(
+    *,
+    trace_key: str,
+    timestamps: list[float],
+    expected_stop_timestamp: float | None,
+    video_fps: int,
+    failures: list[TraceFailure],
+) -> None:
+    """Assert an RGB trace's last on-disk frame isn't stranded before the stop."""
+    if expected_stop_timestamp is None or not timestamps:
+        return
+    if not trace_key.startswith("RGB_IMAGES/"):
+        return
+    gap_s = expected_stop_timestamp - max(timestamps)
+    tolerance_s = TRAILING_RGB_GAP_FRAME_TOLERANCE / video_fps
+    if gap_s > tolerance_s:
+        failures.append(
+            TraceFailure(
+                trace_key=trace_key,
+                body=(
+                    f"last on-disk frame trails the recording's nominal end "
+                    f"by {gap_s:.3f}s, more than the {tolerance_s:.3f}s "
+                    f"tolerance ({TRAILING_RGB_GAP_FRAME_TOLERANCE} video "
+                    f"frame interval(s) at {video_fps}fps) — a tail chunk "
+                    f"may have been orphaned at the window boundary"
+                ),
+            )
+        )
+
+
 def _collapse_trace_failures(failures: list[TraceFailure]) -> list[str]:
     """Collapse failures that share the same body across multiple traces.
 
@@ -411,6 +442,17 @@ def assert_disk_recording_properties(
                     unknowable_timestamps=frozenset(
                         classification.unknowable_timestamps
                     ),
+                )
+                _assert_no_trailing_rgb_gap(
+                    trace_key=trace_key,
+                    timestamps=timestamps,
+                    expected_stop_timestamp=(
+                        result.expected_video_stop_timestamp_by_recording.get(
+                            recording_key
+                        )
+                    ),
+                    video_fps=result.video_fps,
+                    failures=trace_failures,
                 )
 
             if trace_failures:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -345,6 +345,11 @@ class ContextResult:
     depth_mode: DepthMode = "float32"
     has_depth: bool = False
     observed_frame_codes: dict[str, ObservedFrameCodes] = field(default_factory=dict)
+    """Painted camera frame codes per recording, keyed by ``recording_index``."""
+    expected_video_stop_timestamp_by_recording: dict[str, float] = field(
+        default_factory=dict
+    )
+    """Nominal capture-clock upper bound of each recording's video."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -1544,6 +1549,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
         source: tuple[str, int] = (str(robot.id), int(robot.instance))
 
         expected_by_recording: dict[str, RecordingExpectedTimestamps] = {}
+        expected_video_stop_timestamp_by_recording: dict[str, float] = {}
         bounds_by_disk_key: dict[str, RecordingControlBounds] = {}
         observed_frame_codes: dict[str, ObservedFrameCodes] = {}
         ordinal_by_disk_key: dict[str, int] = {}
@@ -1608,6 +1614,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                         timestamp=recording_capture_stop_s,
                     )
                 wall_stopped_at = time.time()
+                expected_video_stop_timestamp_by_recording[disk_recording_key] = (
+                    spec.timestamp_start_s + (recording_ordinal + 1) * case.duration_sec
+                )
 
                 bounds_by_disk_key[disk_recording_key] = RecordingControlBounds(
                     handle=recording_handle,
@@ -1717,6 +1726,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
             depth_mode=case.depth_mode,
             has_depth=bool(depth_camera_name_list),
             observed_frame_codes=observed_frame_codes,
+            expected_video_stop_timestamp_by_recording=(
+                expected_video_stop_timestamp_by_recording
+            ),
         )
     except Exception:
         if robot is not None:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -345,6 +345,11 @@ class ContextResult:
     depth_mode: DepthMode = "float32"
     has_depth: bool = False
     observed_frame_codes: dict[str, ObservedFrameCodes] = field(default_factory=dict)
+    """Painted camera frame codes per recording, keyed by ``recording_index``."""
+    expected_video_stop_timestamp_by_recording: dict[str, float] = field(
+        default_factory=dict
+    )
+    """Nominal capture-clock upper bound of each recording's video."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -1548,6 +1553,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
         source: tuple[str, int] = (str(robot.id), int(robot.instance))
 
         expected_by_recording: dict[str, RecordingExpectedTimestamps] = {}
+        expected_video_stop_timestamp_by_recording: dict[str, float] = {}
         bounds_by_disk_key: dict[str, RecordingControlBounds] = {}
         observed_frame_codes: dict[str, ObservedFrameCodes] = {}
         ordinal_by_disk_key: dict[str, int] = {}
@@ -1612,6 +1618,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                         timestamp=recording_capture_stop_s,
                     )
                 wall_stopped_at = time.time()
+                expected_video_stop_timestamp_by_recording[disk_recording_key] = (
+                    spec.timestamp_start_s + (recording_ordinal + 1) * case.duration_sec
+                )
 
                 bounds_by_disk_key[disk_recording_key] = RecordingControlBounds(
                     handle=recording_handle,
@@ -1721,6 +1730,9 @@ def context_worker(spec: ContextSpec) -> ContextResult:
             depth_mode=case.depth_mode,
             has_depth=bool(depth_camera_name_list),
             observed_frame_codes=observed_frame_codes,
+            expected_video_stop_timestamp_by_recording=(
+                expected_video_stop_timestamp_by_recording
+            ),
         )
     except Exception:
         if robot is not None:

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -128,6 +128,9 @@ STOP_RECORDING_UPLOAD_SLA_PER_VIDEO_PIXEL_S = 3.0e-7
 # Pause after the last stop_recording, so post-stop frames are logged.
 PER_THREAD_LOGGING_TAIL_S = 2.0
 
+# RGB tail may lag stop by up to N frame intervals (prevents silent orphaning).
+TRAILING_RGB_GAP_FRAME_TOLERANCE = 2
+
 BASE_DATASET_READY_TIMEOUT_S = 180.0
 MAX_DATASET_READY_TIMEOUT_S = 3600.0
 DATASET_POLL_INTERVAL_S = 0.25

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -126,6 +126,9 @@ STOP_RECORDING_UPLOAD_SLA_PER_VIDEO_PIXEL_S = 3.0e-7
 # Pause after the last stop_recording, so post-stop frames are logged.
 PER_THREAD_LOGGING_TAIL_S = 2.0
 
+# RGB tail may lag stop by up to N frame intervals (prevents silent orphaning).
+TRAILING_RGB_GAP_FRAME_TOLERANCE = 2
+
 BASE_DATASET_READY_TIMEOUT_S = 180.0
 MAX_DATASET_READY_TIMEOUT_S = 3600.0
 DATASET_POLL_INTERVAL_S = 0.25


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Assert no trailing gap for RGB streams
