### PR TITLE
fix: teardown managers logout

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -18,7 +18,10 @@ from neuracore.core.streaming.p2p.provider.global_live_data_enabled import (
 from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
     StreamManagerOrchestrator,
 )
-from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
+from neuracore.core.streaming.recording_state_manager import (
+    get_recording_state_manager,
+    shutdown_recording_state_manager,
+)
 from neuracore.core.utils import backend_utils
 
 from ..core.auth import get_auth
@@ -103,7 +106,16 @@ def logout() -> None:
     Logs out from the Neuracore server and resets all global state including
     active robots, recording IDs, dataset IDs, and version validation status.
     """
-    get_auth().logout()
+    # Stop and drain every task that uses the shared Auth instance before its
+    # token is cleared. Each cleanup remains best-effort with respect to the
+    # next one, and credentials are always cleared even if cleanup raises.
+    try:
+        try:
+            StreamManagerOrchestrator.shutdown_global()
+        finally:
+            shutdown_recording_state_manager()
+    finally:
+        get_auth().logout()
     GlobalSingleton()._active_robot = None
     GlobalSingleton()._active_dataset_id = None
     GlobalSingleton()._active_dataset = None

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -24,7 +24,10 @@ from neuracore_types import DataType, RobotInstanceIdentifier
 
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.streaming.data_stream import DataStream
-from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
+from neuracore.core.streaming.recording_state_manager import (
+    get_initialized_recording_state_manager,
+    get_recording_state_manager,
+)
 from neuracore.core.utils.http_errors import extract_error_detail
 from neuracore.core.utils.http_session import thread_local_session
 from neuracore.data_daemon import bridge as recording_context
@@ -330,11 +333,15 @@ class Robot:
         if not self.id:
             raise RobotError("Robot not initialized. Call init() first.")
 
+        stop_time = timestamp if timestamp is not None else time.time()
         active_handle = get_recording_state_manager().get_current_recording_id(
             self.id, self.instance
         )
         get_recording_state_manager().recording_stopped(
-            robot_id=self.id, instance=self.instance, recording_id=active_handle
+            robot_id=self.id,
+            instance=self.instance,
+            recording_id=active_handle,
+            stop_time=stop_time,
         )
         self._drain_streams_and_notify_daemon(recording_id, timestamp=timestamp)
 
@@ -683,12 +690,16 @@ class Robot:
             raise RobotError("Robot not initialized. Call init() first.")
 
         self._stop_all_streams()
+        stop_time = timestamp if timestamp is not None else time.time()
         self._get_daemon_recording_context().cancel_recording(timestamp=timestamp)
         active_handle = get_recording_state_manager().get_current_recording_id(
             self.id, self.instance
         )
         get_recording_state_manager().recording_stopped(
-            robot_id=self.id, instance=self.instance, recording_id=active_handle
+            robot_id=self.id,
+            instance=self.instance,
+            recording_id=active_handle,
+            stop_time=stop_time,
         )
 
     def _get_daemon_recording_context(self) -> DaemonRecordingContext:
@@ -761,10 +772,9 @@ class Robot:
     def close(self) -> None:
         """Release local resources owned by this Robot instance."""
         self._cleanup_daemon_recording_context()
-        if self.id is not None:
-            get_recording_state_manager().deregister_remote_stop_handler(
-                self.id, self.instance
-            )
+        recording_manager = get_initialized_recording_state_manager()
+        if self.id is not None and recording_manager is not None:
+            recording_manager.deregister_remote_stop_handler(self.id, self.instance)
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
+++ b/neuracore/core/streaming/p2p/consumer/client_consumer_stream_manager.py
@@ -264,7 +264,7 @@ class ClientConsumerStreamManager(BaseP2PStreamManager):
 
     def _on_close(self) -> None:
         """Internal cleanup method called when streaming is disabled."""
-        for connection in self.connections.values():
+        for connection in list(self.connections.values()):
             connection.close()
 
         self.connections.clear()

--- a/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
+++ b/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
@@ -290,7 +290,9 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
 
     def _on_close(self) -> None:
         """Internal cleanup method called when streaming is disabled."""
-        for connection in self.connections.values():
+        self.background_tracker.stop_background_coroutines()
+
+        for connection in list(self.connections.values()):
             connection.close()
 
         self.connections.clear()

--- a/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
+++ b/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
@@ -6,6 +6,8 @@ integrates with the signalling server to route messages.
 """
 
 import asyncio
