### PR TITLE
perf: batch video chunk encodes

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -20,3 +20,5 @@ The data daemon now works with ffmpeg 8 and later. It selects the frame timing o
 Dataset video decoding now works with ffmpeg 8 and later too. It selects the frame timing option the installed ffmpeg accepts, instead of falling back to the slower PyAV decoder.
 
 Synchronizing a recording is now asynchronous: the SDK starts the synchronization, waits for it to finish, and then downloads the episode directly from storage through a short-lived signed URL instead of receiving it inline from the API. Already-synchronized recordings are ready on the first check, so opening them no longer waits on multi-megabyte responses travelling through the API.
+
+The data daemon batches video chunk encodes under backlog, so a machine that falls behind recovers with fewer ffmpeg invocations.

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -41,7 +41,9 @@ flowchart LR
     DISP --> ACT["per-trace actors"]
     ACT -->|fire-and-forget| TW["trace_writer<br/>batched DB write-behind"]
     ACT -->|fire-and-forget| JW["json_writer (IO thread)"]
-    ACT -->|async subprocess| FF["ffmpeg chunk encode"]
+    ACT -->|enqueue chunk| Q["per-trace encode queue"]
+    Q -->|drain batch on permit| W["EncodeWorker<br/>batch of chunks"]
+    W -->|async subprocess| FF["ffmpeg batch encode"]
     TW --> DB[("SQLite WAL")]
     LIS -->|recording-id queries| DB
     subgraph CLOUD["cloud coordinators"]

--- a/rust/data_daemon/src/encoding/mod.rs
+++ b/rust/data_daemon/src/encoding/mod.rs
@@ -1,11 +1,11 @@
 //! Per-trace on-disk encoders.
 //!
-//! - [`json_trace`] — incremental JSON-array writer used by scalar / sensor
+//! - [`json_trace`], an incremental JSON-array writer used by scalar / sensor
 //!   traces and the video sidecar.
-//! - [`video_encoder`] — supervised `ffmpeg` subprocess that turns a NUT
-//!   chunk into a per-chunk MP4 pair, and stitches the chunk segments into
-//!   the final `lossy.mp4` / `lossless.mp4` on `EndTrace`.
-//! - [`metadata`] — accumulator that flushes the video-trace sidecar
+//! - [`video_encoder`], a supervised `ffmpeg` subprocess that turns one or
+//!   more NUT chunks into one MP4 pair per batch, and stitches the segments
+//!   into the final `lossy.mp4` / `lossless.mp4` on `EndTrace`.
+//! - [`metadata`], an accumulator that flushes the video-trace sidecar
 //!   `trace.json` alongside the mp4 outputs.
 //!
 //! A few writer methods are exercised only by unit tests; those carry a

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -1,9 +1,10 @@
-//! Per-chunk `ffmpeg` transcoder and segment concatenator.
+//! Batched `ffmpeg` transcoder and segment concatenator.
 //!
 //! The producer spools video frames into a sequence of NUT chunk files
-//! beneath each trace's `chunks/` directory. As each chunk arrives the
-//! per-trace actor calls [`VideoEncoder::encode_chunk`] which shells out to
-//! ffmpeg to produce two MP4 segments:
+//! beneath each trace's `chunks/` directory. The per-trace actor's encode
+//! worker hands a batch of one or more contiguous chunks to
+//! [`VideoEncoder::encode_chunk_batch`], which shells out to ffmpeg to
+//! produce two MP4 segments for the whole batch:
 //!
 //! - `chunk_NNNN_lossy.mp4` — `libx264` `-pix_fmt yuv420p -preset ultrafast
 //!   -qp 23` for fast playback, downscaled to a preview resolution (see
@@ -16,6 +17,19 @@
 //!   faster than a `yuv444p10le` pass.
 //!   `ffv1` would also be lossless but is incompatible with the `.mp4`
 //!   container the on-disk layout contract requires.
+//!
+//! A batch of one delegates to [`VideoEncoder::encode_chunk`], which skips
+//! both the concat demuxer and `verify_nut_header`. A batch of two or more
+//! goes through the ffmpeg concat demuxer with a list file that carries one
+//! `duration` line per non-last entry. `declared_batch_span_us` sets that
+//! duration to the capture span to the next chunk's first frame, floored at
+//! the chunk's replayed PTS extent plus 1 us and capped at that extent plus
+//! `MAX_BOUNDARY_DELTA_US`. `verify_nut_header` checks every entry of such a
+//! batch, because the concat demuxer treats an entry it cannot open as end of
+//! stream. The frame cap `-frames:v` is the sum over the
+//! batch, which is correct because a chunk the dispatcher cut is always the
+//! trace's last. The caller names the outputs by the batch's first chunk
+//! index.
 //!
 //! On `EndTrace` the per-trace actor calls [`VideoEncoder::concat_segments`]
 //! which stream-copies the per-chunk segments into the final `lossy.mp4` /
@@ -155,15 +169,15 @@ impl LossyVideoCodec {
     }
 }
 
