### PR TITLE
feat: expose recording encoding type on the SDK Recording

### DIFF
--- a/neuracore/core/data/dataset.py
+++ b/neuracore/core/data/dataset.py
@@ -145,6 +145,7 @@ class Dataset:
             end_time=recording_model.end_time,
             metadata=recording_model.metadata,
             data_types=recording_model.data_types,
+            encoding=recording_model.encoding,
         )
 
     def _initialize_num_recordings(self) -> None:

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -51,8 +51,9 @@ class Recording:
             end_time: Unix timestamp when recording ended.
             metadata: Metadata associated with the recording.
             data_types: Set of DataTypes present in this recording.
-            encoding: Codec used for this recording's camera video.
-                None for recordings finalized before the field existed.
+            encoding: Codec used for this recording's RGB camera video. None
+                when there is nothing to report -- no RGB cameras, cameras
+                that disagreed on a codec, or a recording predating the field.
         """
         self.dataset = dataset
         self.id = recording_id

--- a/neuracore/core/data/recording.py
+++ b/neuracore/core/data/recording.py
@@ -3,7 +3,7 @@
 import sys
 from typing import TYPE_CHECKING
 
-from neuracore_types import CrossEmbodimentUnion, DataType
+from neuracore_types import Codec, CrossEmbodimentUnion, DataType
 from neuracore_types import Recording as RecordingModel
 from neuracore_types import RecordingMetadata, RecordingStatus, SynchronizationDetails
 
@@ -37,6 +37,7 @@ class Recording:
         end_time: float,
         metadata: RecordingMetadata,
         data_types: set[DataType] | None = None,
+        encoding: Codec | None = None,
     ):
         """Initialize episode iterator for a specific recording.
 
@@ -50,6 +51,8 @@ class Recording:
             end_time: Unix timestamp when recording ended.
             metadata: Metadata associated with the recording.
             data_types: Set of DataTypes present in this recording.
+            encoding: Codec used for this recording's camera video.
+                None for recordings finalized before the field existed.
         """
         self.dataset = dataset
         self.id = recording_id
@@ -62,6 +65,7 @@ class Recording:
         self.name = getattr(metadata, "name", None) or recording_id
         self.metadata = metadata
         self.data_types: set[DataType] = data_types or set()
+        self.encoding = encoding
         self._raw = {
             "id": recording_id,
             "total_bytes": total_bytes,

--- a/neuracore/core/video_encoding.py
+++ b/neuracore/core/video_encoding.py
@@ -6,9 +6,6 @@ used for training) plus a small lossy preview (``lossy.mp4``). Selecting a
 is also used for training -- trading a little image fidelity for much smaller
 uploads, which matters for long recordings.
 
-Codec is re-exported here so nc.Codec keeps working. The data daemon mirrors
-the same h264_medium -> libx264 -crf 23 -preset medium mapping.
-
 Depth cameras always keep their lossless storage: their lossy proxy is a
 visualisation, not precise depth, so it is never a valid training source.
 """

--- a/neuracore/core/video_encoding.py
+++ b/neuracore/core/video_encoding.py
@@ -6,9 +6,8 @@ used for training) plus a small lossy preview (``lossy.mp4``). Selecting a
 is also used for training -- trading a little image fidelity for much smaller
 uploads, which matters for long recordings.
 
-This module is the single source of truth for the codec identifiers the SDK
-exposes. The data daemon mirrors the same ``h264_medium`` ->
-``libx264 -crf 23 -preset medium`` mapping.
+Codec is re-exported here so nc.Codec keeps working. The data daemon mirrors
+the same h264_medium -> libx264 -crf 23 -preset medium mapping.
 
 Depth cameras always keep their lossless storage: their lossy proxy is a
 visualisation, not precise depth, so it is never a valid training source.
@@ -17,29 +16,14 @@ visualisation, not precise depth, so it is never a valid training source.
 from __future__ import annotations
 
 import copy
-import enum
 import logging
 from typing import TypedDict
 
+from neuracore_types import Codec
+
+__all__ = ["Codec", "Libx264Options", "codec_option_overrides", "resolve_codec"]
+
 logger = logging.getLogger(__name__)
-
-
-class Codec(str, enum.Enum):
-    """Codecs available for recorded camera video.
-
-    Members are string values so they round-trip cleanly through the daemon
-    profile and the ``NCD_VIDEO_CODEC`` environment variable.
-
-    Attributes:
-        H264_LOSSLESS: The default — keep the lossless archive (used for
-            training) plus a small lossy preview. Select this to switch back
-            from a lossy mode.
-        H264_MEDIUM: Lossy-only — a single full-resolution libx264 CRF 23 video
-            (no lossless archive), used for both preview and training.
-    """
-
-    H264_LOSSLESS = "h264_lossless"
-    H264_MEDIUM = "h264_medium"
 
 
 class Libx264Options(TypedDict, total=False):

