### PR TITLE
fix: support ffmpeg 9 video decoding

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -16,3 +16,5 @@ The data daemon now reports the neuracore version it was built from, and the SDK
 The data daemon encodes video chunks faster on slow machines with a lighter preview scaling filter.
 
 The data daemon now works with ffmpeg 8 and later. It selects the frame timing option that the installed ffmpeg accepts, so new and old ffmpeg builds are both supported.
+
+Dataset video decoding now works with ffmpeg 8 and later too. It selects the frame timing option the installed ffmpeg accepts, instead of falling back to the slower PyAV decoder.

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -44,8 +44,62 @@ if TYPE_CHECKING:
 MAX_DECODING_ATTEMPTS = 3
 _FFMPEG_AVAILABLE: bool | None = None
 
+# `-fps_mode` is accepted from ffmpeg 5.1 onwards and is the only spelling
+# accepted from 8.0, where the legacy `-vsync` name was removed. Resolved
+# once per process and cached, like _FFMPEG_AVAILABLE above.
+_FPS_MODE_ARG = "-fps_mode"
+_VSYNC_ARG = "-vsync"
+_FFMPEG_FRAME_SYNC_ARG: str | None = None
+
 _RGB_VIDEO_FILENAME_PREFERENCE = ("lossless.mp4", "lossy.mp4")
 _DEPTH_VIDEO_FILENAME_PREFERENCE = ("lossless.mp4",)
+
+
+def _resolve_frame_sync_arg() -> str:
+    """Return the flag the local ffmpeg accepts for passthrough frame timing.
+
+    Probes with one synthetic frame piped to the null muxer: `-fps_mode` fails
+    with "Unrecognized option" on ffmpeg < 5.1, so any other outcome (success,
+    or a failure unrelated to the flag) is treated as accepted.
+
+    Returns:
+        "-fps_mode" if the local ffmpeg accepts it, otherwise "-vsync".
+    """
+    global _FFMPEG_FRAME_SYNC_ARG
+    if _FFMPEG_FRAME_SYNC_ARG is not None:
+        return _FFMPEG_FRAME_SYNC_ARG
+
+    frame = bytes([128]) * (16 * 16 * 3 // 2)  # one 16x16 yuv420p frame
+    try:
+        probe = subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "yuv420p",
+                "-video_size",
+                "16x16",
+                "-i",
+                "-",
+                _FPS_MODE_ARG,
+                "passthrough",
+                "-f",
+                "null",
+                "-",
+            ],
+            input=frame,
+            capture_output=True,
+        )
+        rejected = b"Unrecognized option" in probe.stderr
+    except FileNotFoundError:
+        rejected = True
+
+    _FFMPEG_FRAME_SYNC_ARG = _VSYNC_ARG if rejected else _FPS_MODE_ARG
+    return _FFMPEG_FRAME_SYNC_ARG
 
 
 class SynchronizedRecording:
@@ -232,14 +286,15 @@ class SynchronizedRecording:
 
         if _FFMPEG_AVAILABLE:
             output_pattern = str(video_frame_cache_path / "%d.png")
