### PR TITLE
test: keep the timer stats of a context worker that never returns

### DIFF
--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -20,7 +20,7 @@ import sys
 import threading
 import time
 import traceback
-from collections.abc import Generator
+from collections.abc import Container, Generator, MutableMapping
 from contextlib import contextmanager
 
 from neuracore.core.utils.http_session import http_time_snapshot
@@ -320,8 +320,18 @@ def surface_worker_errors(fn):
     return wrapper
 
 
-def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
-    """Route a pool worker's log records to the parent process.
+WorkerTimerStats = MutableMapping[int, dict[str, dict[str, float]]]
+"""Latest timer stats each pool worker has published, keyed by context index."""
+_worker_stats_sink: WorkerTimerStats | None = None
+"""Where this pool worker publishes its timer stats; ``None`` in the parent."""
+
+
+def init_worker_reporting(
+    log_queue: multiprocessing.Queue,
+    level: int,
+    stats_sink: WorkerTimerStats | None = None,
+) -> None:
+    """Route a pool worker's log records, and its timer stats, to the parent.
 
     Pool initializer. Spawned workers (macOS) start with no logging
     configuration, so their INFO records — Timer lines included — are
@@ -330,11 +340,14 @@ def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
     root handlers with a ``QueueHandler`` ships every record to the parent
     instead, where :func:`relayed_worker_logs` replays them through the
     parent's handlers so worker Timer lines appear in the live log exactly
-    like single-context runs.
+    like single-context runs.  *stats_sink* is where
+    :func:`publish_timer_stats` reports this worker's accumulated stats.
     """
+    global _worker_stats_sink
     root = logging.getLogger()
     root.handlers[:] = [logging.handlers.QueueHandler(log_queue)]
     root.setLevel(level)
+    _worker_stats_sink = stats_sink
 
 
 @contextmanager
@@ -356,6 +369,35 @@ def relayed_worker_logs() -> Generator[multiprocessing.Queue]:
     finally:
         log_queue.put(None)
         thread.join(timeout=5.0)
+
+
+def publish_timer_stats(key: int) -> None:
+    """Publish this worker's stats to the parent, replacing its last publication."""
+    if _worker_stats_sink is None:
+        return
+    with Timer._stats_lock:
+        snapshot = {label: dict(stats) for label, stats in Timer._stats.items()}
+    try:
+        _worker_stats_sink[key] = snapshot
+    except (OSError, EOFError):
+        # The parent's manager is already gone; diagnostics never break a run.
+        pass
+
+
+@contextmanager
+def worker_timer_stats_sink() -> Generator[WorkerTimerStats]:
+    """A sink pool workers publish their timer stats into while they run."""
+    with multiprocessing.Manager() as manager:
+        yield manager.dict()
+
+
+def merge_unreturned_worker_stats(
+    sink: WorkerTimerStats, returned_keys: Container[int]
+) -> None:
+    """Merge the published stats of every worker that returned no result."""
+    for key, snapshot in dict(sink).items():
+        if key not in returned_keys:
+            Timer.merge_stats(snapshot)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -20,7 +20,7 @@ import sys
 import threading
 import time
 import traceback
-from collections.abc import Generator
+from collections.abc import Container, Generator, MutableMapping
 from contextlib import contextmanager
 
 from neuracore.core.utils.http_session import http_time_snapshot
@@ -320,8 +320,18 @@ def surface_worker_errors(fn):
     return wrapper
 
 
-def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
-    """Route a pool worker's log records to the parent process.
+WorkerTimerStats = MutableMapping[int, dict[str, dict[str, float]]]
+"""Latest timer stats each pool worker has published, keyed by context index."""
+_worker_stats_sink: WorkerTimerStats | None = None
+"""Where this pool worker publishes its timer stats; ``None`` in the parent."""
+
+
+def init_worker_reporting(
+    log_queue: multiprocessing.Queue,
+    level: int,
+    stats_sink: WorkerTimerStats | None = None,
+) -> None:
+    """Route a pool worker's log records, and its timer stats, to the parent.
 
     Pool initializer. Spawned workers (macOS) start with no logging
     configuration, so their INFO records — Timer lines included — are
@@ -330,11 +340,14 @@ def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
     root handlers with a ``QueueHandler`` ships every record to the parent
     instead, where :func:`relayed_worker_logs` replays them through the
     parent's handlers so worker Timer lines appear in the live log exactly