--- a/rust/data_daemon/src/api/client.rs
+++ b/rust/data_daemon/src/api/client.rs
@@ -545,6 +545,7 @@ fn jitter_below(upper: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::api::auth::StaticAuthProvider;
+    use crate::encoding::video_encoder::LossyVideoCodec;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -615,7 +616,7 @@ mod tests {
             data_type: "RGB_IMAGES".to_string(),
             trace_id: "trace-1".to_string(),
             cloud_files: vec![],
-            codec: Some("h264_lossless".to_string()),
+            codec: Some(LossyVideoCodec::LosslessPlusPreview),
         }];
         let outcome = client.batch_register("org-1", &traces).await.unwrap();
         assert_eq!(outcome.registered_traces.len(), 1);

--- a/rust/data_daemon/src/api/client.rs
+++ b/rust/data_daemon/src/api/client.rs
@@ -615,6 +615,7 @@ mod tests {
             data_type: "RGB_IMAGES".to_string(),
             trace_id: "trace-1".to_string(),
             cloud_files: vec![],
+            codec: Some("h264_lossless".to_string()),
         }];
         let outcome = client.batch_register("org-1", &traces).await.unwrap();
         assert_eq!(outcome.registered_traces.len(), 1);

--- a/rust/data_daemon/src/api/models.rs
+++ b/rust/data_daemon/src/api/models.rs
@@ -34,8 +34,8 @@ pub struct RegisterTraceRequest {
     /// Codec this trace's video was encoded with.
     ///
     /// Only video-family traces carry one; `None` for scalar/JSON traces, which
-    /// have no video to encode. Skipped on the wire when absent so an older
-    /// backend sees the previous body shape unchanged.
+    /// have no video to encode. Omitted rather than sent as null, so the body
+    /// is unchanged for traces that never had a codec.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub codec: Option<String>,
 }

--- a/rust/data_daemon/src/api/models.rs
+++ b/rust/data_daemon/src/api/models.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::encoding::video_encoder::LossyVideoCodec;
+
 /// One file the backend should expect for a trace registration request.
 ///
 /// Matches the body of `POST /org/{org}/recording/traces/batch-register`,
@@ -35,9 +37,11 @@ pub struct RegisterTraceRequest {
     ///
     /// Only video-family traces carry one; `None` for scalar/JSON traces, which
     /// have no video to encode. Omitted rather than sent as null, so the body
-    /// is unchanged for traces that never had a codec.
+    /// is unchanged for traces that never had a codec. Held as the enum and
+    /// rendered to its wire identifier by `Serialize`, so no codec string is
+    /// constructed before the request is encoded.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub codec: Option<String>,
+    pub codec: Option<LossyVideoCodec>,
 }
 
 /// Backend response payload for `POST /traces/batch-register`.
@@ -134,7 +138,7 @@ mod tests {
                 filepath: "rgb/cam_0/lossy.mp4".to_string(),
                 content_type: "video/mp4".to_string(),
             }],
-            codec: Some("h264_medium".to_string()),
+            codec: Some(LossyVideoCodec::H264MediumLossyOnly),
         };
         let body = serde_json::to_value(serde_json::json!({"traces": [request]})).unwrap();
         assert_eq!(

--- a/rust/data_daemon/src/api/models.rs
+++ b/rust/data_daemon/src/api/models.rs
@@ -31,6 +31,13 @@ pub struct RegisterTraceRequest {
     pub trace_id: String,
     /// Files to register for this trace.
     pub cloud_files: Vec<CloudFile>,
+    /// Codec this trace's video was encoded with.
+    ///
+    /// Only video-family traces carry one; `None` for scalar/JSON traces, which
+    /// have no video to encode. Skipped on the wire when absent so an older
+    /// backend sees the previous body shape unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codec: Option<String>,
 }
 
 /// Backend response payload for `POST /traces/batch-register`.
@@ -127,6 +134,7 @@ mod tests {
                 filepath: "rgb/cam_0/lossy.mp4".to_string(),
                 content_type: "video/mp4".to_string(),
             }],
+            codec: Some("h264_medium".to_string()),
         };
         let body = serde_json::to_value(serde_json::json!({"traces": [request]})).unwrap();
         assert_eq!(
@@ -139,9 +147,32 @@ mod tests {
                     "cloud_files": [{
                         "filepath": "rgb/cam_0/lossy.mp4",
                         "content_type": "video/mp4"
-                    }]
+                    }],
+                    "codec": "h264_medium"
                 }]
             })