+import logging
+from concurrent.futures import TimeoutError as FutureTimeoutError
 
 from aiohttp import ClientSession, ClientTimeout
 from neuracore_types import RobotInstanceIdentifier
@@ -35,6 +37,10 @@ from neuracore.core.streaming.p2p.signalling_events_consumer import (
 from neuracore.core.utils.http_session import retry_connection_failures
 from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
 
+logger = logging.getLogger(__name__)
+
+_SHUTDOWN_TIMEOUT_S = 5.0
+
 
 class StreamManagerOrchestrator(
     BaseStreamManagerOrchestrator, metaclass=SingletonMetaclass
@@ -52,7 +58,6 @@ class StreamManagerOrchestrator(
         self,
         org_id: str | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
-        client_session: ClientSession | None = None,
         auth: Auth | None = None,
     ):
         """Initialize the stream manager factory.
@@ -62,8 +67,6 @@ class StreamManagerOrchestrator(
                 defaults to the current org.
             loop: the event loop to run on. Defaults to the running loop if not
                 provided.
-            client_session: The http session to use. Defaults to a new session
-                if not provided.
             auth: The auth instance used to connect to the signalling server or
                 defaults to the global auth provider if not provided.
         """
@@ -77,7 +80,7 @@ class StreamManagerOrchestrator(
         self.org_id = org_id or get_current_org()
         self.auth = auth or get_auth()
         self.loop = loop or get_running_loop()
-        self.client_session = client_session or ClientSession(
+        self.client_session = ClientSession(
             timeout=ClientTimeout(sock_read=None, total=None),
             loop=self.loop,
             middlewares=(retry_connection_failures,),
@@ -94,6 +97,57 @@ class StreamManagerOrchestrator(
                 get_consume_live_data_enabled_manager(),
             ),
         )
+
+    def _close_streaming_resources(self) -> None:
+        """Stop signalling and every manager before authentication is removed."""
+        self.signalling_consumer.close()
+
+        # Manager disable listeners remove themselves from these dictionaries.
+        # Clear the dictionaries first so those callbacks do not recursively
+        # call close() on the manager that is already being disabled.
+        consumer_managers = list(self.consumer_managers.values())
+        provider_managers = list(self.provider_managers.values())
+        self.consumer_managers.clear()
+        self.provider_managers.clear()
+
+        for consumer_manager in consumer_managers:
+            consumer_manager.close()
+        for provider_manager in provider_managers:
+            provider_manager.close()
+
+    async def _finish_shutdown(self) -> None:
+        """Drain cancellation callbacks and close the owned HTTP session."""
+        # Let task-cancellation callbacks run before the authenticated session
+        # is closed and, subsequently, the caller clears authentication.
+        await asyncio.sleep(0)
+        await self.client_session.close()
+
+    def shutdown(self) -> None:
+        """Synchronously stop streaming so logout can safely clear credentials."""
+        # Do this before scheduling anything on the loop. Even if the loop is
+        # blocked, trackers immediately reject new work while cancellation is
+        # queued for tasks already running there.
+        self._close_streaming_resources()
+
+        future = asyncio.run_coroutine_threadsafe(self._finish_shutdown(), self.loop)
+        try:
+            future.result(timeout=_SHUTDOWN_TIMEOUT_S)
+        except FutureTimeoutError:
+            future.cancel()
+            logger.warning(
+                "Timed out waiting for streaming resources to shut down cleanly"
+            )
+
+    @classmethod
+    def shutdown_global(cls) -> None:
+        """Shut down and forget the singleton, allowing a later fresh session."""
+        instance = SingletonMetaclass._instances.get(cls)
+        if instance is None:
+            return
+        try:
+            instance.shutdown()
+        finally:
+            SingletonMetaclass._instances.pop(cls, None)
 
     def get_manager(
         self, type: ManagerType, robot_id: str, robot_instance: int

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -12,9 +12,9 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import NamedTuple
 
-from aiohttp import ClientSession
 from neuracore_types import (
     BaseRecodingUpdatePayload,
     RecordingNotification,
@@ -37,6 +37,8 @@ from neuracore.data_daemon import bridge as _recording_context
 from neuracore.data_daemon.daemon_control import ensure_daemon_running
 
 logger = logging.getLogger(__name__)
+
+_SHUTDOWN_TIMEOUT_S = 5.0
 
 # The producer stamps a recording's start as `int(start_time * 1e9)`, so the
 # value echoed back in a notification can sit a nanosecond below the one held
@@ -101,7 +103,6 @@ class RecordingStateManager(BaseSSEConsumer):
         loop: asyncio.AbstractEventLoop | None = None,
         enabled_manager: EnabledManager | None = None,
         background_coroutine_tracker: BackgroundCoroutineTracker | None = None,
-        client_session: ClientSession | None = None,
         auth: Auth | None = None,
     ):
         """Initialize the recording state manager.
@@ -116,8 +117,6 @@ class RecordingStateManager(BaseSSEConsumer):
             background_coroutine_tracker: The storage for background tasks
                 scheduled on receiving events. Defaults to a new tracker if not
                 provided.
-            client_session: The http session to use. Defaults to a new session
-                if not provided.
             auth: The auth instance used to connect to the signalling server or
                 defaults to the global auth provider if not provided.
         """
@@ -125,7 +124,6 @@ class RecordingStateManager(BaseSSEConsumer):
             loop=loop,
             enabled_manager=enabled_manager,
             background_coroutine_tracker=background_coroutine_tracker,
-            client_session=client_session,
         )
         self.org_id = org_id or get_current_org()
         self.auth = auth if auth is not None else get_auth()
@@ -140,13 +138,59 @@ class RecordingStateManager(BaseSSEConsumer):
         # Not taken by `get_current_recording_id` / `is_recording`: those sit on
         # the `log_*` hot path and a single dict lookup is already atomic.
         self._state_lock = threading.RLock()
+        self._stopped = False
         self.recording_robot_instances: dict[
             RobotInstanceIdentifier, TrackedRecording
         ] = dict()
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
+        self._latest_stopped_times: dict[RobotInstanceIdentifier, float] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
+
+    def _close_recording_resources(self) -> list[asyncio.TimerHandle]:
+        """Stop SSE work and clear all state that can outlive authentication."""
+        with self._state_lock:
+            self._stopped = True
+            timer_handles = [
+                handle
+                for handles in self._recording_timers.values()
+                for handle in handles
+            ]
+            self._recording_timers.clear()
+            self.recording_robot_instances.clear()
+            self._expired_recording_ids.clear()
+            self._latest_stopped_times.clear()
+            self.active_dataset_ids.clear()
+            self._drain_callbacks.clear()
+            self._connected_robot_id = None
+
+        super().close()
+        return timer_handles
+
+    async def _finish_shutdown(self, timer_handles: list[asyncio.TimerHandle]) -> None:
+        """Cancel expiry callbacks and close this manager's HTTP session."""
+        for handle in timer_handles:
+            handle.cancel()
+
+        # Give SSE/background-task cancellation callbacks one loop turn to drain.
+        await asyncio.sleep(0)
+        await self.client_session.close()
+
+    def shutdown(self) -> None:
+        """Synchronously tear down recording state before auth is cleared."""
+        timer_handles = self._close_recording_resources()
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._finish_shutdown(timer_handles), self.loop
+        )
+        try:
+            future.result(timeout=_SHUTDOWN_TIMEOUT_S)
+        except FutureTimeoutError:
+            future.cancel()
+            logger.warning(
+                "Timed out waiting for recording state manager to shut down cleanly"
+            )
 
     def get_current_recording_id(self, robot_id: str, instance: int) -> str | None:
         """Get the current recording ID for a robot instance.
@@ -216,6 +260,8 @@ class RecordingStateManager(BaseSSEConsumer):
                 notifications can be ordered against it.
         """
         with self._state_lock:
+            if self._stopped:
+                return
             self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
@@ -275,7 +321,7 @@ class RecordingStateManager(BaseSSEConsumer):
         recording_id: str,
     ) -> None:
         """Schedule local warning and expiry timers for a recording."""
-        # clear any previous timers for this recording ID just in case
+        # Clear any previous timers for this recording ID just in case.
         self._cancel_recording_timers(recording_id)
 
         def warn_if_still_active() -> None:
@@ -300,15 +346,21 @@ class RecordingStateManager(BaseSSEConsumer):
         loop = get_running_loop()
 
         def _schedule() -> None:
-            warn_handle = loop.call_later(
-                self.RECORDING_EXPIRY_WARNING,
-                warn_if_still_active,
-            )
-            expiry_handle = loop.call_later(
-                self.MAX_RECORDING_DURATION_S,
-                expire_if_still_active,
-            )
-            self._recording_timers[recording_id] = [warn_handle, expiry_handle]
+            with self._state_lock:
+                if self._stopped:
+                    return
+                warn_handle = loop.call_later(
+                    self.RECORDING_EXPIRY_WARNING,
+                    warn_if_still_active,
+                )
+                expiry_handle = loop.call_later(
+                    self.MAX_RECORDING_DURATION_S,
+                    expire_if_still_active,
+                )
+                self._recording_timers[recording_id] = [
+                    warn_handle,
+                    expiry_handle,
+                ]
 
         loop.call_soon_threadsafe(_schedule)
 
@@ -317,14 +369,19 @@ class RecordingStateManager(BaseSSEConsumer):
         loop = get_running_loop()
 
         def _cancel() -> None:
-            handles = self._recording_timers.pop(recording_id, [])
+            with self._state_lock:
+                handles = self._recording_timers.pop(recording_id, [])
             for handle in handles:
                 handle.cancel()
 
         loop.call_soon_threadsafe(_cancel)
 
     def recording_stopped(
-        self, robot_id: str, instance: int, recording_id: str | None
+        self,
+        robot_id: str,
+        instance: int,
+        recording_id: str | None,
+        stop_time: float | None = None,
     ) -> None:
         """Handle recording stop for a robot instance.
 
@@ -335,6 +392,8 @@ class RecordingStateManager(BaseSSEConsumer):
             robot_id: Robot ID
             instance: Instance number of the robot
             recording_id: Unique identifier for the recording session
+            stop_time: Recording window upper bound, on the same clock as its
+                start time. Defaults to wall-clock now.
         """
         instance_key = RobotInstanceIdentifier(
             robot_id=robot_id, robot_instance=instance
@@ -344,6 +403,11 @@ class RecordingStateManager(BaseSSEConsumer):
             if current is None or current.recording_id != recording_id:
                 return
             self.recording_robot_instances.pop(instance_key, None)
+            stopped_at = stop_time if stop_time is not None else time.time()
+            previous_stop = self._latest_stopped_times.get(instance_key)
+            if previous_stop is None or stopped_at > previous_stop:
+                self._latest_stopped_times[instance_key] = stopped_at
+
         # Data-bridge stop is driven by the recording context or expiry timer —
         # not here — so the daemon gets exactly one StopRecording with the
         # correct data-clock boundary.
@@ -359,17 +423,28 @@ class RecordingStateManager(BaseSSEConsumer):
         appropriate start/stop methods if the state actually changed.
 
         Runs under :attr:`_state_lock` so each decision and the state change it
-        implies are atomic against a concurrent local start or stop. Blocking
-        work is done before the lock is taken.
+        implies are atomic against a concurrent local start or stop. Daemon
+        startup happens after an accepted transition releases the lock.
 
         Args:
             is_recording: Whether the robot should be recording
             details: Recording details including robot ID, instance, and recording ID
         """
-        if is_recording and details.robot_id == self._connected_robot_id:
-            self._ensure_daemon_for_recording()
         with self._state_lock:
+            if self._stopped:
+                return
             self._apply_recording_notification(is_recording, details)
+            if not is_recording:
+                return
+            instance_key = RobotInstanceIdentifier(
+                robot_id=details.robot_id, robot_instance=details.instance
+            )
+            current = self.recording_robot_instances.get(instance_key)
+            if current is None or current.recording_id != details.recording_id:
+                return
+
+        # Stale STARTs have been rejected and accepted state is now visible.
+        self._ensure_daemon_for_recording()
 
     def _apply_recording_notification(
         self, is_recording: bool, details: BaseRecodingUpdatePayload
@@ -379,10 +454,10 @@ class RecordingStateManager(BaseSSEConsumer):
         instance = details.instance
         recording_id = details.recording_id
 
-        previous = self.recording_robot_instances.get(
-            RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance),
-            None,
+        instance_key = RobotInstanceIdentifier(
+            robot_id=robot_id, robot_instance=instance
         )
+        previous = self.recording_robot_instances.get(instance_key, None)
         previous_recording_id = previous.recording_id if previous is not None else None
         was_recording = previous_recording_id is not None
 
@@ -397,6 +472,17 @@ class RecordingStateManager(BaseSSEConsumer):
             # Only react to the robot this client connected to, not other
             # robots in the org that may be recording concurrently.
             if robot_id != self._connected_robot_id:
+                return
+
+            latest_stopped_at = self._latest_stopped_times.get(instance_key)
+            if latest_stopped_at is not None and details.start_time < latest_stopped_at:
+                logger.debug(
+                    "ignoring recording start notification older than the latest "
+                    "local stop: recording_id=%s start_time=%s stopped_at=%s",
+                    recording_id,
+                    details.start_time,
+                    latest_stopped_at,
+                )
                 return
 
             # A START describing a recording that began before the tracked one
@@ -423,16 +509,12 @@ class RecordingStateManager(BaseSSEConsumer):
                 len(details.dataset_ids) == 1
             ), "Recording can only be started in one dataset"
             dataset_id = details.dataset_ids[0]
-            instance_key = RobotInstanceIdentifier(
-                robot_id=robot_id, robot_instance=instance
-            )
             self.active_dataset_ids[instance_key] = dataset_id
             logger.info(
                 "active_dataset_received_from_sse: dataset_id=%s recording_id=%s",
                 dataset_id,
                 recording_id,
             )
-            # Daemon already ensured above; this is the state transition only.
             self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
@@ -440,9 +522,6 @@ class RecordingStateManager(BaseSSEConsumer):
                 start_time=details.start_time,
             )
         else:
-            instance_key = RobotInstanceIdentifier(
-                robot_id=robot_id, robot_instance=instance
-            )
             if previous_recording_id != recording_id:
                 return
             callback = self._drain_callbacks.get(instance_key)
@@ -519,6 +598,18 @@ class RecordingStateManager(BaseSSEConsumer):
 _recording_manager: Future[RecordingStateManager] | None = None
 
 
+def shutdown_recording_state_manager() -> None:
+    """Shut down and forget the global manager so later login starts fresh."""
+    global _recording_manager
+
+    manager_future = _recording_manager
+    _recording_manager = None
+    if manager_future is None:
+        return
+
+    manager_future.result().shutdown()
+
+
 async def create_recording_state_manager() -> RecordingStateManager:
     """Create a new recording state manager instance.
 
@@ -527,6 +618,17 @@ async def create_recording_state_manager() -> RecordingStateManager:
             manager with persistent connection
     """
     return RecordingStateManager(loop=get_running_loop())
+
+
+def get_initialized_recording_state_manager() -> RecordingStateManager | None:
+    """Return the existing global manager without creating one.
+
+    Cleanup paths use this after logout so destruction of a late ``Robot``
+    cannot restart authenticated SSE resources.
+    """
+    if _recording_manager is None:
+        return None
+    return _recording_manager.result()
 
 
 def get_recording_state_manager() -> "RecordingStateManager":

--- a/neuracore/core/utils/background_coroutine_tracker.py
+++ b/neuracore/core/utils/background_coroutine_tracker.py
@@ -26,6 +26,7 @@ class BackgroundCoroutineTracker:
         """
         self.background_tasks: list[asyncio.Task] = []
         self.loop = loop or get_running_loop()
+        self._stopped = False
 
     def _task_done(self, task: asyncio.Task) -> None:
         """Cleanup after task completion.
@@ -57,11 +58,18 @@ class BackgroundCoroutineTracker:
         Args:
             coroutine: the coroutine to be run at another time.
         """
+        if self._stopped:
+            coroutine.close()
+            return
         if self.loop.is_closed():
+            coroutine.close()
             logger.warning("Cannot submit coroutine; event loop is closed.")
             return
 
         def _submit_coroutine(coroutine: Coroutine) -> None:
+            if self._stopped:
+                coroutine.close()
+                return
             task = self.loop.create_task(coroutine)
             self.background_tasks.append(task)
             task.add_done_callback(self._task_done)
@@ -73,6 +81,23 @@ class BackgroundCoroutineTracker:
 
         cancels all running background coroutines
         """
-        for task in self.background_tasks:
-            task.cancel()
-        self.background_tasks.clear()
+        self._stopped = True
+
+        def _cancel_tasks() -> None:
+            for task in self.background_tasks:
+                task.cancel()
+            self.background_tasks.clear()
+
+        if self.loop.is_closed():
+            self.background_tasks.clear()
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is self.loop:
+            _cancel_tasks()
+        else:
+            self.loop.call_soon_threadsafe(_cancel_tasks)

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -11,6 +11,9 @@ from neuracore.core import robot as core_robot
 from neuracore.core.auth import get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError, VersionMismatchError
+from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
+    StreamManagerOrchestrator,
+)
 
 
 def test_login_with_api_key(temp_config_dir, monkeypatch):
@@ -60,6 +63,87 @@ def test_logout(temp_config_dir, monkeypatch):
         config = json.load(f)
         assert config["api_key"] is None
         assert config["current_org_id"] is None
+
+
+def test_logout_shuts_down_managers_before_clearing_auth(monkeypatch):
+    """Authentication remains valid until all background managers are stopped."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        StreamManagerOrchestrator,
+        "shutdown_global",
+        lambda: calls.append("streaming_shutdown"),
+    )
+    monkeypatch.setattr(
+        api_core,
+        "shutdown_recording_state_manager",
+        lambda: calls.append("recording_shutdown"),
+    )
+    monkeypatch.setattr(
+        api_core.get_auth(),
+        "logout",
+        lambda: calls.append("auth_logout"),
+    )
+
+    nc.logout()
+
+    assert calls == [
+        "streaming_shutdown",
+        "recording_shutdown",
+        "auth_logout",
+    ]
+
+
+def test_logout_runs_remaining_cleanup_when_streaming_shutdown_fails(monkeypatch):
+    """A P2P cleanup failure must not skip recording cleanup or auth logout."""
+    calls: list[str] = []
+
+    def fail_streaming_shutdown() -> None:
+        calls.append("streaming_shutdown")
+        raise RuntimeError("streaming cleanup failed")
+
+    monkeypatch.setattr(
+        StreamManagerOrchestrator,
+        "shutdown_global",
+        fail_streaming_shutdown,
+    )
+    monkeypatch.setattr(
+        api_core,
+        "shutdown_recording_state_manager",
+        lambda: calls.append("recording_shutdown"),
+    )
+    monkeypatch.setattr(
+        api_core.get_auth(),
+        "logout",
+        lambda: calls.append("auth_logout"),
+    )
+
+    with pytest.raises(RuntimeError, match="streaming cleanup failed"):
+        nc.logout()
+
+    assert calls == [
+        "streaming_shutdown",
+        "recording_shutdown",
+        "auth_logout",
+    ]
+
+
+def test_logout_clears_auth_when_recording_shutdown_fails(monkeypatch):
+    """A recording cleanup failure must still clear authentication."""
+    auth_logout = Mock()
+
+    monkeypatch.setattr(StreamManagerOrchestrator, "shutdown_global", Mock())
+    monkeypatch.setattr(
+        api_core,
+        "shutdown_recording_state_manager",
+        Mock(side_effect=RuntimeError("recording cleanup failed")),
+    )
+    monkeypatch.setattr(api_core.get_auth(), "logout", auth_logout)
+
+    with pytest.raises(RuntimeError, match="recording cleanup failed"):
+        nc.logout()
+
+    auth_logout.assert_called_once_with()
 
 
 def test_auth_instance_singleton():

--- a/tests/unit/core/p2p/test_background_coroutine_tracker.py
+++ b/tests/unit/core/p2p/test_background_coroutine_tracker.py
@@ -68,3 +68,22 @@ async def test_handles_closed_event_loop(caplog):
 
     # Ensure no task was added
     assert len(tracker.background_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_prevents_queued_coroutine_from_starting():
+    """Stopping must reject submissions already queued on the event loop."""
+    started = False
+
+    async def queued_coroutine():
+        nonlocal started
+        started = True
+
+    tracker = BackgroundCoroutineTracker(loop=asyncio.get_running_loop())
+    tracker.submit_background_coroutine(queued_coroutine())
+    tracker.stop_background_coroutines()
+
+    await asyncio.sleep(0)
+
+    assert started is False
+    assert tracker.background_tasks == []

--- a/tests/unit/core/p2p/test_stream_manager_orchestrator.py
+++ b/tests/unit/core/p2p/test_stream_manager_orchestrator.py
@@ -1,0 +1,85 @@
+"""Tests for the global P2P stream orchestrator lifecycle."""
+
+import asyncio
+import threading
+from unittest.mock import Mock, patch
+
+from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
+    StreamManagerOrchestrator,
+)
+from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
+
+
+def test_close_streaming_resources_closes_and_forgets_all_managers():
+    """Shutdown closes signalling and every manager exactly once."""
+    orchestrator = object.__new__(StreamManagerOrchestrator)
+    orchestrator.signalling_consumer = Mock()
+    consumer_manager = Mock()
+    provider_manager = Mock()
+    orchestrator.consumer_managers = {"consumer": consumer_manager}
+    orchestrator.provider_managers = {"provider": provider_manager}
+
+    orchestrator._close_streaming_resources()
+
+    orchestrator.signalling_consumer.close.assert_called_once_with()
+    consumer_manager.close.assert_called_once_with()
+    provider_manager.close.assert_called_once_with()
+    assert orchestrator.consumer_managers == {}
+    assert orchestrator.provider_managers == {}
+
+
+def test_shutdown_global_forgets_singleton_so_it_can_be_recreated():
+    """A later login/connect must not receive the closed orchestrator."""
+    previous_instance = SingletonMetaclass._instances.pop(
+        StreamManagerOrchestrator, None
+    )
+    try:
+        with patch.object(StreamManagerOrchestrator, "__init__", return_value=None):
+            first = StreamManagerOrchestrator()
+            first.shutdown = Mock()
+
+            StreamManagerOrchestrator.shutdown_global()
+            second = StreamManagerOrchestrator()
+
+        first.shutdown.assert_called_once_with()
+        assert second is not first
+    finally:
+        SingletonMetaclass._instances.pop(StreamManagerOrchestrator, None)
+        if previous_instance is not None:
+            SingletonMetaclass._instances[StreamManagerOrchestrator] = previous_instance
+
+
+def test_shutdown_waits_for_client_session_to_close():
+    """Synchronous shutdown drains loop cleanup before returning to logout."""
+    loop = asyncio.new_event_loop()
+    loop_started = threading.Event()
+
+    def run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop_started.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=run_loop, daemon=True)
+    loop_thread.start()
+    loop_started.wait(timeout=1.0)
+
+    class ClientSessionStub:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    orchestrator = object.__new__(StreamManagerOrchestrator)
+    orchestrator.loop = loop
+    orchestrator.client_session = ClientSessionStub()
+    orchestrator.signalling_consumer = Mock()
+    orchestrator.consumer_managers = {}
+    orchestrator.provider_managers = {}
+
+    try:
+        orchestrator.shutdown()
+        assert orchestrator.client_session.closed is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=1.0)
+        loop.close()

