### PR TITLE
fix: logout event

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -103,11 +103,13 @@ def logout() -> None:
     Logs out from the Neuracore server and resets all global state including
     active robots, recording IDs, dataset IDs, and version validation status.
     """
-    get_auth().logout()
-    GlobalSingleton()._active_robot = None
-    GlobalSingleton()._active_dataset_id = None
-    GlobalSingleton()._active_dataset = None
-    GlobalSingleton()._has_validated_version = False
+    try:
+        get_auth().logout()
+    finally:
+        GlobalSingleton()._active_robot = None
+        GlobalSingleton()._active_dataset_id = None
+        GlobalSingleton()._active_dataset = None
+        GlobalSingleton()._has_validated_version = False
 
 
 def set_organization(id_or_name: str) -> None:

--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -10,6 +10,7 @@ import os
 from typing import Any
 
 import requests
+from pyee import EventEmitter
 
 from neuracore.api.orgs_fetch import fetch_org_ids
 from neuracore.core.config.config_manager import get_config_manager
@@ -55,7 +56,7 @@ def _format_version_validation_error(response: requests.Response) -> str:
     )
 
 
-class Auth(metaclass=SingletonMetaclass):
+class Auth(EventEmitter, metaclass=SingletonMetaclass):
     """Singleton class for managing Neuracore authentication state.
 
     This class handles API key management, access token retrieval, configuration
@@ -64,8 +65,11 @@ class Auth(metaclass=SingletonMetaclass):
     loads saved configuration on initialization.
     """
 
+    LOGOUT_EVENT = "logout"
+
     def __init__(self) -> None:
         """Initialize the Auth instance and load saved configuration."""
+        super().__init__()
         self._access_token = None
 
     def login(self, api_key: str | None = None) -> None:
@@ -156,6 +160,7 @@ class Auth(metaclass=SingletonMetaclass):
         config_manager.config.api_key = None
         config_manager.config.current_org_id = None
         config_manager.save_config()
+        self.emit(self.LOGOUT_EVENT)
 
     def validate_version(self) -> None:
         """Validate client version compatibility with the Neuracore server.

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -35,6 +35,7 @@ from .exceptions import RobotError, ValidationError
 
 if TYPE_CHECKING:
     from neuracore.api.logging import JointStreamBinding, ResolvedJointGroup
+    from neuracore.core.streaming.recording_state_manager import RecordingStateManager
 
 logger = logging.getLogger(__name__)
 DaemonRecordingContext = recording_context.RecordingContext
@@ -121,6 +122,7 @@ class Robot:
         )
         self._joint_group_cache: "dict[DataType, ResolvedJointGroup]" = dict()
         self._daemon_recording_context: DaemonRecordingContext | None = None
+        self._recording_state_manager: "RecordingStateManager | None" = None
 
         self.org_id = org_id or get_current_org()
 
@@ -384,11 +386,13 @@ class Robot:
     def _register_remote_stop_handler(self) -> None:
         """Register a callback to drain streams when a remote stop arrives."""
         assert self.id is not None
