### PR TITLE
fix: syn-recording-download-url

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -18,3 +18,5 @@ The data daemon encodes video chunks faster on slow machines with a lighter prev
 The data daemon now works with ffmpeg 8 and later. It selects the frame timing option that the installed ffmpeg accepts, so new and old ffmpeg builds are both supported.
 
 Dataset video decoding now works with ffmpeg 8 and later too. It selects the frame timing option the installed ffmpeg accepts, instead of falling back to the slower PyAV decoder.
+
+Synchronizing a recording is now asynchronous: the SDK starts the synchronization, waits for it to finish, and then downloads the episode directly from storage through a short-lived signed URL instead of receiving it inline from the API. Already-synchronized recordings are ready on the first check, so opening them no longer waits on multi-megabyte responses travelling through the API.

--- a/neuracore/core/data/prefetch.py
+++ b/neuracore/core/data/prefetch.py
@@ -23,7 +23,12 @@ from typing import TYPE_CHECKING
 import aiohttp
 from neuracore_types import DataType, SynchronizationDetails
 from neuracore_types import SynchronizedEpisode as SynchronizedEpisodeModel
-from neuracore_types import SynchronizeRecordingRequest
+from neuracore_types import (
+    SynchronizeRecordingProgress,
+    SynchronizeRecordingRequest,
+    SynchronizeRecordingStartResponse,
+    SynchronizeRecordingStatus,
+)
 from tqdm import tqdm
 
 from neuracore.core.auth import get_auth
@@ -37,6 +42,11 @@ from neuracore.core.data.frame_cache import (
     publish_decoded_frames,
     video_filename_preference,
 )
+from neuracore.core.data.synced_recording import (
+    SYNCED_RECORDING_POLL_INTERVAL_S,
+    SYNCED_RECORDING_TIMEOUT_S,
+)
+from neuracore.core.exceptions import SynchronizationError
 from neuracore.core.utils.download import DOWNLOAD_CHUNK_SIZE
 from neuracore.core.utils.http_session import retry_connection_failures
 
@@ -188,7 +198,7 @@ class VideoPrefetcher:
     async def _get_synced_data(
         self, session: aiohttp.ClientSession, recording_id: str
     ) -> SynchronizedEpisodeModel:
-        """Fetch one recording's synchronized metadata.
+        """Synchronize one recording and download its episode metadata.
 
         Args:
             session: Shared client session.
@@ -197,18 +207,67 @@ class VideoPrefetcher:
         Returns:
             The synchronized episode for the recording.
         """
-        request = SynchronizeRecordingRequest(
-            recording_id=recording_id,
-            synchronization_details=self.synchronization_details,
-        )
-        url = f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording"
+        base_url = f"{API_URL}/org/{self.dataset.org_id}/synchronize"
         async with session.post(
-            url,
-            json=request.model_dump(mode="json"),
+            f"{base_url}/trigger-synchronize-recording",
+            json=SynchronizeRecordingRequest(
+                recording_id=recording_id,
+                synchronization_details=self.synchronization_details,
+            ).model_dump(mode="json"),
             headers=get_auth().get_headers(),
         ) as response:
             response.raise_for_status()
-            payload = await response.json()
+            job = SynchronizeRecordingStartResponse.model_validate(
+                await response.json()
+            )
+
+        deadline = asyncio.get_running_loop().time() + SYNCED_RECORDING_TIMEOUT_S
+        while True:
+            async with session.get(
+                f"{base_url}/synchronize-recording-progress/"
+                f"{job.synchronized_recording_id}",
+                params={"recording_id": recording_id},
+                headers=get_auth().get_headers(),
+            ) as response:
+                response.raise_for_status()
+                progress = SynchronizeRecordingProgress.model_validate(
+                    await response.json()
+                )
+
+            if progress.status is SynchronizeRecordingStatus.READY:
+                if not progress.download_url:
+                    raise SynchronizationError(
+                        f"Synchronizing recording {recording_id} reported READY "
+                        "without a download URL"
+                    )
+                break
+            if progress.status is SynchronizeRecordingStatus.FAILED:
+                raise SynchronizationError(
+                    f"Synchronizing recording {recording_id} failed: "
+                    f"{progress.error or 'no reason given'}"
+                )
+            if asyncio.get_running_loop().time() >= deadline:
+                raise SynchronizationError(
+                    f"Timed out after {SYNCED_RECORDING_TIMEOUT_S:.0f}s waiting "
+                    f"for recording {recording_id} to synchronize"
+                )
+            await asyncio.sleep(SYNCED_RECORDING_POLL_INTERVAL_S)
+
+        try:
+            async with session.get(progress.download_url) as response:
+                response.raise_for_status()
+                payload = await response.json()
+        except aiohttp.ClientError as exc:
+            # aiohttp includes the signed URL (and its credentials) in request
+            # errors, so only expose the response status or exception class.
+            status = (
+                exc.status if isinstance(exc, aiohttp.ClientResponseError) else None
+            )
+            detail = f"HTTP {status}" if status is not None else type(exc).__name__
+            raise SynchronizationError(
+                f"Failed to download synchronized episode for recording "
+                f"{recording_id} ({detail})"
+            ) from None
         return SynchronizedEpisodeModel.model_validate(payload)
 
     async def _fetch_and_download(self, session: aiohttp.ClientSession) -> None:

--- a/neuracore/core/data/synced_recording.py
+++ b/neuracore/core/data/synced_recording.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import tempfile
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -17,9 +18,16 @@ from neuracore_types import (
     SynchronizationDetails,
 )
 from neuracore_types import SynchronizedEpisode as SynchronizedEpisodeModel
-from neuracore_types import SynchronizedPoint, SynchronizeRecordingRequest
+from neuracore_types import (
+    SynchronizedPoint,
+    SynchronizeRecordingProgress,
+    SynchronizeRecordingRequest,
+    SynchronizeRecordingStartResponse,
+    SynchronizeRecordingStatus,
+)
 from neuracore_types.nc_data.point_cloud_data import decode_point_cloud_frame
 from PIL import Image
+from pydantic import ValidationError as PydanticValidationError
 
 from neuracore.core.data.cache_manager import CacheManager
 from neuracore.core.data.frame_cache import (
@@ -31,6 +39,7 @@ from neuracore.core.data.frame_cache import (
     video_filename_preference,
     wait_for_lock_release,
 )
+from neuracore.core.exceptions import SynchronizationError
 from neuracore.core.utils.depth_utils import rgb_to_depth_storage
 from neuracore.core.utils.download import download_bytes, stream_to_file
 from neuracore.core.utils.http_session import thread_local_session
@@ -45,6 +54,40 @@ POINT_CLOUD_TRACE_INDEX_FILE = "trace.json"
 
 if TYPE_CHECKING:
     from neuracore.core.data.dataset import Dataset
+
+SYNCED_RECORDING_POLL_INTERVAL_S = 2.0
+"""Seconds between polls of an in-progress recording synchronization."""
+
+SYNCED_RECORDING_TIMEOUT_S = 1800.0
+"""Seconds to wait for a recording to synchronize before giving up."""
+
+SYNCED_EPISODE_DOWNLOAD_TIMEOUT_S: tuple[float, float] = (15.0, 120.0)
+"""``(connect, read)`` seconds for the synchronized-episode object download.
+
+The read budget bounds the wait for each chunk of the body rather than the whole
+transfer. Object storage streaming a multi-megabyte episode can stall for far
+longer than an API metadata call ever should, so this download does not inherit
+``http_session.DEFAULT_TIMEOUT``. Matches the budget the equally large dataset
+statistics result is fetched with.
+"""
+
+
+def _describe_download_failure(error: requests.RequestException) -> str:
+    """Summarize a download failure without disclosing the signed URL.
+
+    ``requests`` puts the full URL, signing credentials included, in its own
+    error messages, so none of them can be surfaced to the caller.
+
+    Args:
+        error: The failure raised by ``requests``.
+
+    Returns:
+        The HTTP status code where the server answered, otherwise the name of
+        the error class.
+    """
+    if error.response is not None:
+        return f"HTTP {error.response.status_code}"
+    return type(error).__name__
 
 
 class SynchronizedRecording:
@@ -119,16 +162,38 @@ class SynchronizedRecording:
     def _get_synced_data(self) -> SynchronizedEpisodeModel:
         """Retrieve synchronized metadata for the recording.
 
