### PR TITLE
fix: gate a producer's data on the window the daemon announces

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -285,6 +285,7 @@ mcap
 MCAP
 meanpooling
 memfd
+memoryview
 meshgrid
 metadatas
 metafunc

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -235,12 +235,14 @@ def _record_json_to_daemon(
         data: Data object to serialize and persist.
         timestamp: Capture timestamp in seconds.
     """
-    if robot.get_current_recording_id() is None:
+    # The daemon's window decides, not this process's knowledge of one — a
+    # process that never called ``start_recording`` has no local handle offline.
+    # Asked before serialising, which is the expensive part being skipped.
+    context = robot._get_daemon_recording_context()
+    if not context.admits_data():
         return
     payload = json.dumps(data.model_dump(mode="json")).encode("utf-8")
-    robot._get_daemon_recording_context().log_json(
-        data_type.value, storage_name, payload, timestamp
-    )
+    context.log_json(data_type.value, storage_name, payload, timestamp)
 
 
 def _publish_video_to_p2p(
@@ -386,7 +388,13 @@ def _log_group_of_joint_data(
     if bindings_for_type is None:
         bindings_for_type = {}
         binding_cache[data_type] = bindings_for_type
+    # Two different questions with two different answers. The handle drives the
+    # bucket/live streams, which are this process's own concern; whether the
+    # daemon records is the daemon's window, which a non-owner only learns from
+    # the bridge.
     current_recording_id = robot.get_current_recording_id()
+    daemon_context = robot._get_daemon_recording_context()
+    records_to_daemon = daemon_context.admits_data()
     live_data_disabled = get_provide_live_data_enabled_manager().is_disabled()
     robot_id = robot.id
     robot_instance = robot.instance
@@ -406,8 +414,8 @@ def _log_group_of_joint_data(
         native_values = list(joint_data.values())
         for binding, joint_value in zip(group.bindings, native_values):
             binding.stream.record_scalar(timestamp, joint_value)
-        if current_recording_id is not None:
-            robot._get_daemon_recording_context().log_joints(
+        if records_to_daemon:
+            daemon_context.log_joints(
                 data_type.value, timestamp, group.joined_names, native_values
             )
         return
@@ -433,11 +441,11 @@ def _log_group_of_joint_data(
             # allocation-free (see JointDataStream).
             binding.stream.record_scalar(timestamp, joint_value)
 
-        if current_recording_id is not None:
+        if records_to_daemon:
             native_values.append(joint_value)
 
     if native_values:
-        robot._get_daemon_recording_context().log_joints(
+        daemon_context.log_joints(
             data_type.value, timestamp, group.joined_names, native_values
         )
 
@@ -532,9 +540,16 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
+    # The bridge decides, not this process's own view of the world. Gating on
+    # ``get_current_recording_id()`` would ask whether *this* process knows about
+    # a recording — which a camera process that never called ``start_recording``
+    # never does offline, since that handle only arrives over SSE. The bridge
+    # answers for the daemon's window instead, from a cached map read with no IPC
+    # in it, so an idle camera skips the buffer work exactly as it did before.
+    context = robot._get_daemon_recording_context()
+    if context.admits_data():
         contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
-        robot._get_daemon_recording_context().log_frame(
+        context.log_frame(
             camera_type.value,
             storage_name,
             int(image.shape[1]),

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -738,6 +738,7 @@ class Robot:
         if self._daemon_recording_context is None:
             return
         try:
+            self._daemon_recording_context.flush_source()
             self._daemon_recording_context.close()
         except Exception:
             logger.exception("Failed to cleanup daemon recording context")

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -301,6 +301,19 @@ class RecordingContext:
             self._robot_id, self._robot_instance, marker_ns, timeout_s
         )
 
+    def admits_data(self) -> bool:
+        """Whether data logged for this source right now would be recorded.
+
+        A map read, no IPC — safe to call per sample. Lets a caller skip work it
+        would only do to have the sample refused: serialising a JSON payload,
+        materialising a joint value list, making a frame buffer contiguous. Every
+        ``log_*`` re-checks itself, so this is an optimisation and never the
+        guarantee.
+        """
+        if not self._robot_id:
+            return False
+        return _load_native().admits_data(self._robot_id, self._robot_instance)
+
     def close(self) -> None:
         """Release resources owned by this instance.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/data_daemon/src/ipc/announcer.rs
+++ b/rust/data_daemon/src/ipc/announcer.rs
@@ -1,0 +1,175 @@
+//! Daemon → producer window-state announcements.
+//!
+//! The one direction of IPC the daemon initiates. The daemon owns recording
+//! windows, so it tells producers when one opens or closes rather than being
+//! asked: a producer that did not open a window has nothing to identify it with
+//! and could only guess at when to ask.
+//!
+//! Announcements are idempotent and carry no recording identity — a source and a
+//! flag. That is deliberate: a producer needs to know *whether* to spend work,
+//! never which recording the work belongs to, so no announcement can be replayed
+//! as a claim about a particular window.
+//!
+//! ## Why it also re-announces
+//!
+//! Edge-triggered push alone is not self-healing. A producer that attaches after
+//! a window opened, or whose subscriber missed the message, would hear nothing
+//! until the close — and record nothing for the whole recording, silently,
+//! looking exactly like an idle sensor. So the dispatcher restates every live
+//! window periodically. Hearing nothing then means only "no window", which is
+//! also the safe thing for a producer to assume. A daemon with no live windows
+//! announces nothing at all.
+
+use data_daemon_shared::service_name::{
+    MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, WINDOW_STATE,
+    WINDOW_STATE_MAX_PAYLOAD_BYTES, WINDOW_STATE_MAX_SUBSCRIBERS,
+    WINDOW_STATE_SUBSCRIBER_BUFFER_SIZE,
+};
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+use data_daemon_shared::WindowStateAnnouncement;
+use iceoryx2::node::NodeBuilder;
+use iceoryx2::prelude::*;
+
+/// Handle the dispatcher holds to announce window state.
+///
+/// The publisher lives on a thread of its own rather than in the dispatcher,
+/// because iceoryx2's ports are `!Send` and the dispatcher is a `tokio::spawn`'d
+/// task. (The listener gets away with owning ports because it is `block_on`'d on
+/// a dedicated thread.) So the dispatcher holds only a channel, and the thread
+/// on the other end owns the node, service and publisher.
+pub struct WindowStateAnnouncer {
+    tx: Sender<(String, i64, bool)>,
+}
+
+impl WindowStateAnnouncer {
+    /// Start the announcer thread.
+    ///
+    /// Returns `None` (having logged) rather than failing the daemon: a window
+    /// that cannot be announced costs producers that did not open it, and is not a
+    /// reason to refuse recording for the process that did.
+    pub fn bring_up() -> Option<Self> {
+        let (tx, rx) = channel::<(String, i64, bool)>();
+        // Bring the ports up on the thread that will own them, and report back
+        // whether it worked so a failure is visible here rather than as silent
+        // non-announcement.
+        let (ready_tx, ready_rx) = channel::<bool>();
+        std::thread::Builder::new()
+            .name("nc-window-state".to_string())
+            .spawn(move || announce_loop(rx, ready_tx))
+            .map_err(|error| tracing::warn!(%error, "window-state announcer thread unavailable"))
+            .ok()?;
+        if !ready_rx.recv().unwrap_or(false) {
+            return None;
+        }
+        Some(WindowStateAnnouncer { tx })
+    }
+
+    /// Announce whether `(robot_id, robot_instance)` has a window open.
+    ///
+    /// Never blocks the dispatcher: the send is to an unbounded channel, and a
+    /// dead announcer thread is ignored. Every announcement is either restated by
+    /// the next re-announcement or superseded by the next transition, so one lost
+    /// message is not worth surfacing.
+    pub fn announce(&self, robot_id: &str, robot_instance: i64, live: bool) {
+        let _ = self.tx.send((robot_id.to_string(), robot_instance, live));
+    }
+}
+
+/// Own the iceoryx2 ports and publish whatever the dispatcher hands over.
+fn announce_loop(rx: Receiver<(String, i64, bool)>, ready_tx: Sender<bool>) {
+    let Some(publisher) = build_publisher() else {
+        let _ = ready_tx.send(false);
+        return;
+    };
+    let _ = ready_tx.send(true);
+    while let Ok((robot_id, robot_instance, live)) = rx.recv() {
+        let announcement = WindowStateAnnouncement {
+            robot_id,
+            robot_instance,
+            live,
+        };
+        let bytes = match announcement.encode() {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::debug!(%error, "failed to encode window-state announcement");
+                continue;
+            }
+        };
+        let sample = match publisher.loan_slice_uninit(bytes.len()) {
+            Ok(sample) => sample,
+            Err(error) => {
+                tracing::debug!(%error, "failed to loan window-state sample");
+                continue;
+            }
+        };
+        if let Err(error) = sample.write_from_slice(&bytes).send() {
+            tracing::debug!(%error, "failed to publish window-state announcement");
+        }
+    }
+}
+
+/// Open the `window_state` service and build the daemon's publisher on it.
+#[allow(clippy::type_complexity)]
+fn build_publisher() -> Option<iceoryx2::port::publisher::Publisher<ipc::Service, [u8], ()>> {
+    {
+        let node_name = format!("neuracore-window-state-{}", std::process::id());
+        let parsed_name = NodeName::new(&node_name).ok()?;
+        let node = match NodeBuilder::new()
+            .name(&parsed_name)
+            .create::<ipc::Service>()
+        {
+            Ok(node) => node,
+            Err(error) => {
+                tracing::warn!(%error, "window-state announcer node unavailable");
+                return None;
+            }
+        };
+        let service_name = match WINDOW_STATE.try_into() {
+            Ok(name) => name,
+            Err(error) => {
+                tracing::warn!(%error, "window-state service name invalid");
+                return None;
+            }
+        };
+        // Overflow is *enabled* here, unlike the commands service: a producer
+        // whose gate thread is descheduled must never block the dispatcher, and
+        // a dropped announcement is self-correcting via the next
+        // re-announcement. Blocking the dispatcher on a slow subscriber would
+        // stall routing for every source.
+        let service = match node
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .enable_safe_overflow(true)
+            .subscriber_max_buffer_size(WINDOW_STATE_SUBSCRIBER_BUFFER_SIZE)
+            .max_publishers(MAX_PUBLISHERS_PER_SERVICE)
+            .max_subscribers(WINDOW_STATE_MAX_SUBSCRIBERS)
+            .max_nodes(MAX_NODES_PER_SERVICE)
+            .open_or_create()
+        {
+            Ok(service) => service,
+            Err(error) => {
+                tracing::warn!(%error, "window-state service unavailable");
+                return None;
+            }
+        };
+        let publisher = match service
+            .publisher_builder()
+            .initial_max_slice_len(WINDOW_STATE_MAX_PAYLOAD_BYTES)
+            .create()
+        {
+            Ok(publisher) => publisher,
+            Err(error) => {
+                tracing::warn!(%error, "window-state publisher unavailable");
+                return None;
+            }
+        };
+        tracing::info!(service = WINDOW_STATE, "window-state announcer started");
+        // The node and service handle must outlive the publisher, so they are
+        // leaked deliberately: this thread lives for the daemon's lifetime, and
+        // dropping them would tear the service down under the publisher.
+        std::mem::forget(node);
+        std::mem::forget(service);
+        Some(publisher)
+    }
+}

