### PR TITLE
ci: pin ffmpeg to 8.1 in importer staging workflow

### DIFF
--- a/.github/workflows/integration-importer-staging.yaml
+++ b/.github/workflows/integration-importer-staging.yaml
@@ -101,6 +101,12 @@ jobs:
           extras: dev,import
           pytorch-cpu: "true"
 
+      # torchcodec (lerobot importer path) only supports FFmpeg up to 8, not the shared action's 9.0.
+      - name: Downgrade FFmpeg to 8.1 for torchcodec compatibility
+        uses: AnimMouse/setup-ffmpeg@178e0b4a408f06ce40d896c3cd79f50fa6f8b0c3 # v1.2.5
+        with:
+          version: "8.1"
+
       - name: Run Importer Integration Tests
         env:
           NEURACORE_API_URL: https://staging.api.neuracore.com/api


### PR DESCRIPTION
### Bugfixes
 - Pin FFmpeg to 8.1 in the `Integration PF - Importer (Staging)` workflow. The shared `setup-neuracore-from-source` action installs FFmpeg 9.0, but `torchcodec` (used by the lerobot importer path) only ships builds for FFmpeg up to 8. (runs [32316292952](https://github.com/NeuracoreAI/neuracore/actions/runs/32316292952), [32350186238](https://github.com/NeuracoreAI/neuracore/actions/runs/32350186238)). `mcap`/`rlds` were unaffected since they don't decode video through `torchcodec`.

### Related PRs
 - Follows on from #910, which fixed a different FFmpeg-9 regression