-/// Inputs to one per-chunk transcode invocation.
+/// Inputs to one single-entry transcode invocation.
 #[derive(Debug, Clone)]
 pub struct ChunkEncodeRequest {
     /// Source NUT chunk file produced by the producer.
     pub raw_nut: PathBuf,
-    /// Destination for the per-chunk lossy mp4 segment.
+    /// Destination for the lossy mp4 segment of this entry.
     pub lossy_out: PathBuf,
-    /// Destination for the per-chunk lossless mp4 segment. Unused in lossy-only
-    /// mode (no lossless output is produced).
+    /// Destination for the lossless mp4 segment of this entry. Unused in
+    /// lossy-only mode (no lossless output is produced).
     pub lossless_out: PathBuf,
     /// Lossy codec selection for this trace. Controls whether a lossless
     /// archive is produced and how the lossy output is encoded.
@@ -173,7 +187,39 @@ pub struct ChunkEncodeRequest {
     pub frame_count: u32,
 }
 
-/// Outcome of a successful per-chunk transcode.
+/// One NUT entry of a batched chunk encode.
+#[derive(Debug, Clone)]
+pub struct BatchNutInput {
+    /// Source NUT chunk file, already relinked into the trace's chunks dir.
+    pub raw_nut: PathBuf,
+    /// Declared capture span to the next chunk's first frame, in
+    /// microseconds. `None` on the batch's last entry, which gets no
+    /// `duration` line.
+    pub span_to_next_us: Option<i64>,
+    /// Frames this entry contributes to the batch: the whole NUT unless the
+    /// dispatcher cut the chunk (see [`ChunkEncodeRequest::frame_count`]).
+    pub frame_count: u32,
+}
+
+/// Inputs to one batched transcode invocation covering a contiguous run of
+/// NUT chunks. The outputs carry the batch's first chunk index in their
+/// names (the caller builds the paths), so downstream segment handling is
+/// unchanged from the single-chunk case.
+#[derive(Debug, Clone)]
+pub struct BatchEncodeRequest {
+    /// Batch entries in chunk-index order.
+    pub inputs: Vec<BatchNutInput>,
+    /// Destination for the batch's lossy mp4 segment.
+    pub lossy_out: PathBuf,
+    /// Destination for the batch's lossless mp4 segment. Unused in
+    /// lossy-only mode (no lossless output is produced).
+    pub lossless_out: PathBuf,
+    /// Lossy codec selection for this trace.
+    pub codec: LossyVideoCodec,
+}
+
+/// Outcome of a successful transcode: the sizes of the batch's lossy and
+/// lossless output files.
 #[derive(Debug, Clone, Copy)]
 pub struct ChunkEncodeOutcome {
     /// Bytes written to the lossy segment.
@@ -232,6 +278,13 @@ pub enum VideoEncodeError {
     /// `concat_segments` was called with no input segments — caller bug.
     #[error("concat_segments called with empty segment list")]
     EmptySegments,
+    /// A batched NUT input failed the header check before the invocation
+    /// (see [`verify_nut_header`]).
+    #[error("batch input {path} is not a NUT container")]
+    InvalidNutInput {
+        /// The input that failed the header check.
+        path: PathBuf,
+    },
 }
 
 /// Failure modes of [`VideoEncoder::preflight`], surfaced at daemon startup so
@@ -474,9 +527,9 @@ impl VideoEncoder {
     /// idle cores.
     ///
     /// The source `raw.nut` is left in place — the caller is responsible for
-    /// unlinking it after verifying both outputs landed (the per-trace actor
-    /// drops the source as part of its envelope handling so a partial encode
-    /// can be retried via the recovery sweep without needing to re-spool).
+    /// unlinking it after verifying both outputs landed (the encode worker
+    /// unlinks every NUT of the batch once the outputs verify; the NUTs of a
+    /// failed batch stay on disk to be collected by the recovery sweep).
     ///
     /// [`adaptive_encode_threads`]: crate::pipeline::trace_actor::adaptive_encode_threads
     pub async fn encode_chunk(
@@ -534,14 +587,6 @@ impl VideoEncoder {
         // Bound each output's libx264 thread pool to the caller-sized value
         // (see `adaptive_encode_threads`) so the transcode fleet fills idle
         // cores at low concurrency without oversubscribing at high concurrency.
-        let encode_threads = encode_threads.to_string();
-        let frame_sync_arg = self.frame_sync_arg();
-        let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
-        let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
-        let lossy_only = request.codec.is_lossy_only();
-        // Per-output frame cap (see [`ChunkEncodeRequest::frame_count`]), a
-        // no-op unless the dispatcher cut this chunk at a recording boundary.
-        let frame_limit = (request.frame_count > 0).then(|| request.frame_count.to_string());
         let mut command = Command::new(&self.binary);
         command
             .arg("-y")
@@ -552,89 +597,106 @@ impl VideoEncoder {
             .arg("-fflags")
             .arg("+genpts")
             .arg("-i")
-            .arg(&request.raw_nut)
-            .arg("-map")
-            .arg("0:v")
-            .arg(frame_sync_arg)
-            .arg("passthrough");
-        if lossy_only {
-            // Single full-resolution training-quality video: libx264 CRF 23 at
-            // `-preset medium`. No preview downscale and no lossless pass — this
-            // is the canonical (and only) upload for the trace.
-            command
-                .arg("-enc_time_base")
-                .arg(&enc_time_base)
-                .arg("-c:v")
-                .arg("libx264")
-                .arg("-threads")
-                .arg(&encode_threads)
-                .arg("-pix_fmt")
-                .arg("yuv420p")
-                .arg("-preset")
-                .arg("medium")
-                .arg("-crf")
-                .arg("23")
-                .arg("-video_track_timescale")
-                .arg(&track_timescale);
-            if let Some(limit) = frame_limit.as_deref() {
-                command.arg("-frames:v").arg(limit);
-            }
-            command.arg(&request.lossy_out);
-        } else {
-            // Downscale the lossy preview proxy (only) to keep this dominant
-            // pass cheap at high resolution; the lossless output stays native.
-            let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
-            command
-                // Lossy preview proxy only: cap to preview resolution (see
-                // `preview_scale_filter`). Passthrough still emits every input
-                // frame, so the lossy frame count matches the lossless output
-                // and the per-frame timestamp sidecar.
-                .arg("-vf")
-                .arg(&preview_filter)
-                .arg("-enc_time_base")
-                .arg(&enc_time_base)
-                .arg("-c:v")
-                .arg("libx264")
-                .arg("-threads")
-                .arg(&encode_threads)
-                .arg("-pix_fmt")
-                .arg("yuv420p")
-                .arg("-preset")
-                .arg("ultrafast")
-                .arg("-qp")
-                .arg("23")
-                .arg("-video_track_timescale")
-                .arg(&track_timescale);
-            if let Some(limit) = frame_limit.as_deref() {
-                command.arg("-frames:v").arg(limit);
-            }
-            command
-                .arg(&request.lossy_out)
-                .arg("-map")
-                .arg("0:v")
-                .arg(frame_sync_arg)
-                .arg("passthrough")
-                .arg("-enc_time_base")
-                .arg(&enc_time_base)
-                // libx264rgb encodes the rgb24 frames directly: bit-exact to
-                // the captured pixels and ~2.5× faster than a yuv444p10le pass.
-                .arg("-c:v")
-                .arg("libx264rgb")
-                .arg("-threads")
-                .arg(&encode_threads)
-                .arg("-pix_fmt")
-                .arg("rgb24")
-                .arg("-preset")
-                .arg("ultrafast")
-                .arg("-qp")
-                .arg("0")
-                .arg("-video_track_timescale")
-                .arg(&track_timescale);
-            if let Some(limit) = frame_limit.as_deref() {
-                command.arg("-frames:v").arg(limit);
-            }
-            command.arg(&request.lossless_out);
+            .arg(&request.raw_nut);
+        append_encode_output_args(
+            &mut command,
+            request.codec,
+            encode_threads,
+            self.frame_sync_arg(),
+            request.frame_count,
+            &request.lossy_out,
+            &request.lossless_out,
+        );
+        let lossless_out =
+            (!request.codec.is_lossy_only()).then_some(request.lossless_out.as_path());
+        self.run_encode_command(command, &request.lossy_out, lossless_out)
+            .await
+    }
+
+    /// Transcode a contiguous batch of NUT chunks with one ffmpeg
+    /// invocation, fed through the concat demuxer with the per-entry
+    /// `duration` directives that place every frame on its batch-relative
+    /// capture timestamp (see [`write_batch_concat_list`]). A batch of one
+    /// delegates to [`Self::encode_chunk`] for an identical invocation.
+    pub async fn encode_chunk_batch(
+        &self,
+        request: &BatchEncodeRequest,
+        encode_threads: usize,
+    ) -> Result<ChunkEncodeOutcome, VideoEncodeError> {
+        if let [single] = request.inputs.as_slice() {
+            return self
+                .encode_chunk(
+                    &ChunkEncodeRequest {
+                        raw_nut: single.raw_nut.clone(),
+                        lossy_out: request.lossy_out.clone(),
+                        lossless_out: request.lossless_out.clone(),
+                        codec: request.codec,
+                        frame_count: single.frame_count,
+                    },
+                    encode_threads,
+                )
+                .await;
         }
+
+        // The concat demuxer treats a list entry it cannot open as end of
+        // stream: ffmpeg exits 0 and the frames of that entry and every later
+        // entry are silently lost. Verify every input is a NUT container up
+        // front so a corrupt chunk fails the batch instead of truncating it.
+        for input in &request.inputs {
+            verify_nut_header(&input.raw_nut)?;
+        }
+
+        ensure_parent_dirs(&request.lossy_out)?;
+        if !request.codec.is_lossy_only() {
+            ensure_parent_dirs(&request.lossless_out)?;
+        }
+
+        let list_path = list_file_for(&request.lossy_out);
+        write_batch_concat_list(&list_path, &request.inputs)?;
+
+        let mut command = Command::new(&self.binary);
+        command
+            .arg("-y")
+            .arg("-hide_banner")
+            .arg("-nostdin")
+            .arg("-loglevel")
+            .arg("error")
+            .arg("-fflags")
+            .arg("+genpts")
+            .arg("-f")
+            .arg("concat")
+            // `-safe 0` permits the absolute NUT paths in the list file.
+            .arg("-safe")
+            .arg("0")
+            .arg("-i")
+            .arg(&list_path);
+        append_encode_output_args(
+            &mut command,
+            request.codec,
+            encode_threads,
+            self.frame_sync_arg(),
+            batch_frame_count(&request.inputs),
+            &request.lossy_out,
+            &request.lossless_out,
+        );
+        let lossless_out =
+            (!request.codec.is_lossy_only()).then_some(request.lossless_out.as_path());
+        let result = self
+            .run_encode_command(command, &request.lossy_out, lossless_out)
+            .await;
+        let _ = std::fs::remove_file(&list_path);
+        result
+    }
+
+    /// Configure the encode child's stdio and niceness, run it, and verify
+    /// the expected outputs are non-empty. `lossless_out` is `None` in
+    /// lossy-only mode, where no lossless archive is produced.
+    async fn run_encode_command(
+        &self,
+        mut command: Command,
+        lossy_out: &Path,
+        lossless_out: Option<&Path>,
+    ) -> Result<ChunkEncodeOutcome, VideoEncodeError> {
         command
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -673,13 +735,12 @@ impl VideoEncoder {
             });
         }
 
-        let lossy_bytes = non_empty_file_size(&request.lossy_out)?;
-        // In lossy-only mode no lossless archive is produced, so there is no
-        // file to size — report zero rather than erroring on a missing output.
-        let lossless_bytes = if lossy_only {
-            0
-        } else {
-            non_empty_file_size(&request.lossless_out)?
+        let lossy_bytes = non_empty_file_size(lossy_out)?;
+        // With no lossless archive there is no file to size; report zero
+        // rather than erroring on a missing output.
+        let lossless_bytes = match lossless_out {
+            Some(path) => non_empty_file_size(path)?,
+            None => 0,
         };
 
         Ok(ChunkEncodeOutcome {
@@ -687,7 +748,6 @@ impl VideoEncoder {
             lossless_bytes,
         })
     }
-
     /// Stream-copy concatenate `segments` into `out`.
     ///
     /// Uses ffmpeg's `concat` demuxer with `-c copy`, so no transcode
@@ -758,6 +818,234 @@ impl VideoEncoder {
     }
 }
 
+/// Append the per-output encoder arguments, shared by
+/// [`VideoEncoder::encode_chunk`] and [`VideoEncoder::encode_chunk_batch`] so
+/// both invocations keep the same output shape (see `encode_chunk` for the
+/// rationale behind each knob).
+fn append_encode_output_args(
+    command: &mut Command,
+    codec: LossyVideoCodec,
+    encode_threads: usize,
+    frame_sync_arg: &'static str,
+    frame_count: u32,
+    lossy_out: &Path,
+    lossless_out: &Path,
+) {
+    let encode_threads = encode_threads.to_string();
+    let enc_time_base = format!("1:{VIDEO_SPOOL_TICKS_PER_SECOND}");
+    let track_timescale = VIDEO_SPOOL_TICKS_PER_SECOND.to_string();
+    // Per-output frame cap (see [`ChunkEncodeRequest::frame_count`]), a no-op
+    // unless the dispatcher cut a chunk of this encode at a recording boundary.
+    let frame_limit = (frame_count > 0).then(|| frame_count.to_string());
+    command
+        .arg("-map")
+        .arg("0:v")
+        .arg(frame_sync_arg)
+        .arg("passthrough");
+    if codec.is_lossy_only() {
+        // Single full-resolution training-quality video: libx264 CRF 23 at
+        // `-preset medium`. No preview downscale and no lossless pass — this
+        // is the canonical (and only) upload for the trace.
+        command
+            .arg("-enc_time_base")
+            .arg(&enc_time_base)
+            .arg("-c:v")
+            .arg("libx264")
+            .arg("-threads")
+            .arg(&encode_threads)
+            .arg("-pix_fmt")
+            .arg("yuv420p")
+            .arg("-preset")
+            .arg("medium")
+            .arg("-crf")
+            .arg("23")
+            .arg("-video_track_timescale")
+            .arg(&track_timescale);
+        if let Some(limit) = frame_limit.as_deref() {
+            command.arg("-frames:v").arg(limit);
+        }
+        command.arg(lossy_out);
+    } else {
+        // Downscale the lossy preview proxy (only) to keep this dominant
+        // pass cheap at high resolution; the lossless output stays native.
+        let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
+        command
+            // Lossy preview proxy only: cap to preview resolution (see
+            // `preview_scale_filter`). Passthrough frame timing still emits
+            // every input frame, so the lossy frame count matches the
+            // lossless output and the per-frame timestamp sidecar.
+            .arg("-vf")
+            .arg(&preview_filter)
+            .arg("-enc_time_base")
+            .arg(&enc_time_base)
+            .arg("-c:v")
+            .arg("libx264")
+            .arg("-threads")
+            .arg(&encode_threads)
+            .arg("-pix_fmt")
+            .arg("yuv420p")
+            .arg("-preset")
+            .arg("ultrafast")
+            .arg("-qp")
+            .arg("23")
+            .arg("-video_track_timescale")
+            .arg(&track_timescale);
+        if let Some(limit) = frame_limit.as_deref() {
+            command.arg("-frames:v").arg(limit);
+        }
+        command
+            .arg(lossy_out)
+            .arg("-map")
+            .arg("0:v")
+            .arg(frame_sync_arg)
+            .arg("passthrough")
+            .arg("-enc_time_base")
+            .arg(&enc_time_base)
+            // libx264rgb encodes the rgb24 frames directly: bit-exact to
+            // the captured pixels and ~2.5× faster than a yuv444p10le pass.
+            .arg("-c:v")
+            .arg("libx264rgb")
+            .arg("-threads")
+            .arg(&encode_threads)
+            .arg("-pix_fmt")
+            .arg("rgb24")
+            .arg("-preset")
+            .arg("ultrafast")
+            .arg("-qp")
+            .arg("0")
+            .arg("-video_track_timescale")
+            .arg(&track_timescale);
+        if let Some(limit) = frame_limit.as_deref() {
+            command.arg("-frames:v").arg(limit);
+        }
+        command.arg(lossless_out);
+    }
+}
+
+/// Frames a batch's outputs may hold: the sum of what every entry owns.
+///
+/// The cap drops frames from the tail of the concatenated stream, which is
+/// only correct because a cut entry is always the batch's last: the dispatcher
+/// cuts a chunk at the window's stop, and every chunk that opens after that
+/// stop is dropped whole, so no chunk of the trace follows a cut one.
+fn batch_frame_count(inputs: &[BatchNutInput]) -> u32 {
+    inputs
+        .iter()
+        .fold(0u32, |total, input| total.saturating_add(input.frame_count))
+}
+
+/// Ceiling for the boundary step a declared span may add past a chunk's own
+/// content extent. At exactly `i32::MAX` the ultrafast branch silently
+/// collapses the following segment's ladder, so the safe maximum is one
+/// below. A larger real gap is compressed to this step and stays monotonic.
+pub(crate) const MAX_BOUNDARY_DELTA_US: i64 = i32::MAX as i64 - 1;
+
+/// Synthesized-PTS step bounds, mirrored from
+/// `data_daemon_bridge/src/writer.rs`: a stamp that fails to advance steps
+/// by the stream's observed frame gap, clamped to this range.
+const SYNTH_PTS_STEP_MIN_US: u64 = 1_000;
+const SYNTH_PTS_STEP_MAX_US: u64 = 100_000;
+
+/// Convert a capture timestamp in seconds to microseconds with the NUT
+/// writer's truncation: to nanoseconds first, then divide toward zero. This
+/// mirrors the writer's integer microsecond arithmetic, `timestamp_ns /
+/// 1_000` in `data_daemon_bridge/src/writer.rs`, so the replayed extent does
+/// not undershoot the spooled PTS extent. A naive `round(s * 1e6)` is off by
+/// up to 1 us.
+pub(crate) fn capture_timestamp_us(timestamp_s: f64) -> i64 {
+    ((timestamp_s * 1e9) as i64) / 1000
+}
+
+/// Span between two chunks' first capture timestamps, floored at zero so a
+/// backwards announcement cannot emit a negative `duration`. The
+/// extent-relative ceiling belongs to [`declared_batch_span_us`].
+pub(crate) fn declared_span_us(from_timestamp_s: f64, to_timestamp_s: f64) -> i64 {
+    (capture_timestamp_us(to_timestamp_s) - capture_timestamp_us(from_timestamp_s)).max(0)
+}
+
+/// The chunk's content extent: the last frame's PTS relative to the chunk
+/// start, as the spool writer stored it in the NUT.
+///
+/// Replays the writer's PTS synthesis (`data_daemon_bridge/src/writer.rs`)
+/// over the announced stamps. The writer carries its observed frame gap
+/// across chunks and the announcement does not, so the replay seeds that
+/// unknown with the step ceiling and never undershoots the real extent.
+/// Undershooting would let the next chunk start inside this one's content,
+/// which makes a B-frame encode store backwards PTS.
+pub(crate) fn replayed_chunk_extent_us(frame_timestamps_s: &[f64]) -> i64 {
+    let mut origin_us: Option<i64> = None;
+    let mut last_pts_us: Option<u64> = None;
+    let mut observed_frame_gap_us: Option<u64> = None;
+    for &timestamp_s in frame_timestamps_s {
+        let timestamp_us = capture_timestamp_us(timestamp_s);
+        let origin = *origin_us.get_or_insert(timestamp_us);
+        let mut pts = timestamp_us.saturating_sub(origin).max(0) as u64;
+        if let Some(previous) = last_pts_us {
+            if pts <= previous {
+                let step = observed_frame_gap_us
+                    .unwrap_or(SYNTH_PTS_STEP_MAX_US)
+                    .clamp(SYNTH_PTS_STEP_MIN_US, SYNTH_PTS_STEP_MAX_US);
+                pts = previous.saturating_add(step);
+                origin_us = Some(timestamp_us.saturating_sub(pts as i64));
+            } else if pts - previous <= SYNTH_PTS_STEP_MAX_US {
+                observed_frame_gap_us = Some(pts - previous);
+            }
+        }
+        last_pts_us = Some(pts);
+    }
+    last_pts_us.unwrap_or(0) as i64
+}
+
+/// Declared span for a batch entry: the capture span to the next chunk's
+/// first frame, floored at this chunk's content extent plus 1 us and capped
+/// at the extent plus [`MAX_BOUNDARY_DELTA_US`].
+///
+/// Without the floor, a backwards clock step at the boundary declares the
+/// next chunk inside this one's content and a B-frame encode stores
+/// backwards PTS; the floor degrades that to a 1 us ramp. A well-formed
+/// span already sits past the floor and passes through untouched.
+pub(crate) fn declared_batch_span_us(
+    chunk_frame_timestamps_s: &[f64],
+    next_first_timestamp_s: f64,
+) -> i64 {
+    let extent_us = replayed_chunk_extent_us(chunk_frame_timestamps_s);
+    let span_us = match chunk_frame_timestamps_s.first() {
+        Some(&first_timestamp_s) => declared_span_us(first_timestamp_s, next_first_timestamp_s),
+        None => 0,
+    };
+    span_us
+        .max(extent_us + 1)
+        .min(extent_us + MAX_BOUNDARY_DELTA_US)
+}
+
+/// Format a microsecond span as the exact decimal seconds a concat-list
+/// `duration` directive carries.
+fn duration_directive(span_us: i64) -> String {
+    format!("{}.{:06}", span_us / 1_000_000, span_us % 1_000_000)
+}
+
+/// The file id string every NUT container starts with.
+const NUT_FILE_MAGIC: &[u8] = b"nut/multimedia container\0";
+
+/// Verify `raw_nut` starts with the NUT file id string. The concat demuxer
+/// treats a file it cannot open as end of stream and ffmpeg still exits 0,
+/// so an unchecked bad entry would silently drop the rest of the batch. A
+/// truncated file with a healthy header passes, as it does today.
+fn verify_nut_header(raw_nut: &Path) -> Result<(), VideoEncodeError> {
+    let mut file = std::fs::File::open(raw_nut).map_err(|source| VideoEncodeError::Io {
+        path: raw_nut.to_path_buf(),
+        source,
+    })?;
+    let mut header = [0u8; NUT_FILE_MAGIC.len()];
+    let header_read = std::io::Read::read_exact(&mut file, &mut header);
+    if header_read.is_err() || header != *NUT_FILE_MAGIC {
+        return Err(VideoEncodeError::InvalidNutInput {
+            path: raw_nut.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
 /// Build the ffmpeg `-vf` value that downscales the lossy preview proxy to at
 /// most `max_height` lines.
 ///
@@ -810,21 +1098,52 @@ fn write_concat_list(path: &Path, segments: &[PathBuf]) -> Result<(), VideoEncod
         source,
     })?;
     for segment in segments {
-        let absolute = if segment.is_absolute() {
-            segment.clone()
-        } else {
-            std::env::current_dir()
-                .map_err(|source| VideoEncodeError::Io {
-                    path: segment.clone(),
-                    source,
-                })?
-                .join(segment)
-        };
-        let escaped = absolute.to_string_lossy().replace('\'', r"'\''");
-        writeln!(file, "file '{escaped}'").map_err(|source| VideoEncodeError::Io {
+        let line = concat_file_line(segment)?;
+        writeln!(file, "{line}").map_err(|source| VideoEncodeError::Io {
             path: path.to_path_buf(),
             source,
         })?;
+    }
+    Ok(())
+}
+
+/// Render one `file '...'` concat-list entry: the path made absolute (see
+/// [`write_concat_list`]) and single-quoted with embedded quotes escaped per
+/// the demuxer's own rule (`'` -> `'\''`).
+fn concat_file_line(segment: &Path) -> Result<String, VideoEncodeError> {
+    let absolute = if segment.is_absolute() {
+        segment.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|source| VideoEncodeError::Io {
+                path: segment.to_path_buf(),
+                source,
+            })?
+            .join(segment)
+    };
+    let escaped = absolute.to_string_lossy().replace('\'', r"'\''");
+    Ok(format!("file '{escaped}'"))
+}
+
+/// Render the concat list for a batched encode: each NUT entry followed,
+/// for every entry except the last, by its declared `duration`. The demuxer
+/// stacks inputs by declared duration, which is what lands each frame on
+/// its capture timestamp. A single-entry list carries no `duration` line.
+fn write_batch_concat_list(path: &Path, inputs: &[BatchNutInput]) -> Result<(), VideoEncodeError> {
+    let mut file = std::fs::File::create(path).map_err(|source| VideoEncodeError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let write_error = |source| VideoEncodeError::Io {
+        path: path.to_path_buf(),
+        source,
+    };
+    for input in inputs {
+        let line = concat_file_line(&input.raw_nut)?;
+        writeln!(file, "{line}").map_err(write_error)?;
+        if let Some(span_us) = input.span_to_next_us {
+            writeln!(file, "duration {}", duration_directive(span_us)).map_err(write_error)?;
+        }
     }
     Ok(())
 }
@@ -1712,6 +2031,24 @@ mod tests {
         );
 
         // Decode-order PTS, exactly as the backend guard walks them.
+        let pts_values = decoded_frame_pts(ffprobe, video);
+        assert!(
+            !pts_values.is_empty(),
+            "{} yielded no decoded PTS",
+            video.display()
+        );
+        for pair in pts_values.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "{}: decoded PTS must be strictly increasing, got {pair:?}",
+                video.display()
+            );
+        }
+    }
+
+    /// Decode `video` and collect its frames' PTS values in the order the
+    /// decoder presents them.
+    fn decoded_frame_pts(ffprobe: &Path, video: &Path) -> Vec<i64> {
         let probe = StdCommand::new(ffprobe)
             .args([
                 "-v",
@@ -1729,26 +2066,14 @@ mod tests {
             .expect("spawn ffprobe");
         assert!(probe.status.success());
         let stdout = String::from_utf8_lossy(&probe.stdout);
-        let pts_values: Vec<i64> = stdout
+        stdout
             .lines()
             .filter_map(|line| {
                 line.strip_prefix("pts=")
                     .or_else(|| line.strip_prefix("pkt_pts="))
             })
             .filter_map(|value| value.parse().ok())
-            .collect();
-        assert!(
-            !pts_values.is_empty(),
-            "{} yielded no decoded PTS",
-            video.display()
-        );
-        for pair in pts_values.windows(2) {
-            assert!(
-                pair[1] > pair[0],
-                "{}: decoded PTS must be strictly increasing, got {pair:?}",
-                video.display()
-            );
-        }
+            .collect()
     }
 
     #[tokio::test]
@@ -1804,5 +2129,701 @@ mod tests {
             }
             other => panic!("expected Spawn error, got {other:?}"),
         }
+    }
+
+    /// Write a NUT chunk with the real producer NUT writer: one 16x16 RGB
+    /// frame per entry of `frame_pts_us` (chunk-relative microsecond ticks;
+    /// the producer re-anchors every chunk's first frame near 0).
+    fn write_nut_chunk(path: &Path, frame_pts_us: &[i64]) {
+        use data_daemon_bridge::nut_writer::{NutVideoConfig, NutWriter};
+        let rgb = vec![128u8; 16 * 16 * 3];
+        let mut writer = NutWriter::create(
+            path,
+            NutVideoConfig {
+                width: 16,
+                height: 16,
+                time_base_num: 1,
+                time_base_den: VIDEO_SPOOL_TICKS_PER_SECOND,
+            },
+        )
+        .expect("create NUT");
+        for pts in frame_pts_us {
+            writer.write_frame(*pts as u64, &rgb).expect("write frame");
+        }
+        writer.finish().expect("finish NUT");
+    }
+
+    #[test]
+    fn capture_timestamp_us_truncates_like_the_nut_writer() {
+        assert_eq!(capture_timestamp_us(1.0), 1_000_000);
+        assert_eq!(capture_timestamp_us(0.000001), 1);
+        // Truncation toward zero, not rounding: 1.9 us of capture time is
+        // still tick 1, exactly as the writer's ns-then-divide conversion.
+        assert_eq!(capture_timestamp_us(0.0000019), 1);
+    }
+
+    #[test]
+    fn declared_span_never_goes_negative() {
+        assert_eq!(declared_span_us(0.0, 1.0), 1_000_000);
+        // A backwards announcement never yields a negative duration.
+        assert_eq!(declared_span_us(2.0, 1.0), 0);
+    }
+
+    #[test]
+    fn replayed_extent_matches_healthy_stamps() {
+        // Monotonic stamps trigger no synthesis: the extent is the plain
+        // last-minus-first capture span in writer-truncated microseconds.
+        assert_eq!(replayed_chunk_extent_us(&[0.0, 0.016683, 0.033366]), 33_366);
+        assert_eq!(replayed_chunk_extent_us(&[1.0]), 0);
+        assert_eq!(replayed_chunk_extent_us(&[]), 0);
+    }
+
+    #[test]
+    fn replayed_extent_covers_the_writer_synthesis() {
+        // All-duplicate stamps: the writer synthesizes a step per frame from
+        // the healthy gap it carried from earlier chunks. That gap is capped
+        // at 100 ms, so the replay's worst-case seed never undershoots.
+        assert_eq!(replayed_chunk_extent_us(&[1.0, 1.0, 1.0]), 200_000);
+        // A healthy gap observed inside the chunk becomes the step for a
+        // later duplicate, exactly as the writer applies it.
+        assert_eq!(replayed_chunk_extent_us(&[0.0, 0.016683, 0.016683]), 33_366);
+        // After a synthesized step the origin re-anchors on the regressed
+        // frame, so later stamps resume true capture spacing from it.
+        assert_eq!(
+            replayed_chunk_extent_us(&[0.0, 0.016683, 0.016683, 0.033366]),
+            50_049
+        );
+        // A regression below the chunk origin clamps to PTS 0 first, then
+        // synthesizes past the previous frame.
+        assert_eq!(replayed_chunk_extent_us(&[1.0, 0.5]), 100_000);
+    }
+
+    #[test]
+    fn batch_span_floors_at_the_chunk_extent_plus_one() {
+        let capture_s = |us: i64| us as f64 / 1e6;
+        let chunk: Vec<f64> = [0, 16_683, 33_366]
+            .iter()
+            .map(|us| capture_s(*us))
+            .collect();
+        // Overlap: the next chunk's announced start sits inside this chunk's
+        // content span; the declared span floors to the extent plus 1 us.
+        assert_eq!(declared_batch_span_us(&chunk, capture_s(20_000)), 33_367);
+        // A well-formed span is at least the extent plus one frame interval
+        // and passes through unchanged.
+        assert_eq!(declared_batch_span_us(&chunk, capture_s(50_049)), 50_049);
+        // A synthesized-PTS chunk: the announced extent is zero, but the
+        // NUT's real content extends up to one writer step per frame. The
+        // floor tracks the replayed extent, not the announced one.
+        let duplicates = [1.0, 1.0, 1.0];
+        assert_eq!(
+            declared_batch_span_us(&duplicates, capture_s(1_005_000)),
+            200_001
+        );
+        // A chunk whose own extent exceeds the boundary ceiling still floors
+        // to extent plus one; the boundary delta stays 1 us.
+        let long_chunk = [0.0, 5_000.0];
+        assert_eq!(
+            declared_batch_span_us(&long_chunk, capture_s(20_000)),
+            5_000_000_001
+        );
+        // A chunk with no announced frames contributes extent zero and a
+        // 1 us span instead of panicking.
+        assert_eq!(declared_batch_span_us(&[], capture_s(20_000)), 1);
+    }
+
+    #[test]
+    fn batch_span_ceilings_the_boundary_delta() {
+        let capture_s = |us: i64| us as f64 / 1e6;
+        // A gap past ~35.8 minutes saturates the 32-bit mp4 boundary sample
+        // delta: the declared span compresses so the step past the chunk's
+        // content extent never exceeds MAX_BOUNDARY_DELTA_US.
+        assert_eq!(
+            declared_batch_span_us(&[0.0], capture_s(5_000_000_000)),
+            MAX_BOUNDARY_DELTA_US
+        );
+        let chunk = [0.0, 0.016683];
+        assert_eq!(
+            declared_batch_span_us(&chunk, capture_s(5_000_000_000)),
+            16_683 + MAX_BOUNDARY_DELTA_US
+        );
+    }
+
+    #[test]
+    fn duration_directive_formats_exact_decimal_seconds() {
+        assert_eq!(duration_directive(16_683), "0.016683");
+        assert_eq!(duration_directive(1_000_000), "1.000000");
+        assert_eq!(duration_directive(0), "0.000000");
+        assert_eq!(duration_directive(MAX_BOUNDARY_DELTA_US), "2147.483646");
+    }
+
+    #[test]
+    fn batch_concat_list_emits_duration_lines_except_last() {
+        let tempdir = TempDir::new().unwrap();
+        let list = tempdir.path().join("list.txt");
+        let inputs = vec![
+            BatchNutInput {
+                raw_nut: PathBuf::from("/data/trace/chunks/chunk_0000.nut"),
+                span_to_next_us: Some(16_683),
+                frame_count: 2,
+            },
+            BatchNutInput {
+                raw_nut: PathBuf::from("/data/trace/chunks/chunk_0001.nut"),
+                span_to_next_us: Some(MAX_BOUNDARY_DELTA_US),
+                frame_count: 2,
+            },
+            BatchNutInput {
+                raw_nut: PathBuf::from("/data/trace/chunks/chunk_0002.nut"),
+                span_to_next_us: None,
+                frame_count: 2,
+            },
+        ];
+        write_batch_concat_list(&list, &inputs).expect("write list");
+        let contents = std::fs::read_to_string(&list).unwrap();
+        assert_eq!(
+            contents,
+            "file '/data/trace/chunks/chunk_0000.nut'\n\
+             duration 0.016683\n\
+             file '/data/trace/chunks/chunk_0001.nut'\n\
+             duration 2147.483646\n\
+             file '/data/trace/chunks/chunk_0002.nut'\n"
+        );
+    }
+
+    /// Run the batch PTS gate for one fixture, whose `chunk_capture_us` holds
+    /// each chunk's frame times as batch-absolute microseconds. Every output
+    /// of both codec branches must decode to the batch-relative capture
+    /// ladder exactly, frame-complete, monotonic, at the pinned timescale.
+    async fn assert_batch_pts_gate(ffprobe: &Path, chunk_capture_us: &[Vec<i64>]) {
+        // Mirror the production data flow: the announcement carries per-frame
+        // `timestamp_s` seconds; the spooled PTS and the batch spans both
+        // derive from them with the writer's truncation.
+        let capture_s = |us: i64| us as f64 / 1e6;
+        for codec in [
+            LossyVideoCodec::LosslessPlusPreview,
+            LossyVideoCodec::H264MediumLossyOnly,
+        ] {
+            let tempdir = TempDir::new().unwrap();
+            let mut inputs = Vec::new();
+            for (index, chunk) in chunk_capture_us.iter().enumerate() {
+                let chunk_origin_us = capture_timestamp_us(capture_s(chunk[0]));
+                let relative_pts: Vec<i64> = chunk
+                    .iter()
+                    .map(|us| capture_timestamp_us(capture_s(*us)) - chunk_origin_us)
+                    .collect();
+                let raw_nut = tempdir.path().join(format!("chunk_{index:04}.nut"));
+                write_nut_chunk(&raw_nut, &relative_pts);
+                // Spans go through the same helper the worker uses, so a
+                // regression in the production span computation fails the
+                // gate.
+                let chunk_timestamps_s: Vec<f64> = chunk.iter().map(|us| capture_s(*us)).collect();
+                inputs.push(BatchNutInput {
+                    raw_nut,
+                    span_to_next_us: chunk_capture_us.get(index + 1).map(|next| {
+                        declared_batch_span_us(&chunk_timestamps_s, capture_s(next[0]))
+                    }),
+                    frame_count: chunk.len() as u32,
+                });
+            }
+            let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+            let lossless_out = tempdir.path().join("chunk_0000_lossless.mp4");
+            let request = BatchEncodeRequest {
+                inputs,
+                lossy_out: lossy_out.clone(),
+                lossless_out: lossless_out.clone(),
+                codec,
+            };
+            VideoEncoder::new()
+                .encode_chunk_batch(&request, ENCODE_THREADS_PER_OUTPUT)
+                .await
+                .expect("batched transcode");
+
+            let batch_origin_us = capture_timestamp_us(capture_s(chunk_capture_us[0][0]));
+            let expected: Vec<i64> = chunk_capture_us
+                .iter()
+                .flatten()
+                .map(|us| capture_timestamp_us(capture_s(*us)) - batch_origin_us)
+                .collect();
+            let mut outputs = vec![lossy_out];
+            if !codec.is_lossy_only() {
+                outputs.push(lossless_out);
+            }
+            for video in &outputs {
+                assert_merged_video_is_sound(ffprobe, video);
+                assert_eq!(
+                    decoded_frame_pts(ffprobe, video),
+                    expected,
+                    "{} ({codec:?}) must decode to the batch-relative capture ladder",
+                    video.display()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_pts_gate_gapped_chunks() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping batch PTS gate.");
+            return;
+        };
+        // A real capture gap: chunk A at 0/66/133 ms, chunk B at 1000 ms. The
+        // gap must survive the batch instead of collapsing to a frame interval.
+        assert_batch_pts_gate(&ffprobe, &[vec![0, 66_000, 133_000], vec![1_000_000]]).await;
+    }
+
+    #[tokio::test]
+    async fn batch_pts_gate_jittered_chunks() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping batch PTS gate.");
+            return;
+        };
+        // Irregular deltas cycling ~15.4-17.9 ms, continuing across the chunk
+        // boundary like real capture jitter.
+        let deltas = [15_400i64, 16_250, 17_100, 17_900];
+        let mut capture_us = vec![0i64];
+        for index in 0..23usize {
+            capture_us.push(capture_us[index] + deltas[index % deltas.len()]);
+        }
+        let (chunk_a, chunk_b) = capture_us.split_at(12);
+        assert_batch_pts_gate(&ffprobe, &[chunk_a.to_vec(), chunk_b.to_vec()]).await;
+    }
+
+    #[tokio::test]
+    async fn batch_pts_gate_contiguous_chunks() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping batch PTS gate.");
+            return;
+        };
+        // 3 x 48 frames on a metronome 16683 us cadence with no inter-chunk gap.
+        let chunks: Vec<Vec<i64>> = (0..3i64)
+            .map(|chunk| {
+                (0..48i64)
+                    .map(|frame| (chunk * 48 + frame) * 16_683)
+                    .collect()
+            })
+            .collect();
+        assert_batch_pts_gate(&ffprobe, &chunks).await;
+    }
+
+    #[tokio::test]
+    async fn batch_of_one_matches_single_chunk_invocation() {
+        if locate_binary("ffmpeg").is_none() {
+            eprintln!("ffmpeg not on PATH — skipping batch-of-one test.");
+            return;
+        }
+        for codec in [
+            LossyVideoCodec::LosslessPlusPreview,
+            LossyVideoCodec::H264MediumLossyOnly,
+        ] {
+            let tempdir = TempDir::new().unwrap();
+            let raw = tempdir.path().join("chunk_0000.nut");
+            write_nut_chunk(&raw, &[0, 16_683, 33_366, 50_049]);
+
+            let encoder = VideoEncoder::new();
+            let single_lossy = tempdir.path().join("single_lossy.mp4");
+            let single_lossless = tempdir.path().join("single_lossless.mp4");
+            encoder
+                .encode_chunk(
+                    &ChunkEncodeRequest {
+                        raw_nut: raw.clone(),
+                        lossy_out: single_lossy.clone(),
+                        lossless_out: single_lossless.clone(),
+                        codec,
+                        frame_count: 4,
+                    },
+                    ENCODE_THREADS_PER_OUTPUT,
+                )
+                .await
+                .expect("single-chunk transcode");
+
+            let batch_lossy = tempdir.path().join("batch_lossy.mp4");
+            let batch_lossless = tempdir.path().join("batch_lossless.mp4");
+            let outcome = encoder
+                .encode_chunk_batch(
+                    &BatchEncodeRequest {
+                        inputs: vec![BatchNutInput {
+                            raw_nut: raw.clone(),
+                            span_to_next_us: None,
+                            frame_count: 4,
+                        }],
+                        lossy_out: batch_lossy.clone(),
+                        lossless_out: batch_lossless.clone(),
+                        codec,
+                    },
+                    ENCODE_THREADS_PER_OUTPUT,
+                )
+                .await
+                .expect("batch-of-one transcode");
+
+            // The degenerate batch delegates to the single-chunk invocation,
+            // so its outputs are byte-identical to today's.
+            assert_eq!(
+                std::fs::read(&single_lossy).unwrap(),
+                std::fs::read(&batch_lossy).unwrap(),
+                "batch-of-one lossy must match the single-chunk encode ({codec:?})"
+            );
+            if codec.is_lossy_only() {
+                assert_eq!(outcome.lossless_bytes, 0);
+                assert!(!batch_lossless.exists(), "no lossless output ({codec:?})");
+            } else {
+                assert_eq!(
+                    std::fs::read(&single_lossless).unwrap(),
+                    std::fs::read(&batch_lossless).unwrap(),
+                    "batch-of-one lossless must match the single-chunk encode"
+                );
+            }
+            assert!(
+                !list_file_for(&batch_lossy).exists(),
+                "a degenerate batch writes no concat list"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn lossy_only_batch_produces_single_lossy_segment() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping lossy-only batch test.");
+            return;
+        };
+        let tempdir = TempDir::new().unwrap();
+        let mut inputs = Vec::new();
+        for index in 0..3i64 {
+            let raw_nut = tempdir.path().join(format!("chunk_{index:04}.nut"));
+            write_nut_chunk(&raw_nut, &[0, 16_683]);
+            inputs.push(BatchNutInput {
+                raw_nut,
+                span_to_next_us: (index < 2).then_some(33_366),
+                frame_count: 2,
+            });
+        }
+        let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless_out = tempdir.path().join("chunk_0000_lossless.mp4");
+        let outcome = VideoEncoder::new()
+            .encode_chunk_batch(
+                &BatchEncodeRequest {
+                    inputs,
+                    lossy_out: lossy_out.clone(),
+                    lossless_out: lossless_out.clone(),
+                    codec: LossyVideoCodec::H264MediumLossyOnly,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("lossy-only batched transcode");
+
+        assert!(outcome.lossy_bytes > 0);
+        assert_eq!(outcome.lossless_bytes, 0);
+        assert!(
+            !lossless_out.exists(),
+            "no lossless segment in lossy-only mode"
+        );
+        assert_eq!(
+            decoded_frame_pts(&ffprobe, &lossy_out).len(),
+            6,
+            "the single lossy segment must carry every batched frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_frame_count_encodes_only_the_frames_the_recording_owns() {
+        // The dispatcher can only cut the trace's last chunk, so the batch cap
+        // drops frames from the tail of the concatenated stream: the cut
+        // entry's own. Both outputs must stop there, or an mp4 outruns the
+        // sidecar indexing it.
+        let (Some(_), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe")) else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping batch frame-cap test.");
+            return;
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let chunk_a = tempdir.path().join("chunk_0000.nut");
+        let chunk_b = tempdir.path().join("chunk_0001.nut");
+        write_nut_chunk(&chunk_a, &[0, 16_683]);
+        write_nut_chunk(&chunk_b, &[0, 16_683, 33_366]);
+        let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless_out = tempdir.path().join("chunk_0000_lossless.mp4");
+
+        VideoEncoder::new()
+            .encode_chunk_batch(
+                &BatchEncodeRequest {
+                    inputs: vec![
+                        BatchNutInput {
+                            raw_nut: chunk_a,
+                            span_to_next_us: Some(33_366),
+                            frame_count: 2,
+                        },
+                        // Cut at the recording boundary: only its first frame
+                        // belongs to this recording.
+                        BatchNutInput {
+                            raw_nut: chunk_b,
+                            span_to_next_us: None,
+                            frame_count: 1,
+                        },
+                    ],
+                    lossy_out: lossy_out.clone(),
+                    lossless_out: lossless_out.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("batched transcode");
+
+        assert_eq!(
+            decoded_frame_pts(&ffprobe, &lossy_out).len(),
+            3,
+            "the lossy output must stop at the batch's owned frame count"
+        );
+        assert_eq!(
+            decoded_frame_pts(&ffprobe, &lossless_out).len(),
+            3,
+            "the lossless output must stop at the same cut"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_with_corrupt_nut_entry_fails_instead_of_truncating() {
+        if locate_binary("ffmpeg").is_none() {
+            eprintln!("ffmpeg not on PATH — skipping corrupt batch entry test.");
+            return;
+        }
+        // The concat demuxer treats an entry it cannot open as end of stream and
+        // ffmpeg exits 0, so without the header check the batch would
+        // silently lose this chunk and every later one.
+        let tempdir = TempDir::new().unwrap();
+        let good_nut = tempdir.path().join("chunk_0000.nut");
+        write_nut_chunk(&good_nut, &[0, 16_683]);
+        let corrupt_nut = tempdir.path().join("chunk_0001.nut");
+        std::fs::write(&corrupt_nut, b"not a nut container").unwrap();
+
+        let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+        let error = VideoEncoder::new()
+            .encode_chunk_batch(
+                &BatchEncodeRequest {
+                    inputs: vec![
+                        BatchNutInput {
+                            raw_nut: good_nut,
+                            span_to_next_us: Some(33_366),
+                            frame_count: 2,
+                        },
+                        BatchNutInput {
+                            raw_nut: corrupt_nut.clone(),
+                            span_to_next_us: None,
+                            frame_count: 2,
+                        },
+                    ],
+                    lossy_out: lossy_out.clone(),
+                    lossless_out: tempdir.path().join("chunk_0000_lossless.mp4"),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect_err("a corrupt entry must fail the batch");
+        assert!(
+            matches!(error, VideoEncodeError::InvalidNutInput { ref path } if *path == corrupt_nut),
+            "unexpected error variant: {error:?}"
+        );
+        assert!(
+            !lossy_out.exists(),
+            "no output before the batch is validated"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_span_clamp_stays_monotonic_and_frame_complete() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping span clamp test.");
+            return;
+        };
+        // A 4000 s gap sits above the mp4 boundary-delta ceiling, so the
+        // span clamps to the extent plus the largest safe step. The exact
+        // ladder is unattainable; the output must stay monotonic and carry
+        // every frame.
+        let chunk_a_timestamps = [0.0, 0.016683];
+        let span_us = declared_batch_span_us(&chunk_a_timestamps, 4_000.0);
+        assert_eq!(
+            span_us,
+            16_683 + MAX_BOUNDARY_DELTA_US,
+            "the fabricated gap must clamp to the extent plus the ceiling"
+        );
+
+        let tempdir = TempDir::new().unwrap();
+        let chunk_a = tempdir.path().join("chunk_0000.nut");
+        let chunk_b = tempdir.path().join("chunk_0001.nut");
+        write_nut_chunk(&chunk_a, &[0, 16_683]);
+        write_nut_chunk(&chunk_b, &[0, 16_683]);
+        let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless_out = tempdir.path().join("chunk_0000_lossless.mp4");
+        VideoEncoder::new()
+            .encode_chunk_batch(
+                &BatchEncodeRequest {
+                    inputs: vec![
+                        BatchNutInput {
+                            raw_nut: chunk_a,
+                            span_to_next_us: Some(span_us),
+                            frame_count: 2,
+                        },
+                        BatchNutInput {
+                            raw_nut: chunk_b,
+                            span_to_next_us: None,
+                            frame_count: 2,
+                        },
+                    ],
+                    lossy_out: lossy_out.clone(),
+                    lossless_out: lossless_out.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("clamped batched transcode");
+
+        for video in [&lossy_out, &lossless_out] {
+            assert_merged_video_is_sound(&ffprobe, video);
+            assert_eq!(
+                decoded_frame_pts(&ffprobe, video).len(),
+                4,
+                "{} must keep every frame despite the clamped span",
+                video.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_overlap_boundary_stays_monotonic_and_frame_complete() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping overlap boundary test.");
+            return;
+        };
+        // A backwards clock step at the boundary: chunk B's announced start
+        // sits inside chunk A's 33366 us content. The floored span degrades
+        // the boundary to a 1 us ramp, so the exact ladder is unattainable;
+        // the output must stay monotonic and frame-complete, and chunk A's
+        // frames must keep their exact capture PTS.
+        let capture_s = |us: i64| us as f64 / 1e6;
+        let chunk_a_pts_us = [0i64, 16_683, 33_366];
+        let chunk_a_timestamps: Vec<f64> = chunk_a_pts_us.iter().map(|us| capture_s(*us)).collect();
+        let span_us = declared_batch_span_us(&chunk_a_timestamps, capture_s(20_000));
+        for codec in [
+            LossyVideoCodec::LosslessPlusPreview,
+            LossyVideoCodec::H264MediumLossyOnly,
+        ] {
+            let tempdir = TempDir::new().unwrap();
+            let chunk_a = tempdir.path().join("chunk_0000.nut");
+            let chunk_b = tempdir.path().join("chunk_0001.nut");
+            write_nut_chunk(&chunk_a, &chunk_a_pts_us);
+            write_nut_chunk(&chunk_b, &[0, 16_683]);
+            let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+            let lossless_out = tempdir.path().join("chunk_0000_lossless.mp4");
+            VideoEncoder::new()
+                .encode_chunk_batch(
+                    &BatchEncodeRequest {
+                        inputs: vec![
+                            BatchNutInput {
+                                raw_nut: chunk_a,
+                                span_to_next_us: Some(span_us),
+                                frame_count: 3,
+                            },
+                            BatchNutInput {
+                                raw_nut: chunk_b,
+                                span_to_next_us: None,
+                                frame_count: 2,
+                            },
+                        ],
+                        lossy_out: lossy_out.clone(),
+                        lossless_out: lossless_out.clone(),
+                        codec,
+                    },
+                    ENCODE_THREADS_PER_OUTPUT,
+                )
+                .await
+                .expect("overlap batched transcode");
+
+            let mut outputs = vec![lossy_out];
+            if !codec.is_lossy_only() {
+                outputs.push(lossless_out);
+            }
+            for video in &outputs {
+                assert_merged_video_is_sound(&ffprobe, video);
+                let pts_values = decoded_frame_pts(&ffprobe, video);
+                assert_eq!(
+                    pts_values.len(),
+                    5,
+                    "{} ({codec:?}) must keep every frame across the overlap",
+                    video.display()
+                );
+                assert_eq!(
+                    &pts_values[..3],
+                    &chunk_a_pts_us,
+                    "{} ({codec:?}) must keep exact capture PTS before the degraded boundary",
+                    video.display()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_with_synthesized_pts_chunk_stays_monotonic_and_frame_complete() {
+        let (Some(_ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping synthesized-PTS batch test.");
+            return;
+        };
+        // A synthesized-PTS chunk: the announced stamps are all the same
+        // 1.0 s duplicate, so the writer synthesized the monotonic NUT ladder
+        // this test writes directly. The next chunk's announced start sits
+        // inside that real content, so flooring only at the announced extent
+        // would make the preset-medium encode store backwards PTS. The exact
+        // ladder is degraded here; assert positive properties only.
+        let chunk_a_announced = [1.0, 1.0, 1.0];
+        let chunk_a_nut_pts = [0i64, 16_683, 33_366];
+        let span_us = declared_batch_span_us(&chunk_a_announced, 1.005);
+        let tempdir = TempDir::new().unwrap();
+        let chunk_a = tempdir.path().join("chunk_0000.nut");
+        let chunk_b = tempdir.path().join("chunk_0001.nut");
+        write_nut_chunk(&chunk_a, &chunk_a_nut_pts);
+        write_nut_chunk(&chunk_b, &[0, 16_683]);
+        let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
+        VideoEncoder::new()
+            .encode_chunk_batch(
+                &BatchEncodeRequest {
+                    inputs: vec![
+                        BatchNutInput {
+                            raw_nut: chunk_a,
+                            span_to_next_us: Some(span_us),
+                            frame_count: 3,
+                        },
+                        BatchNutInput {
+                            raw_nut: chunk_b,
+                            span_to_next_us: None,
+                            frame_count: 2,
+                        },
+                    ],
+                    lossy_out: lossy_out.clone(),
+                    lossless_out: tempdir.path().join("chunk_0000_lossless.mp4"),
+                    codec: LossyVideoCodec::H264MediumLossyOnly,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("synthesized-PTS batched transcode");
+
+        assert_merged_video_is_sound(&ffprobe, &lossy_out);
+        let pts_values = decoded_frame_pts(&ffprobe, &lossy_out);
+        assert_eq!(
+            pts_values.len(),
+            5,
+            "every frame must survive the synthesized-PTS boundary"
+        );
+        assert!(
+            pts_values.windows(2).all(|pair| pair[1] > pair[0]),
+            "PTS must stay strictly monotonic across the synthesized-PTS boundary: {pts_values:?}"
+        );
     }
 }

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -9,9 +9,32 @@
 //!
 //! Scalar / sensor traces stream into a [`crate::encoding::json_trace::JsonTraceWriter`]; video traces
 //! consume [`TraceActorMessage::Video`] notifications that hand off
-//! daemon-relinked NUT chunks for ffmpeg-side transcoding into per-chunk MP4
-//! segments, then on finalise stitch the segments into the final `lossy.mp4` /
-//! `lossless.mp4` and flush the [`VideoMetadataAccumulator`] sidecar.
+//! daemon-relinked NUT chunks for ffmpeg-side transcoding into MP4 segments
+//! (one batch of up to [`ENCODE_BATCH_MAX_CHUNKS`] queued chunks per
+//! invocation under backlog), then on finalise stitch the segments into the
+//! final `lossy.mp4` / `lossless.mp4` and flush the
+//! [`VideoMetadataAccumulator`] sidecar.
+//!
+//! `TraceWriterKind::Video` owns the `completed_chunks` map, the worker
+//! `JoinSet`, and the shared encode queue and un-encoded chunk counter. The
+//! `EncodeWorker` holds `Arc` clones of the queue, the counter and the ffmpeg
+//! permit pool plus the encoder, paths and codec, and borrows nothing from the
+//! actor state, so it runs independently of the actor task. `handle_video`
+//! pushes the arriving chunk onto the queue and spawns a worker on the
+//! `JoinSet`. The worker that wins an ffmpeg permit drains the queue front
+//! for up to [`ENCODE_BATCH_MAX_CHUNKS`] chunks. The drain stops at a dtype
+//! change and before a chunk whose declared span exceeds
+//! [`ENCODE_BATCH_MAX_SPAN_US`].
+//! The worker relinks its batch from the producer spool only after it wins
+//! that permit, so the fixed spool cap bounds the un-encoded backlog. A worker
+//! reports `NoOp` when an earlier worker took its chunk, `Completed` with one
+//! `CompletedChunk`, or `Failed`. On the arrival path
+//! `drain_completed_encodes` reaps finished workers with `try_join_next` and
+//! marks the trace failed on `Failed`. At finalise `finalise_writer` awaits
+//! every remaining worker with `join_next` and returns `Err` on `Failed`,
+//! which skips the concat. `completed_chunks` is keyed by the batch's first
+//! chunk index, so segment indices are not dense, and finalise concatenates
+//! the segments in key order.
 //!
 //! Finalisation is driven by a single [`TraceActorMessage::WindowClosing`]
 //! signal: the dispatcher sends every routed datum to the actor's FIFO inbox
@@ -31,9 +54,10 @@
 //! before being enqueued, and the batcher further coalesces them per trace and
 //! flushes them in batched transactions.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use data_daemon_shared::FrameDtype;
@@ -46,7 +70,8 @@ use crate::config::DaemonConfig;
 use crate::encoding::json_trace::JsonTraceError;
 use crate::encoding::metadata::{MetadataError, VideoMetadataAccumulator};
 use crate::encoding::video_encoder::{
-    ChunkEncodeRequest, LossyVideoCodec, VideoEncodeError, VideoEncoder, ENCODE_THREADS_PER_OUTPUT,
+    declared_batch_span_us, BatchEncodeRequest, BatchNutInput, LossyVideoCodec, VideoEncodeError,
+    VideoEncoder, ENCODE_THREADS_PER_OUTPUT,
 };
 use crate::pipeline::json_writer::JsonWriteHandle;
 use crate::state::TraceWriteHandle;
@@ -88,9 +113,21 @@ pub struct TraceIdentity {
 /// A finalise always issues a fresh UPDATE so the terminal row is exact.
 const BYTES_WRITTEN_DEBOUNCE_FRAMES: u64 = 32;
 
+/// Cap on how many queued chunks one worker drains into a single batched
+/// ffmpeg invocation. Bounds the latency of any one batch and keeps the
+/// shared permit pool fair across traces under backlog.
+pub(crate) const ENCODE_BATCH_MAX_CHUNKS: usize = 8;
+
+/// Cap on the declared span between two chunks inside one batch. ffmpeg
+/// silently corrupts a preset-medium batched encode once a `duration` line
+/// passes a version-dependent cliff (bisected at 120 s on 5.1; CI runs 4.4).
+/// A gap this large under backlog is a recording stall, so ending the batch
+/// instead costs nothing.
+pub(crate) const ENCODE_BATCH_MAX_SPAN_US: i64 = 30_000_000;
+
 /// Cap on concurrent ffmpeg transcodes.
 ///
-/// Each per-chunk encode bounds its libx264 thread pool to
+/// Each batch encode bounds its libx264 thread pool to
 /// [`ENCODE_THREADS_PER_OUTPUT`] per output stream, so to keep the encode fleet
 /// near — not far past — the host's core count we run roughly
 /// `cores / threads_per_output` invocations at once. Letting the permit count
@@ -141,7 +178,7 @@ pub struct TraceActorContext {
     /// Shared storage-budget tracker. Reserved here so the budget can refuse
     /// frames when the configured quota is exhausted.
     pub storage_budget: Arc<StorageBudget>,
-    /// Encoder used to transcode per-chunk NUT files into MP4 segments and
+    /// Encoder used to transcode batches of NUT files into MP4 segments and
     /// to stream-copy concatenate the segments into the final outputs on
     /// finalise. Cloning a [`VideoEncoder`] is cheap (it carries only the
     /// configured ffmpeg binary path).
@@ -308,7 +345,9 @@ enum TraceWriterKind {
     /// ([`crate::pipeline::json_writer`]); the actor only holds this marker and
     /// drives it by `trace_id` through [`TraceActorContext::json_writer`].
     Json,
-    /// Video trace whose chunk encodes run concurrently as background tasks.
+    /// Video trace whose encode workers run as concurrent background tasks.
+    /// A worker drains at most one batch from the shared queue, and encodes
+    /// nothing if an earlier worker took its chunk.
     Video {
         /// Frame width in pixels (recorded from the first chunk message).
         width: u32,
@@ -317,39 +356,78 @@ enum TraceWriterKind {
         /// Lossy codec for this trace, resolved once at the first chunk and
         /// applied uniformly to every chunk encode and the finalise concat.
         codec: LossyVideoCodec,
-        /// Encodes completed so far, keyed by `chunk_index` so the finalise
-        /// concat can iterate in order regardless of completion order.
+        /// Encodes completed so far, keyed by the batch's first `chunk_index`
+        /// so the finalise concat can iterate in order regardless of
+        /// completion order.
         completed_chunks: BTreeMap<u32, CompletedChunk>,
-        /// Spawned chunk-encode tasks still running.
-        pending_encodes: JoinSet<ChunkEncodeJobResult>,
+        /// Spawned encode workers still running.
+        pending_encodes: JoinSet<EncodeWorkerOutcome>,
+        /// Chunks waiting for a worker to win an ffmpeg permit and drain
+        /// them into a batch. Shared with the spawned workers.
+        encode_queue: Arc<Mutex<VecDeque<QueuedChunk>>>,
+        /// Count of un-encoded chunks: the queue length plus the chunks
+        /// covered by in-flight batches. Reported as `pending_encode_count`
+        /// at finalise.
+        unencoded_chunks: Arc<AtomicUsize>,
     },
 }
 
-/// One successfully encoded chunk, ready to feed into the finalise concat.
+/// One un-encoded chunk waiting in a trace's encode queue for a worker to
+/// drain it into a batch.
+struct QueuedChunk {
+    /// Daemon-assigned, per-trace monotonic chunk index.
+    chunk_index: u32,
+    /// Producer-spooled source NUT, relinked into the trace's chunks dir when
+    /// its batch starts encoding.
+    spool_nut: PathBuf,
+    /// Size of the spooled NUT file in bytes.
+    byte_count: u64,
+    /// Number of frames in the chunk.
+    frame_count: u32,
+    /// Per-frame `timestamp_s` values in capture order. The first entry also
+    /// anchors the batch's inter-chunk duration spans.
+    frame_timestamps_s: Vec<f64>,
+    /// Original dtype of every frame in this chunk. A batch spans one dtype.
+    dtype: FrameDtype,
+}
+
+/// One successfully encoded batch of one or more chunks, keyed by its first
+/// chunk index, ready to feed into the finalise concat.
 struct CompletedChunk {
-    /// `chunk_NNNN_lossy.mp4` segment path.
+    /// `chunk_NNNN_lossy.mp4` segment path (first index of the batch).
     lossy_segment: PathBuf,
-    /// `chunk_NNNN_lossless.mp4` segment path.
+    /// `chunk_NNNN_lossless.mp4` segment path (first index of the batch).
     lossless_segment: PathBuf,
     /// Sum of both segments' on-disk byte counts.
     bytes: u64,
-    /// Per-frame `timestamp_s` values from the chunk message, applied to the
-    /// metadata accumulator at finalise in chunk-index order.
+    /// Per-frame `timestamp_s` values, the in-order concatenation of the
+    /// batch's per-chunk vectors, applied to the metadata accumulator at
+    /// finalise in chunk-index order.
     frame_timestamps_s: Vec<f64>,
-    /// Frame count carried by the chunk message.
+    /// Total frames covered by this entry: the sum over the batch's chunks.
     frame_count: u32,
-    /// This chunk's original frame dtype — stored per chunk (not once for the
-    /// whole trace) so each chunk's metadata entries get their own dtype even
+    /// The batch's original frame dtype — stored per batch (not once for the
+    /// whole trace) so each batch's metadata entries get their own dtype even
     /// if it somehow differs between chunks of one trace.
     dtype: FrameDtype,
 }
 
-/// Outcome of one background chunk-encode task.
-struct ChunkEncodeJobResult {
-    chunk_index: u32,
-    /// `Ok(CompletedChunk)` on success; `Err` is logged and the trace marked
-    /// failed by the polling path.
-    outcome: Result<CompletedChunk, VideoEncodeError>,
+/// Outcome of one background encode worker.
+enum EncodeWorkerOutcome {
+    /// One batch encoded; `chunk_index` is the batch's first index.
+    Completed {
+        chunk_index: u32,
+        completed: CompletedChunk,
+    },
+    /// The worker found the queue empty: an earlier worker's batch already
+    /// covered its chunk. Both reaping paths reap this silently.
+    NoOp,
+    /// The batch failed; the reaping path logs the error and marks the trace
+    /// failed. The batch's relinked NUTs stay on disk for the recovery sweep.
+    Failed {
+        chunk_index: u32,
+        error: VideoEncodeError,
+    },
 }
 
 /// Run the per-trace actor until the dispatcher closes the inbox or sends a
@@ -597,9 +675,11 @@ impl ActorState {
         }
     }
 
-    /// Handle one finished NUT chunk: transcode it to per-chunk MP4 segments,
-    /// append the segment paths to the pending list for the finalise concat,
-    /// and unlink the source NUT.
+    /// Handle one finished NUT chunk: enqueue it and spawn a worker. The
+    /// worker that wins an ffmpeg permit drains up to
+    /// [`ENCODE_BATCH_MAX_CHUNKS`] queued chunks and transcodes them as one
+    /// batch, then unlinks the source NUTs. When the encoder keeps pace the
+    /// queue holds one chunk, so batches form only under backlog.
     #[allow(clippy::too_many_arguments)]
     async fn handle_video(
         &mut self,
@@ -615,9 +695,6 @@ impl ActorState {
     ) {
         let trace_dir = self.trace_directory(context);
         let chunks_dir = trace_dir.join(paths::CHUNKS_DIRNAME);
-        let raw_nut = chunks_dir.join(paths::chunk_filename(chunk_index));
-        let lossy_segment = trace_dir.join(paths::chunk_lossy_filename(chunk_index));
-        let lossless_segment = trace_dir.join(paths::chunk_lossless_filename(chunk_index));
 
         // Allocate the video writer on the first chunk and mark the trace
         // `writing` so the registration coordinator can observe lifecycle
@@ -639,6 +716,8 @@ impl ActorState {
                 codec,
                 completed_chunks: BTreeMap::new(),
                 pending_encodes: JoinSet::new(),
+                encode_queue: Arc::new(Mutex::new(VecDeque::new())),
+                unencoded_chunks: Arc::new(AtomicUsize::new(0)),
             };
         }
 
@@ -672,140 +751,47 @@ impl ActorState {
         let TraceWriterKind::Video {
             pending_encodes,
             codec,
+            encode_queue,
+            unencoded_chunks,
             ..
         } = &mut self.writer
         else {
             // Should be unreachable — we just allocated the writer above.
             return;
         };
-        let codec = *codec;
 
-        // Spawn the encode as a background task. The actor returns to the
-        // inbox immediately so a slow ffmpeg invocation cannot back-pressure
-        // unrelated joint / scalar publishers sharing the commands service.
-        let permits = context.ffmpeg_permits.clone();
-        let permit_total = context.ffmpeg_permit_total;
-        let encode_cores = context.encode_cores;
-        let encoder = context.video_encoder.clone();
-        let trace_id = self.identity.trace_id.clone();
-        let chunks_dir_for_task = chunks_dir.clone();
-        let request = ChunkEncodeRequest {
-            raw_nut: raw_nut.clone(),
-            lossy_out: lossy_segment.clone(),
-            lossless_out: lossless_segment.clone(),
-            codec,
-            frame_count,
+        // Enqueue the chunk, then spawn a worker as a background task. The
+        // actor returns to the inbox immediately so a slow ffmpeg invocation
+        // cannot back-pressure unrelated joint / scalar publishers sharing the
+        // commands service. A worker is not tied to "its" chunk: whichever one
+        // wins a permit drains the queue front, so it may encode several
+        // chunks or none.
+        encode_queue
+            .lock()
+            .expect("encode queue lock")
+            .push_back(QueuedChunk {
+                chunk_index,
+                spool_nut,
+                byte_count,
+                frame_count,
+                frame_timestamps_s,
+                dtype,
+            });
+        unencoded_chunks.fetch_add(1, Ordering::Relaxed);
+
+        let worker = EncodeWorker {
+            permits: context.ffmpeg_permits.clone(),
+            permit_total: context.ffmpeg_permit_total,
+            encode_cores: context.encode_cores,
+            encoder: context.video_encoder.clone(),
+            trace_id: self.identity.trace_id.clone(),
+            trace_dir,
+            chunks_dir,
+            codec: *codec,
+            queue: Arc::clone(encode_queue),
+            unencoded_chunks: Arc::clone(unencoded_chunks),
         };
-        pending_encodes.spawn(async move {
-            // Acquire a permit before relinking + encoding. Gating the relink
-            // (which frees the producer's on-disk spool) on a permit is
-            // deliberate: it makes the fixed spool cap the backstop that bounds
-            // the un-encoded backlog. When the encoder can't keep up, chunks stay
-            // in the spool until a permit frees, the spool fills, and the
-            // *producer* back-pressures — rather than the daemon-side chunks dir
-            // growing without bound. Adaptive threading (below) keeps the encoder
-            // fast enough that this backstop rarely engages. Clone the `Arc` for
-            // the (consuming) acquire so `permits` stays live for the
-            // `available_permits()` read below.
-            let permit = match permits.clone().acquire_owned().await {
-                Ok(permit) => permit,
-                Err(_) => {
-                    return ChunkEncodeJobResult {
-                        chunk_index,
-                        outcome: Err(VideoEncodeError::Spawn {
-                            binary: std::ffi::OsString::from("ffmpeg"),
-                            source: std::io::Error::other("ffmpeg permit pool closed"),
-                        }),
-                    };
-                }
-            };
-            // Relink the producer-spooled NUT into the recording's chunks dir
-            // here rather than on the dispatcher's routing path. The `rename`
-            // (and `mkdir`) are filesystem metadata ops that can stall behind an
-            // ext4 journal commit on the shared spool, so we run them on a
-            // blocking thread — off both the dispatcher and the runtime workers.
-            let relink = {
-                let spool = spool_nut.clone();
-                let dest = request.raw_nut.clone();
-                let chunks = chunks_dir_for_task.clone();
-                tokio::task::spawn_blocking(move || relink_nut(&spool, &chunks, &dest)).await
-            };
-            match relink {
-                Ok(Ok(())) => {}
-                Ok(Err(source)) => {
-                    return ChunkEncodeJobResult {
-                        chunk_index,
-                        outcome: Err(VideoEncodeError::Io {
-                            path: spool_nut.clone(),
-                            source,
-                        }),
-                    };
-                }
-                Err(join_error) => {
-                    return ChunkEncodeJobResult {
-                        chunk_index,
-                        outcome: Err(VideoEncodeError::Spawn {
-                            binary: std::ffi::OsString::from("relink"),
-                            source: std::io::Error::other(format!(
-                                "relink task join failed: {join_error}"
-                            )),
-                        }),
-                    };
-                }
-            }
-            // Size this encode's thread pool to the cores the rest of the fleet
-            // isn't using: with the permit held, `available_permits()` is the
-            // idle capacity, so `total - available` is how many encodes (incl.
-            // this one) are running now. Read after acquiring so we count
-            // ourselves.
-            let active_encodes = permit_total.saturating_sub(permits.available_permits());
-            let encode_threads = adaptive_encode_threads(encode_cores, active_encodes);
-            let outcome = encoder.encode_chunk(&request, encode_threads).await;
-            drop(permit);
-            match outcome {
-                Ok(encode) => {
-                    // Drop the source NUT chunk now that both segments are
-                    // sealed. Failure to unlink leaves the file for the
-                    // recovery sweep to collect.
-                    if let Err(error) = std::fs::remove_file(&request.raw_nut) {
-                        if error.kind() != std::io::ErrorKind::NotFound {
-                            tracing::warn!(
-                                %error,
-                                trace_id = %trace_id,
-                                chunk_index,
-                                path = %request.raw_nut.display(),
-                                "failed to remove source NUT chunk after encode"
-                            );
-                        }
-                    }
-                    let segment_bytes = encode.lossy_bytes.saturating_add(encode.lossless_bytes);
-                    tracing::debug!(
-                        trace_id = %trace_id,
-                        chunk_index,
-                        frame_count,
-                        byte_count,
-                        lossy_bytes = encode.lossy_bytes,
-                        lossless_bytes = encode.lossless_bytes,
-                        "video chunk encoded"
-                    );
-                    ChunkEncodeJobResult {
-                        chunk_index,
-                        outcome: Ok(CompletedChunk {
-                            lossy_segment: request.lossy_out,
-                            lossless_segment: request.lossless_out,
-                            bytes: segment_bytes,
-                            frame_timestamps_s,
-                            frame_count,
-                            dtype,
-                        }),
-                    }
-                }
-                Err(error) => ChunkEncodeJobResult {
-                    chunk_index,
-                    outcome: Err(error),
-                },
-            }
-        });
+        pending_encodes.spawn(worker.run(chunk_index));
 
         // Stamp `writing` on the first chunk so the registration coordinator
         // sees the trace's lifecycle moving forward without waiting for the
@@ -832,22 +818,24 @@ impl ActorState {
         let mut new_frames: u64 = 0;
         while let Some(joined) = pending_encodes.try_join_next() {
             match joined {
-                Ok(result) => match result.outcome {
-                    Ok(completed) => {
-                        new_bytes = new_bytes.saturating_add(completed.bytes);
-                        new_frames = new_frames.saturating_add(completed.frame_count as u64);
-                        completed_chunks.insert(result.chunk_index, completed);
-                    }
-                    Err(error) => {
-                        tracing::warn!(
-                            %error,
-                            trace_id = self.identity.trace_id,
-                            chunk_index = result.chunk_index,
-                            "failed to encode video chunk"
-                        );
-                        any_failure = true;
-                    }
-                },
+                Ok(EncodeWorkerOutcome::Completed {
+                    chunk_index,
+                    completed,
+                }) => {
+                    new_bytes = new_bytes.saturating_add(completed.bytes);
+                    new_frames = new_frames.saturating_add(completed.frame_count as u64);
+                    completed_chunks.insert(chunk_index, completed);
+                }
+                Ok(EncodeWorkerOutcome::NoOp) => {}
+                Ok(EncodeWorkerOutcome::Failed { chunk_index, error }) => {
+                    tracing::warn!(
+                        %error,
+                        trace_id = self.identity.trace_id,
+                        chunk_index,
+                        "failed to encode video chunk batch"
+                    );
+                    any_failure = true;
+                }
                 Err(join_error) => {
                     tracing::warn!(
                         %join_error,
@@ -970,9 +958,13 @@ impl ActorState {
                 codec,
                 mut completed_chunks,
                 mut pending_encodes,
+                encode_queue: _,
+                unencoded_chunks,
             } => {
                 let encode_started = Instant::now();
-                let pending_encode_count = pending_encodes.len();
+                // Un-encoded chunks, not worker tasks: the queue length plus
+                // the chunks covered by in-flight batches.
+                let pending_encode_count = unencoded_chunks.load(Ordering::Relaxed);
                 crate::perf_events::emit(
                     "video_encoding",
                     "started",
@@ -985,13 +977,22 @@ impl ActorState {
                         "already_completed_chunks": completed_chunks.len(),
                     }),
                 );
-                // Drain every still-running encode. A failure here is
-                // terminal — without a complete chunk set the concat would
-                // produce a video with a missing range, which is worse than
-                // marking the trace failed.
+                // Drain every still-running encode worker; a no-op worker
+                // reaps silently. A failure here is terminal — without a
+                // complete chunk set the concat would produce a video with a
+                // missing range, which is worse than marking the trace failed.
                 while let Some(joined) = pending_encodes.join_next().await {
-                    let result = match joined {
-                        Ok(result) => result,
+                    match joined {
+                        Ok(EncodeWorkerOutcome::Completed {
+                            chunk_index,
+                            completed,
+                        }) => {
+                            completed_chunks.insert(chunk_index, completed);
+                        }
+                        Ok(EncodeWorkerOutcome::NoOp) => {}
+                        Ok(EncodeWorkerOutcome::Failed { error, .. }) => {
+                            return Err(error.into());
+                        }
                         Err(join_error) => {
                             return Err(FrameAppendError::VideoEncode(VideoEncodeError::Spawn {
                                 binary: std::ffi::OsString::from("ffmpeg"),
@@ -1000,9 +1001,7 @@ impl ActorState {
                                 )),
                             }))
                         }
-                    };
-                    let completed = result.outcome?;
-                    completed_chunks.insert(result.chunk_index, completed);
+                    }
                 }
                 // The running total is only bumped by `drain_completed_encodes`,
                 // which misses encodes that finish here, at window close.
@@ -1083,6 +1082,9 @@ impl ActorState {
                 // bounded by an ffmpeg permit so a tail-stitch storm
                 // doesn't fork-bomb the host.
                 let concat_started = Instant::now();
+                // `chunks` counts encoded segments, one per batch, which
+                // equals the trace's chunk count only when the encoder kept
+                // pace. Integration reporting reads the field by this name.
                 crate::perf_events::emit(
                     "video_concatenation",
                     "started",
@@ -1217,6 +1219,251 @@ impl ActorState {
     }
 }
 
+/// Everything one spawned encode worker carries: the shared permit pool and
+/// chunk queue plus the per-trace paths and codec its batch encode needs.
+struct EncodeWorker {
+    permits: Arc<Semaphore>,
+    permit_total: usize,
+    encode_cores: usize,
+    encoder: VideoEncoder,
+    trace_id: String,
+    trace_dir: PathBuf,
+    chunks_dir: PathBuf,
+    codec: LossyVideoCodec,
+    queue: Arc<Mutex<VecDeque<QueuedChunk>>>,
+    unencoded_chunks: Arc<AtomicUsize>,
+}
+
+impl EncodeWorker {
+    /// Wait for an ffmpeg permit, then drain and encode one batch from the
+    /// queue front. `arrival_index` is the chunk whose arrival spawned this
+    /// worker; it is the `chunk_index` reported when the permit pool closes
+    /// before any batch is drained.
+    async fn run(self, arrival_index: u32) -> EncodeWorkerOutcome {
+        // Acquire a permit before relinking + encoding. Gating the relink
+        // (which frees the producer's on-disk spool) on a permit is
+        // deliberate: it makes the fixed spool cap the backstop that bounds
+        // the un-encoded backlog. When the encoder can't keep up, chunks stay
+        // in the spool until a permit frees, the spool fills, and the
+        // *producer* back-pressures — rather than the daemon-side chunks dir
+        // growing without bound. Adaptive threading (below) keeps the encoder
+        // fast enough that this backstop rarely engages. Clone the `Arc` for
+        // the (consuming) acquire so `permits` stays live for the
+        // `available_permits()` read below.
+        let permit = match self.permits.clone().acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => {
+                return EncodeWorkerOutcome::Failed {
+                    chunk_index: arrival_index,
+                    error: VideoEncodeError::Spawn {
+                        binary: std::ffi::OsString::from("ffmpeg"),
+                        source: std::io::Error::other("ffmpeg permit pool closed"),
+                    },
+                };
+            }
+        };
+        let batch = drain_encode_batch(&mut self.queue.lock().expect("encode queue lock"));
+        if batch.is_empty() {
+            // An earlier worker's batch already covered this arrival's chunk.
+            return EncodeWorkerOutcome::NoOp;
+        }
+        let batch_len = batch.len();
+        let outcome = self.encode_batch(batch).await;
+        // The drained chunks stop counting as un-encoded once their batch
+        // has an outcome, success or failure alike.
+        self.unencoded_chunks
+            .fetch_sub(batch_len, Ordering::Relaxed);
+        drop(permit);
+        outcome
+    }
+
+    /// Relink and encode one drained batch, then unlink its NUTs on success.
+    /// A failed batch leaves every relinked NUT on disk for the recovery
+    /// sweep.
+    async fn encode_batch(&self, batch: Vec<QueuedChunk>) -> EncodeWorkerOutcome {
+        let first_index = batch[0].chunk_index;
+        let dtype = batch[0].dtype;
+        let raw_nuts: Vec<PathBuf> = batch
+            .iter()
+            .map(|chunk| {
+                self.chunks_dir
+                    .join(paths::chunk_filename(chunk.chunk_index))
+            })
+            .collect();
+
+        // Relink every producer-spooled NUT into the recording's chunks dir
+        // here rather than on the dispatcher's routing path. The `rename`
+        // (and `mkdir`) are filesystem metadata ops that can stall behind an
+        // ext4 journal commit on the shared spool, so we run them on a
+        // blocking thread — off both the dispatcher and the runtime workers.
+        let relink = {
+            let spools: Vec<PathBuf> = batch.iter().map(|chunk| chunk.spool_nut.clone()).collect();
+            let destinations = raw_nuts.clone();
+            let chunks_dir = self.chunks_dir.clone();
+            tokio::task::spawn_blocking(move || -> Result<(), (PathBuf, std::io::Error)> {
+                for (spool, dest) in spools.into_iter().zip(&destinations) {
+                    relink_nut(&spool, &chunks_dir, dest).map_err(|source| (spool, source))?;
+                }
+                Ok(())
+            })
+            .await
+        };
+        match relink {
+            Ok(Ok(())) => {}
+            Ok(Err((spool, source))) => {
+                return EncodeWorkerOutcome::Failed {
+                    chunk_index: first_index,
+                    error: VideoEncodeError::Io {
+                        path: spool,
+                        source,
+                    },
+                };
+            }
+            Err(join_error) => {
+                return EncodeWorkerOutcome::Failed {
+                    chunk_index: first_index,
+                    error: VideoEncodeError::Spawn {
+                        binary: std::ffi::OsString::from("relink"),
+                        source: std::io::Error::other(format!(
+                            "relink task join failed: {join_error}"
+                        )),
+                    },
+                };
+            }
+        }
+
+        // Each entry except the last declares the capture span to the next
+        // chunk's first frame, floored at the chunk's own PTS extent, so the
+        // concat demuxer lands every frame on its batch-relative capture
+        // timestamp and never rewinds at an overlapping announcement.
+        let inputs: Vec<BatchNutInput> = batch
+            .iter()
+            .zip(&raw_nuts)
+            .enumerate()
+            .map(|(position, (chunk, raw_nut))| BatchNutInput {
+                raw_nut: raw_nut.clone(),
+                span_to_next_us: batch
+                    .get(position + 1)
+                    .map(|next| queued_batch_span_us(chunk, next)),
+                frame_count: chunk.frame_count,
+            })
+            .collect();
+        let request = BatchEncodeRequest {
+            inputs,
+            lossy_out: self
+                .trace_dir
+                .join(paths::chunk_lossy_filename(first_index)),
+            lossless_out: self
+                .trace_dir
+                .join(paths::chunk_lossless_filename(first_index)),
+            codec: self.codec,
+        };
+
+        // Size this encode's thread pool to the cores the rest of the fleet
+        // isn't using: with the permit held, `available_permits()` is the
+        // idle capacity, so `total - available` is how many encodes (incl.
+        // this one) are running now. Read after acquiring so we count
+        // ourselves.
+        let active_encodes = self
+            .permit_total
+            .saturating_sub(self.permits.available_permits());
+        let encode_threads = adaptive_encode_threads(self.encode_cores, active_encodes);
+        match self
+            .encoder
+            .encode_chunk_batch(&request, encode_threads)
+            .await
+        {
+            Ok(encode) => {
+                // Drop the source NUT chunks now that the segments are sealed
+                // and verified non-empty. Failure to unlink leaves a file for
+                // the recovery sweep to collect.
+                for raw_nut in &raw_nuts {
+                    if let Err(error) = std::fs::remove_file(raw_nut) {
+                        if error.kind() != std::io::ErrorKind::NotFound {
+                            tracing::warn!(
+                                %error,
+                                trace_id = %self.trace_id,
+                                path = %raw_nut.display(),
+                                "failed to remove source NUT chunk after encode"
+                            );
+                        }
+                    }
+                }
+                let frame_count = batch.iter().map(|chunk| chunk.frame_count).sum::<u32>();
+                tracing::debug!(
+                    trace_id = %self.trace_id,
+                    first_chunk_index = first_index,
+                    batch_len = batch.len(),
+                    frame_count,
+                    byte_count = batch.iter().map(|chunk| chunk.byte_count).sum::<u64>(),
+                    lossy_bytes = encode.lossy_bytes,
+                    lossless_bytes = encode.lossless_bytes,
+                    "video chunk batch encoded"
+                );
+                let frame_timestamps_s: Vec<f64> = batch
+                    .into_iter()
+                    .flat_map(|chunk| chunk.frame_timestamps_s)
+                    .collect();
+                EncodeWorkerOutcome::Completed {
+                    chunk_index: first_index,
+                    completed: CompletedChunk {
+                        lossy_segment: request.lossy_out,
+                        lossless_segment: request.lossless_out,
+                        bytes: encode.lossy_bytes.saturating_add(encode.lossless_bytes),
+                        frame_timestamps_s,
+                        frame_count,
+                        dtype,
+                    },
+                }
+            }
+            Err(error) => EncodeWorkerOutcome::Failed {
+                chunk_index: first_index,
+                error,
+            },
+        }
+    }
+}
+
+/// The declared concat span from `chunk` to `next`, computed with the same
+/// helper that writes the batch `duration` lines. A next chunk that
+/// announced no frames borrows this chunk's first stamp, so the span floors
+/// to the chunk's own extent plus 1 us instead of indexing an empty vector.
+fn queued_batch_span_us(chunk: &QueuedChunk, next: &QueuedChunk) -> i64 {
+    let next_first_timestamp_s = next
+        .frame_timestamps_s
+        .first()
+        .or_else(|| chunk.frame_timestamps_s.first())
+        .copied()
+        .unwrap_or(0.0);
+    declared_batch_span_us(&chunk.frame_timestamps_s, next_first_timestamp_s)
+}
+
+/// Take up to [`ENCODE_BATCH_MAX_CHUNKS`] descriptors from the queue front,
+/// stopping early at a dtype change and before a chunk whose declared span
+/// exceeds [`ENCODE_BATCH_MAX_SPAN_US`]. A stopped-at chunk stays at the
+/// front for the worker its own arrival spawned.
+fn drain_encode_batch(queue: &mut VecDeque<QueuedChunk>) -> Vec<QueuedChunk> {
+    let mut batch: Vec<QueuedChunk> = Vec::new();
+    while batch.len() < ENCODE_BATCH_MAX_CHUNKS {
+        let Some(front) = queue.front() else { break };
+        if batch
+            .first()
+            .is_some_and(|first| first.dtype != front.dtype)
+        {
+            break;
+        }
+        if batch
+            .last()
+            .is_some_and(|last| queued_batch_span_us(last, front) > ENCODE_BATCH_MAX_SPAN_US)
+        {
+            break;
+        }
+        let chunk = queue.pop_front().expect("front exists");
+        batch.push(chunk);
+    }
+    batch
+}
+
 /// Errors that can surface while appending or finalising a frame. The variants
 /// are unified so `handle_data` / `finalise_trace` can log + mark-failed in
 /// one place regardless of which writer raised.
@@ -1289,6 +1536,20 @@ mod tests {
         root: &std::path::Path,
         store: Arc<SqliteStateStore>,
     ) -> Arc<TraceActorContext> {
+        test_context_with_permits(
+            root,
+            store,
+            Arc::new(Semaphore::new(default_ffmpeg_concurrency())),
+        )
+    }
+
+    /// As [`test_context`] but with an explicit ffmpeg permit pool, so the
+    /// batching tests can hold the only permit to force a queue backlog.
+    fn test_context_with_permits(
+        root: &std::path::Path,
+        store: Arc<SqliteStateStore>,
+        ffmpeg_permits: Arc<Semaphore>,
+    ) -> Arc<TraceActorContext> {
         let policy = StoragePolicy {
             storage_limit_bytes: None,
             min_free_disk_bytes: 0,
@@ -1297,10 +1558,11 @@ mod tests {
         let budget = Arc::new(StorageBudget::new(root, policy));
         let (trace_writer, _writer_owner) = crate::state::trace_event_database_writer::spawn(store);
         let (json_writer, _json_owner) = crate::pipeline::json_writer::spawn();
-        Arc::new(TraceActorContext::new(
+        Arc::new(TraceActorContext::with_ffmpeg_permits(
             root.to_path_buf(),
             budget,
             VideoEncoder::new(),
+            ffmpeg_permits,
             trace_writer,
             json_writer,
         ))
@@ -1318,13 +1580,40 @@ mod tests {
     }
 
     fn ffmpeg_available() -> bool {
-        std::process::Command::new("ffmpeg")
+        binary_available("ffmpeg")
+    }
+
+    fn binary_available(name: &str) -> bool {
+        std::process::Command::new(name)
             .arg("-version")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
+    }
+
+    /// Frames ffprobe decodes out of `video`.
+    fn probed_frame_count(video: &std::path::Path) -> usize {
+        let probe = std::process::Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-count_frames",
+                "-show_entries",
+                "stream=nb_read_frames",
+                "-of",
+                "default=nokey=1:noprint_wrappers=1",
+            ])
+            .arg(video)
+            .output()
+            .expect("spawn ffprobe");
+        String::from_utf8_lossy(&probe.stdout)
+            .trim()
+            .parse()
+            .expect("frame count")
     }
 
     #[test]
@@ -1705,5 +1994,584 @@ mod tests {
             TraceWriteStatus::Written,
             "a cancelled trace is never finalised as Written"
         );
+    }
+
+    /// Write a spool NUT chunk with the real producer NUT writer: one 16x16
+    /// RGB frame per entry of `frame_pts_us` (chunk-relative microsecond
+    /// ticks; the producer re-anchors every chunk's first frame near 0).
+    fn write_nut_chunk(path: &std::path::Path, frame_pts_us: &[u64]) {
+        use data_daemon_bridge::nut_writer::{NutVideoConfig, NutWriter};
+        let rgb = vec![128u8; 16 * 16 * 3];
+        let mut writer = NutWriter::create(
+            path,
+            NutVideoConfig {
+                width: 16,
+                height: 16,
+                time_base_num: 1,
+                time_base_den: 1_000_000,
+            },
+        )
+        .expect("create NUT");
+        for pts in frame_pts_us {
+            writer.write_frame(*pts, &rgb).expect("write frame");
+        }
+        writer.finish().expect("finish NUT");
+    }
+
+    /// Spool one chunk whose frames sit at the given batch-absolute capture
+    /// microseconds, then hand it to the actor as a `Video` message.
+    async fn send_video_chunk(
+        state: &mut ActorState,
+        context: &Arc<TraceActorContext>,
+        spool_dir: &std::path::Path,
+        chunk_index: u32,
+        capture_us: &[i64],
+        dtype: FrameDtype,
+    ) {
+        send_cut_video_chunk(
+            state,
+            context,
+            spool_dir,
+            chunk_index,
+            capture_us,
+            capture_us.len() as u32,
+            dtype,
+        )
+        .await;
+    }
+
+    /// As [`send_video_chunk`], for a chunk the dispatcher cut at a recording
+    /// boundary: the NUT holds every frame in `capture_us` but the
+    /// announcement owns only the leading `owned_frames` of them.
+    #[allow(clippy::too_many_arguments)]
+    async fn send_cut_video_chunk(
+        state: &mut ActorState,
+        context: &Arc<TraceActorContext>,
+        spool_dir: &std::path::Path,
+        chunk_index: u32,
+        capture_us: &[i64],
+        owned_frames: u32,
+        dtype: FrameDtype,
+    ) {
+        let spool_nut = spool_dir.join(format!("spool_chunk_{chunk_index}.nut"));
+        let chunk_origin = capture_us[0];
+        let relative_pts: Vec<u64> = capture_us
+            .iter()
+            .map(|us| (us - chunk_origin) as u64)
+            .collect();
+        write_nut_chunk(&spool_nut, &relative_pts);
+        let byte_count = spool_nut.metadata().unwrap().len();
+        let frame_timestamps_s: Vec<f64> = capture_us
+            .iter()
+            .take(owned_frames as usize)
+            .map(|us| *us as f64 / 1e6)
+            .collect();
+        state
+            .handle_video(
+                context,
+                chunk_index,
+                spool_nut,
+                16,
+                16,
+                byte_count,
+                owned_frames,
+                frame_timestamps_s,
+                dtype,
+            )
+            .await;
+    }
+
+    /// Poll `drain_completed_encodes` until every spawned worker is reaped.
+    /// Returns whether any worker reported a failure.
+    async fn drain_all_pending(state: &mut ActorState, context: &Arc<TraceActorContext>) -> bool {
+        let mut any_failure = false;
+        for _ in 0..600 {
+            any_failure |= state.drain_completed_encodes(context);
+            let remaining = match &state.writer {
+                TraceWriterKind::Video {
+                    pending_encodes, ..
+                } => pending_encodes.len(),
+                _ => 0,
+            };
+            if remaining == 0 {
+                return any_failure;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("encode workers did not finish in time");
+    }
+
+    #[test]
+    fn drain_stops_at_dtype_change_and_batch_cap() {
+        fn queued(chunk_index: u32, dtype: FrameDtype) -> QueuedChunk {
+            QueuedChunk {
+                chunk_index,
+                spool_nut: PathBuf::from("unused.nut"),
+                byte_count: 0,
+                frame_count: 1,
+                frame_timestamps_s: vec![0.0],
+                dtype,
+            }
+        }
+        fn indices(batch: &[QueuedChunk]) -> Vec<u32> {
+            batch.iter().map(|chunk| chunk.chunk_index).collect()
+        }
+
+        // A dtype change stops the drain so one batch spans one dtype.
+        let mut queue: VecDeque<QueuedChunk> = [
+            queued(0, FrameDtype::Rgb8),
+            queued(1, FrameDtype::Rgb8),
+            queued(2, FrameDtype::DepthF16),
+            queued(3, FrameDtype::Rgb8),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![0, 1]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![2]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![3]);
+        assert!(queue.is_empty());
+
+        // The batch cap bounds a same-dtype drain.
+        let mut queue: VecDeque<QueuedChunk> = (0..10)
+            .map(|index| queued(index, FrameDtype::Rgb8))
+            .collect();
+        let batch = drain_encode_batch(&mut queue);
+        assert_eq!(batch.len(), ENCODE_BATCH_MAX_CHUNKS);
+        assert_eq!(indices(&batch), (0..8).collect::<Vec<u32>>());
+        assert_eq!(queue.len(), 2);
+
+        // An empty queue yields an empty (no-op) batch.
+        assert!(drain_encode_batch(&mut VecDeque::new()).is_empty());
+    }
+
+    #[test]
+    fn drain_stops_before_a_chunk_past_the_span_cap() {
+        fn queued(chunk_index: u32, frame_capture_us: &[i64]) -> QueuedChunk {
+            QueuedChunk {
+                chunk_index,
+                spool_nut: PathBuf::from("unused.nut"),
+                byte_count: 0,
+                frame_count: frame_capture_us.len() as u32,
+                frame_timestamps_s: frame_capture_us.iter().map(|us| *us as f64 / 1e6).collect(),
+                dtype: FrameDtype::Rgb8,
+            }
+        }
+        fn indices(batch: &[QueuedChunk]) -> Vec<u32> {
+            batch.iter().map(|chunk| chunk.chunk_index).collect()
+        }
+
+        // Chunk 1 starts exactly one cap after chunk 0 (span == cap stays in
+        // the batch). Chunk 2's declared span from chunk 1 exceeds the cap
+        // by 1 us, so it stays at the queue front for its own worker; the
+        // drain resumes normally from it.
+        let cap_us = ENCODE_BATCH_MAX_SPAN_US;
+        let mut queue: VecDeque<QueuedChunk> = [
+            queued(0, &[0, 16_683]),
+            queued(1, &[cap_us, cap_us + 16_683]),
+            queued(2, &[2 * cap_us + 1]),
+            queued(3, &[2 * cap_us + 1 + 16_683]),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![0, 1]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![2, 3]);
+        assert!(queue.is_empty());
+
+        // A chunk that announced no frames contributes extent zero: its span
+        // floors to 1 us, so it never splits the batch and never panics.
+        let mut queue: VecDeque<QueuedChunk> = [
+            queued(0, &[0, 16_683]),
+            queued(1, &[]),
+            queued(2, &[33_366]),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn batched_backlog_produces_one_completed_chunk_keyed_by_first_index() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping batch accounting test.");
+            return;
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+            .await
+            .expect("open store");
+        let store_arc = Arc::new(store.clone());
+        let permits = Arc::new(Semaphore::new(1));
+        let context = test_context_with_permits(
+            &tempdir.path().join("recordings"),
+            store_arc.clone(),
+            permits.clone(),
+        );
+        let spool_dir = tempdir.path().join("spool");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut state = ActorState::new(identity(1, "trace-batch", "RGB_IMAGES"));
+        state.send_create(&context);
+
+        // Hold the only permit while three chunks arrive so every worker
+        // blocks, then release: the first worker drains all three as one
+        // batch and the other two must no-op.
+        let gate = permits.clone().acquire_owned().await.unwrap();
+        let chunks: [Vec<i64>; 3] = [vec![0, 16_683], vec![33_366, 50_049], vec![66_732, 83_415]];
+        for (chunk_index, capture_us) in chunks.iter().enumerate() {
+            send_video_chunk(
+                &mut state,
+                &context,
+                &spool_dir,
+                chunk_index as u32,
+                capture_us,
+                FrameDtype::Rgb8,
+            )
+            .await;
+        }
+        drop(gate);
+
+        let any_failure = drain_all_pending(&mut state, &context).await;
+        assert!(!any_failure, "the batch must encode cleanly");
+
+        let trace_dir = TracePath::new("1", "RGB_IMAGES", "trace-batch")
+            .directory(context.recordings_root.as_path());
+        let chunks_dir = trace_dir.join(paths::CHUNKS_DIRNAME);
+        {
+            let TraceWriterKind::Video {
+                completed_chunks,
+                unencoded_chunks,
+                ..
+            } = &state.writer
+            else {
+                panic!("video writer expected");
+            };
+            assert_eq!(completed_chunks.len(), 1, "one CompletedChunk per batch");
+            let (first_index, completed) = completed_chunks.iter().next().unwrap();
+            assert_eq!(*first_index, 0, "the batch is keyed by its first index");
+            assert_eq!(completed.frame_count, 6, "frame_count is the batch sum");
+            let expected_timestamps: Vec<f64> =
+                chunks.iter().flatten().map(|us| *us as f64 / 1e6).collect();
+            assert_eq!(
+                completed.frame_timestamps_s, expected_timestamps,
+                "timestamps concatenate in chunk order"
+            );
+            assert_eq!(
+                completed.lossy_segment,
+                trace_dir.join(paths::chunk_lossy_filename(0))
+            );
+            assert!(completed.lossy_segment.exists());
+            assert!(completed.lossless_segment.exists());
+            assert_eq!(
+                unencoded_chunks.load(Ordering::Relaxed),
+                0,
+                "no chunk is left un-encoded"
+            );
+        }
+        // The covered indices produce no segments of their own, and every
+        // batched NUT is unlinked after the outputs verified non-empty.
+        assert!(!trace_dir.join(paths::chunk_lossy_filename(1)).exists());
+        assert!(!trace_dir.join(paths::chunk_lossy_filename(2)).exists());
+        for chunk_index in 0..3u32 {
+            assert!(!chunks_dir.join(paths::chunk_filename(chunk_index)).exists());
+        }
+
+        // The finalise concat consumes the batch segment unchanged.
+        state.finalise_trace(&context).await;
+        context.trace_writer.flush().await;
+        assert!(trace_dir.join(paths::LOSSY_VIDEO_FILENAME).exists());
+        let sidecar: Value = serde_json::from_slice(
+            &std::fs::read(trace_dir.join(paths::TRACE_JSON_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(sidecar.as_array().unwrap().len(), 6);
+        let trace = store.get_trace("trace-batch").await.unwrap().unwrap();
+        assert_eq!(trace.write_status, TraceWriteStatus::Written);
+    }
+
+    #[tokio::test]
+    async fn batch_stops_at_the_frames_the_recording_owns() {
+        if !ffmpeg_available() || !binary_available("ffprobe") {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping batch frame-cap test.");
+            return;
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+            .await
+            .expect("open store");
+        let store_arc = Arc::new(store.clone());
+        let permits = Arc::new(Semaphore::new(1));
+        let context = test_context_with_permits(
+            &tempdir.path().join("recordings"),
+            store_arc.clone(),
+            permits.clone(),
+        );
+        let spool_dir = tempdir.path().join("spool");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut state = ActorState::new(identity(1, "trace-cut", "RGB_IMAGES"));
+        state.send_create(&context);
+
+        // The dispatcher cuts the trace's last chunk at the recording stop, so
+        // the batch must encode two frames of chunk 0 and one of chunk 1.
+        let gate = permits.clone().acquire_owned().await.unwrap();
+        send_video_chunk(
+            &mut state,
+            &context,
+            &spool_dir,
+            0,
+            &[0, 16_683],
+            FrameDtype::Rgb8,
+        )
+        .await;
+        send_cut_video_chunk(
+            &mut state,
+            &context,
+            &spool_dir,
+            1,
+            &[33_366, 50_049, 66_732],
+            1,
+            FrameDtype::Rgb8,
+        )
+        .await;
+        drop(gate);
+
+        let any_failure = drain_all_pending(&mut state, &context).await;
+        assert!(!any_failure, "the batch must encode cleanly");
+
+        let trace_dir = TracePath::new("1", "RGB_IMAGES", "trace-cut")
+            .directory(context.recordings_root.as_path());
+        let TraceWriterKind::Video {
+            completed_chunks, ..
+        } = &state.writer
+        else {
+            panic!("video writer expected");
+        };
+        let completed = completed_chunks.values().next().expect("one batch");
+        assert_eq!(
+            completed.frame_count, 3,
+            "the cut chunk contributes only the frames it owns"
+        );
+        assert_eq!(
+            probed_frame_count(&completed.lossy_segment),
+            3,
+            "the lossy segment must not outrun the sidecar"
+        );
+        assert_eq!(
+            probed_frame_count(&completed.lossless_segment),
+            3,
+            "the lossless segment must stop at the same cut"
+        );
+        assert!(trace_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn racing_worker_noop_is_reaped_silently_at_finalise() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping worker racing test.");
+            return;
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+            .await
+            .expect("open store");
+        let store_arc = Arc::new(store.clone());
+        let permits = Arc::new(Semaphore::new(1));
+        let context = test_context_with_permits(
+            &tempdir.path().join("recordings"),
+            store_arc.clone(),
+            permits.clone(),
+        );
+        let spool_dir = tempdir.path().join("spool");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut state = ActorState::new(identity(1, "trace-race", "RGB_IMAGES"));
+        state.send_create(&context);
+
+        // Two workers race for one queued backlog: the first drains both
+        // chunks, the second finds the queue empty and must no-op. Finalise
+        // reaps both without treating the no-op as an error or a chunk.
+        let gate = permits.clone().acquire_owned().await.unwrap();
+        send_video_chunk(
+            &mut state,
+            &context,
+            &spool_dir,
+            0,
+            &[0, 16_683],
+            FrameDtype::Rgb8,
+        )
+        .await;
+        send_video_chunk(
+            &mut state,
+            &context,
+            &spool_dir,
+            1,
+            &[33_366, 50_049],
+            FrameDtype::Rgb8,
+        )
+        .await;
+        drop(gate);
+        state.finalise_trace(&context).await;
+        context.trace_writer.flush().await;
+
+        let trace_dir = TracePath::new("1", "RGB_IMAGES", "trace-race")
+            .directory(context.recordings_root.as_path());
+        assert!(trace_dir.join(paths::LOSSY_VIDEO_FILENAME).exists());
+        // Four sidecar entries: each frame encoded exactly once.
+        let sidecar: Value = serde_json::from_slice(
+            &std::fs::read(trace_dir.join(paths::TRACE_JSON_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(sidecar.as_array().unwrap().len(), 4);
+        let trace = store.get_trace("trace-race").await.unwrap().unwrap();
+        assert_eq!(
+            trace.write_status,
+            TraceWriteStatus::Written,
+            "a no-op worker must not fail the trace"
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_nut_in_batch_marks_trace_failed_and_leaves_nuts() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping batch failure test.");
+            return;
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+            .await
+            .expect("open store");
+        let store_arc = Arc::new(store.clone());
+        let permits = Arc::new(Semaphore::new(1));
+        let context = test_context_with_permits(
+            &tempdir.path().join("recordings"),
+            store_arc.clone(),
+            permits.clone(),
+        );
+        let spool_dir = tempdir.path().join("spool");
+        std::fs::create_dir_all(&spool_dir).unwrap();
+
+        let mut state = ActorState::new(identity(1, "trace-bad", "RGB_IMAGES"));
+        state.send_create(&context);
+
+        let gate = permits.clone().acquire_owned().await.unwrap();
+        send_video_chunk(
+            &mut state,
+            &context,
+            &spool_dir,
+            0,
+            &[0, 16_683],
+            FrameDtype::Rgb8,
+        )
+        .await;
+        // A corrupt second chunk poisons the whole batch invocation.
+        let corrupt_nut = spool_dir.join("spool_chunk_1.nut");
+        std::fs::write(&corrupt_nut, b"not a nut container").unwrap();
+        state
+            .handle_video(
+                &context,
+                1,
+                corrupt_nut,
+                16,
+                16,
+                19,
+                2,
+                vec![0.1, 0.116683],
+                FrameDtype::Rgb8,
+            )
+            .await;
+        drop(gate);
+
+        let any_failure = drain_all_pending(&mut state, &context).await;
+        assert!(any_failure, "the corrupt batch must surface as a failure");
+        context.trace_writer.flush().await;
+
+        let trace = store.get_trace("trace-bad").await.unwrap().unwrap();
+        assert_eq!(trace.write_status, TraceWriteStatus::Failed);
+
+        // Both relinked NUTs stay on disk for the recovery sweep.
+        let trace_dir = TracePath::new("1", "RGB_IMAGES", "trace-bad")
+            .directory(context.recordings_root.as_path());
+        let chunks_dir = trace_dir.join(paths::CHUNKS_DIRNAME);
+        assert!(chunks_dir.join(paths::chunk_filename(0)).exists());
+        assert!(chunks_dir.join(paths::chunk_filename(1)).exists());
+    }
+
+    #[tokio::test]
+    async fn single_chunk_batch_matches_todays_completed_chunk() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping single-chunk batch test.");
+            return;
+        }
+
+        for lossy_only in [false, true] {
+            let tempdir = TempDir::new().unwrap();
+            let store = SqliteStateStore::open(&tempdir.path().join("state.db"))
+                .await
+                .expect("open store");
+            let store_arc = Arc::new(store.clone());
+            let mut context = test_context(&tempdir.path().join("recordings"), store_arc.clone());
+            let _config_tx;
+            if lossy_only {
+                let (config_tx, config_rx) = watch::channel(DaemonConfig {
+                    video_codec: Some("h264_medium".to_string()),
+                    ..DaemonConfig::default()
+                });
+                _config_tx = config_tx;
+                context = Arc::new((*context).clone().with_config_rx(config_rx));
+            }
+            let spool_dir = tempdir.path().join("spool");
+            std::fs::create_dir_all(&spool_dir).unwrap();
+
+            let mut state = ActorState::new(identity(1, "trace-single", "RGB_IMAGES"));
+            state.send_create(&context);
+            let capture_us = [0i64, 16_683];
+            send_video_chunk(
+                &mut state,
+                &context,
+                &spool_dir,
+                0,
+                &capture_us,
+                FrameDtype::Rgb8,
+            )
+            .await;
+
+            let any_failure = drain_all_pending(&mut state, &context).await;
+            assert!(!any_failure, "the single-chunk batch must encode cleanly");
+
+            let trace_dir = TracePath::new("1", "RGB_IMAGES", "trace-single")
+                .directory(context.recordings_root.as_path());
+            {
+                let TraceWriterKind::Video {
+                    completed_chunks, ..
+                } = &state.writer
+                else {
+                    panic!("video writer expected");
+                };
+                assert_eq!(completed_chunks.len(), 1);
+                let completed = &completed_chunks[&0];
+                assert_eq!(completed.frame_count, 2);
+                assert_eq!(completed.frame_timestamps_s, vec![0.0, 0.016683]);
+                assert_eq!(
+                    completed.lossy_segment,
+                    trace_dir.join(paths::chunk_lossy_filename(0)),
+                    "segment names keep today's shape (lossy_only={lossy_only})"
+                );
+                assert!(completed.lossy_segment.exists());
+                assert_eq!(
+                    completed.lossless_segment.exists(),
+                    !lossy_only,
+                    "a lossless segment exists exactly when not lossy-only"
+                );
+            }
+
+            state.finalise_trace(&context).await;
+            context.trace_writer.flush().await;
+            let trace = store.get_trace("trace-single").await.unwrap().unwrap();
+            assert_eq!(trace.write_status, TraceWriteStatus::Written);
+        }
     }
 }

--- a/rust/data_daemon/src/storage/paths.rs
+++ b/rust/data_daemon/src/storage/paths.rs
@@ -105,12 +105,15 @@ pub fn chunk_filename(chunk_index: u32) -> String {
     format!("chunk_{chunk_index:04}.nut")
 }
 
-/// Build the filename for a per-chunk encoded lossy mp4 segment.
+/// Build the filename for an encoded lossy mp4 segment. A segment covers one
+/// encode batch and is named after the batch's first chunk index, so segment
+/// indices are not dense when the encoder batches under backlog.
 pub fn chunk_lossy_filename(chunk_index: u32) -> String {
     format!("chunk_{chunk_index:04}_lossy.mp4")
 }
 
-/// Build the filename for a per-chunk encoded lossless mp4 segment.
+/// Build the filename for an encoded lossless mp4 segment. Named after the
+/// batch's first chunk index, like the lossy segment.
 pub fn chunk_lossless_filename(chunk_index: u32) -> String {
     format!("chunk_{chunk_index:04}_lossless.mp4")
 }

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -68,10 +68,12 @@ use crate::publisher::{now_ns, publisher_tx, ProducerError, PublishMsg};
 ///
 /// Each chunk pays a fixed per-encode cost on the daemon side (~100-200 ms of
 /// ffmpeg fork+exec + libx264 init for two output codecs). 256 MiB keeps that
-/// fixed cost a small fraction of the per-chunk wall time. The threshold is
-/// checked *after* each frame, so the on-disk file can exceed it by at most
-/// one frame. A chunk is also rolled at every lifecycle event so a single NUT
-/// only ever holds frames from one recording window.
+/// fixed cost a small fraction of the per-chunk wall time. Under backlog the
+/// daemon batches several chunks into one ffmpeg invocation, which amortises
+/// that fixed cost further, but this sizing assumes the keep-pace case. The
+/// threshold is checked *after* each frame, so the on-disk file can exceed it
+/// by at most one frame. A chunk is also rolled at every lifecycle event so a
+/// single NUT only ever holds frames from one recording window.
 ///
 /// This byte threshold has a companion frame-count cap
 /// ([`MAX_VIDEO_CHUNK_FRAMES`]): a chunk is sealed at whichever bound is hit


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - The daemon now batches up to 8 video chunk encodes into one ffmpeg invocation when a trace falls behind, via the concat demuxer with per-entry `duration` directives computed from capture timestamps. Measured ~12% encode throughput on its own and +52% combined with the `fast_bilinear` scaler from PR #907. When the encoder keeps pace, batches hold one chunk and the invocation is byte-identical to today's single-chunk path.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1274](https://neuracore.atlassian.net/browse/NCP-1274)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - Builds on the scaler change from #907
 - #912 make PTS exact