+        );
+    }
+
+    #[test]
+    fn batch_register_body_omits_absent_codec() {
+        // A scalar trace has no video and so no codec. The field must vanish from
+        // the body rather than serialising as null, leaving the pre-codec wire
+        // shape byte-identical for traces that never had one.
+        let request = RegisterTraceRequest {
+            recording_id: "rec-1".to_string(),
+            data_type: "JOINT_POSITIONS".to_string(),
+            trace_id: "trace-2".to_string(),
+            cloud_files: vec![CloudFile {
+                filepath: "JOINT_POSITIONS/arm0/trace.json".to_string(),
+                content_type: "application/json".to_string(),
+            }],
+            codec: None,
+        };
+        let body = serde_json::to_value(&request).unwrap();
+        assert!(
+            body.get("codec").is_none(),
+            "codec must be omitted entirely when absent, got {body}"
         );
     }
 

--- a/rust/data_daemon/src/cloud/cloud_files.rs
+++ b/rust/data_daemon/src/cloud/cloud_files.rs
@@ -47,6 +47,17 @@ fn content_type_for(data_type: &str) -> ContentKind {
     }
 }
 
+/// Whether a data type produces video artefacts at all.
+///
+/// The public face of [`content_type_for`], so callers outside this module can
+/// gate on the video family without re-listing the data types (and drifting from
+/// the artefact layout this module owns). Used by the registration coordinator to
+/// decide whether a trace has a codec worth reporting: a scalar trace has no
+/// video, so reporting a codec for it would be meaningless.
+pub fn is_video_family(data_type: &str) -> bool {
+    matches!(content_type_for(data_type), ContentKind::Rgb)
+}
+
 /// The MIME content-type the daemon registers (and re-acquires session URIs)
 /// for an artefact, keyed off its filename suffix. The single source of truth
 /// for the mapping, shared by [`cloud_file_list`] and the uploader's session

--- a/rust/data_daemon/src/cloud/cloud_files.rs
+++ b/rust/data_daemon/src/cloud/cloud_files.rs
@@ -49,11 +49,9 @@ fn content_type_for(data_type: &str) -> ContentKind {
 
 /// Whether a data type produces video artefacts at all.
 ///
-/// The public face of [`content_type_for`], so callers outside this module can
-/// gate on the video family without re-listing the data types (and drifting from
-/// the artefact layout this module owns). Used by the registration coordinator to
-/// decide whether a trace has a codec worth reporting: a scalar trace has no
-/// video, so reporting a codec for it would be meaningless.
+/// The public face of [`content_type_for`], so callers can gate on the video
+/// family without re-listing the data types and drifting from the artefact
+/// layout this module owns.
 pub fn is_video_family(data_type: &str) -> bool {
     matches!(content_type_for(data_type), ContentKind::Rgb)
 }

--- a/rust/data_daemon/src/cloud/coordinators/registration.rs
+++ b/rust/data_daemon/src/cloud/coordinators/registration.rs
@@ -23,7 +23,7 @@ use tokio::time::{interval, MissedTickBehavior};
 
 use crate::api::models::RegisterTraceRequest;
 use crate::api::ApiClient;
-use crate::cloud::cloud_files::cloud_file_list;
+use crate::cloud::cloud_files::{cloud_file_list, is_video_family};
 use crate::cloud::{ConfigRx, OrgIdRx};
 use crate::encoding::video_encoder::LossyVideoCodec;
 use crate::lifecycle::shutdown::ShutdownSignal;
@@ -225,8 +225,7 @@ async fn submit_batch(
             .iter()
             .map(|trace| {
                 let data_type = trace.data_type.as_deref().unwrap_or("");
-                let lossy_only =
-                    LossyVideoCodec::for_trace(data_type, codec_value.as_deref()).is_lossy_only();
+                let codec = LossyVideoCodec::for_trace(data_type, codec_value.as_deref());
                 RegisterTraceRequest {
                     recording_id: cloud_id.clone(),
                     data_type: trace.data_type.clone().unwrap_or_default(),
@@ -234,8 +233,13 @@ async fn submit_batch(
                     cloud_files: cloud_file_list(
                         data_type,
                         trace.data_type_name.as_deref(),
-                        lossy_only,
+                        codec.is_lossy_only(),
                     ),
+                    // Report the codec only where there is video to encode. A
+                    // scalar trace resolves to the default via `for_trace`'s
+                    // fallthrough, which is a placeholder rather than a claim
+                    // about how it was stored, so it must not reach the backend.
+                    codec: is_video_family(data_type).then(|| codec.as_wire_str().to_string()),
                 }
             })
             .collect();

--- a/rust/data_daemon/src/cloud/coordinators/registration.rs
+++ b/rust/data_daemon/src/cloud/coordinators/registration.rs
@@ -238,7 +238,7 @@ async fn submit_batch(
                     // Report the codec only where there is video to encode. A
                     // scalar trace resolves to the default via `for_trace`'s
                     // fallthrough, which is a placeholder rather than a claim
-                    // about how it was stored, so it must not reach the backend.
+                    // about how it was stored, so it is left unreported.
                     codec: is_video_family(data_type).then(|| codec.as_wire_str().to_string()),
                 }
             })

--- a/rust/data_daemon/src/cloud/coordinators/registration.rs
+++ b/rust/data_daemon/src/cloud/coordinators/registration.rs
@@ -239,7 +239,7 @@ async fn submit_batch(
                     // scalar trace resolves to the default via `for_trace`'s
                     // fallthrough, which is a placeholder rather than a claim
                     // about how it was stored, so it is left unreported.
-                    codec: is_video_family(data_type).then(|| codec.as_wire_str().to_string()),
+                    codec: is_video_family(data_type).then_some(codec),
                 }
             })
             .collect();

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -167,6 +167,18 @@ impl LossyVideoCodec {
     pub fn is_lossy_only(self) -> bool {
         matches!(self, Self::H264MediumLossyOnly)
     }
+
+    /// The wire identifier for this codec — the inverse of [`Self::from_config_str`].
+    ///
+    /// The backend stores these strings verbatim on the trace, so they are the
+    /// same identifiers the config and `NCD_VIDEO_CODEC` accept. The round trip
+    /// is pinned by a unit test.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::LosslessPlusPreview => "h264_lossless",
+            Self::H264MediumLossyOnly => "h264_medium",
+        }
+    }
 }
 
 /// Inputs to one single-entry transcode invocation.
