### PR TITLE
fix: support ffmpeg 9 frame timing option

### DIFF
--- a/.github/workflows/rust-data-daemon.yaml
+++ b/.github/workflows/rust-data-daemon.yaml
@@ -55,19 +55,44 @@ jobs:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      # The video-encoder tests early-return when ffmpeg is absent, so without
-      # this the encode/preflight path (and the ffmpeg-4.4.2 `-vsync` vs
-      # `-fps_mode` compatibility the daemon defends against) is never exercised
-      # in CI. ubuntu-22.04 ships ffmpeg 4.4.x, matching the target host.
-      - name: Install ffmpeg
+      # The daemon resolves the passthrough option from the installed ffmpeg
+      # (`-vsync` before 5.1, `-fps_mode` from 8.0), so both ends need a run.
+      # apt gives 4.4.x; setup-ffmpeg cannot pin this end because it serves only
+      # the in-support versions, all past the `-vsync` removal.
+      - name: Install oldest tested ffmpeg
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg
+          ffmpeg -version | head -n 1
 
-      - name: Test (workspace)
+      # A runner-image bump would otherwise leave `-vsync` untested, silently.
+      - name: Check the oldest ffmpeg predates -fps_mode
+        run: |
+          if ffmpeg -hide_banner -loglevel error -f lavfi \
+              -i testsrc=duration=1:size=16x16:rate=1 \
+              -fps_mode passthrough -f null - 2>/dev/null; then
+            echo "::error::apt ffmpeg accepts -fps_mode, so the -vsync path is untested"
+            exit 1
+          fi
+
+      - name: Test (workspace, oldest tested ffmpeg)
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: cargo test --workspace --verbose
+
+      # Takes precedence over the apt build on PATH. Keep the pin in step with
+      # the setup-neuracore actions in NeuracoreAI/shared-workflows.
+      - name: Install newest tested ffmpeg
+        uses: AnimMouse/setup-ffmpeg@178e0b4a408f06ce40d896c3cd79f50fa6f8b0c3 # v1.2.5
+        with:
+          version: "9.0"
+
+      - name: Test (workspace, newest tested ffmpeg)
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          ffmpeg -version | head -n 1
+          cargo test --workspace --verbose
 
       - name: Build release (workspace)
         env:

--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -14,3 +14,5 @@ Example: "This release adds support for multi-GPU training and improves streamin
 The data daemon now reports the neuracore version it was built from, and the SDK checks it before it uses the daemon. A daemon left over from an earlier install is reported with the steps to fix it instead of being used silently.
 
 The data daemon encodes video chunks faster on slow machines with a lighter preview scaling filter.
+
+The data daemon now works with ffmpeg 8 and later. It selects the frame timing option that the installed ffmpeg accepts, so new and old ffmpeg builds are both supported.

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -275,6 +275,7 @@ loglevel
 loglik
 logsigmoid
 logvar