--- a/rust/data_daemon/src/ipc/mod.rs
+++ b/rust/data_daemon/src/ipc/mod.rs
@@ -13,5 +13,6 @@
 //! `IDLE_POLL_INTERVAL` (25 ms) once the subscriber has been empty for a while,
 //! keeping active-load latency low while leaving idle daemons near-quiescent.
 
+pub mod announcer;
 pub mod listener;
 pub mod node;

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -90,6 +90,13 @@ const IDLE_REAP: Duration = Duration::from_secs(30);
 /// negligible against the holdback.
 const HOUSEKEEP_INTERVAL: Duration = Duration::from_millis(25);
 
+/// How often every live window is restated to producers.
+///
+/// Only bounds the *cold* path — a producer already subscribed when a window
+/// opens hears the transition immediately. It bounds how long a producer that
+/// attached mid-recording, or that missed a message, keeps doing nothing.
+const WINDOW_STATE_REANNOUNCE_INTERVAL: Duration = Duration::from_millis(100);
+
 /// Upper bound on how long a `RefreshConfig` may park the dispatcher loop
 /// waiting for the watcher's ack. The refresh is a fast `spawn_blocking` profile
 /// read, so this only guards against a stalled watcher wedging the hot path; on
@@ -326,6 +333,13 @@ struct Dispatcher {
     actor_handles: Vec<JoinHandle<()>>,
     /// Rate-limited orphan-drop counter (data outside any window).
     orphan_drops: u64,
+    /// Publishes window-state announcements to producers, so a process that did
+    /// not open a window still learns of it. `None` when the service could not be
+    /// opened — recording for the owning process is unaffected.
+    announcer: Option<crate::ipc::announcer::WindowStateAnnouncer>,
+    /// When every live window was last restated. See
+    /// [`WINDOW_STATE_REANNOUNCE_INTERVAL`].
+    last_reannounce: Instant,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
     /// doesn't re-run the two full window scans (and their `Vec` allocations)
@@ -348,8 +362,41 @@ impl Dispatcher {
             held: VecDeque::new(),
             actor_handles: Vec::new(),
             orphan_drops: 0,
+            announcer: crate::ipc::announcer::WindowStateAnnouncer::bring_up(),
+            last_reannounce: Instant::now(),
             last_housekeep: Instant::now(),
         }
+    }
+
+    /// Tell producers whether a source has a window open.
+    fn announce_window(&self, source: &Source, live: bool) {
+        if let Some(announcer) = &self.announcer {
+            announcer.announce(&source.0, source.1, live);
+        }
+    }
+
+    /// Restate every live window, so a producer that attached late or missed a
+    /// transition converges without ever having to ask.
+    fn reannounce_live_windows(&mut self, now: Instant) {
+        if now.duration_since(self.last_reannounce) < WINDOW_STATE_REANNOUNCE_INTERVAL {
+            return;
+        }
+        self.last_reannounce = now;
+        let live: Vec<Source> = self
+            .windows
+            .iter()
+            .filter(|(_, entry)| entry.live.is_some())
+            .map(|(source, _)| source.clone())
+            .collect();
+        for source in live {
+            self.announce_window(&source, true);
+        }
+    }
+
+    /// Whether any source has a window open, which keeps the loop on its short
+    /// cadence so re-announcements stay timely.
+    fn any_live(&self) -> bool {
+        self.windows.values().any(|entry| entry.live.is_some())
     }
 
     async fn run(
@@ -365,7 +412,10 @@ impl Dispatcher {
         loop {
             // When there is in-flight work, poll frequently for due releases /
             // evictions; otherwise sleep until the next idle-reap horizon.
-            let housekeep_after = if self.held.is_empty() && !self.any_closing() {
+            // A live window is a reason not to be idle even with nothing held:
+            // its re-announcement is what lets a late producer converge.
+            let housekeep_after = if self.held.is_empty() && !self.any_closing() && !self.any_live()
+            {
                 IDLE_REAP
             } else {
                 HOUSEKEEP_INTERVAL
@@ -390,6 +440,7 @@ impl Dispatcher {
             // Holdback releases run on every wake-up; the housekeeping scans
             // are throttled to HOUSEKEEP_INTERVAL (see `last_housekeep`).
             let now = Instant::now();
+            self.reannounce_live_windows(now);
             self.release_due_holdback(now).await;
             if now.duration_since(self.last_housekeep) >= HOUSEKEEP_INTERVAL {
                 self.housekeep(now).await;
@@ -631,7 +682,7 @@ impl Dispatcher {
         };
         tracing::info!(recording_index, robot_id = source.0, "recording started");
 
-        let entry = self.windows.entry(source).or_default();
+        let entry = self.windows.entry(source.clone()).or_default();
         entry.last_seen = Some(recv_at);
         // An idle-reaped window sits in `closing` with an open upper bound
         // (`i64::MAX`) to catch stragglers; clamp any such window to this new
@@ -675,6 +726,9 @@ impl Dispatcher {
             flushed_producers: HashSet::new(),
             traces: HashMap::new(),
         });
+        // Tell producers the moment the window exists. A camera process already
+        // subscribed sees this with no round trip and no polling latency.
+        self.announce_window(&source, true);
 
         if let Some(retired_index) = retired {
             tracing::warn!(
@@ -734,6 +788,12 @@ impl Dispatcher {
             window.awaiting_flush = true;
             let recording_index = window.recording_index;
             entry.closing.push(window);
+            // No longer live, so producers must stop spending work on it. A
+            // closing window still *accepts* late data — that is what retention
+            // is for — but the process that owns the stop has already published
+            // it, and any other process's tail is bounded by its own flush
+            // rather than by how long it keeps logging.
+            self.announce_window(&source, false);
             // Persist `stopped_at` before publishing the event: the cloud
             // stop-notifier reads this row on `RecordingStopped`, so the
             // timestamp must be on disk first.
@@ -832,6 +892,7 @@ impl Dispatcher {
             windows.push(live);
         }
         windows.append(&mut entry.closing);
+        self.announce_window(&source, false);
 
         for window in windows {
             let recording_index = window.recording_index;
@@ -987,6 +1048,9 @@ impl Dispatcher {
             })
             .map(|(source, _)| source.clone())
             .collect();
+        // Collected rather than announced inline: the announce borrows `self`
+        // immutably while the loop below holds a mutable borrow of `self.windows`.
+        let mut force_closed: Vec<Source> = Vec::new();
         for source in stale {
             tracing::warn!(
                 robot_id = source.0,
@@ -998,6 +1062,7 @@ impl Dispatcher {
             let Some(mut window) = entry.live.take() else {
                 continue;
             };
+            force_closed.push(source.clone());
             // The producer crashed without a Stop, so there is no next
             // recording to partition against — keep the window's publish upper
             // bound open (`i64::MAX`) to catch any straggler data before
@@ -1018,6 +1083,9 @@ impl Dispatcher {
             } else if let Some(bus) = self.context.event_bus.as_ref() {
                 bus.publish(DaemonEvent::RecordingStopped { recording_index });
             }
+        }
+        for source in force_closed {
+            self.announce_window(&source, false);
         }
     }
 

--- a/rust/data_daemon_bridge/Cargo.toml
+++ b/rust/data_daemon_bridge/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/data_daemon_bridge/src/gate.rs
+++ b/rust/data_daemon_bridge/src/gate.rs
@@ -1,0 +1,621 @@
+//! Whether this process should spend work on a source's data right now.
+//!
+//! Correctness never needed this gate. The daemon routes by publish stamp and
+//! drops what falls outside a window, so a producer that logged unconditionally
+//! would still land in the right recording. What it would also do is encode and
+//! spool continuously while idle — the writer's NUT chunks are written *here*, in
+//! the producer, against a spool budget shared with a real recording (see
+//! [`crate::writer`]). So the gate exists to save work, not to decide truth.
+//!
+//! That split is why a stale answer is survivable: a late open costs a few
+//! dropped frames, never a misrouted one.
+//!
+//! ## Who decides
+//!
+//! The daemon, in both directions:
+//!
+//! 1. **This process opened the window.** `start_recording` says so locally, so
+//!    the gate opens with zero latency. Waiting for the daemon's announcement
+//!    instead would drop the frames logged between the call and the round trip.
+//! 2. **Otherwise the daemon's announcements govern** — the only thing available
+//!    to a process that did *not* open a window, and the only signal that works
+//!    offline, where no cloud recording id exists to name one with.
+//!
+//! Announcements carry no recording identity, just a source and a flag. A
+//! producer learns whether to work, never which recording the work belongs to.
+//!
+//! ## Why nothing here polls, and why nothing here gets stuck
+//!
+//! The gate is driven by its own window-state subscriber ([`build_subscriber`]),
+//! drained on a thread of its own. No IPC on the logging path at all, and no
+//! request-response: the daemon knows the instant a window opens and says so.
+//!
+//! Push alone would be fragile in both directions, so both are closed:
+//!
+//! - **Stuck shut** — a producer that attached after the open, or that missed the
+//!   message, would hear nothing until the close and record nothing for the whole
+//!   recording. The daemon re-announces every live window periodically, so
+//!   hearing nothing only ever means "no window".
+//! - **Stuck open** — a daemon that dies mid-recording would announce no close,
+//!   leaving this process encoding and spooling forever with nothing to route it.
+//!   So an open gate is a *lease*: it needs to keep hearing that the window
+//!   lives, and expires after [`LIVE_LEASE`] of silence.
+//!
+//! Both bounds come from the daemon's re-announcement cadence rather than from
+//! anything this side chooses, which is what keeps one authority in charge.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+use data_daemon_shared::service_name::{
+    MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, WINDOW_STATE, WINDOW_STATE_MAX_SUBSCRIBERS,
+    WINDOW_STATE_SUBSCRIBER_BUFFER_SIZE,
+};
+use data_daemon_shared::WindowStateAnnouncement;
+use iceoryx2::node::NodeBuilder;
+use iceoryx2::port::subscriber::Subscriber;
+use iceoryx2::prelude::*;
+
+use crate::publisher::{flush_published_data, now_ns};
+use crate::writer::{writer_queue, WriterMsg};
+
+/// How long the refresher blocks waiting for the next announcement before
+/// looping to re-check leases.
+///
+/// Only bounds how promptly an *expiry* is noticed; an arriving announcement
+/// wakes the drain immediately.
+const DRAIN_POLL: Duration = Duration::from_millis(20);
+
+/// How long an open gate survives without hearing that its window still lives.
+///
+/// The daemon re-announces every live window on a 100 ms cadence, so this is
+/// several missed announcements' worth of grace — long enough that a briefly
+/// busy daemon never shuts a healthy gate, short enough that a dead one stops
+/// this process spooling into the void.
+const LIVE_LEASE: Duration = Duration::from_millis(600);
+
+/// Cadence while waiting for the first announcement of a drain.
+const ANNOUNCEMENT_RECEIVE_POLL: Duration = Duration::from_millis(2);
+
+/// A source key, matching the daemon's own `(robot_id, robot_instance)`.
+pub(crate) type Source = (String, i64);
+
+/// What one source's gate knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GateState {
+    /// Whether frames are currently admitted.
+    open: bool,
+    /// Whether this process opened the window. While true the daemon's answer is
+    /// ignored: local knowledge is both fresher and authoritative for our own
+    /// call.
+    owned: bool,
+    /// When the daemon last confirmed this window lives. Bounds how long an open
+    /// gate survives the daemon going away; `None` for a source we have never
+    /// heard is live.
+    confirmed_at: Option<Instant>,
+}
+
+impl GateState {
+    /// A source seen for the first time: closed, unowned, never confirmed.
+    const fn unknown() -> Self {
+        GateState {
+            open: false,
+            owned: false,
+            confirmed_at: None,
+        }
+    }
+}
+
+/// A gate that changed, and what the writer owes as a result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GateTransition {
+    /// A window opened for a source this process does not own. The writer must
+    /// arm a boundary split so no chunk spans the open.
+    Opened { source: Source },
+    /// The window closed. The writer must seal and announce the source's tail
+    /// chunks — nothing else will, since this process publishes no stop.
+    Closed { source: Source },
+}
+
+struct GateRegistry {
+    owner_pid: u32,
+    /// PID whose refresher thread is running, if any. Stored rather than using a
+    /// [`std::sync::Once`] because a thread does not survive `fork`: a `Once`
+    /// already tripped by the parent would leave a forked child with no
+    /// refresher, so its gates would never open.
+    refresher_pid: Option<u32>,
+    sources: HashMap<Source, GateState>,
+}
+
+static GATES: LazyLock<Mutex<GateRegistry>> = LazyLock::new(|| {
+    Mutex::new(GateRegistry {
+        owner_pid: 0,
+        refresher_pid: None,
+        sources: HashMap::new(),
+    })
+});
+
+/// Lock the gate registry and run `operation` against it.
+///
+/// Heals on fork the same way the chunk registry does: a child inherits the
+/// parent's map but none of its windows, so stale entries are cleared before
+/// use. Getting this wrong would have a forked camera process believe it was
+/// mid-recording because its parent was.
+fn with_registry<R>(operation: impl FnOnce(&mut HashMap<Source, GateState>) -> R) -> R {
+    let mut registry = GATES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let pid = std::process::id();
+    if registry.owner_pid != pid {
+        registry.sources.clear();
+        // The parent's refresher thread did not come across the fork.
+        registry.refresher_pid = None;
+        registry.owner_pid = pid;
+    }
+    operation(&mut registry.sources)
+}
+
+/// Start this process's refresher thread if it has none.
+///
+/// The thread must be the gate's own, not the writer's: the writer thread is
+/// spawned by the first frame it is handed, and behind a shut gate no frame is
+/// ever handed to it — so hanging the refresh off the writer would mean the gate
+/// could only open after it had already opened.
+fn ensure_refresher() {
+    let pid = std::process::id();
+    let needs_spawn = {
+        let mut registry = GATES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.refresher_pid == Some(pid) {
+            false
+        } else {
+            registry.refresher_pid = Some(pid);
+            true
+        }
+    };
+    if !needs_spawn {
+        return;
+    }
+    let spawned = std::thread::Builder::new()
+        .name("nc-gate-refresh".to_string())
+        .spawn(|| {
+            // One subscriber for the whole process, owned by the thread that
+            // drains it — iceoryx2 ports are `!Send`, and a port per thread would
+            // multiply the daemon's publisher segment by the thread count.
+            let Some(subscriber) = build_subscriber() else {
+                tracing::warn!(
+                    "no window-state subscriber; video for a source this process \
+                     did not open will not be recorded"
+                );
+                return;
+            };
+            loop {
+                settle_transitions(drain_announcements(&subscriber));
+                settle_transitions(expire_stale_leases());
+            }
+        });
+    if let Err(error) = spawned {
+        tracing::warn!(%error, "failed to start the gate refresher; video for a \
+             source this process did not open will not be recorded");
+        let mut registry = GATES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Let a later frame try again rather than failing silently forever.
+        registry.refresher_pid = None;
+    }
+}
+
+/// Act on what changed, through the writer's existing control messages.
+///
+/// Reuses the paths `start_recording` and `flush_source` already drive rather
+/// than reaching into chunk state from this thread, so a gate-driven open or
+/// close is indistinguishable to the writer from an owner-driven one.
+fn settle_transitions(transitions: Vec<GateTransition>) {
+    for transition in transitions {
+        match transition {
+            GateTransition::Opened { source } => {
+                // Arm at now, not at the window's true open: the frames in
+                // between were refused, so nothing already written straddles the
+                // boundary. This is the leading gap the gate trades for not being
+                // pushed to.
+                let _ = writer_queue().push(WriterMsg::Boundary {
+                    robot_id: source.0,
+                    robot_instance: source.1,
+                    publish_ns: now_ns(),
+                });
+            }
+            GateTransition::Closed { source } => {
+                // Seal what this process owes. It publishes no stop, so without
+                // this its tail chunk sits open until exit while the daemon holds
+                // the window waiting on a flush marker that never arrives.
+                let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+                let _ = writer_queue().push(WriterMsg::FlushSource {
+                    robot_id: source.0,
+                    robot_instance: source.1,
+                    ack: ack_tx,
+                });
+                let _ = ack_rx.recv();
+                // The ack means spooled and queued; this puts the announcements
+                // on the wire.
+                flush_published_data();
+            }
+        }
+    }
+}
+
+/// Record that *this* process opened a window for the source.
+///
+/// Called from `start_recording`, so the gate is open before the call returns
+/// and the owner's first frame is never dropped.
+pub(crate) fn note_window_opened_locally(robot_id: &str, robot_instance: i64) {
+    with_registry(|sources| {
+        let state = sources
+            .entry((robot_id.to_string(), robot_instance))
+            .or_insert_with(GateState::unknown);
+        state.open = true;
+        state.owned = true;
+    });
+}
+
+/// Record that this process closed the window it opened.
+///
+/// Leaves `owned` false so the daemon's answer governs again: another process may
+/// hold a window open for this source, and after our own stop we have no local
+/// claim on the truth.
+pub(crate) fn note_window_closed_locally(robot_id: &str, robot_instance: i64) {
+    with_registry(|sources| {
+        if let Some(state) = sources.get_mut(&(robot_id.to_string(), robot_instance)) {
+            state.open = false;
+            state.owned = false;
+            // Another process may still hold this source open, so the daemon's
+            // announcements decide from here.
+            state.confirmed_at = None;
+        }
+    });
+}
+
+/// Whether data for this source should be forwarded to the daemon.
+///
+/// **Never blocks and never does IPC.** A map read under a short-lived lock, on
+/// a path a robot control loop calls at frame rate; the daemon is asked only on
+/// the writer thread. A source seen for the first time is registered here so the
+/// refresh sweep starts covering it, and refused until that sweep answers — so a
+/// process attaching mid-recording begins contributing within one poll interval
+/// rather than immediately.
+///
+/// One gate for every data type, not just video: a process that cannot discover
+/// a window cannot log joints into it either, and gating only the expensive path
+/// would leave that half-fixed.
+///
+/// Paying that uniform bound is what buys a logging path with no round trip in
+/// it. The alternative — asking once, synchronously, on the first frame — would
+/// put a whole IPC round trip inside `log_rgb` for every process that touches a
+/// camera, including ones that never record at all.
+pub(crate) fn admits_data(robot_id: &str, robot_instance: i64) -> bool {
+    ensure_refresher();
+    with_registry(|sources| {
+        sources
+            .entry((robot_id.to_string(), robot_instance))
+            .or_insert_with(GateState::unknown)
+            .open
+    })
+}
+
+/// Apply every announcement the daemon has published since the last drain.
+///
+/// Blocks up to [`DRAIN_POLL`] for the first one so the thread is not spinning,
+/// then takes everything queued. Returns what actually changed — a
+/// re-announcement of a state already held is a no-op, which is what lets the
+/// daemon restate the truth as often as it likes.
+fn drain_announcements(subscriber: &Subscriber<ipc::Service, [u8], ()>) -> Vec<GateTransition> {
+    let mut transitions = Vec::new();
+    let deadline = Instant::now() + DRAIN_POLL;
+    loop {
+        match next_announcement(subscriber) {
+            Some((source, live)) => {
+                if let Some(transition) = apply_announcement(source, live) {
+                    transitions.push(transition);
+                }
+                // Keep draining without waiting: a burst is one wake-up.
+                continue;
+            }
+            None => {
+                if !transitions.is_empty() || Instant::now() >= deadline {
+                    return transitions;
+                }
+                std::thread::sleep(ANNOUNCEMENT_RECEIVE_POLL);
+            }
+        }
+    }
+}
+
+/// Record one announcement, returning the transition if the gate moved.
+fn apply_announcement(source: Source, live: bool) -> Option<GateTransition> {
+    with_registry(|sources| {
+        let state = sources
+            .entry(source.clone())
+            .or_insert_with(GateState::unknown);
+        // Our own window: we know its state first-hand and the daemon's view of
+        // it can only be older.
+        if state.owned {
+            return None;
+        }
+        if live {
+            // Refresh the lease even when already open — that is the whole point
+            // of a re-announcement.
+            state.confirmed_at = Some(Instant::now());
+        } else {
+            state.confirmed_at = None;
+        }
+        if state.open == live {
+            return None;
+        }
+        state.open = live;
+        Some(if live {
+            GateTransition::Opened { source }
+        } else {
+            GateTransition::Closed { source }
+        })
+    })
+}
+
+/// Shut any gate whose lease has run out.
+///
+/// The answer to a daemon that vanished mid-recording: without this the gate
+/// stays open and this process spools frames nothing will ever route. Owned
+/// windows are exempt — this process knows first-hand that its own window lives,
+/// and a daemon restart does not retract that.
+pub(crate) fn expire_stale_leases() -> Vec<GateTransition> {
+    let now = Instant::now();
+    let expired: Vec<Source> = with_registry(|sources| {
+        sources
+            .iter()
+            .filter(|(_, state)| state.open && !state.owned)
+            .filter(|(_, state)| match state.confirmed_at {
+                None => true,
+                Some(confirmed_at) => now.duration_since(confirmed_at) >= LIVE_LEASE,
+            })
+            .map(|(source, _)| source.clone())
+            .collect()
+    });
+    let mut transitions = Vec::new();
+    for source in expired {
+        let shut = with_registry(|sources| {
+            let state = sources.get_mut(&source)?;
+            if !state.open || state.owned {
+                return None;
+            }
+            state.open = false;
+            state.confirmed_at = None;
+            Some(())
+        });
+        if shut.is_some() {
+            tracing::warn!(
+                robot_id = source.0,
+                "no window confirmation from the daemon; closing the gate"
+            );
+            transitions.push(GateTransition::Closed { source });
+        }
+    }
+    transitions
+}
+
+/// Take the next queued announcement, or `None` when the queue is empty.
+///
+/// A decode failure is dropped rather than retried: the next re-announcement
+/// restates the same truth.
+fn next_announcement(subscriber: &Subscriber<ipc::Service, [u8], ()>) -> Option<(Source, bool)> {
+    match subscriber.receive() {
+        Ok(Some(sample)) => WindowStateAnnouncement::decode(sample.payload())
+            .map(|announcement| {
+                (
+                    (announcement.robot_id, announcement.robot_instance),
+                    announcement.live,
+                )
+            })
+            .ok(),
+        Ok(None) => None,
+        Err(error) => {
+            tracing::debug!(%error, "window-state receive failed");
+            None
+        }
+    }
+}
+
+/// Build this process's window-state subscriber, on the gate thread that owns it.
+fn build_subscriber() -> Option<Subscriber<ipc::Service, [u8], ()>> {
+    let node = NodeBuilder::new()
+        .create::<ipc::Service>()
+        .map_err(|error| tracing::warn!(%error, "window-state node unavailable"))
+        .ok()?;
+    let service_name = WINDOW_STATE
+        .try_into()
+        .map_err(|error| tracing::warn!(%error, "window-state service name invalid"))
+        .ok()?;
+    let service = node
+        .service_builder(&service_name)
+        .publish_subscribe::<[u8]>()
+        .enable_safe_overflow(true)
+        .subscriber_max_buffer_size(WINDOW_STATE_SUBSCRIBER_BUFFER_SIZE)
+        .max_publishers(MAX_PUBLISHERS_PER_SERVICE)
+        .max_subscribers(WINDOW_STATE_MAX_SUBSCRIBERS)
+        .max_nodes(MAX_NODES_PER_SERVICE)
+        .open_or_create()
+        .map_err(|error| tracing::warn!(%error, "window-state service unavailable"))
+        .ok()?;
+    let subscriber = service
+        .subscriber_builder()
+        .create()
+        .map_err(|error| tracing::warn!(%error, "window-state subscriber unavailable"))
+        .ok()?;
+    // The node and service must outlive the subscriber, and this thread runs for
+    // the life of the process.
+    std::mem::forget(node);
+    std::mem::forget(service);
+    Some(subscriber)
+}
+
+/// Forget every gate. Test-only: the registry is process-wide, so cases that
+/// assert on transitions must not inherit each other's sources.
+#[cfg(test)]
+fn reset_for_test() {
+    with_registry(|sources| sources.clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry is process-wide, so these run under one lock rather than
+    /// racing each other's sources.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn source(name: &str) -> Source {
+        (name.to_string(), 0)
+    }
+
+    #[test]
+    fn an_owner_is_open_immediately_and_ignores_announcements() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        note_window_opened_locally("owner-robot", 0);
+        assert!(admits_data("owner-robot", 0));
+
+        // The daemon's view of our own window can only be older than ours, so a
+        // stale "closed" must not shut a window this process is holding open.
+        assert!(apply_announcement(source("owner-robot"), false).is_none());
+        assert!(admits_data("owner-robot", 0));
+
+        // And an owned window never expires: we know first-hand that it lives.
+        assert!(expire_stale_leases().is_empty());
+        assert!(admits_data("owner-robot", 0));
+    }
+
+    #[test]
+    fn closing_locally_shuts_the_gate_and_returns_the_source_to_the_daemon() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        note_window_opened_locally("stopping-robot", 0);
+        note_window_closed_locally("stopping-robot", 0);
+
+        let state = with_registry(|sources| sources[&source("stopping-robot")]);
+        assert!(!state.open, "the gate closes with the window");
+        assert!(
+            !state.owned,
+            "another process may still hold this source open"
+        );
+        assert!(state.confirmed_at.is_none());
+    }
+
+    #[test]
+    fn a_never_seen_source_is_refused_and_registered() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        // Refused: nothing has been announced, and refusing is the safe reading.
+        assert!(!admits_data("fresh-robot", 0));
+        let known = with_registry(|sources| sources.contains_key(&source("fresh-robot")));
+        assert!(known, "the source is tracked from its first sample");
+    }
+
+    #[test]
+    fn admitting_data_never_touches_the_daemon() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        // An announced-open source with no daemon attached: a gate that asked
+        // would have nothing to ask. This is the hot path's contract — no IPC
+        // inside any `log_*`, ever.
+        assert_eq!(
+            apply_announcement(source("cached-robot"), true),
+            Some(GateTransition::Opened {
+                source: source("cached-robot")
+            })
+        );
+        assert!(admits_data("cached-robot", 0));
+    }
+
+    #[test]
+    fn a_repeat_announcement_is_not_a_transition_but_renews_the_lease() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        assert!(apply_announcement(source("held-robot"), true).is_some());
+        let first = with_registry(|sources| sources[&source("held-robot")].confirmed_at);
+
+        // Restating the same state must not read as a change — the daemon
+        // restates constantly — but it must push the lease out, or a healthy
+        // window would expire under us.
+        assert!(
+            apply_announcement(source("held-robot"), true).is_none(),
+            "a re-announcement of a known state is a no-op"
+        );
+        let renewed = with_registry(|sources| sources[&source("held-robot")].confirmed_at);
+        assert!(renewed >= first, "the lease is renewed, not ignored");
+        assert!(admits_data("held-robot", 0));
+    }
+
+    #[test]
+    fn an_open_gate_expires_when_the_daemon_stops_confirming() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        // A window announced open, then a daemon that died: no close ever
+        // arrives. Without expiry this process would spool frames forever with
+        // nothing to route them.
+        with_registry(|sources| {
+            sources.insert(
+                source("abandoned-robot"),
+                GateState {
+                    open: true,
+                    owned: false,
+                    confirmed_at: Some(Instant::now() - LIVE_LEASE - Duration::from_millis(1)),
+                },
+            );
+        });
+
+        assert_eq!(
+            expire_stale_leases(),
+            vec![GateTransition::Closed {
+                source: source("abandoned-robot")
+            }]
+        );
+        assert!(!admits_data("abandoned-robot", 0));
+    }
+
+    #[test]
+    fn a_fresh_lease_does_not_expire() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        apply_announcement(source("healthy-robot"), true);
+        assert!(
+            expire_stale_leases().is_empty(),
+            "a window confirmed just now must not be shut"
+        );
+        assert!(admits_data("healthy-robot", 0));
+    }
+
+    #[test]
+    fn a_close_announcement_shuts_the_gate_once() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+
+        apply_announcement(source("cycling-robot"), true);
+        assert_eq!(
+            apply_announcement(source("cycling-robot"), false),
+            Some(GateTransition::Closed {
+                source: source("cycling-robot")
+            })
+        );
+        assert!(!admits_data("cycling-robot", 0));
+        assert!(
+            apply_announcement(source("cycling-robot"), false).is_none(),
+            "a repeated close is not a second transition"
+        );
+    }
+}

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -31,6 +31,7 @@
 //! This file is a thin PyO3 façade: the `#[pyfunction]` wrappers do argument
 //! validation, release the GIL, and delegate into the submodules.
 //!