-    like single-context runs.
+    like single-context runs.  *stats_sink* is where
+    :func:`publish_timer_stats` reports this worker's accumulated stats.
     """
+    global _worker_stats_sink
     root = logging.getLogger()
     root.handlers[:] = [logging.handlers.QueueHandler(log_queue)]
     root.setLevel(level)
+    _worker_stats_sink = stats_sink
 
 
 @contextmanager
@@ -360,6 +373,35 @@ def relayed_worker_logs(
     finally:
         log_queue.put(None)
         thread.join(timeout=5.0)
+
+
+def publish_timer_stats(key: int) -> None:
+    """Publish this worker's stats to the parent, replacing its last publication."""
+    if _worker_stats_sink is None:
+        return
+    with Timer._stats_lock:
+        snapshot = {label: dict(stats) for label, stats in Timer._stats.items()}
+    try:
+        _worker_stats_sink[key] = snapshot
+    except (OSError, EOFError):
+        # The parent's manager is already gone; diagnostics never break a run.
+        pass
+
+
+@contextmanager
+def worker_timer_stats_sink() -> Generator[WorkerTimerStats]:
+    """A sink pool workers publish their timer stats into while they run."""
+    with multiprocessing.Manager() as manager:
+        yield manager.dict()
+
+
+def merge_unreturned_worker_stats(
+    sink: WorkerTimerStats, returned_keys: Container[int]
+) -> None:
+    """Merge the published stats of every worker that returned no result."""
+    for key, snapshot in dict(sink).items():
+        if key not in returned_keys:
+            Timer.merge_stats(snapshot)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
@@ -15,9 +15,12 @@ import neuracore as nc
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import (
     Timer,
-    init_worker_logging,
+    init_worker_reporting,
+    merge_unreturned_worker_stats,
+    publish_timer_stats,
     relayed_worker_logs,
     surface_worker_errors,
+    worker_timer_stats_sink,
 )
 from tests.integration.platform.data_daemon.shared.test_case.boundaries import (
     EmittedFrame,
@@ -195,7 +198,10 @@ def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     multiprocessing.current_process().name = f"ctx-{spec.context_index}"
     Timer._stats.clear()
     ensure_login()
-    return context_worker(spec)
+    try:
+        return context_worker(spec)
+    finally:
+        publish_timer_stats(spec.context_index)
 
 
 def context_worker(spec: ContextSpec) -> ContextResult:
@@ -313,6 +319,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                     stop_settled_at=gate_closed_at.result,
                 )
                 ordinal_by_disk_key[disk_recording_key] = recording_ordinal
+                publish_timer_stats(spec.context_index)
         finally:
             # A surviving producer thread breaks the cleanup assertions.
             session.finish()
