### PR TITLE
test: make the producer channel a case subclass

### DIFF
--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
@@ -23,6 +23,7 @@ from tests.integration.platform.data_daemon.shared.runners import online_daemon_
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestBatch,
     DataDaemonTestCase,
+    Synchronous,
     camera_names,
     case_ids,
     has_configured_org,
@@ -49,14 +50,14 @@ logger = logging.getLogger(__name__)
 
 _CASES = DataDaemonTestBatch(
     cases=(
-        DataDaemonTestCase(
+        Synchronous(
             duration_sec=5,
             joint_count=4,
             video_count=1,
             image_width=64,
             image_height=64,
         ),
-        DataDaemonTestCase(
+        Synchronous(
             duration_sec=5,
             joint_count=4,
             video_count=1,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_explicit_capture_timestamps.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_explicit_capture_timestamps.py
@@ -29,7 +29,7 @@ from tests.integration.platform.data_daemon.shared.disk_helpers import (
 from tests.integration.platform.data_daemon.shared.process_control import Timer
 from tests.integration.platform.data_daemon.shared.runners import offline_daemon_running
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
-    DataDaemonTestCase,
+    Synchronous,
     has_configured_org,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
@@ -50,7 +50,7 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
     scoped_storage_state,
 )
 
-_CASE = DataDaemonTestCase(
+_CASE = Synchronous(
     duration_sec=3,
     joint_count=4,
     video_count=1,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_multi_process_producers.py
@@ -28,7 +28,7 @@ from tests.integration.platform.data_daemon.shared.db_helpers import (
 )
 from tests.integration.platform.data_daemon.shared.runners import online_daemon_running
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
-    DataDaemonTestCase,
+    Synchronous,
     has_configured_org,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
@@ -210,7 +210,7 @@ def test_three_processes_log_to_one_sse_started_recording() -> None:
     run_id = uuid.uuid4().hex[:10]
     dataset_name = f"multi_producer_dataset_{run_id}"
     robot_name = f"multi_producer_robot_{run_id}"
-    case = DataDaemonTestCase(
+    case = Synchronous(
         duration_sec=1,
         parallel_contexts=_PRODUCER_COUNT,
         joint_count=0,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_offline_to_online.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_offline_to_online.py
@@ -19,6 +19,7 @@ from tests.integration.platform.data_daemon.shared.runners import (
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestBatch,
     DataDaemonTestCase,
+    Synchronous,
     case_ids,
     has_configured_org,
 )
@@ -37,11 +38,11 @@ from tests.integration.platform.data_daemon.shared.test_infrastructure import (
 
 _CASES = DataDaemonTestBatch(
     cases=(
-        DataDaemonTestCase(
+        Synchronous(
             duration_sec=5,
             joint_count=4,
         ),
-        DataDaemonTestCase(
+        Synchronous(
             duration_sec=5,
             joint_count=4,
             video_count=1,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -38,6 +38,7 @@ from tests.integration.platform.data_daemon.shared.process_control import (
 from tests.integration.platform.data_daemon.shared.runners import online_daemon_running
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
+    Synchronous,
     case_ids,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
@@ -303,11 +304,11 @@ def test_online_daemon_running_exit_cleans_up_after_active_recording() -> None:
 
 # Minimal joints-only case used by kill-and-restart tests.
 _KILL_RESTART_CASES: list[DataDaemonTestCase] = [
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=5,
         joint_count=4,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=5,
         joint_count=4,
         video_count=2,

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -39,6 +39,7 @@ from tests.integration.platform.data_daemon.shared.process_control import (
 from tests.integration.platform.data_daemon.shared.runners import online_daemon_running
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
+    Synchronous,
     case_ids,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
@@ -304,11 +305,11 @@ def test_online_daemon_running_exit_cleans_up_after_active_recording() -> None:
 
 # Minimal joints-only case used by kill-and-restart tests.
 _KILL_RESTART_CASES: list[DataDaemonTestCase] = [
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=5,
         joint_count=4,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=5,
         joint_count=4,
         video_count=2,

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -1,5 +1,6 @@
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
-    DataDaemonTestCase,
+    OldPerThread,
+    Synchronous,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DETAIL_FLAT,
@@ -8,18 +9,17 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     MODE_STAGGERED,
     PACING_BURST_VIDEO,
     PACING_SATURATE,
-    PRODUCER_OLD_PER_THREAD,
 )
 
 PRE_NETWORK_INTEGRITY_CASES = (
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         parallel_contexts=1,
         recording_count=1,
         producer_pacing=PACING_SATURATE,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -36,7 +36,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -49,7 +49,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         joint_count=7,
         recording_count=4,
@@ -59,7 +59,6 @@ PRE_NETWORK_INTEGRITY_CASES = (
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         joint_fps=15,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         parallel_contexts=2,
         mode=MODE_STAGGERED,
         # Depth via the threaded producer, covering `float16` under a more
@@ -72,7 +71,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -80,12 +79,11 @@ PRE_NETWORK_INTEGRITY_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 1000 but flaky due to sync
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         wait=False,
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=4,
         video_count=1,
@@ -93,13 +91,12 @@ PRE_NETWORK_INTEGRITY_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 500 but flaky due to sync
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         random_phase=True,
         wait=False,
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -115,7 +112,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
 PRE_NETWORK_PERFORMANCE_CASES = (
     # High frequency robot control at 100Hz joint data
     # Tests: high-frequency sampling, temporal jitter, joint-only streaming
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -128,7 +125,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # recordings. Tests: multi-robot contention, mixed data types,
     # moderate-res cameras (256x256),
     # one producer thread per robot, back-to-back recordings
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -137,7 +134,6 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         producer_pacing=PACING_BURST_VIDEO,
@@ -150,7 +146,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # One trace is produced per joint per data type and each pays a fixed
     # upload cost regardless of size, so 1000 joints dominates the suite's
     # runtime and puts enough load on the backend to destabilise it.
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
@@ -160,7 +156,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # 3x longer duration recordings
     # Tests: long-running stability, memory leak detection, large dataset
     # accumulation
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -174,7 +170,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -189,7 +185,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -197,7 +193,6 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 1000 but flaky due to sync
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         wait=False,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
@@ -207,7 +202,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
 NETWORK_PERFORMANCE_CASES = (
     # High frequency robot control at 100Hz joint data
     # Tests: high-frequency sampling, temporal jitter, joint-only streaming
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -216,7 +211,7 @@ NETWORK_PERFORMANCE_CASES = (
         context_duration_mode=DURATION_MODE_FIXED,
         joint_fps=100,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -230,7 +225,7 @@ NETWORK_PERFORMANCE_CASES = (
     # recordings. Tests: multi-robot contention, mixed data types,
     # moderate-res cameras (256x256),
     # one producer thread per robot, back-to-back recordings
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -239,13 +234,12 @@ NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -254,7 +248,6 @@ NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         wait=True,
@@ -268,14 +261,14 @@ NETWORK_PERFORMANCE_CASES = (
     # One trace is produced per joint per data type and each pays a fixed
     # upload cost regardless of size, so 1000 joints dominates the suite's
     # runtime and puts enough load on the backend to destabilise it.
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
         parallel_contexts=1,
         recording_count=3,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
@@ -286,7 +279,7 @@ NETWORK_PERFORMANCE_CASES = (
     # 3x longer duration recordings
     # Tests: long-running stability, memory leak detection, large dataset
     # accumulation
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -300,7 +293,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -315,7 +308,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -330,7 +323,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -346,7 +339,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -354,11 +347,10 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -366,12 +358,11 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         wait=True,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    OldPerThread(
         duration_sec=10,
         recording_count=4,
         video_count=1,
@@ -379,7 +370,6 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_OLD_PER_THREAD,
         random_phase=True,
         wait=False,
         producer_pacing=PACING_BURST_VIDEO,

--- a/tests/integration/platform/data_daemon/daemon_test_cases.py
+++ b/tests/integration/platform/data_daemon/daemon_test_cases.py
@@ -1,5 +1,6 @@
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
-    DataDaemonTestCase,
+    PerThread,
+    Synchronous,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DETAIL_FLAT,
@@ -8,18 +9,17 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     MODE_STAGGERED,
     PACING_BURST_VIDEO,
     PACING_SATURATE,
-    PRODUCER_PER_THREAD,
 )
 
 PRE_NETWORK_INTEGRITY_CASES = (
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         parallel_contexts=1,
         recording_count=1,
         producer_pacing=PACING_SATURATE,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -36,7 +36,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -49,7 +49,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         joint_count=7,
         recording_count=4,
@@ -59,7 +59,6 @@ PRE_NETWORK_INTEGRITY_CASES = (
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         joint_fps=15,
-        producer_channels=PRODUCER_PER_THREAD,
         parallel_contexts=2,
         mode=MODE_STAGGERED,
         # Depth via the threaded producer, covering `float16` under a more
@@ -72,7 +71,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -80,12 +79,11 @@ PRE_NETWORK_INTEGRITY_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 1000 but flaky due to sync
-        producer_channels=PRODUCER_PER_THREAD,
         wait=False,
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=4,
         video_count=1,
@@ -93,13 +91,12 @@ PRE_NETWORK_INTEGRITY_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 500 but flaky due to sync
-        producer_channels=PRODUCER_PER_THREAD,
         random_phase=True,
         wait=False,
         producer_pacing=PACING_SATURATE,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=10,
         joint_count=7,
         recording_count=1,
@@ -115,7 +112,7 @@ PRE_NETWORK_INTEGRITY_CASES = (
 PRE_NETWORK_PERFORMANCE_CASES = (
     # High frequency robot control at 100Hz joint data
     # Tests: high-frequency sampling, temporal jitter, joint-only streaming
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -128,7 +125,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # recordings. Tests: multi-robot contention, mixed data types,
     # moderate-res cameras (256x256),
     # one producer thread per robot, back-to-back recordings
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -137,7 +134,6 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         producer_pacing=PACING_BURST_VIDEO,
@@ -150,7 +146,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # One trace is produced per joint per data type and each pays a fixed
     # upload cost regardless of size, so 1000 joints dominates the suite's
     # runtime and puts enough load on the backend to destabilise it.
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
@@ -160,7 +156,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
     # 3x longer duration recordings
     # Tests: long-running stability, memory leak detection, large dataset
     # accumulation
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -174,7 +170,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -189,7 +185,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -197,7 +193,6 @@ PRE_NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,  # previously 1000 but flaky due to sync
-        producer_channels=PRODUCER_PER_THREAD,
         wait=False,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
@@ -207,7 +202,7 @@ PRE_NETWORK_PERFORMANCE_CASES = (
 NETWORK_PERFORMANCE_CASES = (
     # High frequency robot control at 100Hz joint data
     # Tests: high-frequency sampling, temporal jitter, joint-only streaming
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -216,7 +211,7 @@ NETWORK_PERFORMANCE_CASES = (
         context_duration_mode=DURATION_MODE_FIXED,
         joint_fps=100,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=60,
         joint_count=7,
         video_count=0,
@@ -230,7 +225,7 @@ NETWORK_PERFORMANCE_CASES = (
     # recordings. Tests: multi-robot contention, mixed data types,
     # moderate-res cameras (256x256),
     # one producer thread per robot, back-to-back recordings
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -239,13 +234,12 @@ NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=20,
         joint_count=7,
         video_count=1,
@@ -254,7 +248,6 @@ NETWORK_PERFORMANCE_CASES = (
         parallel_contexts=8,
         recording_count=16,
         joint_fps=80,
-        producer_channels=PRODUCER_PER_THREAD,
         context_duration_mode=DURATION_MODE_VARIABLE,
         video_fps=30,
         wait=True,
@@ -268,14 +261,14 @@ NETWORK_PERFORMANCE_CASES = (
     # One trace is produced per joint per data type and each pays a fixed
     # upload cost regardless of size, so 1000 joints dominates the suite's
     # runtime and puts enough load on the backend to destabilise it.
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
         parallel_contexts=1,
         recording_count=3,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=30,
         joint_count=100,
         video_count=0,
@@ -286,7 +279,7 @@ NETWORK_PERFORMANCE_CASES = (
     # 3x longer duration recordings
     # Tests: long-running stability, memory leak detection, large dataset
     # accumulation
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -300,7 +293,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -315,7 +308,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -330,7 +323,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    Synchronous(
         duration_sec=300,
         joint_count=10,
         video_count=1,
@@ -346,7 +339,7 @@ NETWORK_PERFORMANCE_CASES = (
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -354,11 +347,10 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_PER_THREAD,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=1,
         video_count=1,
@@ -366,12 +358,11 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_PER_THREAD,
         wait=True,
         producer_pacing=PACING_BURST_VIDEO,
         video_detail=DETAIL_FLAT,
     ),
-    DataDaemonTestCase(
+    PerThread(
         duration_sec=10,
         recording_count=4,
         video_count=1,
@@ -379,7 +370,6 @@ NETWORK_PERFORMANCE_CASES = (
         image_width=120,
         video_fps=120,
         joint_fps=250,
-        producer_channels=PRODUCER_PER_THREAD,
         random_phase=True,
         wait=False,
         producer_pacing=PACING_BURST_VIDEO,

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -16,7 +16,7 @@ import math
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from tests.integration.platform.data_daemon.shared.test_case.context_spec import (
@@ -48,6 +48,7 @@ from tests.integration.platform.data_daemon.shared.test_case.constants import (
     STORAGE_STATE_EMPTY,
     DepthMode,
     LogAction,
+    ProducerChannels,
     ProducerPacing,
     StopMethod,
     StorageStateAction,
@@ -132,22 +133,13 @@ class DataDaemonTestCase:
             joint_count: Number of joint channels to log per frame.  Names are
             drawn from ``BASE_JOINT_NAMES`` and extended with synthetic names
             when the count exceeds the base list length.
-        producer_channels: How producer threads are allocated, and how long
-            they live.  ``"per_thread"`` runs one thread per stream for the
-            whole context lifetime — started before the first
-            ``start_recording`` and stopped after the last ``stop_recording``,
-            mid-loop at every boundary — mirroring a real camera that does not
-            stop between recordings, and the only mode under which the daemon
-            is shown what it does with frames logged as a window opens and
-            closes.  The other two scope their threads to a single recording
-            and join them before ``stop_recording``, so no frame is ever in
-            flight when a boundary passes: ``"synchronous"`` (default) logs
-            every data type from a single thread in sequence, and
-            ``"old_per_thread"`` gives each stream its own thread so they race
-            each other inside the recording.  Producer lifetime belongs on this
-            axis rather than a separate flag because logging across recordings
-            *requires* a thread per stream, so it is not independent of the
-            allocation.
+        CHANNELS: How producer threads are allocated, and how long they live —
+            a class attribute, not a field, so it is chosen by constructing the
+            matching subclass.  This class is :class:`Synchronous`; see
+            :class:`PerThread` and :class:`OldPerThread`.  Producer lifetime
+            belongs on this axis rather than a separate flag because logging
+            across recordings *requires* a thread per stream, so it is not
+            independent of the allocation.
         video_count: Number of RGB camera streams to log per recording.  A
             value of ``0`` disables video entirely.
         image_width: Horizontal resolution of each camera frame in pixels.
@@ -229,12 +221,13 @@ class DataDaemonTestCase:
         start is guaranteed to fall before context 0's timestamp end.
     """
 
+    CHANNELS: ClassVar[ProducerChannels] = PRODUCER_SYNCHRONOUS
+
     duration_sec: int = 5
     parallel_contexts: int = 1
     recording_count: int = 1
     mode: str = MODE_SEQUENTIAL
     joint_count: int = 10
-    producer_channels: str = PRODUCER_SYNCHRONOUS
     video_count: int = 0
     image_width: int | None = None
     image_height: int | None = None
@@ -260,6 +253,14 @@ class DataDaemonTestCase:
         problem = _unsupported_combination(self)
         if problem is not None:
             raise ValueError(problem)
+
+    @property
+    def producer_channels(self) -> ProducerChannels:
+        """The producer model this case runs under, fixed by its class.
+
+        Not a field: a variant *is* its producer model, so it cannot contradict itself.
+        """
+        return type(self).CHANNELS
 
     @property
     def has_video(self) -> bool:
@@ -306,6 +307,29 @@ class DataDaemonTestCase:
 
 
 @dataclass(frozen=True)
+class Synchronous(DataDaemonTestCase):
+    """Logs every data type from one thread; no frame is in flight at a boundary."""
+
+    CHANNELS: ClassVar[ProducerChannels] = PRODUCER_SYNCHRONOUS
+
+
+@dataclass(frozen=True)
+class OldPerThread(DataDaemonTestCase):
+    """One thread per stream, joined before ``stop_recording``: races inside a
+    recording but stops clean at its edges."""
+
+    CHANNELS: ClassVar[ProducerChannels] = PRODUCER_OLD_PER_THREAD
+
+
+@dataclass(frozen=True)
+class PerThread(DataDaemonTestCase):
+    """One thread per stream, running the whole context lifetime — mid-loop at
+    every recording boundary."""
+
+    CHANNELS: ClassVar[ProducerChannels] = PRODUCER_PER_THREAD
+
+
+@dataclass(frozen=True)
 class DataDaemonTestBatch:
     """A named collection of test cases sharing common infrastructure parameters.
 
@@ -328,14 +352,10 @@ class DataDaemonTestBatch:
         skip: When ``True``, every case in the batch is skipped at collection
             time.  When ``False`` (default), each case keeps its own per-case
             ``skip`` value, so individual cases can still opt out.
-        producer_channels: Workload override applied to every case when set;
-            see ``DataDaemonTestCase.producer_channels``.  ``None`` (default)
-            leaves each case's own value alone.  Lets a suite declare one
-            producer model — e.g. ``"per_thread"`` — across its whole matrix
-            instead of restating it on every case.
-        producer_pacing: Workload override applied to every case when set; see
-            ``DataDaemonTestCase.producer_pacing``.  ``None`` (default) leaves
-            each case's own value alone.
+        producer_variant: Subclass applied to every case when set; ``None``
+            (default) keeps each case's own class.
+        producer_pacing: Override applied to every case when set; a case whose
+            shape cannot honour it raises ``ValueError`` at construction.
     """
 
     cases: tuple[DataDaemonTestCase, ...]
@@ -345,7 +365,7 @@ class DataDaemonTestBatch:
     preserve_artifacts_per_test: bool = False
     stop_method: StopMethod = STOP_METHOD_CLI
     skip: bool = False
-    producer_channels: str | None = None
+    producer_variant: type[DataDaemonTestCase] | None = None
     producer_pacing: ProducerPacing | None = None
 
     def as_cases(self) -> list[DataDaemonTestCase]:
@@ -359,13 +379,10 @@ class DataDaemonTestBatch:
         }
         if self.skip:
             batch_overrides["skip"] = True
-        # Workload overrides are opt-in; unset = keep case default.
-        if self.producer_channels is not None:
-            batch_overrides["producer_channels"] = self.producer_channels
         if self.producer_pacing is not None:
             batch_overrides["producer_pacing"] = self.producer_pacing
         return [
-            DataDaemonTestCase(**{
+            (self.producer_variant or type(c))(**{
                 **{
                     f.name: getattr(c, f.name)
                     for f in fields(c)
@@ -383,35 +400,37 @@ class DataDaemonTestBatch:
 
 
 def case_id(case: DataDaemonTestCase) -> str:
-    """Generate a short human-readable ID for a test case."""
+    """Generate a short human-readable ID for a test case.
+
+    The variant class leads; every other value is only named when it differs
+    from *this case's own class* default.
+    """
+    default = type(case)
     mode_short = "seq" if case.mode == MODE_SEQUENTIAL else "stag"
     parts = [
+        *([] if default is DataDaemonTestCase else [default.__name__]),
         f"{case.duration_sec}s",
         f"{case.recording_count}recs",
         *(["variable"] if case.context_duration_mode == DURATION_MODE_VARIABLE else []),
     ]
-    if case.parallel_contexts > DataDaemonTestCase.parallel_contexts:
+    if case.parallel_contexts > default.parallel_contexts:
         parts.append(f"{case.parallel_contexts}ctx")
         parts.append(mode_short)
     parts.append(f"{case.joint_count}joints")
-    if case.joint_fps != DataDaemonTestCase.joint_fps:
+    if case.joint_fps != default.joint_fps:
         parts.append(f"{case.joint_fps}hz")
     if case.has_video:
         parts.append(f"{case.video_count}cam")
         parts.append(f"{case.image_width}x{case.image_height}")
-        if case.video_fps != DataDaemonTestCase.video_fps:
+        if case.video_fps != default.video_fps:
             parts.append(f"{case.video_fps}hz")
         if case.video_codec is not None:
             parts.append(case.video_codec)
-        if case.video_detail != DataDaemonTestCase.video_detail:
+        if case.video_detail != default.video_detail:
             parts.append(f"{case.video_detail}frames")
     if case.has_depth:
         parts.append(f"{case.depth_count}depth")
         parts.append(case.depth_mode)
-    if case.producer_channels == PRODUCER_OLD_PER_THREAD:
-        parts.append("old-per-thread")
-    elif case.producer_channels == PRODUCER_PER_THREAD:
-        parts.append("per-thread")
     if case.producer_pacing != DataDaemonTestCase.producer_pacing:
         parts.append(case.producer_pacing)
     if case.random_phase:

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -113,6 +113,7 @@ derives from the array's own dtype (`image.dtype.name`)."""
 LogAction = Literal["preserve", "delete"]
 VideoDetail = Literal["realistic", "flat"]
 ProducerPacing = Literal["deadline", "burst-video", "saturate"]
+ProducerChannels = Literal["synchronous", "old_per_thread", "per_thread"]
 
 # The ``nc.log_joint_*`` calls a joint stream makes per frame.
 JOINT_KINDS = ("joint_positions", "joint_velocities", "joint_torques")


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Make producer channels a primary citizen of test case so implementations can be extended into the future