### PR TITLE
test: keep the timer stats of a producer child that failed

### DIFF
--- a/tests/integration/platform/data_daemon/shared/disk_helpers.py
+++ b/tests/integration/platform/data_daemon/shared/disk_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import shutil
 import subprocess
@@ -736,6 +737,42 @@ def assert_video_artifacts(
             )
 
 
+@functools.cache
+def _passthrough_frame_sync_arg(ffmpeg: str) -> str:
+    """Return the option *ffmpeg* accepts to select passthrough frame timing.
+
+    ``-fps_mode`` replaced ``-vsync`` in ffmpeg 5.1 and is the only spelling
+    accepted from ffmpeg 8 onwards, which dropped ``-vsync`` entirely.
+    Mirrors ``data_daemon_shared::ffmpeg::passthrough_frame_sync_arg`` on the
+    Rust side of this same compatibility gap.
+    """
+    probe = subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "yuv420p",
+            "-video_size",
+            "16x16",
+            "-i",
+            "-",
+            "-fps_mode",
+            "passthrough",
+            "-f",
+            "null",
+            "-",
+        ],
+        input=bytes(16 * 16 * 3 // 2),
+        capture_output=True,
+        check=False,
+    )
+    return "-vsync" if b"Unrecognized option" in probe.stderr else "-fps_mode"
+
+
 def _decode_frame_codes(video_path: Path) -> list[int] | None:
     """Return the code painted into every frame of *video_path*, in stream order.
 
@@ -756,7 +793,7 @@ def _decode_frame_codes(video_path: Path) -> list[int] | None:
             "-nostdin",
             "-i",
             str(video_path),
-            "-vsync",
+            _passthrough_frame_sync_arg(ffmpeg),
             "passthrough",
             "-vf",
             f"crop={FRAME_GRID_SIZE}:{FRAME_GRID_SIZE}:0:0",

--- a/tests/integration/platform/data_daemon/shared/test_case/producers.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/producers.py
@@ -557,8 +557,12 @@ def _producer_process(
             "report": report,
             "timer_stats": {label: dict(v) for label, v in Timer._stats.items()},
         })
-    except BaseException:  # noqa: BLE001 - propagate full child traceback
-        result_queue.put({"ok": False, "traceback": traceback.format_exc()})
+    except BaseException:  # noqa: BLE001
+        result_queue.put({
+            "ok": False,
+            "traceback": traceback.format_exc(),
+            "timer_stats": {label: dict(v) for label, v in Timer._stats.items()},
+        })
     finally:
         if robot is not None:
             robot.close()
@@ -703,6 +707,8 @@ class MultiProcessProducerSession(ProducerSession):
             outcome = child.result_queue.get(timeout=PRODUCER_PROCESS_REPORT_TIMEOUT_S)
         except queue.Empty:
             outcome = None
+        if outcome is not None:
+            Timer.merge_stats(outcome.get("timer_stats", {}))
         child.process.join(timeout=PRODUCER_PROCESS_JOIN_TIMEOUT_S)
         if child.process.is_alive():
             child.process.terminate()
@@ -719,7 +725,6 @@ class MultiProcessProducerSession(ProducerSession):
             )
         # Trace keys are disjoint across producers, so no trace is interleaved.
         self._child_frames.update(outcome["report"])
-        Timer.merge_stats(outcome.get("timer_stats", {}))
         return ""
 
     def report(self) -> dict[str, list[EmittedFrame]]:

--- a/tests/integration/platform/data_daemon/shared/test_case/producers.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/producers.py
@@ -559,8 +559,12 @@ def _producer_process(
             "report": report,
             "timer_stats": {label: dict(v) for label, v in Timer._stats.items()},
         })
-    except BaseException:  # noqa: BLE001 - propagate full child traceback
-        result_queue.put({"ok": False, "traceback": traceback.format_exc()})
+    except BaseException:  # noqa: BLE001
+        result_queue.put({
+            "ok": False,
+            "traceback": traceback.format_exc(),
+            "timer_stats": {label: dict(v) for label, v in Timer._stats.items()},
+        })
     finally:
         if robot is not None:
             robot.close()
@@ -707,6 +711,8 @@ class MultiProcessProducerSession(ProducerSession):
             outcome = child.result_queue.get(timeout=PRODUCER_PROCESS_REPORT_TIMEOUT_S)
         except queue.Empty:
             outcome = None
+        if outcome is not None:
+            Timer.merge_stats(outcome.get("timer_stats", {}))
         child.process.join(timeout=PRODUCER_PROCESS_JOIN_TIMEOUT_S)
         if child.process.is_alive():
             child.process.terminate()
@@ -723,7 +729,6 @@ class MultiProcessProducerSession(ProducerSession):
             )
         # Trace keys are disjoint across producers, so no trace is interleaved.
         self._child_frames.update(outcome["report"])
-        Timer.merge_stats(outcome.get("timer_stats", {}))
         return ""
 
     def report(self) -> dict[str, list[EmittedFrame]]:


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Retain logging timer stats for a threaded producer child that fails

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
