### PR TITLE
fix: late sse restart daemon

### DIFF
--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -137,6 +137,9 @@ class RecordingStateManager(BaseSSEConsumer):
         self.recording_robot_instances: dict[
             RobotInstanceIdentifier, TrackedRecording
         ] = dict()
+        # Newest completed recording start time for each source. This lets us
+        # recognize its delayed SSE START after the active entry has been removed.
+        self._completed_start_time_watermarks: dict[RobotInstanceIdentifier, float] = {}
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
@@ -178,6 +181,7 @@ class RecordingStateManager(BaseSSEConsumer):
                     handle.cancel()
             self._recording_timers.clear()
             self.recording_robot_instances.clear()
+            self._completed_start_time_watermarks.clear()
             self._expired_recording_ids.clear()
             self.active_dataset_ids.clear()
             self._drain_callbacks.clear()
@@ -417,6 +421,11 @@ class RecordingStateManager(BaseSSEConsumer):
             if current is None or current.recording_id != recording_id:
                 return
             self.recording_robot_instances.pop(instance_key, None)
+            # Never move the completed-recording boundary backward if stops
+            # arrive out of order.
+            watermark = self._completed_start_time_watermarks.get(instance_key)
+            if watermark is None or current.start_time > watermark:
+                self._completed_start_time_watermarks[instance_key] = current.start_time
         # Data-bridge stop is driven by the recording context or expiry timer —
         # not here — so the daemon gets exactly one StopRecording with the
         # correct data-clock boundary.
@@ -432,17 +441,29 @@ class RecordingStateManager(BaseSSEConsumer):
         appropriate start/stop methods if the state actually changed.
 
         Runs under :attr:`_state_lock` so each decision and the state change it
-        implies are atomic against a concurrent local start or stop. Blocking
-        work is done before the lock is taken.
+        implies are atomic against a concurrent local start or stop. Daemon
+        startup is performed after the lock is released.
 
         Args:
             is_recording: Whether the robot should be recording
             details: Recording details including robot ID, instance, and recording ID
         """
-        if is_recording and details.robot_id == self._connected_robot_id:
-            self._ensure_daemon_for_recording()
+        instance_key = RobotInstanceIdentifier(
+            robot_id=details.robot_id, robot_instance=details.instance
+        )
         with self._state_lock:
             self._apply_recording_notification(is_recording, details)
+            active = self.recording_robot_instances.get(instance_key)
+            # Rejected stale or foreign STARTs do not become the active recording
+            # and therefore must not auto-start a replacement daemon.
+            should_ensure_daemon = (
+                is_recording
+                and details.robot_id == self._connected_robot_id
+                and active is not None
+                and active.recording_id == details.recording_id
+            )
+        if should_ensure_daemon:
+            self._ensure_daemon_for_recording()
 
     def _apply_recording_notification(
         self, is_recording: bool, details: BaseRecodingUpdatePayload
@@ -470,6 +491,26 @@ class RecordingStateManager(BaseSSEConsumer):
             # Only react to the robot this client connected to, not other
             # robots in the org that may be recording concurrently.
             if robot_id != self._connected_robot_id:
+                return
+
+            completed_start_watermark = self._completed_start_time_watermarks.get(
+                instance_key
+            )
+            # A local stop may beat its matching SSE START; timestamps identify
+            # it even when the local and cloud recording IDs differ.
+            if (
+                completed_start_watermark is not None
+                and details.start_time
+                <= completed_start_watermark + STALE_START_TOLERANCE_S
+            ):
+                logger.debug(
+                    "ignoring delayed recording start notification: "
+                    "recording_id=%s start_time=%s is not newer than completed "
+                    "start_time=%s",
+                    recording_id,
+                    details.start_time,
+                    completed_start_watermark,
+                )
                 return
 
             # A START describing a recording that began before the tracked one
@@ -502,7 +543,6 @@ class RecordingStateManager(BaseSSEConsumer):
                 dataset_id,
                 recording_id,
             )
-
             # Only open the window if no one else has already.
             opened_locally = previous is not None and previous.opened_locally
             if not opened_locally:

--- a/tests/unit/core/p2p/test_recording_state_manager.py
+++ b/tests/unit/core/p2p/test_recording_state_manager.py
@@ -1,0 +1,85 @@
+"""Focused tests for recording notification ordering."""
+
+import threading
+from unittest.mock import MagicMock
+
+from neuracore_types import RecordingStartPayload, RobotInstanceIdentifier
+
+from neuracore.core.streaming.recording_state_manager import (
+    RecordingStateManager,
+    TrackedRecording,
+)
+
+
+def _manager() -> RecordingStateManager:
+    """Build the state-only portion of a manager without opening an SSE stream."""
+    manager = RecordingStateManager.__new__(RecordingStateManager)
+    manager._connected_robot_id = "robot-1"
+    manager._state_lock = threading.RLock()
+    manager.recording_robot_instances = {}
+    manager._completed_start_time_watermarks = {}
+    manager._expired_recording_ids = set()
+    manager._recording_timers = {}
+    manager.active_dataset_ids = {}
+    manager._drain_callbacks = {}
+    manager._start_callbacks = {}
+    manager._cancel_recording_timers = MagicMock()
+    manager._schedule_recording_timers = MagicMock()
+    manager._ensure_daemon_for_recording = MagicMock()
+    return manager
+
+
+def _start_payload(*, recording_id: str, start_time: float) -> RecordingStartPayload:
+    return RecordingStartPayload(
+        recording_id=recording_id,
+        robot_id="robot-1",
+        instance=0,
+        created_by="test",
+        dataset_ids=["dataset-1"],
+        data_types=set(),
+        start_time=start_time,
+    )
+
+
+def test_delayed_start_after_local_stop_does_not_restart_daemon() -> None:
+    manager = _manager()
+    source = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
+    manager.recording_robot_instances[source] = TrackedRecording(
+        recording_id="local-handle",
+        start_time=100.0,
+        opened_locally=True,
+    )
+
+    manager.recording_stopped("robot-1", 0, "local-handle")
+    manager.updated_recording_state(
+        True,
+        _start_payload(recording_id="cloud-id", start_time=100.0),
+    )
+
+    assert source not in manager.recording_robot_instances
+    assert source not in manager.active_dataset_ids
+    manager._ensure_daemon_for_recording.assert_not_called()
+
+
+def test_newer_start_after_local_stop_is_applied_and_starts_daemon() -> None:
+    manager = _manager()
+    source = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
+    manager.recording_robot_instances[source] = TrackedRecording(
+        recording_id="first-recording",
+        start_time=100.0,
+        opened_locally=True,
+    )
+    manager.recording_stopped("robot-1", 0, "first-recording")
+
+    manager.updated_recording_state(
+        True,
+        _start_payload(recording_id="second-recording", start_time=101.0),
+    )
+
+    assert manager.recording_robot_instances[source] == TrackedRecording(
+        recording_id="second-recording",
+        start_time=101.0,
+        opened_locally=True,
+    )
+    assert manager.active_dataset_ids[source] == "dataset-1"
+    manager._ensure_daemon_for_recording.assert_called_once_with()


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Late SSE start events could restart the data daemon causing flaky issues in tests with the error 'AssertionError: Producer/runner sub processes still alive after test — PIDs: [26886]'.
 - The fix is to keep track of the start times for stopped recordings, so if we receive a notification update from an SSE, we can can compare the start times of that SSE against the start time we have for a stopped recordings, and if the start time coming from the SSE is the same (or earlier) then we ignore it as it is a duplicate late arrival of an already received local stop. 