+//! - [`gate`] — whether a source's data is worth forwarding right now.
 //! - [`paths`] — filesystem layout shared with the daemon (recordings root,
 //!   spool paths, `(source, sensor)` stream keys).
 //! - [`publisher`] — per-thread iceoryx2 publisher state, fork safety, the
@@ -43,6 +44,8 @@
 pub mod nut_writer;
 
 mod depth;
+mod gate;
+mod logging;
 mod paths;
 mod publisher;
 mod query;
@@ -103,6 +106,10 @@ fn start_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // This process opened the window, so its own gate needs no round trip
+        // and must not lag: frames logged between here and the daemon's row
+        // write would otherwise be dropped.
+        gate::note_window_opened_locally(&robot_id, robot_instance);
         // Tell the writer where the window opened, so no chunk spans it.
         let _ = writer_queue().push(WriterMsg::Boundary {
             robot_id,
@@ -142,6 +149,12 @@ fn log_joints(
         ));
     }
     if values.is_empty() {
+        return Ok(());
+    }
+    // The same gate video goes through. A process that cannot discover a window
+    // cannot log joints into one either, so refusing only the expensive path
+    // would leave a non-owner half-recorded.
+    if !gate::admits_data(robot_id, robot_instance) {
         return Ok(());
     }
     let robot_id = robot_id.to_string();