+luma
 makereport
 manylinux
 matplotlib

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -192,10 +192,11 @@ fn run_daemon(
 
     // Verify ffmpeg is present and supports the options the encoder depends on
     // *before* standing up the runtime — an incompatible build (e.g. one that
-    // lacks `-vsync passthrough`, or is missing libx264) otherwise fails every
-    // video encode silently at recording time, marking traces `failed`. Mirrors
-    // the fail-fast PID-file acquisition above. Reused as the pipeline's encoder
-    // so the probe and the real encodes share one configured binary.
+    // lacks a passthrough frame-timing mode, or is missing libx264) otherwise
+    // fails every video encode silently at recording time, marking traces
+    // `failed`. Mirrors the fail-fast PID-file acquisition above. Reused as the
+    // pipeline's encoder so the probe and the real encodes share one configured
+    // binary.
     let video_encoder = VideoEncoder::new();
     match video_encoder.preflight() {
         Ok(version) => tracing::info!(ffmpeg_version = %version, "ffmpeg preflight passed"),

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -32,6 +32,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use data_daemon_shared::ffmpeg::passthrough_frame_sync_arg;
 use data_daemon_shared::service_name::VIDEO_SPOOL_TICKS_PER_SECOND;
 
 use tokio::process::Command;
@@ -250,13 +251,13 @@ pub enum FfmpegPreflightError {
         source: std::io::Error,
     },
     /// ffmpeg ran but rejected a capability the encoder depends on: the
-    /// `-vsync passthrough` frame-timing mode or the libx264 encoder.
+    /// passthrough frame-timing mode or the libx264 encoder.
     #[error(
         "ffmpeg at `{}` (version {version}) is incompatible: a required capability was \
-         rejected. The daemon needs `-vsync passthrough` (drop-free, frame-accurate \
-         encoding — note `-fps_mode passthrough` is ffmpeg >= 5.1 only) and the libx264 / \
-         libx264rgb encoders. Install a compatible ffmpeg (>= 4.0 with libx264). ffmpeg \
-         reported:\n{stderr_tail}",
+         rejected. The daemon needs passthrough frame timing (drop-free, frame-accurate \
+         encoding; spelled `{frame_sync_arg}` on this build) and the libx264 / libx264rgb \
+         encoders. Install a compatible ffmpeg (>= 4.0 with libx264). ffmpeg reported:\
+         \n{stderr_tail}",
         binary.to_string_lossy()
     )]
     Incompatible {
@@ -264,6 +265,8 @@ pub enum FfmpegPreflightError {
         binary: OsString,
         /// Detected ffmpeg version, or `"unknown"`.
         version: String,
+        /// Passthrough frame-timing option the probe used on this build.
+        frame_sync_arg: &'static str,
         /// Tail of ffmpeg's stderr from the failed probe.
         stderr_tail: String,
     },
@@ -297,6 +300,12 @@ impl VideoEncoder {
         self
     }
 
+    /// Option name this ffmpeg accepts for passthrough frame timing; the two
+    /// spellings do not overlap across the supported version range.
+    fn frame_sync_arg(&self) -> &'static str {
+        passthrough_frame_sync_arg(&self.binary)
+    }
+
     /// Verify the configured ffmpeg is present and supports the capabilities
     /// [`encode_chunk`](Self::encode_chunk) depends on, returning the detected
     /// version string on success.