--- a/tests/unit/core/test_recording_state_manager.py
+++ b/tests/unit/core/test_recording_state_manager.py
@@ -1,0 +1,165 @@
+"""Tests for recording-state manager teardown."""
+
+import asyncio
+import threading
+from concurrent.futures import Future
+from unittest.mock import Mock
+
+from neuracore_types import RecordingStartPayload, RobotInstanceIdentifier
+
+from neuracore.core.streaming import recording_state_manager as manager_module
+from neuracore.core.streaming.p2p.enabled_manager import EnabledManager
+from neuracore.core.streaming.recording_state_manager import (
+    RecordingStateManager,
+    TrackedRecording,
+    shutdown_recording_state_manager,
+)
+
+
+def test_shutdown_cancels_timers_clears_state_and_closes_session():
+    """No recording callbacks or authenticated SSE resources survive logout."""
+    loop = asyncio.new_event_loop()
+    loop_started = threading.Event()
+
+    def run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop_started.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=run_loop, daemon=True)
+    loop_thread.start()
+    loop_started.wait(timeout=1.0)
+
+    class ClientSessionStub:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    manager = object.__new__(RecordingStateManager)
+    manager.loop = loop
+    manager.enabled_manager = EnabledManager(True, loop=loop)
+    manager.enabled_manager.add_listener(EnabledManager.DISABLED, manager._on_close)
+    manager.background_tracker = Mock()
+    manager.signalling_stream_future = Mock()
+    manager.client_session = ClientSessionStub()
+    manager._state_lock = threading.RLock()
+
+    key = RobotInstanceIdentifier(robot_id="robot-id", robot_instance=0)
+    timer_handle = Mock()
+    manager.recording_robot_instances = {
+        key: TrackedRecording(recording_id="recording-id", start_time=1.0)
+    }
+    manager._expired_recording_ids = {"expired-id"}
+    manager._recording_timers = {"recording-id": [timer_handle]}
+    manager._latest_stopped_times = {key: 2.0}
+    manager.active_dataset_ids = {key: "dataset-id"}
+    manager._drain_callbacks = {key: Mock()}
+    manager._connected_robot_id = "robot-id"
+
+    try:
+        manager.shutdown()
+
+        manager.background_tracker.stop_background_coroutines.assert_called_once_with()
+        manager.signalling_stream_future.cancel.assert_called_once_with()
+        timer_handle.cancel.assert_called_once_with()
+        assert manager.client_session.closed is True
+        assert manager.recording_robot_instances == {}
+        assert manager._expired_recording_ids == set()
+        assert manager._recording_timers == {}
+        assert manager._latest_stopped_times == {}
+        assert manager.active_dataset_ids == {}
+        assert manager._drain_callbacks == {}
+        assert manager._connected_robot_id is None
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_queued_timer_registration_is_rejected_after_shutdown(monkeypatch):
+    """A timer callback queued before logout cannot recreate expiry state."""
+    queued_callbacks = []
+    loop = Mock()
+    loop.call_soon_threadsafe.side_effect = queued_callbacks.append
+    monkeypatch.setattr(manager_module, "get_running_loop", lambda: loop)
+
+    manager = object.__new__(RecordingStateManager)
+    manager.loop = loop
+    manager.enabled_manager = Mock()
+    manager._state_lock = threading.RLock()
+    manager._stopped = False
+    manager.recording_robot_instances = {}
+    manager._expired_recording_ids = set()
+    manager._recording_timers = {}
+    manager._latest_stopped_times = {}
+    manager.active_dataset_ids = {}
+    manager._drain_callbacks = {}
+    manager._connected_robot_id = None
+
+    manager._schedule_recording_timers("robot-id", 0, "recording-id")
+    manager._close_recording_resources()
+
+    for callback in queued_callbacks:
+        callback()
+
+    assert manager._recording_timers == {}
+    loop.call_later.assert_not_called()
+
+
+def test_shutdown_global_forgets_manager_so_it_can_be_recreated(monkeypatch):
+    """The next login/connect must not reuse a closed recording manager."""
+    manager = Mock()
+    manager_future: Future[RecordingStateManager] = Future()
+    manager_future.set_result(manager)
+    monkeypatch.setattr(manager_module, "_recording_manager", manager_future)
+
+    shutdown_recording_state_manager()
+
+    manager.shutdown.assert_called_once_with()
+    assert manager_module._recording_manager is None
+
+
+def test_late_start_after_local_stop_does_not_restart_daemon(monkeypatch):
+    """A delayed START for a finished recording must remain stopped."""
+    key = RobotInstanceIdentifier(robot_id="robot-id", robot_instance=0)
+    loop = Mock()
+    loop.call_soon_threadsafe.side_effect = lambda callback: callback()
+    monkeypatch.setattr(manager_module, "get_running_loop", lambda: loop)
+
+    manager = object.__new__(RecordingStateManager)
+    manager.loop = loop
+    manager._state_lock = threading.RLock()
+    manager._stopped = False
+    manager._connected_robot_id = "robot-id"
+    manager.recording_robot_instances = {
+        key: TrackedRecording(recording_id="local-handle", start_time=100.0)
+    }
+    manager._expired_recording_ids = set()
+    manager._recording_timers = {}
+    manager._latest_stopped_times = {}
+    manager.active_dataset_ids = {}
+    manager._drain_callbacks = {}
+    manager._ensure_daemon_for_recording = Mock()
+
+    manager.recording_stopped(
+        robot_id="robot-id",
+        instance=0,
+        recording_id="local-handle",
+        stop_time=105.0,
+    )
+    manager.updated_recording_state(
+        is_recording=True,
+        details=RecordingStartPayload(
+            recording_id="delayed-cloud-id",
+            robot_id="robot-id",
+            instance=0,
+            created_by="test",
+            dataset_ids=["dataset-id"],
+            start_time=100.0,
+        ),
+    )
+
+    assert manager.recording_robot_instances == {}
+    assert manager.active_dataset_ids == {}
+    manager._ensure_daemon_for_recording.assert_not_called()

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -59,6 +59,24 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
     fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
 
 