@@ -218,6 +231,14 @@ fn log_frame(
         return Err(PyValueError::new_err(
             "video frame buffer must be C-contiguous",
         ));
+    }
+    // Ask before copying: an idle camera process would otherwise pay a full
+    // frame copy, encode and spool write per frame against the same budget a
+    // real recording draws on. Argument validation still runs above, so a caller
+    // learns about a malformed frame whether or not a window is open. A map read,
+    // so it holds the GIL rather than paying a detach/reattach per frame.
+    if !gate::admits_data(robot_id, robot_instance) {
+        return Ok(());
     }
     // Resolve the recordings root *here*, on the GIL, before copying the frame
     // or handing it to the writer thread. Video is the only path that needs the
@@ -297,6 +318,12 @@ fn log_json(
         return Err(PyValueError::new_err(
             "robot_id, data_type and name must not be empty",
         ));
+    }
+    // As for joints and video: refuse before copying the payload, and refuse for
+    // the same reason — one gate for every data type, or a non-owner records
+    // only the half that was cheap to fix.
+    if !gate::admits_data(robot_id, robot_instance) {
+        return Ok(());
     }
     let robot_id = robot_id.to_string();
     let data_type = data_type.to_string();
@@ -382,6 +409,10 @@ fn stop_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // Shut our own gate with the window. Deliberately after the publish, so
+        // the boundary the daemon records and the last frame we admit are on the
+        // same side of the same instant.
+        gate::note_window_closed_locally(&robot_id, robot_instance);
         // Split from [`flush_source`] so the caller can close its logging gate
         // in between, rather than after a backlog-length barrier.
         Ok(())