@@ -2009,6 +2021,30 @@ mod tests {
                 LossyVideoCodec::LosslessPlusPreview
             );
         }
+    }
+
+    #[test]
+    fn wire_str_round_trips_through_from_config_str() {
+        // The backend persists these strings verbatim, so a drift here silently
+        // mislabels every recording.
+        for codec in [
+            LossyVideoCodec::LosslessPlusPreview,
+            LossyVideoCodec::H264MediumLossyOnly,
+        ] {
+            assert_eq!(
+                LossyVideoCodec::from_config_str(Some(codec.as_wire_str())),
+                codec,
+                "{codec:?} must survive a wire round trip"
+            );
+        }
+        assert_eq!(
+            LossyVideoCodec::LosslessPlusPreview.as_wire_str(),
+            "h264_lossless"
+        );
+        assert_eq!(
+            LossyVideoCodec::H264MediumLossyOnly.as_wire_str(),
+            "h264_medium"
+        );
     }
 
     #[tokio::test]

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -170,9 +170,9 @@ impl LossyVideoCodec {
 
     /// The wire identifier for this codec — the inverse of [`Self::from_config_str`].
     ///
-    /// The backend stores these strings verbatim on the trace, so they are the
-    /// same identifiers the config and `NCD_VIDEO_CODEC` accept. The round trip
-    /// is pinned by a unit test.
+    /// These are the same identifiers the profile and `NCD_VIDEO_CODEC` accept,
+    /// and they are persisted as-is against the recording, so the round trip is
+    /// pinned by a unit test.
     pub fn as_wire_str(self) -> &'static str {
         match self {
             Self::LosslessPlusPreview => "h264_lossless",
@@ -2025,8 +2025,8 @@ mod tests {
 
     #[test]
     fn wire_str_round_trips_through_from_config_str() {
-        // The backend persists these strings verbatim, so a drift here silently
-        // mislabels every recording.
+        // These strings are persisted as-is against the recording, so a drift
+        // here silently mislabels every one.
         for codec in [
             LossyVideoCodec::LosslessPlusPreview,
             LossyVideoCodec::H264MediumLossyOnly,

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -48,6 +48,7 @@ use std::process::Stdio;
 
 use data_daemon_shared::ffmpeg::passthrough_frame_sync_arg;
 use data_daemon_shared::service_name::VIDEO_SPOOL_TICKS_PER_SECOND;
+use serde::{Serialize, Serializer};
 
 use tokio::process::Command;
 
@@ -178,6 +179,14 @@ impl LossyVideoCodec {
             Self::LosslessPlusPreview => "h264_lossless",
             Self::H264MediumLossyOnly => "h264_medium",
         }
+    }
+}
+
+/// Serialise as the wire identifier, so callers hold the enum right up to the
+/// point a request is encoded and no codec string exists anywhere else.
+impl Serialize for LossyVideoCodec {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire_str())
     }
 }
 


### PR DESCRIPTION
### Features
 - Expose the recording encoding type on the Recording
 - Default to UNKNOWN so existing callers are unaffected

### Items
 - [NCP-1128](https://neuracore.atlassian.net/browse/NCP-1128)