@@ -305,9 +314,8 @@ impl VideoEncoder {
     /// clear message instead of silently marking every video trace `failed` at
     /// recording time. Two steps: `ffmpeg -version` confirms the binary runs
     /// (and yields a version for diagnostics), then a one-frame synthetic
-    /// encode to the null muxer exercises the exact `-vsync passthrough` knob —
-    /// the option ffmpeg < 5.1 rejects when spelled `-fps_mode` — together with
-    /// the libx264 encoder.
+    /// encode to the null muxer exercises the passthrough frame-timing mode
+    /// together with the libx264 encoder.
     pub fn preflight(&self) -> Result<String, FfmpegPreflightError> {
         let version = self.detect_ffmpeg_version()?;
         self.probe_passthrough_encode(&version)?;
@@ -334,17 +342,18 @@ impl VideoEncoder {
     /// Encode one synthetic frame to the null muxer through **both** output
     /// configurations the real [`encode_chunk`](Self::encode_chunk) uses — the
     /// `yuv420p libx264` lossy pass *and* the `rgb24 libx264rgb -qp 0` lossless
-    /// pass. A non-zero exit means the local ffmpeg lacks a capability the
-    /// encoder needs. The lossless `libx264rgb` path is the one that actually
-    /// varies between builds, so probing only the lossy pass (as before) let the
-    /// "fail fast at startup" check pass while every real lossless encode failed
-    /// at recording time.
+    /// pass, with the passthrough spelling this build accepts. A non-zero exit
+    /// means the local ffmpeg lacks a capability the encoder needs. The
+    /// lossless `libx264rgb` path is the one that actually varies between
+    /// builds, so probing only the lossy pass (as before) let the "fail fast at
+    /// startup" check pass while every real lossless encode failed at recording
+    /// time.
     fn probe_passthrough_encode(&self, version: &str) -> Result<(), FfmpegPreflightError> {
         // One 16x16 yuv420p frame (a 16x16 plane plus two 8x8 planes = 384
         // bytes) fed via the rawvideo demuxer on stdin — no lavfi/input-file
         // dependency, so the probe works even on a minimal build. ffmpeg parses
         // (and would reject) the options before reading stdin, so an unsupported
-        // `-vsync passthrough`, `-enc_time_base` or `libx264rgb` encode fails
+        // passthrough mode, `-enc_time_base` or `libx264rgb` encode fails
         // immediately rather than on a healthy input. The two `-map 0:v -c:v …`
         // blocks exercise the same codec, pixel formats and timestamp pinning
         // as `encode_chunk` (the build-dependent parts); the real lossy encode
@@ -361,6 +370,7 @@ impl VideoEncoder {
         let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let mp4_probe_out =
             std::env::temp_dir().join(format!("ncd_ffmpeg_preflight_{}.mp4", std::process::id()));
+        let frame_sync_arg = self.frame_sync_arg();
 
         let child = std::process::Command::new(&self.binary)
             .arg("-y")
@@ -380,7 +390,7 @@ impl VideoEncoder {
             // validated.
             .arg("-map")
             .arg("0:v")
-            .arg("-vsync")
+            .arg(frame_sync_arg)
             .arg("passthrough")
             .arg("-enc_time_base")
             .arg(&enc_time_base)
@@ -397,7 +407,7 @@ impl VideoEncoder {
             // build-dependent `libx264rgb` rgb24 capability the encoder relies on.
             .arg("-map")
             .arg("0:v")
-            .arg("-vsync")
+            .arg(frame_sync_arg)
             .arg("passthrough")
             .arg("-enc_time_base")
             .arg(&enc_time_base)
@@ -447,6 +457,7 @@ impl VideoEncoder {
             Err(FfmpegPreflightError::Incompatible {
                 binary: self.binary.clone(),
                 version: version.to_string(),
+                frame_sync_arg,
                 stderr_tail: tail_stderr(&output.stderr),
             })
         }
@@ -480,7 +491,7 @@ impl VideoEncoder {
         // `-y` overwrites existing outputs (resume safety: a previous failed
         // run may have left a partial mp4). `-fflags +genpts` rebuilds the
         // presentation timestamps from the NUT timing when the spool was
-        // truncated mid-frame. `-vsync passthrough` (applied per output) is
+        // truncated mid-frame. Passthrough frame timing (applied per output) is
         // the critical knob here: the NUT chunk uses `time_base = 1/1_000_000`
         // so ffmpeg's demuxer reports `r_frame_rate = 1_000_000/1` (one
         // million fps). With the default `cfr` policy the encoder would then
@@ -498,14 +509,10 @@ impl VideoEncoder {
         // emits every input frame exactly once at its original PTS and never
         // drops, which is what real-time camera capture actually is.
         //
-        // We spell this `-vsync passthrough` rather than the newer
-        // `-fps_mode passthrough`: the two select the identical passthrough
-        // mode, but `-fps_mode` is unrecognised by ffmpeg < 5.1 (e.g. the 4.4
-        // build shipped on Ubuntu 22.04 / the integration host), where it aborts
-        // the encode with "Unrecognized option 'fps_mode'". `-vsync` is accepted
-        // on both (only deprecated, not removed, on 5.1+). The default branch
-        // emits two `-map 0:v -c:v ...` output blocks from a single demux pass;
-        // lossy-only emits a single block (no preview/archive split).
+        // `frame_sync_arg` resolves the spelling this build accepts; the two
+        // do not overlap across the supported ffmpeg versions. The default
+        // branch emits two `-map 0:v -c:v ...` output blocks from a single demux
+        // pass; lossy-only emits a single block (no preview/archive split).
         //
         // Every output also pins its timing to the NUT's microsecond clock
         // ([`VIDEO_SPOOL_TICKS_PER_SECOND`], shared with the producer's NUT
@@ -525,6 +532,7 @@ impl VideoEncoder {
         // (see `adaptive_encode_threads`) so the transcode fleet fills idle
         // cores at low concurrency without oversubscribing at high concurrency.
         let encode_threads = encode_threads.to_string();
+        let frame_sync_arg = self.frame_sync_arg();
         let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
         let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
         let lossy_only = request.codec.is_lossy_only();
@@ -541,7 +549,7 @@ impl VideoEncoder {
             .arg(&request.raw_nut)
             .arg("-map")
             .arg("0:v")
-            .arg("-vsync")
+            .arg(frame_sync_arg)
             .arg("passthrough");
         if lossy_only {
             // Single full-resolution training-quality video: libx264 CRF 23 at
@@ -569,9 +577,9 @@ impl VideoEncoder {
             let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
             command
                 // Lossy preview proxy only: cap to preview resolution (see
-                // `preview_scale_filter`). vsync passthrough still emits every
-                // input frame, so the lossy frame count matches the lossless
-                // output and the per-frame timestamp sidecar.
+                // `preview_scale_filter`). Passthrough still emits every input
+                // frame, so the lossy frame count matches the lossless output
+                // and the per-frame timestamp sidecar.
                 .arg("-vf")
                 .arg(&preview_filter)
                 .arg("-enc_time_base")
@@ -591,7 +599,7 @@ impl VideoEncoder {
                 .arg(&request.lossy_out)
                 .arg("-map")
                 .arg("0:v")
-                .arg("-vsync")
+                .arg(frame_sync_arg)
                 .arg("passthrough")
                 .arg("-enc_time_base")
                 .arg(&enc_time_base)

--- a/rust/data_daemon_bridge/src/nut_writer.rs
+++ b/rust/data_daemon_bridge/src/nut_writer.rs
@@ -1040,6 +1040,7 @@ fn png_crc32(bytes: &[u8]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use data_daemon_shared::ffmpeg::passthrough_frame_sync_arg;
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::TempDir;
@@ -1339,9 +1340,15 @@ mod tests {
         // Decode the whole NUT back to packed RGB24 and assert it is bit-exact
         // to what we wrote — PNG is lossless, so the round-trip must be exact.
         let decoded = Command::new(&ffmpeg)
-            .args(["-v", "error", "-vsync", "passthrough"])
+            .args(["-v", "error"])
             .arg("-i")
             .arg(&path)
+            // Without passthrough the NUT's microsecond time base yields a
+            // duplicate frame per tick. Output-only from 5.1, so after `-i`.
+            .args([
+                passthrough_frame_sync_arg(ffmpeg.as_os_str()),
+                "passthrough",
+            ])
             .args(["-f", "rawvideo", "-pix_fmt", "rgb24", "-"])
             .output()
             .expect("spawn ffmpeg");

--- a/rust/data_daemon_shared/src/ffmpeg.rs
+++ b/rust/data_daemon_shared/src/ffmpeg.rs
@@ -1,0 +1,223 @@
+//! ffmpeg command-line compatibility.
+//!
+//! The daemon transcodes with the system ffmpeg and the producer's NUT tests
+//! decode with it. No single spelling of the passthrough frame-timing option
+//! works on every supported ffmpeg, so it is resolved against the installed
+//! build.
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+
+/// Spelling accepted from ffmpeg 5.1 onwards, and the only one accepted from
+/// 8.0 where the legacy name was removed.
+const FPS_MODE_ARG: &str = "-fps_mode";
+
+/// Spelling accepted before ffmpeg 5.1. Deprecated from 5.1 and removed in 8.0.
+const VSYNC_ARG: &str = "-vsync";
+
+/// One 16x16 yuv420p frame: a 16x16 luma plane plus two 8x8 chroma planes.
+const PROBE_FRAME_LEN: usize = 16 * 16 * 3 / 2;
+
+/// Start of the message ffmpeg prints when it rejects an unknown option.
+const UNKNOWN_OPTION_MESSAGE: &str = "Unrecognized option";
+
+/// Spellings already resolved, keyed by binary. The daemon resolves its binary
+/// during startup preflight, before the async runtime exists, so transcodes
+/// only ever reach the lookup.
+static RESOLVED_ARGS: OnceLock<Mutex<HashMap<OsString, &'static str>>> = OnceLock::new();
+
+/// Return the option name `binary` accepts to select passthrough frame timing
+/// (used as `<arg> passthrough`).
+///
+/// `-fps_mode` does not exist before ffmpeg 5.1 and `-vsync` was removed in
+/// 8.0, so builds outside 5.1..=7.x accept only one of the two.
+///
+/// A probe failure that does not name the option is warned about and resolves
+/// to the pre-5.1 spelling, leaving the caller's real invocation to report the
+/// underlying problem.
+pub fn passthrough_frame_sync_arg(binary: &OsStr) -> &'static str {
+    let mut resolved = RESOLVED_ARGS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(arg) = resolved.get(binary) {
+        return arg;
+    }
+    let arg = if accepts_fps_mode(binary) {
+        FPS_MODE_ARG
+    } else {
+        VSYNC_ARG
+    };
+    tracing::debug!(
+        binary = %binary.to_string_lossy(),
+        arg,
+        "resolved ffmpeg passthrough frame-timing option"
+    );
+    resolved.insert(binary.to_os_string(), arg);
+    arg
+}
+
+/// Encode one synthetic frame to the null muxer with [`FPS_MODE_ARG`],
+/// reporting whether ffmpeg accepted it.
+///
+/// rawvideo on stdin and the null muxer need no input file, no `lavfi` and no
+/// encoder library, so the option under test is the only build-dependent part
+/// left.
+fn accepts_fps_mode(binary: &OsStr) -> bool {
+    let spawned = Command::new(binary)
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "yuv420p",
+            "-video_size",
+            "16x16",
+            "-i",
+            "-",
+            FPS_MODE_ARG,
+            "passthrough",
+            "-f",
+            "null",
+            "-",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn();
+    let mut child = match spawned {
+        Ok(child) => child,
+        Err(error) => {
+            tracing::warn!(
+                binary = %binary.to_string_lossy(),
+                %error,
+                "could not run ffmpeg to resolve its passthrough frame-timing option"
+            );
+            return false;
+        }
+    };
+    // The frame is far smaller than a pipe buffer, so writing then dropping
+    // stdin cannot deadlock against ffmpeg's reads.
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(&[128u8; PROBE_FRAME_LEN]);
+    }
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(
+                binary = %binary.to_string_lossy(),
+                %error,
+                "ffmpeg passthrough probe could not be collected"
+            );
+            return false;
+        }
+    };
+    if output.status.success() {
+        return true;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.contains(UNKNOWN_OPTION_MESSAGE) {
+        tracing::warn!(
+            binary = %binary.to_string_lossy(),
+            stderr = %stderr.trim(),
+            "ffmpeg passthrough probe failed for an unexpected reason; assuming the \
+             pre-5.1 spelling"
+        );
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    /// Write an executable stand-in for ffmpeg that exits with `fps_mode_status`
+    /// when it is given `-fps_mode`, and succeeds otherwise. It lets the
+    /// selection be tested on a host with one ffmpeg version installed.
+    fn write_ffmpeg_stub(directory: &Path, name: &str, fps_mode_status: u8) -> PathBuf {
+        let path = directory.join(name);
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\n\
+                 for argument in \"$@\"; do\n\
+                 if [ \"$argument\" = \"{FPS_MODE_ARG}\" ]; then\n\
+                 echo \"{UNKNOWN_OPTION_MESSAGE} 'fps_mode'.\" >&2\n\
+                 exit {fps_mode_status}\n\
+                 fi\n\
+                 done\n\
+                 exit 0\n"
+            ),
+        )
+        .expect("write ffmpeg stub");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("mark ffmpeg stub executable");
+        path
+    }
+
+    #[test]
+    fn a_build_that_rejects_fps_mode_resolves_to_the_legacy_spelling() {
+        let directory = TempDir::new().unwrap();
+        let stub = write_ffmpeg_stub(directory.path(), "ffmpeg-pre-5-1", 1);
+        assert_eq!(passthrough_frame_sync_arg(stub.as_os_str()), VSYNC_ARG);
+    }
+
+    #[test]
+    fn a_build_that_accepts_fps_mode_resolves_to_the_modern_spelling() {
+        let directory = TempDir::new().unwrap();
+        let stub = write_ffmpeg_stub(directory.path(), "ffmpeg-5-1-or-newer", 0);
+        assert_eq!(passthrough_frame_sync_arg(stub.as_os_str()), FPS_MODE_ARG);
+    }
+
+    #[test]
+    fn a_binary_is_probed_once_per_process() {
+        // Swap the binary after resolving it: a second probe would return the
+        // new answer, the memo keeps the first.
+        let directory = TempDir::new().unwrap();
+        let stub = write_ffmpeg_stub(directory.path(), "ffmpeg-swapped", 1);
+        assert_eq!(passthrough_frame_sync_arg(stub.as_os_str()), VSYNC_ARG);
+
+        write_ffmpeg_stub(directory.path(), "ffmpeg-swapped", 0);
+        assert_eq!(passthrough_frame_sync_arg(stub.as_os_str()), VSYNC_ARG);
+    }
+
+    #[test]
+    fn unusable_binary_resolves_to_the_legacy_spelling() {
+        assert_eq!(
+            passthrough_frame_sync_arg(OsStr::new("nc-definitely-not-a-real-ffmpeg-binary")),
+            VSYNC_ARG
+        );
+    }
+
+    #[test]
+    fn resolved_spelling_is_accepted_by_the_local_ffmpeg() {
+        // Skip where the toolchain is unavailable, matching the encoder tests.
+        let Ok(located) = Command::new("which").arg("ffmpeg").output() else {
+            return;
+        };
+        if !located.status.success() {
+            return;
+        }
+        let binary = OsString::from(String::from_utf8_lossy(&located.stdout).trim());
+        let arg = passthrough_frame_sync_arg(&binary);
+        let probe = Command::new(&binary)
+            .args(["-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i"])
+            .arg("testsrc=duration=1:size=16x16:rate=1")
+            .args([arg, "passthrough", "-f", "null", "-"])
+            .output()
+            .expect("spawn ffmpeg");
+        assert!(
+            probe.status.success(),
+            "ffmpeg rejected the resolved `{arg}`: {}",
+            String::from_utf8_lossy(&probe.stderr)
+        );
+    }
+}

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -13,7 +13,9 @@
 //! the same inputs: the daemon configuration model ([`config`]) and the
 //! filesystem layout ([`paths`]). Keeping these here is what stops the daemon
 //! and producer from drifting on, say, the spool-backlog cap or the recordings
-//! root.
+//! root. [`ffmpeg`] lives here for a weaker reason: both crates shell out to
+//! ffmpeg (the daemon to transcode, the producer only in its tests) and must
+//! spell its options the same way.
 //!
 //! Envelopes are encoded with [`postcard`], a compact length-prefixed binary
 //! format. Payload bytes travel raw (length-prefix + bytes — no base64 or
@@ -46,6 +48,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub mod config;
+pub mod ffmpeg;
 pub mod paths;
 
 /// iceoryx2 service-name conventions shared by daemon and producer.


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - The daemon selects the passthrough frame timing option that the installed ffmpeg accepts, instead of always sending `-vsync`. ffmpeg 8 removed `-vsync` and ffmpeg 5.1 added `-fps_mode`, so no single spelling covers the supported range. This unblocks the daemon staging runs that fail at preflight since CI moved to ffmpeg 9.
 - The unit workflow now runs the suite a second time against ffmpeg 9, so both ends of the supported range are tested.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1275](https://neuracore.atlassian.net/browse/NCP-1275)