@@ -455,6 +486,7 @@ fn cancel_recording(
         let _ = ack_rx.recv();
         // Publish `CancelRecording` from THIS (the calling) thread's publisher,
         // ordered with Start/Stop on the same port (see the writer module note).
+        gate::note_window_closed_locally(&robot_id, robot_instance);
         publish(&Envelope::CancelRecording {
             robot_id,
             robot_instance,
@@ -526,6 +558,21 @@ fn get_recording_id(
     })
 }
 
+/// Whether data logged for this source would currently be recorded.
+///
+/// A map read, no IPC — safe to call per sample. Lets the SDK skip work it would
+/// only do to have the sample refused: serialising a JSON payload, materialising
+/// a joint value list, making a frame buffer contiguous. Every `log_*` entry
+/// point re-checks itself, so this is an optimisation and never the guarantee.
+#[pyfunction]
+#[pyo3(signature = (robot_id, robot_instance))]
+fn admits_data(robot_id: &str, robot_instance: i64) -> PyResult<bool> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    Ok(gate::admits_data(robot_id, robot_instance))
+}
+
 /// Wait until the Rust daemon answers a side-effect-free IPC health probe.
 #[pyfunction]
 #[pyo3(signature = (timeout_s))]
@@ -562,6 +609,9 @@ fn refresh_config(py: Python<'_>) -> PyResult<()> {
 /// Python module entrypoint registered as `neuracore.data_daemon._data_bridge`.
 #[pymodule]
 fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Before anything else can want to report a problem: several failures in
+    // here are otherwise indistinguishable from an idle sensor.
+    logging::init();
     module.add_function(wrap_pyfunction!(start_recording, module)?)?;
     module.add_function(wrap_pyfunction!(log_joints, module)?)?;
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;
@@ -570,6 +620,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
+    module.add_function(wrap_pyfunction!(admits_data, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(daemon_version, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;

--- a/rust/data_daemon_bridge/src/logging.rs
+++ b/rust/data_daemon_bridge/src/logging.rs
@@ -1,0 +1,40 @@
+//! Producer-side tracing, so this crate's own diagnostics can be seen.
+//!
+//! Without a subscriber every `tracing` event here is dropped: only the daemon
+//! binary installs one, and the producer is a library living inside somebody
+//! else's process. The events that most need to arrive are the ones reporting a
+//! *silent* loss — a gate that cannot subscribe to window state records nothing
+//! for a source it did not open, and looks exactly like an idle sensor.
+//!
+//! Hence a default of `warn` on stderr rather than off: the failures worth a
+//! line are the ones a caller would otherwise never learn about. `RUST_LOG`
+//! overrides the filter and `NDD_DEBUG` raises the default to `debug`, matching
+//! the daemon's own `init_tracing`.
+
+use std::sync::Once;
+
+use data_daemon_shared::config::env::RuntimeEnv;
+
+static INIT: Once = Once::new();
+
+/// Install this process's subscriber, at most once.
+///
+/// `try_init` rather than `init`: an embedding application — or a test harness —
+/// may already own the global subscriber, and losing our events to theirs is far
+/// better than panicking inside a Python import.
+pub(crate) fn init() {
+    INIT.call_once(|| {
+        let default_level = if RuntimeEnv::from_env().debug {
+            "debug"
+        } else {
+            "warn"
+        };
+        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(false)
+            .with_writer(std::io::stderr)
+            .try_init();
+    });
+}

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -267,13 +267,21 @@ pub mod service_name {
     /// cap and the producer's later open observes the same attribute set.
     pub const MAX_PUBLISHERS_PER_SERVICE: usize = 128;
 
-    /// Maximum number of concurrent subscribers per service.
+    /// Maximum number of concurrent subscribers per service, for the services
+    /// only the daemon subscribes to.
     ///
-    /// The daemon opens exactly one subscriber per service; producers never
-    /// subscribe. iceoryx2 sizes every publisher's data segment as
+    /// The daemon opens exactly one subscriber on each of those. iceoryx2 sizes
+    /// every publisher's data segment as
     /// `max_subscribers × (buffer + borrowed) × slice`, so the default of 8
-    /// inflates each segment 8× for subscribers that never exist. Pinning
-    /// this to 1 keeps the segment proportional to the real topology.
+    /// inflates each segment 8× for subscribers that never exist; pinning this to
+    /// 1 keeps the segment proportional to the real topology.
+    ///
+    /// **Not usable for a service producers subscribe to.** [`WINDOW_STATE`] is
+    /// one, and reusing this there fails in the worst way: the first subscriber
+    /// takes the only slot and every later one silently cannot connect, so a
+    /// producer simply never hears anything. That service carries its own
+    /// [`WINDOW_STATE_MAX_SUBSCRIBERS`], sized with the same segment arithmetic
+    /// in mind.
     pub const MAX_SUBSCRIBERS_PER_SERVICE: usize = 1;
 
     /// Maximum number of concurrent iceoryx2 nodes attached to any service.
@@ -339,6 +347,60 @@ pub mod service_name {
     /// Maximum size of a single `recording_ids` service sample. Both the request and
     /// the reply are a handful of UUID strings + integers; 4 KiB is generous.
     pub const RECORDING_ID_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
+
+    /// Pub/sub service the **daemon** uses to announce which sources have a
+    /// recording window open. The only IPC that flows daemon → producer.
+    ///
+    /// The daemon owns window state, so it announces rather than being asked:
+    /// a producer that did not open a window has nothing to offer a query and
+    /// would only be guessing at when to ask. Announcements carry no recording
+    /// identity — just the source and a boolean — so nothing here lets a
+    /// producer name the window it contributes to.
+    ///
+    /// Two kinds of announcement, and the second is what makes the design
+    /// self-healing: a **transition** the instant a window opens or closes, and
+    /// a periodic **re-announcement** of every live window. Edge-triggered push
+    /// alone would strand a producer that attached after the open or missed the
+    /// message — it would hear nothing until the close, and silently record
+    /// nothing for the whole recording. With re-announcement, hearing nothing
+    /// only ever means "no window", which is exactly what a producer should
+    /// then do: nothing. An idle daemon with no live windows publishes nothing
+    /// at all.
+    ///
+    /// See [`crate::WindowStateAnnouncement`].
+    pub const WINDOW_STATE: &str = "neuracore/data_daemon/window_state";
+
+    /// Maximum size of a single `window_state` sample: a robot id plus an
+    /// instance and a flag, so a few dozen bytes.
+    ///
+    /// Kept small on purpose. iceoryx2 sizes a publisher's data segment as
+    /// `max_subscribers × (buffer + borrowed) × slice`, and this is the only
+    /// service with more than one subscriber, so the slice length is a
+    /// multiplier on real memory here in a way it is not elsewhere.
+    pub const WINDOW_STATE_MAX_PAYLOAD_BYTES: usize = 256;
+
+    /// How many announcements a producer's subscriber may buffer.
+    ///
+    /// Ample for the traffic — one message per window transition plus a
+    /// periodic re-announcement per live source — while staying small because it
+    /// multiplies the segment size (see
+    /// [`WINDOW_STATE_MAX_PAYLOAD_BYTES`]). Overflow is survivable regardless:
+    /// the next re-announcement restates the truth.
+    pub const WINDOW_STATE_SUBSCRIBER_BUFFER_SIZE: usize = 16;
+
+    /// Maximum number of concurrent `window_state` subscribers.
+    ///
+    /// The one service producers subscribe to, so
+    /// [`MAX_SUBSCRIBERS_PER_SERVICE`] (pinned to 1 on the documented
+    /// assumption that they never do) cannot be reused here — with it, the first
+    /// subscriber takes the only slot and every other producer silently fails to
+    /// connect.
+    ///
+    /// Sized per *process*, not per thread: the gate owns a single subscriber
+    /// for the whole process, on the one thread that drains it. That is what
+    /// keeps this a small multiple rather than the 128 a per-thread port would
+    /// need.
+    pub const WINDOW_STATE_MAX_SUBSCRIBERS: usize = 64;
 
     /// Maximum number of concurrent request-response clients. Mirrors
     /// [`MAX_PUBLISHERS_PER_SERVICE`]: the data bridge parks one client port
@@ -731,6 +793,32 @@ pub struct RecordingIdReply {
     pub recording_id: Option<String>,
 }
 
+/// One announcement on [`service_name::WINDOW_STATE`]: whether this source has a
+/// recording window open, as the daemon sees it.
+///
+/// Idempotent by construction — a re-announcement of a state the producer
+/// already holds is a no-op — so the daemon can restate the truth freely and a
+/// producer never has to reason about whether it already knew.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowStateAnnouncement {
+    pub robot_id: String,
+    pub robot_instance: i64,
+    /// Whether a recording is open for this source.
+    pub live: bool,
+}
+
+impl WindowStateAnnouncement {
+    /// Encode as a postcard byte vector for a `window_state` sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `window_state` sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
 /// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HealthRequest {
@@ -874,6 +962,21 @@ mod tests {
             VersionReply::decode(&reply.encode().unwrap()).unwrap(),
             reply
         );
+    }
+
+    #[test]
+    fn window_state_announcement_round_trips() {
+        for live in [true, false] {
+            let announcement = WindowStateAnnouncement {
+                robot_id: "robot-1".into(),
+                robot_instance: 3,
+                live,
+            };
+            assert_eq!(
+                WindowStateAnnouncement::decode(&announcement.encode().unwrap()).unwrap(),
+                announcement
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Add a gate to the bridge so data meant for the window can be provided to the window

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Multi process recordings could only be informed by an online only sse gate

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - None

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>