@@ -485,16 +492,25 @@ def _run_context_specs(
     if case.parallel_contexts == 1:
         return [context_worker(specs[0])]
 
-    with relayed_worker_logs() as log_queue:
-        with multiprocessing.Pool(
-            case.parallel_contexts,
-            initializer=init_worker_logging,
-            initargs=(log_queue, logging.getLogger().getEffectiveLevel()),
-        ) as pool:
-            results: list[ContextResult] = []
-            for result in pool.imap_unordered(_subprocess_context_worker, specs):
-                Timer.merge_stats(result.timer_stats)
-                results.append(result)
+    with relayed_worker_logs() as log_queue, worker_timer_stats_sink() as stats_sink:
+        results: list[ContextResult] = []
+        try:
+            with multiprocessing.Pool(
+                case.parallel_contexts,
+                initializer=init_worker_reporting,
+                initargs=(
+                    log_queue,
+                    logging.getLogger().getEffectiveLevel(),
+                    stats_sink,
+                ),
+            ) as pool:
+                for result in pool.imap_unordered(_subprocess_context_worker, specs):
+                    Timer.merge_stats(result.timer_stats)
+                    results.append(result)
+        finally:
+            merge_unreturned_worker_stats(
+                stats_sink, {result.context_index for result in results}
+            )
     return results
 
 

--- a/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
@@ -15,9 +15,12 @@ import neuracore as nc
 from tests.integration.platform.data_daemon.shared.auth import ensure_login
 from tests.integration.platform.data_daemon.shared.process_control import (
     Timer,
-    init_worker_logging,
+    init_worker_reporting,
+    merge_unreturned_worker_stats,
+    publish_timer_stats,
     relayed_worker_logs,
     surface_worker_errors,
+    worker_timer_stats_sink,
 )
 from tests.integration.platform.data_daemon.shared.test_case.boundaries import (
     EmittedFrame,
@@ -191,7 +194,10 @@ def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     multiprocessing.current_process().name = f"ctx-{spec.context_index}"
     Timer._stats.clear()
     ensure_login()
-    return context_worker(spec)
+    try:
+        return context_worker(spec)
+    finally:
+        publish_timer_stats(spec.context_index)
 
 
 def context_worker(spec: ContextSpec) -> ContextResult:
@@ -308,6 +314,7 @@ def context_worker(spec: ContextSpec) -> ContextResult:
                     stop_settled_at=gate_closed_at.result,
                 )
                 ordinal_by_disk_key[disk_recording_key] = recording_ordinal
+                publish_timer_stats(spec.context_index)
         finally:
             # A surviving producer thread breaks the cleanup assertions.
             session.finish()
@@ -477,16 +484,28 @@ def _run_context_specs(
         return [context_worker(specs[0])]
 
     process_context = multiprocessing.get_context("spawn")
-    with relayed_worker_logs(process_context) as log_queue:
-        with process_context.Pool(
-            case.parallel_contexts,
-            initializer=init_worker_logging,
-            initargs=(log_queue, logging.getLogger().getEffectiveLevel()),
-        ) as pool:
-            results: list[ContextResult] = []
-            for result in pool.imap_unordered(_subprocess_context_worker, specs):
-                Timer.merge_stats(result.timer_stats)
-                results.append(result)
+    with (
+        relayed_worker_logs(process_context) as log_queue,
+        worker_timer_stats_sink() as stats_sink,
+    ):
+        results: list[ContextResult] = []
+        try:
+            with process_context.Pool(
+                case.parallel_contexts,
+                initializer=init_worker_reporting,
+                initargs=(
+                    log_queue,
+                    logging.getLogger().getEffectiveLevel(),
+                    stats_sink,
+                ),
+            ) as pool:
+                for result in pool.imap_unordered(_subprocess_context_worker, specs):
+                    Timer.merge_stats(result.timer_stats)
+                    results.append(result)
+        finally:
+            merge_unreturned_worker_stats(
+                stats_sink, {result.context_index for result in results}
+            )
     return results
 
 

--- a/tests/unit/data_daemon/test_worker_timer_stats.py
+++ b/tests/unit/data_daemon/test_worker_timer_stats.py
@@ -1,0 +1,107 @@
+"""Timer stats published by a pool worker that never returns a result."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from tests.integration.platform.data_daemon.shared import process_control
+from tests.integration.platform.data_daemon.shared.process_control import (
+    Timer,
+    WorkerTimerStats,
+    merge_unreturned_worker_stats,
+    publish_timer_stats,
+    worker_timer_stats_sink,
+)
+
+CONTEXT_INDEX = 7
+
+
+@contextmanager
+def publishing_worker(sink: WorkerTimerStats) -> Generator[None]:
+    """Make ``publish_timer_stats`` behave as it does inside a pool worker."""
+    previous = process_control._worker_stats_sink
+    process_control._worker_stats_sink = sink
+    try:
+        yield
+    finally:
+        process_control._worker_stats_sink = previous
+
+
+@contextmanager
+def timed_block(label: str) -> Generator[None]:
+    """Accumulate one block under *label*, and leave no stats behind."""
+    try:
+        with Timer(1.0, label=label, assert_deadline=False):
+            pass
+        yield
+    finally:
+        Timer._stats.pop(label, None)
+
+
+def _forget_locally(label: str) -> None:
+    """Drop the publisher's own copy, standing in for the process boundary.
+
+    A real worker's ``Timer._stats`` is not the parent's, so what the parent
+    ends up with is only ever what it merged.
+    """
+    Timer._stats.pop(label)
+
+
+def test_stats_of_a_worker_that_never_returned_reach_the_parent() -> None:
+    """The sink carries what the return value would have."""
+    label = "test.unreturned"
+    sink: WorkerTimerStats = {}
+    with timed_block(label):
+        with publishing_worker(sink):
+            publish_timer_stats(CONTEXT_INDEX)
+        _forget_locally(label)
+
+        merge_unreturned_worker_stats(sink, returned_keys=set())
+
+        assert Timer._stats[label]["count"] == 1.0
+
+
+def test_only_the_latest_publication_of_a_worker_is_merged() -> None:
+    """Publications are cumulative, so summing them would double-count."""
+    label = "test.latest_publication"
+    sink: WorkerTimerStats = {}
+    with timed_block(label):
+        with publishing_worker(sink):
+            publish_timer_stats(CONTEXT_INDEX)
+            with Timer(1.0, label=label, assert_deadline=False):
+                pass
+            publish_timer_stats(CONTEXT_INDEX)
+        _forget_locally(label)
+
+        merge_unreturned_worker_stats(sink, returned_keys=set())
+
+        assert Timer._stats[label]["count"] == 2.0
+
+
+def test_a_worker_that_returned_is_not_merged_twice() -> None:
+    """Its result already carried these stats to the parent."""
+    label = "test.returned"
+    sink: WorkerTimerStats = {}
+    with timed_block(label):
+        with publishing_worker(sink):
+            publish_timer_stats(CONTEXT_INDEX)
+        _forget_locally(label)
+
+        merge_unreturned_worker_stats(sink, returned_keys={CONTEXT_INDEX})
+
+        assert label not in Timer._stats
+
+
+def test_the_managed_sink_carries_a_publication_across_processes() -> None:
+    """The real sink is a manager proxy, not the plain dict above."""
+    label = "test.managed_sink"
+    with timed_block(label):
+        with worker_timer_stats_sink() as sink:
+            with publishing_worker(sink):
+                publish_timer_stats(CONTEXT_INDEX)
+            _forget_locally(label)
+
+            merge_unreturned_worker_stats(sink, returned_keys=set())
+
+        assert Timer._stats[label]["count"] == 1.0


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Retain timer stats for logging functions on a test case that fails

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