+            frame_sync_arg = _resolve_frame_sync_arg()
             try:
                 subprocess.run(
                     [
                         "ffmpeg",
                         "-i",
                         str(video_location),
-                        "-vsync",
-                        "0",
+                        frame_sync_arg,
+                        "passthrough",
                         "-pix_fmt",
                         "rgb24",
                         "-q:v",

--- a/tests/unit/core/data/test_synchronized_episode.py
+++ b/tests/unit/core/data/test_synchronized_episode.py
@@ -529,3 +529,82 @@ class TestSynchronizedRecording:
         assert not any(final_dir.parent.rglob("*recording.lock"))
         leftovers = [p for p in final_dir.parent.iterdir() if p != final_dir]
         assert leftovers == []
+
+    def test_decode_video_uses_resolved_frame_sync_arg(
+        self, synced_recording, tmp_path
+    ):
+        """The ffmpeg decode command must use the probed flag, not a hard-coded
+        `-vsync`: that spelling was removed in ffmpeg 8, so hard-coding it
+        breaks decoding on any ffmpeg 8+ install.
+        """
+        video_location = tmp_path / "video.mp4"
+        video_location.touch()
+        frames_dir = tmp_path / "frames"
+        frames_dir.mkdir()
+
+        with (
+            patch(f"{MODULE}._FFMPEG_AVAILABLE", True),
+            patch(f"{MODULE}._resolve_frame_sync_arg", return_value="-fps_mode"),
+            patch(f"{MODULE}.subprocess.run") as mock_run,
+        ):
+            synced_recording._decode_video(video_location, frames_dir)
+
+        ffmpeg_args = mock_run.call_args[0][0]
+        assert "-fps_mode" in ffmpeg_args
+        flag_index = ffmpeg_args.index("-fps_mode")
+        assert ffmpeg_args[flag_index + 1] == "passthrough"
+        assert "-vsync" not in ffmpeg_args
+
+
+class TestResolveFrameSyncArg:
+    """Tests for _resolve_frame_sync_arg's ffmpeg passthrough flag probe."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """Clear the module-level memo so each test probes fresh."""
+        import neuracore.core.data.synced_recording as synced_recording_module
+
+        synced_recording_module._FFMPEG_FRAME_SYNC_ARG = None
+        yield
+        synced_recording_module._FFMPEG_FRAME_SYNC_ARG = None
+
+    def test_returns_fps_mode_when_ffmpeg_accepts_it(self):
+        """ffmpeg >= 5.1 accepts -fps_mode, so it should be preferred."""
+        from neuracore.core.data.synced_recording import _resolve_frame_sync_arg
+
+        with patch(f"{MODULE}.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stderr=b"")
+
+            assert _resolve_frame_sync_arg() == "-fps_mode"
+
+    def test_returns_vsync_when_ffmpeg_rejects_fps_mode(self):
+        """ffmpeg < 5.1 rejects -fps_mode as unrecognised, so fall back to -vsync."""
+        from neuracore.core.data.synced_recording import _resolve_frame_sync_arg
+
+        with patch(f"{MODULE}.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode=1, stderr=b"Unrecognized option 'fps_mode'."
+            )
+
+            assert _resolve_frame_sync_arg() == "-vsync"
+
+    def test_returns_vsync_when_ffmpeg_binary_is_missing(self):
+        """No ffmpeg on PATH resolves to the legacy spelling, matching the
+        pre-existing _FFMPEG_AVAILABLE probe's fall-back behaviour.
+        """
+        from neuracore.core.data.synced_recording import _resolve_frame_sync_arg
+
+        with patch(f"{MODULE}.subprocess.run", side_effect=FileNotFoundError):
+            assert _resolve_frame_sync_arg() == "-vsync"
+
+    def test_probes_ffmpeg_only_once(self):
+        """The result is memoized: a second call must not spawn ffmpeg again."""
+        from neuracore.core.data.synced_recording import _resolve_frame_sync_arg
+
+        with patch(f"{MODULE}.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stderr=b"")
+
+            assert _resolve_frame_sync_arg() == "-fps_mode"
+            assert _resolve_frame_sync_arg() == "-fps_mode"
+
+        mock_run.assert_called_once()


### PR DESCRIPTION
### Bugfixes
 - `SynchronizedRecording._decode_video` hard-coded `-vsync 0` for the ffmpeg decode pass. FFmpeg 8 removed `-vsync`, so on ffmpeg 8+ every decode falls back to PyAV
 - Adds `_resolve_frame_sync_arg()`, a Python port of the same probe used on the daemon side. it tries `-fps_mode` (ffmpeg >= 5.1, the only spelling from 8.0 on) and falls back to `-vsync` if ffmpeg rejects it as unrecognized, memoized once per process. `_decode_video` now uses the resolved flag instead of the hard-coded one.

### Related PRs
 - Stacked on #915.
 - Companion fix to #910 (daemon side); this is the SDK-side decode path #910 left open.
