### PR TITLE
fix: surface a stalled spool backlog as its own error

### DIFF
--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -43,6 +43,10 @@ def _load_native() -> ModuleType:
     return _DATA_BRIDGE_MODULE
 
 
+class LoggingStalledError(RuntimeError):
+    """The daemon is not draining its spool backlog fast enough to admit a frame."""
+
+
 def notify_daemon_config_changed() -> None:
     """Try ask a running daemon to reload its profile immediately."""
     try:
@@ -175,18 +179,22 @@ class RecordingContext:
         """
         robot_id = self._require_source("log_frame")
         timestamp_ns = int(timestamp * 1_000_000_000)
-        _load_native().log_frame(
-            robot_id,
-            self._robot_instance,
-            data_type,
-            name,
-            int(width),
-            int(height),
-            dtype,
-            payload,
-            timestamp_ns,
-            timestamp,
-        )
+        native = _load_native()
+        try:
+            native.log_frame(
+                robot_id,
+                self._robot_instance,
+                data_type,
+                name,
+                int(width),
+                int(height),
+                dtype,
+                payload,
+                timestamp_ns,
+                timestamp,
+            )
+        except native.LoggingStalledError as error:
+            raise LoggingStalledError(str(error)) from error
 
     def log_json(
         self,

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -168,6 +168,17 @@ fn log_joints(
     Ok(())
 }
 
+// A distinct type (rather than a bare `PyRuntimeError`, which `log_frame` also
+// raises for an unrelated failure below) so callers can retry on this specific
+// condition without inspecting the message. Subclasses `RuntimeError` so
+// existing broad catches still work.
+pyo3::create_exception!(
+    _data_bridge,
+    LoggingStalledError,
+    PyRuntimeError,
+    "The daemon is not draining its on-disk spool backlog fast enough to admit a frame."
+);
+
 /// Log one video frame for a camera. The frame is appended to the
 /// `(source, sensor)` in-progress NUT chunk under the inbox; when the chunk
 /// crosses the chunk-flush threshold a [`Envelope::VideoChunkReady`] is
@@ -253,7 +264,7 @@ fn log_frame(
         writer_queue().push(WriterMsg::Frame(job))
     })
     .map_err(|_| {
-        PyRuntimeError::new_err(
+        LoggingStalledError::new_err(
             "video logging stalled: the data daemon is not draining the spool \
              backlog (frame rejected after 1s of backpressure)",
         )
@@ -562,6 +573,10 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(daemon_version, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;
+    module.add(
+        "LoggingStalledError",
+        module.py().get_type::<LoggingStalledError>(),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Add specific error code for spool backlog error so producers can catch explicity


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>