+        Synchronization is asynchronous: the API starts it and then reports its
+        progress, and the finished episode is downloaded straight from object
+        storage rather than served back through the API.
+
         Returns:
             SynchronizedEpisode object containing synchronized frames and metadata.
 
         Raises:
+            requests.HTTPError: If a synchronization API request fails.
+            SynchronizationError: If the synchronization fails or exceeds its
+                deadline, if the API reports a state the caller cannot act on,
+                if the download fails, or if the downloaded episode is not a
+                valid synchronized episode.
+        """
+        job = self._start_synchronization()
+        return self._download_synced_data(self._await_synced_data_url(job))
+
+    def _start_synchronization(self) -> SynchronizeRecordingStartResponse:
+        """Ask the API to synchronize this recording.
+
+        Returns:
+            The synchronization's initial state, identifying the artifact to
+            poll for.
+
+        Raises:
             requests.HTTPError: If the API request fails.
+            SynchronizationError: If the response is not tracking metadata.
         """
         auth = get_auth()
         session = thread_local_session(retry_transient=True)
         response = session.post(
-            f"{API_URL}/org/{self.dataset.org_id}/synchronize/synchronize-recording",
+            f"{API_URL}/org/{self.dataset.org_id}/synchronize/trigger-synchronize-recording",
             json=SynchronizeRecordingRequest(
                 recording_id=self.id,
                 synchronization_details=self.synchronization_details,
@@ -136,7 +201,133 @@ class SynchronizedRecording:
             headers=auth.get_headers(),
         )
         response.raise_for_status()
-        return SynchronizedEpisodeModel.model_validate(response.json())
+        try:
+            return SynchronizeRecordingStartResponse.model_validate_json(
+                response.content
+            )
+        except PydanticValidationError as exc:
+            raise SynchronizationError(
+                f"Synchronization start response for recording {self.id} is not"
+                f" tracking metadata ({exc.error_count()} validation errors)"
+            ) from exc
+
+    def _poll_synchronization(
+        self,
+        job: SynchronizeRecordingStartResponse | SynchronizeRecordingProgress,
+    ) -> SynchronizeRecordingProgress:
+        """Read the current state of a started synchronization.
+
+        Args:
+            job: The state the synchronization was started with.
+
+        Returns:
+            The synchronization's latest state.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+            SynchronizationError: If the response is not tracking metadata.
+        """
+        auth = get_auth()
+        session = thread_local_session(retry_transient=True)
+        synchronize_recording_id = (
+            job.synchronized_recording_id
+            if isinstance(job, SynchronizeRecordingStartResponse)
+            else job.synchronize_recording_id
+        )
+        response = session.get(
+            f"{API_URL}/org/{self.dataset.org_id}/synchronize"
+            f"/synchronize-recording-progress/{synchronize_recording_id}",
+            params={"recording_id": job.recording_id},
+            headers=auth.get_headers(),
+        )
+        response.raise_for_status()
+        try:
+            return SynchronizeRecordingProgress.model_validate_json(response.content)
+        except PydanticValidationError as exc:
+            raise SynchronizationError(
+                f"Synchronization progress response for recording {self.id} is not"
+                f" tracking metadata ({exc.error_count()} validation errors)"
+            ) from exc
+
+    def _await_synced_data_url(self, job: SynchronizeRecordingStartResponse) -> str:
+        """Poll a synchronization until its episode can be downloaded.
+
+        An artifact the server has already cached reports READY on the first
+        poll, so nothing sleeps in the common case.
+
+        Args:
+            job: The state the synchronization was started with.
+
+        Returns:
+            Signed object-storage URL for the synchronized episode. Its query
+            string carries temporary credentials, so it must never be logged.
+
+        Raises:
+            requests.HTTPError: If a poll fails.
+            SynchronizationError: If the synchronization fails, exceeds its
+                deadline, or reports READY without a download URL.
+        """
+        deadline = time.monotonic() + SYNCED_RECORDING_TIMEOUT_S
+        while True:
+            job = self._poll_synchronization(job)
+
+            if job.status is SynchronizeRecordingStatus.READY:
+                if not job.download_url:
+                    raise SynchronizationError(
+                        f"Synchronizing recording {self.id} reported READY without"
+                        " a download URL"
+                    )
+                return job.download_url
+
+            if job.status is SynchronizeRecordingStatus.FAILED:
+                raise SynchronizationError(
+                    f"Synchronizing recording {self.id} failed:"
+                    f" {job.error or 'no reason given'}"
+                )
+
+            if time.monotonic() >= deadline:
+                raise SynchronizationError(
+                    f"Timed out after {SYNCED_RECORDING_TIMEOUT_S:.0f}s waiting for"
+                    f" recording {self.id} to synchronize (status"
+                    f" {job.status.value}). The synchronization is still running;"
+                    " reading the recording again resumes waiting rather than"
+                    " starting over."
+                )
+
+            time.sleep(SYNCED_RECORDING_POLL_INTERVAL_S)
+
+    def _download_synced_data(self, download_url: str) -> SynchronizedEpisodeModel:
+        """Download and validate the synchronized episode behind a signed URL.
+
+        Args:
+            download_url: Signed object-storage URL for the episode JSON.
+
+        Returns:
+            The validated synchronized episode.
+
+        Raises:
+            SynchronizationError: If the download fails, or the downloaded body
+                is not a valid synchronized episode.
+        """
+        session = thread_local_session(retry_transient=True, retry_read_timeout=True)
+        try:
+            response = session.get(
+                download_url, timeout=SYNCED_EPISODE_DOWNLOAD_TIMEOUT_S
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise SynchronizationError(
+                f"Failed to download synchronized episode for recording {self.id}"
+                f" ({_describe_download_failure(exc)})"
+            ) from None
+
+        try:
+            return SynchronizedEpisodeModel.model_validate_json(response.content)
+        except PydanticValidationError as exc:
+            raise SynchronizationError(
+                f"Downloaded synchronized episode for recording {self.id} is not a"
+                f" valid synchronized episode ({exc.error_count()} validation errors)"
+            ) from exc
 
     def _get_recording_file_url(self, filepath: str) -> str:
         """Get a signed download URL for a file in this recording.

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -5,9 +5,8 @@ Verifies that stopping the daemon via SIGTERM, SIGINT, SIGKILL, or the CLI
 and no lingering runner subprocess.
 
 Each test starts a fresh daemon in online mode, isolated by the
