### PR TITLE
test: reclaim leftover daemons only when the daemon-stop check fails

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -454,6 +454,7 @@ sencode
 seqlen
 serde
 sess
+sessionfinish
 setpriority
 setsid
 setuptools

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -462,6 +462,7 @@ sencode
 seqlen
 serde
 sess
+sessionfinish
 setpriority
 setpts
 setsid

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import time
@@ -14,7 +15,10 @@ from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
 )
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
-from tests.integration.platform.data_daemon.shared.process_control import Timer
+from tests.integration.platform.data_daemon.shared.process_control import (
+    Timer,
+    reclaim_leftover_daemons,
+)
 from tests.integration.platform.data_daemon.shared.profiles import (
     cleanup_test_profiles,
     profile_path,
@@ -60,6 +64,8 @@ if _REPO_ROOT not in sys.path:
 
 
 _BATCH_START_CLEANED_NODEIDS: set[str] = set()
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -329,6 +335,15 @@ def performance_report(
         )
 
     return create
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Stop any daemon still running when the session ends."""
+    del session, exitstatus
+    try:
+        reclaim_leftover_daemons()
+    except Exception as error:
+        logger.warning("could not stop leftover daemons at session end: %s", error)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import time
@@ -15,6 +16,7 @@ from tests.integration.platform.data_daemon.shared.assertions import (
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import (
     Timer,
+    reclaim_leftover_daemons,
     stop_daemon,
 )
 from tests.integration.platform.data_daemon.shared.profiles import (
@@ -63,6 +65,8 @@ if _REPO_ROOT not in sys.path:
 
 
 _BATCH_START_CLEANED_NODEIDS: set[str] = set()
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -327,6 +331,15 @@ def performance_report(
         )
 
     return create
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Stop any daemon still running when the session ends."""
+    del session, exitstatus
+    try:
+        reclaim_leftover_daemons()
+    except Exception as error:
+        logger.warning("could not stop leftover daemons at session end: %s", error)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -363,11 +363,14 @@ def relayed_worker_logs() -> Generator[multiprocessing.Queue]:
 # ---------------------------------------------------------------------------
 
 
+DAEMON_BINARY_MARKER = "neuracore/data_daemon/bin/data-daemon"
+"""Argv substring that identifies the bundled daemon binary."""
+
+
 def get_runner_pids() -> set[int]:
     """Return the PIDs of all running neuracore data-daemon processes.
 
-    Matches the bundled daemon binary
-    (``neuracore/data_daemon/bin/data-daemon``).
+    Matches the bundled daemon binary (:data:`DAEMON_BINARY_MARKER`).
     """
     env = {**os.environ, "COLUMNS": "32768"}
     output = subprocess.check_output(["ps", "-eo", "pid=,args="], text=True, env=env)
@@ -377,9 +380,31 @@ def get_runner_pids() -> set[int]:
         if len(parts) != 2:
             continue
         pid_text, args = parts
-        if "neuracore/data_daemon/bin/data-daemon" in args:
+        if DAEMON_BINARY_MARKER in args:
             runner_pids.add(int(pid_text))
     return runner_pids
+
+
+def pid_is_daemon(pid: int) -> bool:
+    """Whether ``pid`` is one of our daemon processes, rather than merely alive.
+
+    The PID file is written by a daemon, but nothing keeps the process it names
+    from being something else by the time we read it: a stale file outlives its
+    process and PIDs are recycled, and anything that redirects
+    ``NEURACORE_DAEMON_PID_PATH`` can leave it naming an unrelated process — a
+    unit test pointing it at a temp file containing ``os.getpid()`` is enough,
+    and that is pytest. Callers go on to SIGTERM what they are handed, so
+    identity is checked here rather than assumed.
+    """
+    try:
+        args = subprocess.check_output(
+            ["ps", "-o", "args=", "-p", str(pid)],
+            text=True,
+            env={**os.environ, "COLUMNS": "32768"},
+        )
+    except (subprocess.CalledProcessError, ValueError):
+        return False
+    return DAEMON_BINARY_MARKER in args
 
 
 def _live_daemon_pids() -> set[int]:
@@ -387,7 +412,9 @@ def _live_daemon_pids() -> set[int]:
     pid_path = get_daemon_pid_path()
     pids: set[int] = set(get_runner_pids())
     stored_pid = read_pid_from_file(pid_path)
-    if stored_pid is not None and pid_is_running(stored_pid):
+    # Running is not enough — it also has to be a daemon (see `pid_is_daemon`),
+    # or a PID file naming something else fails the isolation assertions.
+    if stored_pid is not None and pid_is_daemon(stored_pid):
         pids.add(stored_pid)
     return pids
 
@@ -398,10 +425,14 @@ def _live_daemon_pids() -> set[int]:
 
 
 def _collect_candidate_pids() -> set[int]:
-    """Return all daemon PIDs that need to be waited on or killed."""
+    """Return all daemon PIDs that need to be waited on or killed.
+
+    Every PID here is a signal target, so the PID file's is admitted only once
+    confirmed to name a daemon.
+    """
     pids: set[int] = set(get_runner_pids())
     pid_file_value = read_pid_from_file(get_daemon_pid_path())
-    if pid_file_value is not None:
+    if pid_file_value is not None and pid_is_daemon(pid_file_value):
         pids.add(pid_file_value)
     return pids
 
@@ -515,6 +546,26 @@ def stop_daemon(
         else:
             _wait_and_escalate(candidate_pids, graceful_timeout_s=graceful_timeout_s)
         _remove_ipc_artefacts()
+
+
+def reclaim_leftover_daemons() -> None:
+    """Stop daemon processes an earlier test left behind.
+
+    Raises:
+        RuntimeError: When a leftover process survives :func:`stop_daemon`.
+    """
+    leftover = sorted(get_runner_pids())
+    if not leftover:
+        return
+    logger.warning(
+        "Stopping daemon processes left over from an earlier test: %s", leftover
+    )
+    stop_daemon()
+    survivors = sorted(get_runner_pids())
+    if survivors:
+        raise RuntimeError(
+            f"Leftover daemon processes survived stop_daemon(): {survivors}"
+        )
 
 
 def _parallel_startup_worker(

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -367,11 +367,14 @@ def relayed_worker_logs(
 # ---------------------------------------------------------------------------
 
 
+DAEMON_BINARY_MARKER = "neuracore/data_daemon/bin/data-daemon"
+"""Argv substring that identifies the bundled daemon binary."""
+
+
 def get_runner_pids() -> set[int]:
     """Return the PIDs of all running neuracore data-daemon processes.
 
-    Matches the bundled daemon binary
-    (``neuracore/data_daemon/bin/data-daemon``).
+    Matches the bundled daemon binary (:data:`DAEMON_BINARY_MARKER`).
     """
     env = {**os.environ, "COLUMNS": "32768"}
     output = subprocess.check_output(["ps", "-eo", "pid=,args="], text=True, env=env)
@@ -381,9 +384,31 @@ def get_runner_pids() -> set[int]:
         if len(parts) != 2:
             continue
         pid_text, args = parts
-        if "neuracore/data_daemon/bin/data-daemon" in args:
+        if DAEMON_BINARY_MARKER in args:
             runner_pids.add(int(pid_text))
     return runner_pids
+
+
+def pid_is_daemon(pid: int) -> bool:
+    """Whether ``pid`` is one of our daemon processes, rather than merely alive.
+
+    The PID file is written by a daemon, but nothing keeps the process it names
+    from being something else by the time we read it: a stale file outlives its
+    process and PIDs are recycled, and anything that redirects
+    ``NEURACORE_DAEMON_PID_PATH`` can leave it naming an unrelated process — a
+    unit test pointing it at a temp file containing ``os.getpid()`` is enough,
+    and that is pytest. Callers go on to SIGTERM what they are handed, so
+    identity is checked here rather than assumed.
+    """
+    try:
+        args = subprocess.check_output(
+            ["ps", "-o", "args=", "-p", str(pid)],
+            text=True,
+            env={**os.environ, "COLUMNS": "32768"},
+        )
+    except (subprocess.CalledProcessError, ValueError):
+        return False
+    return DAEMON_BINARY_MARKER in args
 
 
 def _live_daemon_pids() -> set[int]:
@@ -391,7 +416,9 @@ def _live_daemon_pids() -> set[int]:
     pid_path = get_daemon_pid_path()
     pids: set[int] = set(get_runner_pids())
     stored_pid = read_pid_from_file(pid_path)
-    if stored_pid is not None and pid_is_running(stored_pid):
+    # Running is not enough — it also has to be a daemon (see `pid_is_daemon`),
+    # or a PID file naming something else fails the isolation assertions.
+    if stored_pid is not None and pid_is_daemon(stored_pid):
         pids.add(stored_pid)
     return pids
 
@@ -402,10 +429,14 @@ def _live_daemon_pids() -> set[int]:
 
 
 def _collect_candidate_pids() -> set[int]:
-    """Return all daemon PIDs that need to be waited on or killed."""
+    """Return all daemon PIDs that need to be waited on or killed.
+
+    Every PID here is a signal target, so the PID file's is admitted only once
+    confirmed to name a daemon.
+    """
     pids: set[int] = set(get_runner_pids())
     pid_file_value = read_pid_from_file(get_daemon_pid_path())
-    if pid_file_value is not None:
+    if pid_file_value is not None and pid_is_daemon(pid_file_value):
         pids.add(pid_file_value)
     return pids
 
@@ -519,6 +550,26 @@ def stop_daemon(
         else:
             _wait_and_escalate(candidate_pids, graceful_timeout_s=graceful_timeout_s)
         _remove_ipc_artefacts()
+
+
+def reclaim_leftover_daemons() -> None:
+    """Stop daemon processes an earlier test left behind.
+
+    Raises:
+        RuntimeError: When a leftover process survives :func:`stop_daemon`.
+    """
+    leftover = sorted(get_runner_pids())
+    if not leftover:
+        return
+    logger.warning(
+        "Stopping daemon processes left over from an earlier test: %s", leftover
+    )
+    stop_daemon()
+    survivors = sorted(get_runner_pids())
+    if survivors:
+        raise RuntimeError(
+            f"Leftover daemon processes survived stop_daemon(): {survivors}"
+        )
 
 
 def _parallel_startup_worker(

--- a/tests/integration/platform/data_daemon/shared/runners.py
+++ b/tests/integration/platform/data_daemon/shared/runners.py
@@ -19,6 +19,7 @@ from tests.integration.platform.data_daemon.shared.assertions import (
 )
 from tests.integration.platform.data_daemon.shared.process_control import (
     Timer,
+    reclaim_leftover_daemons,
     stop_daemon,
 )
 from tests.integration.platform.data_daemon.shared.profiles import (
@@ -56,6 +57,26 @@ def scoped_daemon_storage_env() -> Generator[None]:
             os.environ.pop("NEURACORE_DAEMON_DB_PATH", None)
 
 
+def stop_daemon_and_verify() -> None:
+    """Stop the daemon and assert nothing of it is left behind.
+
+    Reclaims leftovers only when that assertion fails. A leak is exactly what
+    this assertion catches, so scanning for one on every test's happy path is
+    wasted work; reclaiming on the way out of the failure keeps the leak to the
+    test that caused it rather than to every test after it.
+
+    Raises:
+        AssertionError: When a daemon process, PID file, or producer subprocess
+            survives the stop.
+    """
+    stop_daemon()
+    try:
+        assert_daemon_cleanup()
+    except AssertionError:
+        reclaim_leftover_daemons()
+        raise
+
+
 @contextmanager
 def offline_daemon_running() -> Generator[None]:
     """Run the daemon in offline mode for the duration of the block.
@@ -74,13 +95,11 @@ def offline_daemon_running() -> Generator[None]:
     """
     with scoped_daemon_storage_env(), scoped_offline_profile():
         try:
-            stop_daemon()
-            assert_daemon_cleanup()
+            stop_daemon_and_verify()
             ensure_daemon_running(timeout_s=DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS)
             yield
         finally:
-            stop_daemon()
-            assert_daemon_cleanup()
+            stop_daemon_and_verify()
 
 
 @contextmanager
@@ -106,8 +125,7 @@ def online_daemon_running() -> Generator[None]:
                     always_log=True,
                     assert_deadline=False,
                 ):
-                    stop_daemon()
-                    assert_daemon_cleanup()
+                    stop_daemon_and_verify()
                     ensure_daemon_running(
                         timeout_s=DEFAULT_DAEMON_STARTUP_TIMEOUT_SECONDS
                     )
@@ -120,5 +138,4 @@ def online_daemon_running() -> Generator[None]:
                     always_log=True,
                     assert_deadline=False,
                 ):
-                    stop_daemon()
-                    assert_daemon_cleanup()
+                    stop_daemon_and_verify()

--- a/tests/unit/data_daemon/test_daemon_control.py
+++ b/tests/unit/data_daemon/test_daemon_control.py
@@ -25,6 +25,23 @@ INSTALLED_SDK_VERSION = "99.9.9"
 STALE_DAEMON_VERSION = "13.0.1"
 
 
+@pytest.fixture(autouse=True)
+def contain_daemon_path_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep ``ensure_daemon_running``'s environment side effect inside the test.
+
+    It ``os.environ.setdefault``s ``NEURACORE_DAEMON_PID_PATH`` /
+    ``NEURACORE_DAEMON_DB_PATH`` from whatever the path helpers resolve to, which
+    ``monkeypatch.setattr`` on those helpers cannot undo — the variable outlives
+    the test and governs every later one in the process. Several tests here point
+    the pid path at a file holding ``os.getpid()``, so the leak names *pytest*:
+    a later integration test then reads it as the daemon's pid and stops "the
+    daemon" by signalling us. Pre-setting both via ``monkeypatch`` makes the
+    ``setdefault`` a no-op and restores them on teardown.
+    """
+    monkeypatch.setenv("NEURACORE_DAEMON_PID_PATH", str(tmp_path / "env-daemon.pid"))
+    monkeypatch.setenv("NEURACORE_DAEMON_DB_PATH", str(tmp_path / "env-state.db"))
+
+
 class _FakePopen:
     def __init__(
         self,


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Reclaim left over daemons when test fails isolation assertion so that the failure doesn't leak into other tests.
 - Perform similarly on session end so mid suite termination cleans up