+def test_close_does_not_create_recording_manager_after_logout() -> None:
+    """Late object cleanup must not recreate authenticated streaming state."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+
+    with (
+        patch(
+            "neuracore.core.robot.get_initialized_recording_state_manager",
+            return_value=None,
+        ),
+        patch("neuracore.core.robot.get_recording_state_manager") as create_manager,
+    ):
+        robot.close()
+
+    create_manager.assert_not_called()
+    robot.id = None
+
+
 def test_stop_all_streams_logs_stop_failure_and_continues() -> None:
     """One stream failing to stop must not prevent the others from stopping."""
     robot = Robot("robot", instance=0, org_id="org-1")


### PR DESCRIPTION
Streaming managers and authenticated background tasks remained active after logout. This allowed SSE/P2P work to race with authentication being cleared, causing authentication errors, retaining stale recording state, and potentially reusing stale resources after a later login.

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
- Shuts down and resets the global P2P orchestrator and recording-state manager during logout.
- Cancels background tasks and recording timers, closes HTTP sessions, clears cached state, and allows clean re-   login.
- Safely closes active P2P connections without dictionary-mutation races.
- Prevents queued work and delayed SSE notifications from restoring recording state after shutdown or a local stop.
- Prevents late Robot.close() calls from recreating the recording manager after logout.
- Removes unused session-injection, fork-handling, and test-only defensive paths.