-        get_recording_state_manager().register_remote_stop_handler(
+        manager = get_recording_state_manager()
+        manager.register_remote_stop_handler(
             robot_id=self.id,
             instance=self.instance,
             callback=self._drain_streams_and_notify_daemon,
         )
+        self._recording_state_manager = manager
 
     def _stop_all_streams(self) -> None:
         """Stop recording on all data streams for this robot instance."""
@@ -789,10 +793,10 @@ class Robot:
     def close(self) -> None:
         """Release local resources owned by this Robot instance."""
         self._cleanup_daemon_recording_context()
-        if self.id is not None:
-            get_recording_state_manager().deregister_remote_stop_handler(
-                self.id, self.instance
-            )
+        manager = self._recording_state_manager
+        self._recording_state_manager = None
+        if self.id is not None and manager is not None:
+            manager.deregister_remote_stop_handler(self.id, self.instance)
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/base_sse_consumer.py
+++ b/neuracore/core/streaming/base_sse_consumer.py
@@ -14,6 +14,7 @@ from neuracore.core.const import (
     STREAMING_MAXIMUM_BACKOFF_TIME_S,
     STREAMING_MINIMUM_BACKOFF_TIME_S,
 )
+from neuracore.core.exceptions import AuthenticationError
 from neuracore.core.streaming.event_loop_utils import get_running_loop
 from neuracore.core.streaming.p2p.enabled_manager import EnabledManager
 from neuracore.core.utils.background_coroutine_tracker import BackgroundCoroutineTracker
@@ -122,6 +123,10 @@ class BaseSSEConsumer(ABC):
         """Disables the current enable manger, therefore cleaning up resources."""
         self.enabled_manager.disable()
 
+    def on_authentication_error(self) -> None:
+        """Close the owner of this consumer after terminal authentication failure."""
+        self.close()
+
     async def _message_received_loop(self) -> None:
         backoff_time = STREAMING_MINIMUM_BACKOFF_TIME_S
 
@@ -168,5 +173,8 @@ class BaseSSEConsumer(ABC):
                         logger.warning(
                             f'Unsupported SSE event type "{event.type}" received'
                         )
+            except (AuthenticationError, ConnectionRefusedError):
+                self.on_authentication_error()
+                return
             except Exception as e:
                 logger.warning(f"Streaming signalling error: {e}")

--- a/neuracore/core/streaming/p2p/base_p2p_connection_manager.py
+++ b/neuracore/core/streaming/p2p/base_p2p_connection_manager.py
@@ -88,6 +88,11 @@ class BaseStreamManagerOrchestrator(ABC):
     """Base class for a object that creates and manages stream managers."""
 
     @abstractmethod
+    def close(self) -> None:
+        """Close every streaming resource owned by this orchestrator."""
+        raise NotImplementedError("close not implemented")
+
+    @abstractmethod
     def get_manager(
         self, type: ManagerType, robot_id: str, robot_instance: int
     ) -> BaseP2PStreamManager:

--- a/neuracore/core/streaming/p2p/consumer/org_nodes_manager.py
+++ b/neuracore/core/streaming/p2p/consumer/org_nodes_manager.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from concurrent.futures import Future
 from typing import TypeAlias
 
-from aiohttp import ClientSession
 from neuracore_types import (
     AvailableRobot,
     AvailableRobotCapacityInit,
@@ -68,7 +67,6 @@ class OrgNodesManager(BaseSSEConsumer):
         loop: asyncio.AbstractEventLoop | None = None,
         enabled_manager: EnabledManager | None = None,
         background_coroutine_tracker: BackgroundCoroutineTracker | None = None,
-        client_session: ClientSession | None = None,
         auth: Auth | None = None,
         stream_manager_orchestrator: StreamManagerOrchestrator | None = None,
     ) -> None:
@@ -84,8 +82,6 @@ class OrgNodesManager(BaseSSEConsumer):
             background_coroutine_tracker: The storage for background tasks
                 scheduled on receiving events. Defaults to a new tracker if not
                 provided.
-            client_session: The http session to use. Defaults to a new session
-                if not provided.
             auth: The auth instance used to connect to the signalling server or
                 defaults to the global auth provider if not provided.
             stream_manager_orchestrator: the factory used to create stream managers
@@ -95,7 +91,6 @@ class OrgNodesManager(BaseSSEConsumer):
             loop=loop,
             enabled_manager=enabled_manager,
             background_coroutine_tracker=background_coroutine_tracker,
-            client_session=client_session,
         )
         self.stream_manager_orchestrator = (
             stream_manager_orchestrator or StreamManagerOrchestrator()
@@ -111,6 +106,27 @@ class OrgNodesManager(BaseSSEConsumer):
         self.last_nodes: InstanceStreamMap = defaultdict(dict)
 
         self.last_update: AvailableRobotCapacityInit | None = None
+
+        self._logout_listener = self._on_logout
+        self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
+
+    def _on_logout(self) -> None:
+        """Schedule teardown on the streaming event loop."""
+        self._discard_cached_manager()
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(self.close)
+
+    def _discard_cached_manager(self) -> None:
+        """Remove this manager from the existing per-organization cache."""
+        manager_future = _org_node_managers.get(self.org_id)
+        if manager_future is None or not manager_future.done():
+            return
+        try:
+            cached_manager = manager_future.result()
+        except Exception:
+            return
+        if cached_manager is self:
+            _org_node_managers.pop(self.org_id, None)
 
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.
@@ -502,6 +518,21 @@ class OrgNodesManager(BaseSSEConsumer):
             robot_consumer.close()
 
         self.consumers.clear()
+        self.connections.clear()
+        self.last_nodes.clear()
+        self.last_update = None
+        self._remove_logout_listener()
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(
+                self.loop.create_task, self.client_session.close()
+            )
+
+        self._discard_cached_manager()
+
+    def _remove_logout_listener(self) -> None:
+        """Remove the logout listener when it has not already fired."""
+        if self._logout_listener in self.auth.listeners(Auth.LOGOUT_EVENT):
+            self.auth.remove_listener(Auth.LOGOUT_EVENT, self._logout_listener)
 
 
 _org_node_managers: dict[str, Future[OrgNodesManager]] = {}

--- a/neuracore/core/streaming/p2p/signalling_events_consumer.py
+++ b/neuracore/core/streaming/p2p/signalling_events_consumer.py
@@ -82,6 +82,10 @@ class SignallingEventsConsumer(BaseSSEConsumer):
         self.message_queue: list[HandshakeMessage] = []
         self.auth = auth or get_auth()
 
+    def on_authentication_error(self) -> None:
+        """Propagate terminal authentication failure to the root owner."""
+        self.manager_factory.close()
+
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.
 

--- a/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
+++ b/neuracore/core/streaming/p2p/stream_manager_orchestrator.py
@@ -52,7 +52,6 @@ class StreamManagerOrchestrator(
         self,
         org_id: str | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
-        client_session: ClientSession | None = None,
         auth: Auth | None = None,
     ):
         """Initialize the stream manager factory.
@@ -62,8 +61,6 @@ class StreamManagerOrchestrator(
                 defaults to the current org.
             loop: the event loop to run on. Defaults to the running loop if not
                 provided.
-            client_session: The http session to use. Defaults to a new session
-                if not provided.
             auth: The auth instance used to connect to the signalling server or
                 defaults to the global auth provider if not provided.
         """
@@ -77,7 +74,7 @@ class StreamManagerOrchestrator(
         self.org_id = org_id or get_current_org()
         self.auth = auth or get_auth()
         self.loop = loop or get_running_loop()
-        self.client_session = client_session or ClientSession(
+        self.client_session = ClientSession(
             timeout=ClientTimeout(sock_read=None, total=None),
             loop=self.loop,
             middlewares=(retry_connection_failures,),
@@ -94,6 +91,42 @@ class StreamManagerOrchestrator(
                 get_consume_live_data_enabled_manager(),
             ),
         )
+        self._closed = False
+        self._logout_listener = self._on_logout
+        self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
+
+    def _on_logout(self) -> None:
+        """Schedule teardown on the streaming event loop."""
+        StreamManagerOrchestrator.discard_instance(self)
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(self.close)
+
+    def close(self) -> None:
+        """Close all streaming resources owned by this orchestrator."""
+        if self._closed:
+            return
+        self._closed = True
+        self._remove_logout_listener()
+
+        self.signalling_consumer.close()
+
+        provider_managers = list(self.provider_managers.values())
+        consumer_managers = list(self.consumer_managers.values())
+        self.provider_managers.clear()
+        self.consumer_managers.clear()
+
+        for provider_manager in provider_managers:
+            provider_manager.close()
+        for consumer_manager in consumer_managers:
+            consumer_manager.close()
+
+        self.loop.create_task(self.client_session.close())
+        StreamManagerOrchestrator.discard_instance(self)
+
+    def _remove_logout_listener(self) -> None:
+        """Remove the logout listener when it has not already fired."""
+        if self._logout_listener in self.auth.listeners(Auth.LOGOUT_EVENT):
+            self.auth.remove_listener(Auth.LOGOUT_EVENT, self._logout_listener)
 
     def get_manager(
         self, type: ManagerType, robot_id: str, robot_instance: int

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -14,7 +14,6 @@ from collections.abc import Callable
 from concurrent.futures import Future
 from typing import NamedTuple
 
-from aiohttp import ClientSession
 from neuracore_types import (
     BaseRecodingUpdatePayload,
     RecordingNotification,
@@ -98,7 +97,6 @@ class RecordingStateManager(BaseSSEConsumer):
         loop: asyncio.AbstractEventLoop | None = None,
         enabled_manager: EnabledManager | None = None,
         background_coroutine_tracker: BackgroundCoroutineTracker | None = None,
-        client_session: ClientSession | None = None,
         auth: Auth | None = None,
     ):
         """Initialize the recording state manager.
@@ -113,8 +111,6 @@ class RecordingStateManager(BaseSSEConsumer):
             background_coroutine_tracker: The storage for background tasks
                 scheduled on receiving events. Defaults to a new tracker if not
                 provided.
-            client_session: The http session to use. Defaults to a new session
-                if not provided.
             auth: The auth instance used to connect to the signalling server or
                 defaults to the global auth provider if not provided.
         """
@@ -122,7 +118,6 @@ class RecordingStateManager(BaseSSEConsumer):
             loop=loop,
             enabled_manager=enabled_manager,
             background_coroutine_tracker=background_coroutine_tracker,
-            client_session=client_session,
         )
         self.org_id = org_id or get_current_org()
         self.auth = auth if auth is not None else get_auth()
@@ -144,6 +139,56 @@ class RecordingStateManager(BaseSSEConsumer):
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
+
+        self._logout_listener = self._on_logout
+        self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
+
+    def _on_logout(self) -> None:
+        """Schedule teardown on the streaming event loop."""
+        self._discard_cached_manager()
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(self.close)
+
+    def _discard_cached_manager(self) -> None:
+        """Remove this manager from the existing global cache."""
+        global _recording_manager
+
+        if _recording_manager is None or not _recording_manager.done():
+            return
+        try:
+            cached_manager = _recording_manager.result()
+        except Exception:
+            return
+        if cached_manager is self:
+            _recording_manager = None
+
+    def _on_close(self) -> None:
+        """Close the SSE stream and clear locally owned recording state."""
+        super()._on_close()
+        self._remove_logout_listener()
+
+        with self._state_lock:
+            for handles in self._recording_timers.values():
+                for handle in handles:
+                    handle.cancel()
+            self._recording_timers.clear()
+            self.recording_robot_instances.clear()
+            self._expired_recording_ids.clear()
+            self.active_dataset_ids.clear()
+            self._drain_callbacks.clear()
+            self._connected_robot_id = None
+
+        if not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(
+                self.loop.create_task, self.client_session.close()
+            )
+
+        self._discard_cached_manager()
+
+    def _remove_logout_listener(self) -> None:
+        """Remove the logout listener when it has not already fired."""
+        if self._logout_listener in self.auth.listeners(Auth.LOGOUT_EVENT):
+            self.auth.remove_listener(Auth.LOGOUT_EVENT, self._logout_listener)
 
     def get_current_recording_id(self, robot_id: str, instance: int) -> str | None:
         """Get the current recording ID for a robot instance.

--- a/neuracore/core/utils/singleton_metaclass.py
+++ b/neuracore/core/utils/singleton_metaclass.py
@@ -34,3 +34,8 @@ class SingletonMetaclass(ABCMeta, Generic[T]):
             instance = super().__call__(*args, **kwargs)
             cls._instances[cls] = instance
         return cls._instances[cls]
+
+    def discard_instance(cls, instance: Any) -> None:
+        """Discard ``instance`` if it is still the cached singleton."""
+        if cls._instances.get(cls) is instance:
+            del cls._instances[cls]

--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_signal_cleanup.py
@@ -390,7 +390,8 @@ def test_sigkill_mid_recording_allows_clean_restart(case: DataDaemonTestCase) ->
 
             # Run the producer workload in a child process so a SIGKILL at any point
             # cannot leave an uninterruptible background thread in this test process.
-            worker = multiprocessing.Process(
+            process_context = multiprocessing.get_context("spawn")
+            worker = process_context.Process(
                 target=run_case_contexts,
                 args=(case,),
                 kwargs={"specs": specs},

--- a/tests/integration/platform/data_daemon/shared/process_control.py
+++ b/tests/integration/platform/data_daemon/shared/process_control.py
@@ -275,9 +275,13 @@ def init_worker_logging(log_queue: multiprocessing.Queue, level: int) -> None:
 
 
 @contextmanager
-def relayed_worker_logs() -> Generator[multiprocessing.Queue]:
+def relayed_worker_logs(
+    process_context: multiprocessing.context.BaseContext | None = None,
+) -> Generator[multiprocessing.Queue]:
     """Replay pool-worker log records through this process's handlers."""
-    log_queue: multiprocessing.Queue = multiprocessing.Queue()
+    if process_context is None:
+        process_context = multiprocessing.get_context()
+    log_queue: multiprocessing.Queue = process_context.Queue()
 
     def _relay() -> None:
         while True:

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -1027,12 +1027,8 @@ def _bind_worker_dataset(spec: ContextSpec) -> None:
 def _subprocess_context_worker(spec: ContextSpec) -> ContextResult:
     """Subprocess wrapper for context_worker used by multiprocessing.Pool.
 
-    On Linux, Pool uses fork so workers inherit a copy of the parent's
-    Timer._stats. Clearing it here ensures workers only capture their own
-    timers and the parent's pre-fork timers (e.g. nc.login) are not
-    double-counted when stats are merged back. Spawned workers (macOS)
-    additionally re-authenticate, as they do not inherit the parent's
-    in-process auth state.
+    Workers use a fresh interpreter, so clear timing state and authenticate
+    before running the context workload.
     """
     multiprocessing.current_process().name = f"ctx-{spec.context_index}"
     Timer._stats.clear()
@@ -1256,8 +1252,9 @@ def run_case_contexts(
     if case.parallel_contexts == 1:
         results = [context_worker(specs[0])]
     else:
-        with relayed_worker_logs() as log_queue:
-            with multiprocessing.Pool(
+        process_context = multiprocessing.get_context("spawn")
+        with relayed_worker_logs(process_context) as log_queue:
+            with process_context.Pool(
                 case.parallel_contexts,
                 initializer=init_worker_logging,
                 initargs=(log_queue, logging.getLogger().getEffectiveLevel()),

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -8,7 +8,7 @@ import requests_mock
 import neuracore as nc
 from neuracore.api import core as api_core
 from neuracore.core import robot as core_robot
-from neuracore.core.auth import get_auth
+from neuracore.core.auth import Auth, get_auth
 from neuracore.core.const import API_URL
 from neuracore.core.exceptions import AuthenticationError, VersionMismatchError
 
@@ -52,14 +52,47 @@ def test_logout(temp_config_dir, monkeypatch):
     with open(config_file, "w") as f:
         json.dump({"api_key": "test_key", "current_org_id": "test-org-id"}, f)
 
-    # Perform logout
-    nc.logout()
+    logout_listener = Mock()
+    auth = get_auth()
+    auth.add_listener(Auth.LOGOUT_EVENT, logout_listener)
+
+    try:
+        # Perform logout
+        nc.logout()
+    finally:
+        auth.remove_listener(Auth.LOGOUT_EVENT, logout_listener)
+
+    logout_listener.assert_called_once_with()
 
     # Verify config contents
     with open(config_file) as f:
         config = json.load(f)
         assert config["api_key"] is None
         assert config["current_org_id"] is None
+
+
+def test_logout_resets_global_state_when_listener_raises(temp_config_dir):
+    """A failing teardown listener must not leave stale public API state."""
+    global_state = api_core.GlobalSingleton()
+    global_state._active_robot = Mock()
+    global_state._active_dataset_id = "dataset-id"
+    global_state._active_dataset = Mock()
+    global_state._has_validated_version = True
+
+    auth = get_auth()
+    failing_listener = Mock(side_effect=RuntimeError("teardown failed"))
+    auth.add_listener(Auth.LOGOUT_EVENT, failing_listener)
+
+    try:
+        with pytest.raises(RuntimeError, match="teardown failed"):
+            nc.logout()
+    finally:
+        auth.remove_listener(Auth.LOGOUT_EVENT, failing_listener)
+
+    assert global_state._active_robot is None
+    assert global_state._active_dataset_id is None
+    assert global_state._active_dataset is None
+    assert global_state._has_validated_version is False
 
 
 def test_auth_instance_singleton():

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -1,0 +1,295 @@
+"""Tests for root streaming teardown after an explicit logout event."""
+
+import asyncio
+import threading
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+from neuracore_types import RobotInstanceIdentifier
+from pyee import EventEmitter
+
+from neuracore.core.auth import Auth
+from neuracore.core.exceptions import AuthenticationError
+from neuracore.core.streaming import recording_state_manager as recording_module
+from neuracore.core.streaming.p2p.consumer import org_nodes_manager as org_module
+from neuracore.core.streaming.p2p.consumer.org_nodes_manager import OrgNodesManager
+from neuracore.core.streaming.p2p.enabled_manager import EnabledManager
+from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
+    StreamManagerOrchestrator,
+)
+from neuracore.core.streaming.recording_state_manager import (
+    RecordingStateManager,
+    TrackedRecording,
+)
+from neuracore.core.utils.singleton_metaclass import SingletonMetaclass
+
+
+class FakeAuth(EventEmitter):
+    """Minimal auth emitter used to isolate logout behavior."""
+
+    def get_headers(self) -> dict[str, str]:
+        return {}
+
+
+class UnauthenticatedAuth(FakeAuth):
+    """Auth double that reproduces a post-logout header request."""
+
+    def get_headers(self) -> dict[str, str]:
+        raise AuthenticationError("Not authenticated")
+
+
+class FakeSession:
+    """Client session double whose asynchronous closure can be observed."""
+
+    def __init__(self) -> None:
+        self.closed_event = threading.Event()
+
+    async def close(self) -> None:
+        self.closed_event.set()
+
+
+class UnauthorizedEventSource:
+    """SSE source double matching aiohttp-sse-client's HTTP 401 exception."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self):
+        raise ConnectionRefusedError("fetch https://stream.test failed: 401")
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        pass
+
+
+@pytest.fixture
+def nc_loop():
+    """Run a dedicated streaming loop on a background thread."""
+    loop = asyncio.new_event_loop()
+    stopped = threading.Event()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+        loop.close()
+        stopped.set()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    stopped.wait(timeout=2)
+
+
+def test_stream_orchestrator_tears_down_and_can_be_recreated(nc_loop) -> None:
+    auth = FakeAuth()
+    session = FakeSession()
+    replacement_session = FakeSession()
+    signalling_consumer = MagicMock()
+    provider_manager = MagicMock()
+    consumer_manager = MagicMock()
+
+    with (
+        patch.dict(SingletonMetaclass._instances, {}, clear=True),
+        patch(
+            "neuracore.core.streaming.p2p.stream_manager_orchestrator."
+            "SignallingEventsConsumer",
+            return_value=signalling_consumer,
+        ),
+        patch(
+            "neuracore.core.streaming.p2p.stream_manager_orchestrator.ClientSession",
+            side_effect=[session, replacement_session],
+        ),
+    ):
+        manager = StreamManagerOrchestrator(
+            org_id="org-1",
+            loop=nc_loop,
+            auth=auth,
+        )
+        manager.provider_managers[MagicMock()] = provider_manager
+        manager.consumer_managers[MagicMock()] = consumer_manager
+
+        auth.emit(Auth.LOGOUT_EVENT)
+
+        replacement = StreamManagerOrchestrator(
+            org_id="org-1",
+            loop=nc_loop,
+            auth=auth,
+        )
+        assert replacement is not manager
+
+        assert session.closed_event.wait(timeout=2)
+        signalling_consumer.close.assert_called_once_with()
+        provider_manager.close.assert_called_once_with()
+        consumer_manager.close.assert_called_once_with()
+        assert manager._logout_listener not in auth.listeners(Auth.LOGOUT_EVENT)
+        assert replacement._logout_listener in auth.listeners(Auth.LOGOUT_EVENT)
+
+        nc_loop.call_soon_threadsafe(replacement.close)
+        assert replacement_session.closed_event.wait(timeout=2)
+        assert auth.listeners(Auth.LOGOUT_EVENT) == []
+
+
+def test_org_nodes_manager_tears_down(nc_loop) -> None:
+    auth = FakeAuth()
+    session = FakeSession()
+    enabled = EnabledManager(True, loop=nc_loop)
+    consumer = MagicMock()
+    with patch(
+        "neuracore.core.streaming.base_sse_consumer.ClientSession",
+        return_value=session,
+    ):
+        manager = OrgNodesManager(
+            org_id="org-1",
+            loop=nc_loop,
+            enabled_manager=enabled,
+            auth=auth,
+            stream_manager_orchestrator=MagicMock(),
+        )
+    manager.consumers[MagicMock()] = consumer
+    manager.connections[MagicMock()]["stream"] = ("connection", 1)
+
+    manager_future: Future[OrgNodesManager] = Future()
+    manager_future.set_result(manager)
+    org_module._org_node_managers[manager.org_id] = manager_future
+
+    auth.emit(Auth.LOGOUT_EVENT)
+    assert manager.org_id not in org_module._org_node_managers
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0), nc_loop).result(timeout=2)
+
+    assert enabled.is_disabled()
+    assert manager.signalling_stream_future.cancelled()
+    assert session.closed_event.wait(timeout=2)
+    consumer.close.assert_called_once_with()
+    assert manager.connections == {}
+    assert auth.listeners(Auth.LOGOUT_EVENT) == []
+
+
+def test_sse_consumer_stops_on_authentication_error(nc_loop, caplog) -> None:
+    auth = UnauthenticatedAuth()
+    session = FakeSession()
+    enabled = EnabledManager(True, loop=nc_loop)
+    with patch(
+        "neuracore.core.streaming.base_sse_consumer.ClientSession",
+        return_value=session,
+    ):
+        manager = OrgNodesManager(
+            org_id="org-1",
+            loop=nc_loop,
+            enabled_manager=enabled,
+            auth=auth,
+            stream_manager_orchestrator=MagicMock(),
+        )
+
+    async def wait_until_disabled() -> None:
+        for _ in range(100):
+            if enabled.is_disabled():
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("SSE consumer did not stop after authentication failure")
+
+    asyncio.run_coroutine_threadsafe(wait_until_disabled(), nc_loop).result(timeout=2)
+
+    assert manager.signalling_stream_future.cancelled()
+    assert session.closed_event.wait(timeout=2)
+    assert not any(
+        "Streaming signalling error" in record.message for record in caplog.records
+    )
+
+
+def test_signalling_http_401_tears_down_orchestrator(nc_loop, caplog) -> None:
+    auth = FakeAuth()
+    session = FakeSession()
+    enabled = EnabledManager(True, loop=nc_loop)
+
+    with (
+        patch.dict(SingletonMetaclass._instances, {}, clear=True),
+        patch.object(EnabledManager, "any_enabled", return_value=enabled),
+        patch(
+            "neuracore.core.streaming.p2p.stream_manager_orchestrator.ClientSession",
+            return_value=session,
+        ),
+        patch(
+            "neuracore.core.streaming.base_sse_consumer.EventSource",
+            UnauthorizedEventSource,
+        ),
+    ):
+        manager = StreamManagerOrchestrator(
+            org_id="org-1",
+            loop=nc_loop,
+            auth=auth,
+        )
+
+        assert session.closed_event.wait(timeout=2)
+        assert manager._closed
+        assert manager._logout_listener not in auth.listeners(Auth.LOGOUT_EVENT)
+        assert SingletonMetaclass._instances.get(StreamManagerOrchestrator) is None
+
+    assert not any(
+        "Streaming signalling error" in record.message for record in caplog.records
+    )
+
+
+def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
+    auth = FakeAuth()
+    session = FakeSession()
+    enabled = EnabledManager(True, loop=nc_loop)
+    with patch(
+        "neuracore.core.streaming.base_sse_consumer.ClientSession",
+        return_value=session,
+    ):
+        manager = RecordingStateManager(
+            org_id="org-1",
+            loop=nc_loop,
+            enabled_manager=enabled,
+            auth=auth,
+        )
+
+    key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
+    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
+    manager.active_dataset_ids[key] = "dataset-1"
+    manager._drain_callbacks[key] = MagicMock()
+    timer = MagicMock()
+    manager._recording_timers["recording-1"] = [timer]
+
+    manager_future: Future[RecordingStateManager] = Future()
+    manager_future.set_result(manager)
+    recording_module._recording_manager = manager_future
+
+    auth.emit(Auth.LOGOUT_EVENT)
+    assert recording_module._recording_manager is None
+
+    assert session.closed_event.wait(timeout=2)
+    assert enabled.is_disabled()
+    assert manager.signalling_stream_future.cancelled()
+    timer.cancel.assert_called_once_with()
+    assert manager.recording_robot_instances == {}
+    assert manager.active_dataset_ids == {}
+    assert manager._drain_callbacks == {}
+    assert auth.listeners(Auth.LOGOUT_EVENT) == []
+
+    auth.emit(Auth.LOGOUT_EVENT)
+
+
+@pytest.mark.parametrize(
+    "manager_type",
+    [StreamManagerOrchestrator, OrgNodesManager, RecordingStateManager],
+)
+def test_closed_loop_logout_does_not_leak_listener(manager_type) -> None:
+    """One-shot listeners detach even when their manager loop is already closed."""
+    auth = FakeAuth()
+    manager = object.__new__(manager_type)
+    manager.auth = auth
+    manager.loop = MagicMock()
+    manager.loop.is_closed.return_value = True
+
+    if hasattr(manager, "_discard_cached_manager"):
+        manager._discard_cached_manager = MagicMock()
+
+    manager._logout_listener = manager._on_logout
+    auth.once(Auth.LOGOUT_EVENT, manager._logout_listener)
+
+    auth.emit(Auth.LOGOUT_EVENT)
+
+    assert auth.listeners(Auth.LOGOUT_EVENT) == []
+    manager.loop.call_soon_threadsafe.assert_not_called()

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -73,3 +73,24 @@ def test_stop_all_streams_logs_stop_failure_and_continues() -> None:
 
     assert failing.stop_calls == 1
     assert active.stop_calls == 1
+
+
+def test_close_uses_registered_manager_without_creating_another() -> None:
+    """Post-logout cleanup must not recreate the global recording manager."""
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+    manager = MagicMock()
+
+    with patch(
+        "neuracore.core.robot.get_recording_state_manager", return_value=manager
+    ):
+        robot._register_remote_stop_handler()
+
+    with patch(
+        "neuracore.core.robot.get_recording_state_manager",
+        side_effect=AssertionError("must not create a manager during close"),
+    ):
+        robot.close()
+
+    manager.deregister_remote_stop_handler.assert_called_once_with("robot-id-1", 0)
+    assert robot._recording_state_manager is None


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - None

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Created a logout event so that managers can tear down after logout without causing auth error.
 - Auth errors now propagate up the workers to tear down the manager/resource instead of retying indefiitely.
 - Robot now gets initalised with recording state manager so when it tears down it closes that as opposed to a new one which might have juts been initalised.