-``daemon_setup_teardown`` autouse fixture and ``online_daemon_running``,
-calls :func:`stop_daemon` with the method under test, then asserts cleanup
-invariants.
+batch-start storage fixture and ``online_daemon_running``, calls
+:func:`stop_daemon` with the method under test, then asserts cleanup invariants.
 
 Graceful methods (CLI, SIGTERM, SIGINT) let the daemon run its own shutdown
 path, releasing the PID file and IPC artefacts. SIGKILL bypasses that entirely;
@@ -186,8 +185,8 @@ def test_sigkill_terminates_daemon_process() -> None:
     SIGKILL cannot be caught or ignored; the daemon's cleanup handler never
     runs.  The test only asserts that the process is dead — it does NOT assert
     that IPC artefacts were cleaned up, since that is not guaranteed.
-    Teardown (``daemon_setup_teardown`` + ``online_daemon_running``) is
-    responsible for removing stale artefacts after an unclean kill.
+    ``online_daemon_running`` teardown is responsible for removing stale
+    artefacts after an unclean kill.
     """
 
     with online_daemon_running():
@@ -328,9 +327,9 @@ def test_sigkill_after_recording_allows_clean_restart(case: DataDaemonTestCase) 
       5. Assert the new PID differs from the killed one and is alive.
       6. Verify full cleanup after the second block exits.
 
-    This exercises the restart path that the ``daemon_setup_teardown`` autouse
-    fixture relies on between tests: stale IPC artefacts from the SIGKILL must
-    not prevent ``ensure_daemon_running`` from succeeding.
+    This exercises the restart path that test isolation relies on between
+    tests: stale IPC artefacts from the SIGKILL must not prevent
+    ``ensure_daemon_running`` from succeeding.
     """
 
     specs = build_context_specs(case=case)
@@ -349,8 +348,8 @@ def test_sigkill_after_recording_allows_clean_restart(case: DataDaemonTestCase) 
                 pid_first
             ), f"pid_is_running still True for killed daemon pid={pid_first}"
 
-        # IPC artefacts may be stale here — daemon_setup_teardown cleans them up.
-        # A second online_daemon_running block must succeed from scratch.
+        # IPC artefacts may be stale here. A second online_daemon_running block
+        # must clean them up and succeed from scratch.
         with online_daemon_running():
             pid_second = assert_exactly_one_daemon_pid()
             assert pid_second != pid_first, (

--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -14,7 +14,10 @@ from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
 )
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
-from tests.integration.platform.data_daemon.shared.process_control import Timer
+from tests.integration.platform.data_daemon.shared.process_control import (
+    Timer,
+    stop_daemon,
+)
 from tests.integration.platform.data_daemon.shared.profiles import (
     cleanup_test_profiles,
     profile_path,
@@ -167,7 +170,10 @@ def apply_batch_start_storage_state(request: pytest.FixtureRequest) -> None:
 
     A batch is defined as one parametrized test function over ``case``.  The
     fixture keys by the unparameterized node id, so cleanup runs once before
-    the first case and is skipped for the remaining cases in that batch.
+    the first case and is skipped for the remaining cases in that batch. Stop
+    any daemon left by an interrupted or SIGKILL test before deleting its
+    storage; the storage helper intentionally refuses to mutate live daemon
+    files.
     """
     if "case" not in request.fixturenames:
         return
@@ -177,6 +183,7 @@ def apply_batch_start_storage_state(request: pytest.FixtureRequest) -> None:
         return
 
     request.getfixturevalue("case")
+    stop_daemon()
     apply_storage_state_action(STORAGE_STATE_DELETE)
     _BATCH_START_CLEANED_NODEIDS.add(nodeid_without_param)
 

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -32,6 +32,13 @@ FREQ = 30
 PTS_FRACT = 90000  # Common timebase for h264
 
 MOCKED_ORG_ID = "test-org-id"
+SYNCED_RECORDING_ID = "synced-rec1"
+"""Artifact ID the mocked synchronization reports for recording rec1."""
+
+SYNCED_EPISODE_DOWNLOAD_URL = (
+    "https://storage.example/synced-episodes/rec1.json?signature=test-signature"
+)
+"""Stand-in for the signed object-storage URL a READY synchronization reports."""
 TEST_ROBOT_ID_1 = "20a621b7-2f9b-4699-a08e-7d080488a5a3"
 TEST_ROBOT_ID_2 = "30b731c8-3f9c-5799-b19e-8d190599b6b4"
 
@@ -39,6 +46,29 @@ TEST_ROBOT_ID_2 = "30b731c8-3f9c-5799-b19e-8d190599b6b4"
 @pytest.fixture
 def mocked_org_id():
     return MOCKED_ORG_ID
+
+
+@pytest.fixture
+def synced_episode_download_url():
+    """URL a READY synchronization hands back for the episode download."""
+    return SYNCED_EPISODE_DOWNLOAD_URL
+
+
+@pytest.fixture
+def synced_recording_id():
+    """Artifact ID the mocked synchronization reports."""
+    return SYNCED_RECORDING_ID
+
+
+@pytest.fixture
+def dataset_mock(dataset_dict, recordings_list, tmp_path):
+    """Create a dataset whose cache lives under the test's tmp_path."""
+    from neuracore.core.data.dataset import Dataset
+
+    dataset = Dataset(**dataset_dict, recordings=recordings_list)
+    dataset.cache_dir = tmp_path / "cache"
+    dataset.cache_dir.mkdir(parents=True, exist_ok=True)
+    return dataset
 
 
 @pytest.fixture
@@ -100,7 +130,11 @@ def mock_prefetch_transport(monkeypatch):
     its concurrency, locking, staging and atomic publish -- under test.
     """
     from neuracore_types import SynchronizedEpisode as SynchronizedEpisodeModel
-    from neuracore_types import SynchronizeRecordingRequest
+    from neuracore_types import (
+        SynchronizeRecordingProgress,
+        SynchronizeRecordingRequest,
+        SynchronizeRecordingStartResponse,
+    )
 
     from neuracore.core.auth import get_auth
     from neuracore.core.data.frame_cache import video_filename_preference
@@ -110,7 +144,8 @@ def mock_prefetch_transport(monkeypatch):
 
     async def fake_get_synced_data(self, session, recording_id):
         response = thread_local_session().post(
-            f"{API_URL}/org/{self.dataset.org_id}" "/synchronize/synchronize-recording",
+            f"{API_URL}/org/{self.dataset.org_id}"
+            "/synchronize/trigger-synchronize-recording",
             json=SynchronizeRecordingRequest(
                 recording_id=recording_id,
                 synchronization_details=self.synchronization_details,
@@ -118,7 +153,18 @@ def mock_prefetch_transport(monkeypatch):
             headers=get_auth().get_headers(),
         )
         response.raise_for_status()
-        return SynchronizedEpisodeModel.model_validate(response.json())
+        job = SynchronizeRecordingStartResponse.model_validate(response.json())
+        response = thread_local_session().get(
+            f"{API_URL}/org/{self.dataset.org_id}/synchronize"
+            f"/synchronize-recording-progress/{job.synchronized_recording_id}",
+            params={"recording_id": recording_id},
+            headers=get_auth().get_headers(),
+        )
+        response.raise_for_status()
+        progress = SynchronizeRecordingProgress.model_validate(response.json())
+        response = thread_local_session().get(progress.download_url)
+        response.raise_for_status()
+        return SynchronizedEpisodeModel.model_validate_json(response.content)
 
     async def fake_get_video_url(self, session, target):
         preference = video_filename_preference(target.data_type)
@@ -342,9 +388,36 @@ def mock_data_requests(
         status_code=200,
     )
 
-    # Mock sync endpoint
+    # Mock sync endpoint. Starting only ever reports PENDING; the terminal state
+    # and the signed URL come from the progress endpoint, and the episode JSON is
+    # downloaded straight from object storage.
     mock_auth_requests.post(
-        re.compile(f"{API_URL}/org/{mocked_org_id}/synchronize/synchronize-recording"),
+        re.compile(
+            f"{API_URL}/org/{mocked_org_id}/synchronize/trigger-synchronize-recording"
+        ),
+        json={
+            "recording_id": "rec1",
+            "synchronized_recording_id": SYNCED_RECORDING_ID,
+            "status": "PENDING",
+        },
+        status_code=200,
+    )
+    mock_auth_requests.get(
+        re.compile(
+            f"{API_URL}/org/{mocked_org_id}/synchronize"
+            f"/synchronize-recording-progress/{SYNCED_RECORDING_ID}"
+        ),
+        json={
+            "recording_id": "rec1",
+            "synchronize_recording_id": SYNCED_RECORDING_ID,
+            "status": "READY",
+            "download_url": SYNCED_EPISODE_DOWNLOAD_URL,
+            "error": None,
+        },
+        status_code=200,
+    )
+    mock_auth_requests.get(
+        SYNCED_EPISODE_DOWNLOAD_URL,
         json=synced_data.model_dump(mode="json"),
         status_code=200,
     )

--- a/tests/unit/core/data/test_synchronized_dataset.py
+++ b/tests/unit/core/data/test_synchronized_dataset.py
@@ -540,7 +540,7 @@ class TestSynchronizationParameterPassthrough:
             mock_data_requests, "synchronize-dataset"
         )
         recording_details = self._sync_details_sent_to(
-            mock_data_requests, "synchronize-recording"
+            mock_data_requests, "trigger-synchronize-recording"
         )
 
         assert len(dataset_details) == 1

--- a/tests/unit/core/data/test_synchronized_episode.py
+++ b/tests/unit/core/data/test_synchronized_episode.py
@@ -1,25 +1,104 @@
 """Tests for SynchronizedRecording class."""
 
 import re
-from types import SimpleNamespace
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest
+import requests
 from neuracore_types import (
     CameraData,
     DataType,
     JointData,
     SynchronizationDetails,
+    SynchronizedEpisode,
     SynchronizedPoint,
+    SynchronizeRecordingRequest,
 )
 from PIL import Image
 
 from neuracore.core.const import API_URL
-from neuracore.core.data.synced_recording import SynchronizedRecording
+from neuracore.core.data.synced_recording import (
+    SYNCED_EPISODE_DOWNLOAD_TIMEOUT_S,
+    SynchronizedRecording,
+)
+from neuracore.core.exceptions import SynchronizationError
+from neuracore.core.utils.http_session import DEFAULT_TIMEOUT, thread_local_session
 
 MODULE = "neuracore.core.data.synced_recording"
+
+SIGNED_URL = "https://storage.example/synced/rec1.json?X-Goog-Signature=secret"
+
+
+def start_json(
+    recording_id: str = "rec1", synchronized_recording_id: str = "synced-rec1"
+) -> dict:
+    """Build the payload the API answers a synchronization start with.
+
+    Args:
+        recording_id: Recording the synchronization was requested for.
+        synchronized_recording_id: Artifact the synchronization produces.
+
+    Returns:
+        The identifiers and the PENDING status, and nothing else.
+    """
+    return {
+        "recording_id": recording_id,
+        "synchronized_recording_id": synchronized_recording_id,
+        "status": "PENDING",
+    }
+
+
+def job_json(
+    status: str = "PENDING",
+    download_url: str | None = None,
+    error: str | None = None,
+    recording_id: str = "rec1",
+    synchronize_recording_id: str = "synced-rec1",
+) -> dict:
+    """Build a synchronization progress payload.
+
+    Args:
+        status: Lifecycle stage the poll reports.
+        download_url: Signed URL a READY poll carries.
+        error: Failure message a FAILED poll carries.
+        recording_id: Recording the synchronization was requested for.
+        synchronize_recording_id: Artifact the synchronization produces.
+
+    Returns:
+        The progress payload.
+    """
+    return {
+        "recording_id": recording_id,
+        "synchronize_recording_id": synchronize_recording_id,
+        "status": status,
+        "download_url": download_url,
+        "error": error,
+    }
+
+
+def build_recording(dataset, recording_id: str = "rec1") -> SynchronizedRecording:
+    """Construct a recording, which retrieves its synchronized episode.
+
+    Args:
+        dataset: Parent dataset supplying the org and the cache directory.
+        recording_id: Recording to synchronize.
+
+    Returns:
+        The constructed recording.
+    """
+    return SynchronizedRecording(
+        dataset=dataset,
+        recording_id=recording_id,
+        recording_name="recording1",
+        robot_id="robot1",
+        instance=1,
+        synchronization_details=SynchronizationDetails(
+            frequency=30,
+            cross_embodiment_union=None,
+        ),
+    )
 
 
 @pytest.mark.usefixtures("mock_login")
@@ -27,44 +106,11 @@ class TestSynchronizedRecording:
     """Tests for the SynchronizedRecording class."""
 
     @pytest.fixture
-    def dataset_mock(self, dataset_dict, recordings_list, tmp_path):
-        """Create a mock dataset object."""
-        from neuracore.core.data.dataset import Dataset
-
-        dataset = Dataset(**dataset_dict, recordings=recordings_list)
-        dataset.cache_dir = tmp_path / "cache"
-        dataset.cache_dir.mkdir(parents=True, exist_ok=True)
-        return dataset
-
-    @pytest.fixture
-    def mock_synced_api(self, mock_data_requests, synced_data, mocked_org_id):
-        """Set up mocks for synchronization API endpoints."""
-        # Mock sync endpoint
-        mock_data_requests.post(
-            re.compile(
-                f"{API_URL}/org/{mocked_org_id}/synchronize/synchronize-recording"
-            ),
-            json=synced_data.model_dump(mode="json"),
-            status_code=200,
-        )
-        yield mock_data_requests
-
-    @pytest.fixture
     def synced_recording(
         self, dataset_mock, mock_data_requests
     ) -> SynchronizedRecording:
         """Create a SynchronizedRecording instance for testing."""
-        return SynchronizedRecording(
-            dataset=dataset_mock,
-            recording_id="rec1",
-            recording_name="recording1",
-            robot_id="robot1",
-            instance=1,
-            synchronization_details=SynchronizationDetails(
-                frequency=30,
-                cross_embodiment_union=None,
-            ),
-        )
+        return build_recording(dataset_mock)
 
     def test_init(self, synced_recording: SynchronizedRecording, dataset_mock):
         """Test SynchronizedRecording initialization."""
@@ -111,31 +157,69 @@ class TestSynchronizedRecording:
         assert result.start_time == synced_data.start_time
         assert result.end_time == synced_data.end_time
 
-    def test_get_synced_data_requests_a_retrying_session(self, synced_data) -> None:
-        """Test that _get_synced_data requests the retrying session."""
-        fake_self = SimpleNamespace(
-            id="rec-1",
-            dataset=SimpleNamespace(org_id="org-1"),
-            synchronization_details=SynchronizationDetails(
-                frequency=30,
-                cross_embodiment_union=None,
+    def test_construction_initializes_episode_state(
+        self, synced_recording: SynchronizedRecording, synced_data
+    ):
+        """Construction still populates the episode state from the download."""
+        assert synced_recording._episode_synced is not None
+        assert synced_recording._episode_length == len(synced_data.observations)
+        assert synced_recording.start_time == synced_data.start_time
+        assert synced_recording.end_time == synced_data.end_time
+
+    def test_episode_retrieval_makes_three_requests(
+        self,
+        synced_recording: SynchronizedRecording,
+        mock_data_requests,
+        mocked_org_id,
+        synced_recording_id,
+    ):
+        """Retrieval starts the synchronization, polls it, then downloads."""
+        requested = [
+            (request.method, request.url.split("?")[0])
+            for request in mock_data_requests.request_history
+            if "synchronize" in request.path or "storage.example" in request.hostname
+        ]
+
+        base = f"{API_URL}/org/{mocked_org_id}/synchronize"
+        assert requested == [
+            ("POST", f"{base}/trigger-synchronize-recording"),
+            (
+                "GET",
+                f"{base}/synchronize-recording-progress/{synced_recording_id}",
             ),
+            ("GET", "https://storage.example/synced-episodes/rec1.json"),
+        ]
+
+    def test_failed_download_yields_no_recording(
+        self, dataset_mock, mock_data_requests, synced_episode_download_url
+    ):
+        """A failed artifact download must not produce a partial recording."""
+        mock_data_requests.get(
+            synced_episode_download_url, status_code=403, text="Forbidden"
         )
-        session = MagicMock()
-        response = MagicMock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = synced_data.model_dump(mode="json")
-        session.post.return_value = response
-        auth = MagicMock()
-        auth.get_headers = MagicMock(return_value={})
 
-        with (
-            patch(f"{MODULE}.thread_local_session", return_value=session) as mock,
-            patch(f"{MODULE}.get_auth", return_value=auth),
-        ):
-            SynchronizedRecording._get_synced_data(fake_self)
+        with pytest.raises(SynchronizationError, match="rec1"):
+            build_recording(dataset_mock)
 
-        mock.assert_called_with(retry_transient=True)
+    def test_every_request_uses_a_retrying_session(
+        self, dataset_mock, mock_data_requests
+    ) -> None:
+        """Both API calls and the download go through retrying sessions."""
+        requested_policies = []
+
+        def record(**kwargs):
+            requested_policies.append(kwargs)
+            return thread_local_session(**kwargs)
+
+        with patch(f"{MODULE}.thread_local_session", side_effect=record):
+            build_recording(dataset_mock)
+
+        assert requested_policies == [
+            {"retry_transient": True},  # start
+            {"retry_transient": True},  # poll
+            # The download is an idempotent GET, so read timeouts are retried too.
+            {"retry_transient": True, "retry_read_timeout": True},
+        ]
 
     def test_len(self, synced_recording):
         """Test __len__ returns correct number of frames."""
@@ -193,26 +277,30 @@ class TestSynchronizedRecording:
         synced_data_multiple_frames,
     ):
         """Test slicing with step parameter."""
-        # Mock the API to return more frames
+        # Mock the API to serve an artifact with more frames
+        download_url = "https://storage.example/synced-episodes/multi-frame.json"
+        base = f"{API_URL}/org/{dataset_mock.org_id}/synchronize"
         mock_data_requests.post(
-            re.compile(
-                f"{API_URL}/org/{dataset_mock.org_id}/synchronize/synchronize-recording"
+            re.compile(f"{base}/trigger-synchronize-recording"),
+            json=start_json(synchronized_recording_id="synced-multi-frame"),
+            status_code=200,
+        )
+        mock_data_requests.get(
+            f"{base}/synchronize-recording-progress/synced-multi-frame",
+            json=job_json(
+                "READY",
+                download_url=download_url,
+                synchronize_recording_id="synced-multi-frame",
             ),
+            status_code=200,
+        )
+        mock_data_requests.get(
+            download_url,
             json=synced_data_multiple_frames.model_dump(mode="json"),
             status_code=200,
         )
 
-        synced = SynchronizedRecording(
-            dataset=dataset_mock,
-            recording_id="rec1",
-            recording_name="recording1",
-            robot_id="robot1",
-            instance=1,
-            synchronization_details=SynchronizationDetails(
-                frequency=30,
-                cross_embodiment_union=None,
-            ),
-        )
+        synced = build_recording(dataset_mock)
 
         frames = synced[0:5:2]
 
@@ -481,3 +569,320 @@ class TestSynchronizedRecording:
         assert not any(final_dir.parent.rglob("*recording.lock"))
         leftovers = [p for p in final_dir.parent.iterdir() if p != final_dir]
         assert leftovers == []
+
+
+@pytest.mark.usefixtures("mock_login")
+class TestSyncedEpisodeRetrieval:
+    """Tests for the start, poll and download flow behind one episode.
+
+    Synchronization is asynchronous: starting it only ever reports tracking
+    metadata, the terminal state arrives from the progress endpoint, and the
+    episode itself is downloaded straight from object storage.
+    """
+
+    @pytest.fixture(autouse=True)
+    def no_poll_delay(self, monkeypatch):
+        """Remove the poll delay so the loop runs at full speed."""
+        monkeypatch.setattr(f"{MODULE}.SYNCED_RECORDING_POLL_INTERVAL_S", 0)
+
+    @pytest.fixture
+    def endpoints(self, mocked_org_id):
+        """The three requests one episode retrieval makes."""
+        base = f"{API_URL}/org/{mocked_org_id}/synchronize"
+        return {
+            "start": f"{base}/trigger-synchronize-recording",
+            "progress": f"{base}/synchronize-recording-progress/synced-rec1",
+            "download": SIGNED_URL,
+        }
+
+    def test_start_response_is_only_tracking_metadata(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """Starting identifies the artifact; the episode arrives from storage."""
+        start = mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        download = mock_data_requests.get(
+            endpoints["download"], json=synced_data.model_dump(mode="json")
+        )
+
+        recording = build_recording(dataset_mock)
+
+        # The synchronization request body is unchanged by the async contract.
+        assert start.call_count == 1
+        assert start.last_request.json() == (
+            SynchronizeRecordingRequest(
+                recording_id="rec1",
+                synchronization_details=recording.synchronization_details,
+            ).model_dump(mode="json")
+        )
+        # Both identifiers the start reported are used to poll the artifact.
+        assert progress.call_count == 1
+        assert progress.last_request.qs == {"recording_id": ["rec1"]}
+        assert download.call_count == 1
+        assert isinstance(recording._episode_synced, SynchronizedEpisode)
+        assert recording._episode_synced.robot_id == synced_data.robot_id
+        assert len(recording) == len(synced_data.observations)
+
+    def test_pending_polls_until_ready(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """Polling continues while the artifact is still being built."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(
+            endpoints["progress"],
+            [
+                {"json": job_json("PENDING")},
+                {"json": job_json("PENDING")},
+                {"json": job_json("READY", download_url=SIGNED_URL)},
+            ],
+        )
+        download = mock_data_requests.get(
+            endpoints["download"], json=synced_data.model_dump(mode="json")
+        )
+
+        recording = build_recording(dataset_mock)
+
+        assert progress.call_count == 3
+        assert download.call_count == 1
+        assert len(recording) == len(synced_data.observations)
+
+    def test_cached_artifact_is_ready_on_the_first_poll(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """A cached artifact costs one poll and no waiting at all."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        mock_data_requests.get(
+            endpoints["download"], json=synced_data.model_dump(mode="json")
+        )
+
+        with patch(f"{MODULE}.time.sleep") as sleep:
+            build_recording(dataset_mock)
+
+        assert progress.call_count == 1
+        sleep.assert_not_called()
+
+    def test_failed_synchronization_raises_with_the_server_error(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A FAILED poll surfaces the server's reason and downloads nothing."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(
+            endpoints["progress"],
+            json=job_json("FAILED", error="joint stream missing"),
+        )
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(SynchronizationError, match="joint stream missing") as exc:
+            build_recording(dataset_mock)
+
+        assert "rec1" in str(exc.value)
+        assert download.call_count == 0
+
+    def test_failed_without_a_reason_still_names_the_recording(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A FAILED poll carrying no message still identifies the recording."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(endpoints["progress"], json=job_json("FAILED"))
+
+        with pytest.raises(SynchronizationError, match="rec1") as exc:
+            build_recording(dataset_mock)
+
+        assert "no reason given" in str(exc.value)
+
+    def test_ready_without_a_download_url_is_invalid(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """READY without a URL is a broken server response, not a retry."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=None)
+        )
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(
+            SynchronizationError, match="READY without a download URL"
+        ) as exc:
+            build_recording(dataset_mock)
+
+        assert "rec1" in str(exc.value)
+        assert progress.call_count == 1
+        assert download.call_count == 0
+
+    def test_polling_gives_up_at_the_deadline(
+        self, mock_data_requests, dataset_mock, endpoints, monkeypatch
+    ):
+        """A synchronization that never finishes fails with a timeout."""
+        monkeypatch.setattr(f"{MODULE}.SYNCED_RECORDING_TIMEOUT_S", 0)
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(endpoints["progress"], json=job_json())
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(SynchronizationError, match="Timed out") as exc:
+            build_recording(dataset_mock)
+
+        assert "rec1" in str(exc.value)
+        assert "PENDING" in str(exc.value)
+        assert progress.call_count == 1
+        assert download.call_count == 0
+
+    def test_start_response_is_never_parsed_as_an_episode(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """An inline episode body is rejected instead of being used as one."""
+        mock_data_requests.post(
+            endpoints["start"], json=synced_data.model_dump(mode="json")
+        )
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(SynchronizationError, match="start response") as exc:
+            build_recording(dataset_mock)
+
+        assert "not tracking metadata" in str(exc.value)
+        assert progress.call_count == 0
+        assert download.call_count == 0
+
+    def test_malformed_progress_response_is_rejected(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A progress body that is not tracking metadata fails clearly."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(endpoints["progress"], text="not json at all")
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(SynchronizationError, match="progress response") as exc:
+            build_recording(dataset_mock)
+
+        assert "rec1" in str(exc.value)
+        assert download.call_count == 0
+
+    def test_start_failure_is_surfaced_before_any_polling(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A failed start propagates and nothing downstream is attempted."""
+        mock_data_requests.post(endpoints["start"], status_code=500, text="boom")
+        progress = mock_data_requests.get(endpoints["progress"], json=job_json())
+        download = mock_data_requests.get(endpoints["download"], json={})
+
+        with pytest.raises(requests.HTTPError):
+            build_recording(dataset_mock)
+
+        assert progress.call_count == 0
+        assert download.call_count == 0
+
+    def test_auth_headers_are_sent_only_to_the_api(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """Neuracore credentials reach the API but never object storage."""
+        start = mock_data_requests.post(endpoints["start"], json=start_json())
+        progress = mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        download = mock_data_requests.get(
+            endpoints["download"], json=synced_data.model_dump(mode="json")
+        )
+
+        build_recording(dataset_mock)
+
+        assert start.last_request.headers["Authorization"]
+        assert progress.last_request.headers["Authorization"]
+        # The URL is already signed; forwarding Neuracore credentials to object
+        # storage would have the request rejected.
+        assert "Authorization" not in download.last_request.headers
+
+    def test_download_uses_its_own_read_timeout(
+        self, mock_data_requests, dataset_mock, endpoints, synced_data
+    ):
+        """The object download gets a longer read budget than API calls."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        download = mock_data_requests.get(
+            endpoints["download"], json=synced_data.model_dump(mode="json")
+        )
+
+        build_recording(dataset_mock)
+
+        assert download.last_request.timeout == SYNCED_EPISODE_DOWNLOAD_TIMEOUT_S
+        assert SYNCED_EPISODE_DOWNLOAD_TIMEOUT_S[1] > DEFAULT_TIMEOUT[1]
+
+    def test_download_failure_reports_recording_and_stage(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A failed download names the recording without leaking the URL."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        mock_data_requests.get(endpoints["download"], status_code=403, text="Forbidden")
+
+        with pytest.raises(SynchronizationError) as exc:
+            build_recording(dataset_mock)
+
+        message = str(exc.value)
+        assert "download" in message
+        assert "rec1" in message
+        assert "HTTP 403" in message
+        # The signed URL carries temporary credentials: neither it nor the
+        # requests error that embeds it may reach the caller.
+        assert "X-Goog-Signature" not in message
+        assert exc.value.__cause__ is None
+
+    def test_download_transport_failure_hides_the_signed_url(
+        self, mock_data_requests, dataset_mock, endpoints
+    ):
+        """A transport failure names the recording without exposing the URL."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        mock_data_requests.get(
+            endpoints["download"],
+            exc=requests.ConnectionError(
+                f"Max retries exceeded with url: {SIGNED_URL}"
+            ),
+        )
+
+        with pytest.raises(SynchronizationError) as exc:
+            build_recording(dataset_mock)
+
+        message = str(exc.value)
+        assert "rec1" in message
+        assert "ConnectionError" in message
+        assert "X-Goog-Signature" not in message
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            b"",
+            b"{not json",
+            b"\xff\xfe\x00not-utf8",
+            b'{"observations": "not-a-list"}',
+            b"[1, 2, 3]",
+        ],
+        ids=["empty", "malformed", "invalid-utf8", "wrong-types", "wrong-shape"],
+    )
+    def test_invalid_downloaded_artifact_fails_validation(
+        self, mock_data_requests, dataset_mock, endpoints, content
+    ):
+        """A malformed or structurally invalid artifact fails clearly."""
+        mock_data_requests.post(endpoints["start"], json=start_json())
+        mock_data_requests.get(
+            endpoints["progress"], json=job_json("READY", download_url=SIGNED_URL)
+        )
+        mock_data_requests.get(endpoints["download"], content=content)
+
+        with pytest.raises(SynchronizationError, match="rec1") as exc:
+            build_recording(dataset_mock)
+
+        assert "valid synchronized episode" in str(exc.value)
+        assert "validation errors" in str(exc.value)


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 -Replaces inline synchronized-recording responses with an asynchronous flow:Start synchronization.
- Poll until READY or FAILED.
- Download the episode JSON from a signed storage URL.
- Adds a 30-minute synchronization deadline and dedicated download timeouts.
- Prevents Neuracore auth headers from being sent to object storage.
- Ensures errors and tracebacks never expose signed-URL credentials.
- Validates start, progress, and downloaded episode payloads with Pydantic.
- Adds tests covering polling, cached recordings, failures, timeouts, malformed responses, credential safety, and invalid downloads.
