### PR TITLE
fix: make the daemon the sole authority on whether data is written

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -285,6 +285,7 @@ mcap
 MCAP
 meanpooling
 memfd
+memoryview
 meshgrid
 metadatas
 metafunc

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -226,7 +226,8 @@ def _record_json_to_daemon(
     ``log_json`` entry point is datatype-agnostic, so adding a new JSON type
     needs no daemon-side change.
 
-    A no-op unless a recording is in progress.
+    Always forwarded; the daemon is the one that decides whether a recording
+    is in progress and drops the sample if not.
 
     Args:
         robot: Robot instance owning the daemon recording context.
@@ -235,12 +236,9 @@ def _record_json_to_daemon(
         data: Data object to serialize and persist.
         timestamp: Capture timestamp in seconds.
     """
-    if robot.get_current_recording_id() is None:
-        return
+    context = robot._get_daemon_recording_context()
     payload = json.dumps(data.model_dump(mode="json")).encode("utf-8")
-    robot._get_daemon_recording_context().log_json(
-        data_type.value, storage_name, payload, timestamp
-    )
+    context.log_json(data_type.value, storage_name, payload, timestamp)
 
 
 def _publish_video_to_p2p(
@@ -386,7 +384,10 @@ def _log_group_of_joint_data(
     if bindings_for_type is None:
         bindings_for_type = {}
         binding_cache[data_type] = bindings_for_type
+    # The bucket/live streams key off this process's own recording handle; the
+    # daemon decides for itself, from the same call, whether it's recording.
     current_recording_id = robot.get_current_recording_id()
+    daemon_context = robot._get_daemon_recording_context()
     live_data_disabled = get_provide_live_data_enabled_manager().is_disabled()
     robot_id = robot.id
     robot_instance = robot.instance
@@ -406,10 +407,9 @@ def _log_group_of_joint_data(
         native_values = list(joint_data.values())
         for binding, joint_value in zip(group.bindings, native_values):
             binding.stream.record_scalar(timestamp, joint_value)
-        if current_recording_id is not None:
-            robot._get_daemon_recording_context().log_joints(
-                data_type.value, timestamp, group.joined_names, native_values
-            )
+        daemon_context.log_joints(
+            data_type.value, timestamp, group.joined_names, native_values
+        )
         return
 
     native_values = []
@@ -433,11 +433,10 @@ def _log_group_of_joint_data(
             # allocation-free (see JointDataStream).
             binding.stream.record_scalar(timestamp, joint_value)
 
-        if current_recording_id is not None:
-            native_values.append(joint_value)
+        native_values.append(joint_value)
 
     if native_values:
-        robot._get_daemon_recording_context().log_joints(
+        daemon_context.log_joints(
             data_type.value, timestamp, group.joined_names, native_values
         )
 
@@ -532,17 +531,19 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
-        contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
-        robot._get_daemon_recording_context().log_frame(
-            camera_type.value,
-            storage_name,
-            int(image.shape[1]),
-            int(image.shape[0]),
-            image.dtype.name,
-            memoryview(contiguous).cast("B"),
-            camera_data_without_frame.timestamp,
-        )
+    # The daemon decides whether this lands in a recording, not this process —
+    # always forward and let it route by window.
+    context = robot._get_daemon_recording_context()
+    contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
+    context.log_frame(
+        camera_type.value,
+        storage_name,
+        int(image.shape[1]),
+        int(image.shape[0]),
+        image.dtype.name,
+        memoryview(contiguous).cast("B"),
+        camera_data_without_frame.timestamp,
+    )
 
     _publish_video_to_p2p(robot, name, camera_type, camera_data_without_frame, image)
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -770,6 +770,7 @@ class Robot:
         if self._daemon_recording_context is None:
             return
         try:
+            self._daemon_recording_context.flush_source()
             self._daemon_recording_context.close()
         except Exception:
             logger.exception("Failed to cleanup daemon recording context")

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -256,6 +256,11 @@ class RecordingContext:
         window. ``timestamp`` is the recording's *capture* stop time and is
         separate from that boundary, never used for window membership.
 
+        Any producer may stop a recording, whether or not it opened the window.
+        The stop names the window it means, so several processes stopping the same
+        recording — which one web-initiated stop causes — cannot end up closing a
+        later one.
+
         This publishes the stop only; :meth:`flush_source` seals the writer's
         tail chunks and must be called straight after, so the caller can close
         its own logging gate in between.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -479,6 +479,7 @@ fn run_daemon(
             listener::run(
                 transport,
                 dispatcher_tx.clone(),
+                dispatcher_handle.window_query_tx.clone(),
                 Arc::new(state_store.clone()),
                 shutdown_tx.subscribe(),
             )

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -20,17 +20,18 @@ use std::time::Duration;
 
 use data_daemon_shared::{
     Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, VersionReply,
-    VersionRequest,
+    VersionRequest, WindowStartedAtQuery, WindowStartedAtReply,
 };
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::ipc;
 use tokio::select;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::time::sleep;
 
 use crate::ipc::node::IpcTransport;
 use crate::lifecycle::shutdown::ShutdownSignal;
+use crate::pipeline::dispatcher::WindowQuery;
 use crate::state::{SqliteStateStore, StateStore};
 
 /// Poll cadence while envelopes are actively flowing.
@@ -69,6 +70,7 @@ const IDLE_POLL_AFTER_EMPTY: u32 = 64;
 pub async fn run(
     transport: IpcTransport,
     dispatcher_tx: mpsc::Sender<Envelope>,
+    window_query_tx: mpsc::Sender<WindowQuery>,
     store: Arc<SqliteStateStore>,
     mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) {
@@ -77,6 +79,7 @@ pub async fn run(
         recording_ids = data_daemon_shared::service_name::RECORDING_IDS,
         health = data_daemon_shared::service_name::HEALTH,
         version = data_daemon_shared::service_name::VERSION,
+        window_started_at = data_daemon_shared::service_name::WINDOW_STARTED_AT,
         "ipc listener started"
     );
 
@@ -129,6 +132,14 @@ pub async fn run(
         // borrow makes this future `!Send`, which is fine: `run` is awaited
         // inline under `block_on`, never `tokio::spawn`'d.
         serve_recording_id_queries(transport.recording_id_server(), &store).await;
+
+        // -- Answer window-started-at queries ------------------------------------
+        // Only a non-owning producer asks: the opener already knows its own
+        // window's boundary first-hand. Forwarded to the dispatcher (the only
+        // holder of live window state) via a oneshot, since a window's
+        // `started_at_ns` is never persisted.
+        serve_window_started_at_queries(transport.window_started_at_server(), &window_query_tx)
+            .await;
 
         // -- Yield / shutdown ---------------------------------------------------
         // Poll fast while data is flowing; relax once the bus has been empty
@@ -294,6 +305,77 @@ async fn serve_recording_id_queries(
                 Err(error) => tracing::warn!(%error, "failed to loan recording-id reply sample"),
             },
             Err(error) => tracing::warn!(%error, "failed to encode recording-id reply"),
+        }
+    }
+}
+
+/// Drain every pending window-started-at query, answering each from the
+/// dispatcher's live window state.
+///
+/// Unlike [`serve_recording_id_queries`], this cannot answer from the store —
+/// a window's `started_at_ns` (the publish-clock boundary) is never persisted,
+/// only the caller's capture clock is. So each request is forwarded into the
+/// dispatcher's `window_query_tx` with a fresh oneshot reply channel and
+/// awaited before answering the iceoryx2 client. Traffic is low (one ask per
+/// non-owning `stop_recording()` call), so a request that outlives the
+/// dispatcher's inbox capacity or never gets a reply (e.g. the dispatcher is
+/// mid-shutdown) is logged and skipped rather than blocking the listener loop.
+async fn serve_window_started_at_queries(
+    server: &Server<ipc::Service, [u8], (), [u8], ()>,
+    window_query_tx: &mpsc::Sender<WindowQuery>,
+) {
+    loop {
+        let active = match server.receive() {
+            Ok(Some(active)) => active,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(%error, "window-started-at server receive failed");
+                return;
+            }
+        };
+
+        let query = match WindowStartedAtQuery::decode(active.payload()) {
+            Ok(query) => query,
+            Err(error) => {
+                tracing::warn!(%error, "dropping malformed window-started-at query");
+                continue;
+            }
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if window_query_tx
+            .send(WindowQuery {
+                source: (query.robot_id.clone(), query.robot_instance),
+                reply: reply_tx,
+            })
+            .await
+            .is_err()
+        {
+            tracing::warn!("dispatcher window-query inbox closed; dropping request");
+            continue;
+        }
+        let started_at_ns = match reply_rx.await {
+            Ok(started_at_ns) => started_at_ns,
+            Err(error) => {
+                tracing::warn!(%error, "dispatcher dropped window-query reply");
+                None
+            }
+        };
+
+        let reply = WindowStartedAtReply { started_at_ns };
+        match reply.encode() {
+            Ok(bytes) => match active.loan_slice_uninit(bytes.len()) {
+                Ok(response) => {
+                    let response = response.write_from_slice(&bytes);
+                    if let Err(error) = response.send() {
+                        tracing::warn!(%error, "failed to send window-started-at reply");
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "failed to loan window-started-at reply sample")
+                }
+            },
+            Err(error) => tracing::warn!(%error, "failed to encode window-started-at reply"),
         }
     }
 }

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -14,7 +14,8 @@ use data_daemon_shared::service_name::{
     COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
     MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
-    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
+    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES, WINDOW_STARTED_AT,
+    WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
 use iceoryx2::port::server::Server;
@@ -106,6 +107,12 @@ pub struct IpcTransport {
     version_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the version server.
     _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response server on `neuracore/data_daemon/window_started_at`
+    /// that answers a non-owning producer's ask for the live window's
+    /// `started_at_ns`, so its stop can name the window it means.
+    window_started_at_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the window-started-at server.
+    _window_started_at_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
 }
 
 impl IpcTransport {
@@ -135,6 +142,11 @@ impl IpcTransport {
             open_query_server(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
         let (version_service, version_server) =
             open_query_server(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
+        let (window_started_at_service, window_started_at_server) = open_query_server(
+            &node,
+            WINDOW_STARTED_AT,
+            WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+        )?;
 
         Ok(IpcTransport {
             _node: node,
@@ -146,6 +158,8 @@ impl IpcTransport {
             _health_service: health_service,
             version_server,
             _version_service: version_service,
+            window_started_at_server,
+            _window_started_at_service: window_started_at_service,
         })
     }
 
@@ -167,6 +181,11 @@ impl IpcTransport {
     /// Borrow the `version` request-response server port.
     pub fn version_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
         &self.version_server
+    }
+
+    /// Borrow the `window_started_at` request-response server port.
+    pub fn window_started_at_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.window_started_at_server
     }
 }
 

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -52,7 +52,7 @@ use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use uuid::Uuid;
@@ -107,6 +107,19 @@ const DISPATCHER_INBOX_CAPACITY: usize = 1024;
 /// Source identity: `(robot_id, robot_instance)`.
 type Source = (String, i64);
 
+/// A producer's ask for the currently live window's `started_at_ns` boundary
+/// for a source, sent alongside the dispatcher's regular `Envelope` inbox
+/// (not through it: this carries a reply channel, which `Envelope` — postcard
+/// wire-encoded — cannot).
+pub(crate) struct WindowQuery {
+    pub(crate) source: Source,
+    pub(crate) reply: oneshot::Sender<Option<i64>>,
+}
+
+/// Bounded producer → dispatcher window-query channel. Low volume (one ask per
+/// non-owning `stop_recording()` call), so a small buffer is ample.
+const WINDOW_QUERY_INBOX_CAPACITY: usize = 64;
+
 /// Resolve the configured holdback, honouring the `NCD_HOLDBACK_MS` override.
 fn configured_holdback() -> Duration {
     let millis = std::env::var(HOLDBACK_ENV)
@@ -120,6 +133,9 @@ fn configured_holdback() -> Duration {
 /// per-trace actor.
 pub struct DispatcherHandle {
     join: JoinHandle<()>,
+    /// Sender a producer's `window_started_at` query is forwarded through; the
+    /// listener clones this to reach the dispatcher's live window state.
+    pub window_query_tx: mpsc::Sender<WindowQuery>,
 }
 
 impl DispatcherHandle {
@@ -169,11 +185,19 @@ pub fn spawn_with_context(
     shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) -> (mpsc::Sender<Envelope>, DispatcherHandle) {
     let (tx, rx) = mpsc::channel::<Envelope>(DISPATCHER_INBOX_CAPACITY);
+    let (window_query_tx, window_query_rx) =
+        mpsc::channel::<WindowQuery>(WINDOW_QUERY_INBOX_CAPACITY);
     let join = tokio::spawn(async move {
         let mut dispatcher = Dispatcher::new(store, actor_context, context);
-        dispatcher.run(rx, shutdown_rx).await;
+        dispatcher.run(rx, window_query_rx, shutdown_rx).await;
     });
-    (tx, DispatcherHandle { join })
+    (
+        tx,
+        DispatcherHandle {
+            join,
+            window_query_tx,
+        },
+    )
 }
 
 /// A per-trace actor's routing handle, stored inside its window.
@@ -352,9 +376,25 @@ impl Dispatcher {
         }
     }
 
+    /// Answer a producer's ask for the currently live window's boundary.
+    ///
+    /// Only a non-owning producer needs this — the opener already knows its
+    /// own window's `started_at_ns` first-hand. Answered straight from
+    /// in-memory state: `started_at_ns` is never persisted (only the caller's
+    /// capture clock is stored on the recording row).
+    fn handle_window_query(&self, query: WindowQuery) {
+        let started_at_ns = self
+            .windows
+            .get(&query.source)
+            .and_then(|entry| entry.live.as_ref())
+            .map(|window| window.started_at_ns);
+        let _ = query.reply.send(started_at_ns);
+    }
+
     async fn run(
         &mut self,
         mut rx: mpsc::Receiver<Envelope>,
+        mut window_query_rx: mpsc::Receiver<WindowQuery>,
         mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
     ) {
         tracing::info!(
@@ -383,6 +423,11 @@ impl Dispatcher {
                         break;
                     };
                     self.handle_inbound(envelope, Instant::now()).await;
+                }
+                query = window_query_rx.recv() => {
+                    if let Some(query) = query {
+                        self.handle_window_query(query);
+                    }
                 }
                 _ = sleep(housekeep_after) => {}
             }
@@ -428,11 +473,13 @@ impl Dispatcher {
                 robot_instance,
                 publish_timestamp_ns,
                 timestamp_ns,
+                window_started_at_ns,
             } => {
                 self.handle_stop(
                     (robot_id, robot_instance),
                     publish_timestamp_ns,
                     timestamp_ns,
+                    window_started_at_ns,
                     recv_at,
                 )
                 .await;
@@ -666,7 +713,7 @@ impl Dispatcher {
         };
         tracing::info!(recording_index, robot_id = source.0, "recording started");
 
-        let entry = self.windows.entry(source).or_default();
+        let entry = self.windows.entry(source.clone()).or_default();
         entry.last_seen = Some(recv_at);
         // An idle-reaped window sits in `closing` with an open upper bound
         // (`i64::MAX`) to catch stragglers; clamp any such window to this new
@@ -761,6 +808,7 @@ impl Dispatcher {
         source: Source,
         publish_timestamp_ns: i64,
         timestamp_ns: i64,
+        window_started_at_ns: Option<i64>,
         recv_at: Instant,
     ) {
         let Some(entry) = self.windows.get_mut(&source) else {
@@ -769,17 +817,62 @@ impl Dispatcher {
         };
         entry.last_seen = Some(recv_at);
 
+        // A stop that names its window is matched on that boundary, not on when
+        // it happened to be sent. Any producer may stop a recording, so one
+        // web-initiated stop reaches the daemon once per process that connected
+        // to the robot; without the name, a duplicate delayed behind its own
+        // flush barrier is stamped late enough to look like a stop for whatever
+        // recording is live by then, and ends that one instead.
+        if let Some(named) = window_started_at_ns {
+            let names_live = entry
+                .live
+                .as_ref()
+                .is_some_and(|window| window.started_at_ns == named);
+            if !names_live {
+                let already_stopped = entry
+                    .closing
+                    .iter()
+                    .any(|window| window.started_at_ns == named && window.awaiting_flush);
+                if already_stopped {
+                    // A second stop for a window a producer already stopped. Its
+                    // tail is sealed by its own flush marker, so there is nothing
+                    // left for this to do.
+                    tracing::debug!(
+                        robot_id = source.0,
+                        named,
+                        "duplicate stop for an already-stopped window; ignoring"
+                    );
+                    return;
+                }
+                if !entry
+                    .closing
+                    .iter()
+                    .any(|window| window.started_at_ns == named)
+                {
+                    tracing::debug!(
+                        robot_id = source.0,
+                        named,
+                        "stop names a window that is no longer retained; ignoring"
+                    );
+                    return;
+                }
+                // Falls through to the closing-window path: a genuine late stop
+                // for a window `handle_start` retired without one.
+            }
+        }
+
         // A stop whose publish time falls inside the live window closes the live
         // recording normally. A stop that predates the live window is a delayed
         // stop for a recording `handle_start` already retired (an inverted
         // start/stop pair) — it is matched against the closing windows instead.
         // Both paths converge on the shared post-persist tail below, so a
         // retired recording also becomes notifiable (fires `RecordingStopped`).
-        let recording_index = if entry
-            .live
-            .as_ref()
-            .is_some_and(|window| window.contains(publish_timestamp_ns))
-        {
+        let recording_index = if entry.live.as_ref().is_some_and(
+            |window| match window_started_at_ns {
+                Some(named) => window.started_at_ns == named,
+                None => window.contains(publish_timestamp_ns),
+            },
+        ) {
             let mut window = entry
                 .live
                 .take()
@@ -1532,6 +1625,18 @@ mod tests {
             robot_instance: 0,
             publish_timestamp_ns,
             timestamp_ns: publish_timestamp_ns,
+            window_started_at_ns: None,
+        }
+    }
+
+    /// A stop that names the window it means, as a real producer's does.
+    fn stop_naming(robot: &str, publish_timestamp_ns: i64, window_started_at_ns: i64) -> Envelope {
+        Envelope::StopRecording {
+            robot_id: robot.into(),
+            robot_instance: 0,
+            publish_timestamp_ns,
+            timestamp_ns: publish_timestamp_ns,
+            window_started_at_ns: Some(window_started_at_ns),
         }
     }
 
@@ -1734,6 +1839,110 @@ mod tests {
         let a: serde_json::Value =
             serde_json::from_slice(&std::fs::read(a_dir.join("trace.json")).unwrap()).unwrap();
         assert_eq!(a, serde_json::json!([{"i": 1}]));
+    }
+
+    #[tokio::test]
+    async fn a_stop_naming_an_earlier_window_never_closes_the_next_recording() {
+        // Any producer may stop a recording, so one web-initiated stop reaches
+        // the daemon once per process that connected to the robot. The duplicate
+        // is stamped at its own send, after its own flush barrier, so it can
+        // arrive stamped *inside* the next recording's window:
+        //   start(A, 100) -> stop(A, sent 200) -> start(B, 300)
+        //   -> stop(A, sent 400, still naming A) -> data(B, 450) -> stop(B, 500)
+        // Matched by publish time, that fourth envelope ends B. Matched by the
+        // window it names, it is a duplicate of A's stop and does nothing.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(8);
+        let (tx, handle) = spawn(store.clone(), context.clone(), shutdown_rx);
+
+        tx.send(start("robot-1", 100)).await.unwrap();
+        tx.send(stop_naming("robot-1", 200, 100)).await.unwrap();
+        tx.send(start("robot-1", 300)).await.unwrap();
+        tx.send(stop_naming("robot-1", 400, 100)).await.unwrap();
+        tx.send(datum("robot-1", 450, 1)).await.unwrap();
+        tx.send(stop_naming("robot-1", 500, 300)).await.unwrap();
+
+        drop(tx);
+        timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("dispatcher shut down in time");
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 2);
+        let second = &recordings[1];
+        // The datum is the proof B was still live at 450: had the duplicate
+        // closed B at 400, it would have fallen outside every window.
+        let traces = store
+            .list_traces_for_recording(second.recording_index)
+            .await
+            .unwrap();
+        assert_eq!(
+            traces.len(),
+            1,
+            "data published after the duplicate stop must still reach the live recording"
+        );
+        assert_eq!(
+            second.stop_timestamp_ns,
+            Some(500),
+            "B must be stopped by its own stop, not by a duplicate of A's"
+        );
+    }
+
+    #[tokio::test]
+    async fn window_query_answers_from_live_state_only() {
+        // A non-owning producer's stop_recording() asks this to learn what to
+        // name its stop. It must see the live window's boundary while one is
+        // open, and `None` before any window and after it closes — a closing
+        // (not-yet-evicted) window still accepts late data, but is not "live".
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let now = Instant::now();
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        dispatcher.handle_window_query(WindowQuery {
+            source: source.clone(),
+            reply: reply_tx,
+        });
+        assert_eq!(
+            reply_rx.await.unwrap(),
+            None,
+            "no window has ever opened for this source"
+        );
+
+        dispatcher
+            .handle_start(source.clone(), None, 100, 100, now)
+            .await;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        dispatcher.handle_window_query(WindowQuery {
+            source: source.clone(),
+            reply: reply_tx,
+        });
+        assert_eq!(
+            reply_rx.await.unwrap(),
+            Some(100),
+            "a live window answers its own started_at_ns"
+        );
+
+        dispatcher
+            .handle_stop(source.clone(), 200, 200, None, now)
+            .await;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        dispatcher.handle_window_query(WindowQuery {
+            source: source.clone(),
+            reply: reply_tx,
+        });
+        assert_eq!(
+            reply_rx.await.unwrap(),
+            None,
+            "a closed window is no longer live, even while retained for late data"
+        );
     }
 
     #[tokio::test]
@@ -2012,7 +2221,7 @@ mod tests {
             .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .handle_stop(source.clone(), stop_ns, stop_ns, None, opened_at)
             .await;
 
         let (publish_ts, thread_id) = (150, 7);
@@ -2056,7 +2265,7 @@ mod tests {
             .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
+            .handle_stop(source.clone(), stop_ns, stop_ns, None, opened_at)
             .await;
 
         let (publish_ts, thread_id) = (150, 7);
@@ -2345,7 +2554,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
         assert_eq!(
             dispatcher.windows.get(&source).unwrap().closing.len(),
@@ -2387,7 +2596,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // Well past the retention deadline.
@@ -2433,7 +2642,7 @@ mod tests {
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         let at_cap = stopped_at + FLUSH_MARKER_WAIT_CAP + Duration::from_millis(1);
@@ -2487,7 +2696,7 @@ mod tests {
 
         let stopped_at = opened_at + Duration::from_millis(2);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // The lifecycle process owns no video, so its marker lands at once.
@@ -2548,7 +2757,7 @@ mod tests {
             .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
-            .handle_stop(source.clone(), 200, 200, opened_at)
+            .handle_stop(source.clone(), 200, 200, None, opened_at)
             .await;
 
         // Published after the stop: past every window's upper bound.
@@ -2597,7 +2806,7 @@ mod tests {
 
         let stopped_at = opened_at + Duration::from_millis(2);
         dispatcher
-            .handle_stop(source.clone(), 200, 200, stopped_at)
+            .handle_stop(source.clone(), 200, 200, None, stopped_at)
             .await;
 
         // Producer B owns no video, so its marker lands immediately.

--- a/rust/data_daemon_bridge/Cargo.toml
+++ b/rust/data_daemon_bridge/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -31,21 +31,26 @@
 //! This file is a thin PyO3 façade: the `#[pyfunction]` wrappers do argument
 //! validation, release the GIL, and delegate into the submodules.
 //!
+//! - [`window_identity`] — which window, if any, this process opened for a
+//!   source, so its own `stop_recording()` can name it.
 //! - [`paths`] — filesystem layout shared with the daemon (recordings root,
 //!   spool paths, `(source, sensor)` stream keys).
 //! - [`publisher`] — per-thread iceoryx2 publisher state, fork safety, the
 //!   synchronous `publish`, and the background data-publisher thread.
 //! - [`writer`] — the background video-writer thread, the in-progress
 //!   video-chunk registry, and chunk seal/announce/flush logic.
-//! - [`query`] — recording-id resolution over the `queries` service.
+//! - [`query`] — recording-id and window-identity resolution over the
+//!   `queries` services.
 //! - [`nut_writer`] — minimal NUT-container muxer for raw RGB video.
 
 pub mod nut_writer;
 
 mod depth;
+mod logging;
 mod paths;
 mod publisher;
 mod query;
+mod window_identity;
 mod writer;
 
 use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery};
@@ -110,6 +115,10 @@ fn start_recording(
             timestamp_ns: capture_timestamp_ns,
             cloud_recording_id,
         })?;
+        // This process opened the window, so it knows the boundary first-hand —
+        // recorded here so a later stop from this process can name it without
+        // asking the daemon.
+        window_identity::note_opened(&robot_id, robot_instance, publish_timestamp_ns);
         // Tell the writer where the window opened, so no chunk spans it.
         let _ = writer_queue().push(WriterMsg::Boundary {
             robot_id,
@@ -329,6 +338,14 @@ fn log_json(
 
 /// Drain the data publisher, then publish one `StopRecording`.
 ///
+/// Any producer may stop a recording, whether or not it opened the window. The
+/// stop names the window it means — from [`window_identity::opened_locally`]
+/// when this process opened it, else by asking the daemon (see
+/// [`query::resolve_window_started_at`]), read before the drain barrier — so
+/// the daemon closes *that* window or drops the stop: several processes
+/// stopping the same recording, which one web-initiated stop causes, cannot
+/// end up closing a later one.
+///
 /// Two barriers, in order: the data publisher's queue is drained first, so the
 /// recording's joint/JSON tail is on the wire before the window's upper bound
 /// is stamped, and only then is the stop published. The writer's tail video
@@ -361,6 +378,13 @@ fn stop_recording(
     }
     let robot_id = robot_id.to_string();
     py.detach(|| -> PyResult<()> {
+        // Which window this stop means, read BEFORE the flush barrier below. That
+        // barrier is the slow part — over a second under burst logging — and the
+        // window it was called against is the one the caller means to stop, not
+        // whichever has become live by the time the drain finishes. Local first
+        // (this process's own window, no IPC); only a non-owner asks the daemon.
+        let window_started_at_ns = window_identity::opened_locally(&robot_id, robot_instance)
+            .or_else(|| query::resolve_window_started_at(&robot_id, robot_instance));
         // Drain the data publisher before stamping the window's upper bound.
         // `log_joint_*` / `log_json` only hand their envelope to the background
         // publisher thread's unbounded queue, which nothing drains at process
@@ -388,9 +412,13 @@ fn stop_recording(
             robot_instance,
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
+            window_started_at_ns,
         })?;
-        // Split from [`flush_source`] so the caller can close its logging gate
-        // in between, rather than after a backlog-length barrier.
+        // Forget our claim on the window. Deliberately after the publish, so a
+        // concurrent stop from this process can't read a stale boundary.
+        window_identity::note_closed(&robot_id, robot_instance);
+        // Split from [`flush_source`] so the caller can seal the writer's tail
+        // chunks in between, rather than after a backlog-length barrier.
         Ok(())
     })
 }
@@ -462,6 +490,7 @@ fn cancel_recording(
         let _ = ack_rx.recv();
         // Publish `CancelRecording` from THIS (the calling) thread's publisher,
         // ordered with Start/Stop on the same port (see the writer module note).
+        window_identity::note_closed(&robot_id, robot_instance);
         publish(&Envelope::CancelRecording {
             robot_id,
             robot_instance,
@@ -569,6 +598,9 @@ fn refresh_config(py: Python<'_>) -> PyResult<()> {
 /// Python module entrypoint registered as `neuracore.data_daemon._data_bridge`.
 #[pymodule]
 fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Before anything else can want to report a problem: several failures in
+    // here are otherwise indistinguishable from an idle sensor.
+    logging::init();
     module.add_function(wrap_pyfunction!(start_recording, module)?)?;
     module.add_function(wrap_pyfunction!(log_joints, module)?)?;
     module.add_function(wrap_pyfunction!(log_frame, module)?)?;

--- a/rust/data_daemon_bridge/src/logging.rs
+++ b/rust/data_daemon_bridge/src/logging.rs
@@ -1,0 +1,40 @@
+//! Producer-side tracing, so this crate's own diagnostics can be seen.
+//!
+//! Without a subscriber every `tracing` event here is dropped: only the daemon
+//! binary installs one, and the producer is a library living inside somebody
+//! else's process. The events that most need to arrive are the ones reporting a
+//! *silent* loss — a write that failed, or a query the daemon never answered —
+//! which would otherwise look exactly like an idle sensor.
+//!
+//! Hence a default of `warn` on stderr rather than off: the failures worth a
+//! line are the ones a caller would otherwise never learn about. `RUST_LOG`
+//! overrides the filter and `NDD_DEBUG` raises the default to `debug`, matching
+//! the daemon's own `init_tracing`.
+
+use std::sync::Once;
+
+use data_daemon_shared::config::env::RuntimeEnv;
+
+static INIT: Once = Once::new();
+
+/// Install this process's subscriber, at most once.
+///
+/// `try_init` rather than `init`: an embedding application — or a test harness —
+/// may already own the global subscriber, and losing our events to theirs is far
+/// better than panicking inside a Python import.
+pub(crate) fn init() {
+    INIT.call_once(|| {
+        let default_level = if RuntimeEnv::from_env().debug {
+            "debug"
+        } else {
+            "warn"
+        };
+        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(false)
+            .with_writer(std::io::stderr)
+            .try_init();
+    });
+}

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -46,7 +46,7 @@ use data_daemon_shared::service_name::{
     LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE, MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE,
     MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION,
-    VERSION_MAX_PAYLOAD_BYTES,
+    VERSION_MAX_PAYLOAD_BYTES, WINDOW_STARTED_AT, WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
 };
 use data_daemon_shared::{BatchedDataItem, Envelope};
 use iceoryx2::node::{Node, NodeBuilder};
@@ -117,6 +117,12 @@ pub(crate) struct ProducerState {
     _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
     /// Request-response client used to read the running daemon's build version.
     pub(crate) version_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the window-started-at client so port
+    /// discovery doesn't race the handle going out of scope.
+    _window_started_at_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response client used by a non-owning `stop_recording()` to ask
+    /// the daemon which window is currently live for a source.
+    pub(crate) window_started_at_client: Client<ipc::Service, [u8], (), [u8], ()>,
 }
 
 /// Work item for the publisher thread.
@@ -378,6 +384,11 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         open_query_client(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
     let (version_service, version_client) =
         open_query_client(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
+    let (window_started_at_service, window_started_at_client) = open_query_client(
+        &node,
+        WINDOW_STARTED_AT,
+        WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+    )?;
 
     Ok(ProducerState {
         _node: node,
@@ -389,6 +400,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         health_client,
         _version_service: version_service,
         version_client,
+        _window_started_at_service: window_started_at_service,
+        window_started_at_client,
     })
 }
 

--- a/rust/data_daemon_bridge/src/query.rs
+++ b/rust/data_daemon_bridge/src/query.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use data_daemon_shared::{
     HealthReply, HealthRequest, RecordingIdReply, VersionReply, VersionRequest,
+    WindowStartedAtQuery, WindowStartedAtReply,
 };
 
 use crate::publisher::{now_ns, with_producer, ProducerError, ProducerState};
@@ -31,6 +32,16 @@ const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const VERSION_RESPONSE_WAIT: Duration = Duration::from_millis(20);
 /// Poll cadence while waiting for one version reply.
 const VERSION_RECEIVE_POLL: Duration = Duration::from_millis(2);
+/// How long a window-started-at request waits for the daemon's reply.
+///
+/// A single bounded wait, not a retry-until-available loop like
+/// [`resolve_recording_id`]: the dispatcher answers immediately from its own
+/// in-memory state, so there is no "not yet minted" case to wait out — only
+/// "no daemon answering", which this treats the same as "no window" (`None`),
+/// same graceful degradation `stop_recording` already had without a gate.
+const WINDOW_STARTED_AT_RESPONSE_WAIT: Duration = Duration::from_millis(50);
+/// Poll cadence while waiting for one window-started-at reply.
+const WINDOW_STARTED_AT_RECEIVE_POLL: Duration = Duration::from_millis(2);
 
 fn bounded_timeout(timeout_s: f64) -> Duration {
     // Clamp before converting: `Duration::from_secs_f64` panics on a non-finite
@@ -209,5 +220,67 @@ fn resolve_recording_id_once(
             return Ok(None);
         }
         std::thread::sleep(RECORDING_ID_RECEIVE_POLL);
+    }
+}
+
+/// Ask the daemon which window, if any, is currently live for a source.
+///
+/// Only called by a non-owning `stop_recording()` — the opener already knows
+/// its own window's boundary first-hand (see [`crate::window_identity`]). A
+/// single request with one short bounded wait: unlike [`resolve_recording_id`],
+/// there is nothing to retry-until-available, so any failure (no daemon
+/// running, malformed reply, timeout) collapses to `None` — the same "name it
+/// unnamed" fallback `stop_recording` already had.
+pub(crate) fn resolve_window_started_at(robot_id: &str, robot_instance: i64) -> Option<i64> {
+    let query = WindowStartedAtQuery {
+        robot_id: robot_id.to_string(),
+        robot_instance,
+    };
+    let request_bytes = match query.encode() {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::debug!(%error, "failed to encode window-started-at query");
+            return None;
+        }
+    };
+    match with_producer(|state| window_started_at_once(state, &request_bytes)) {
+        Ok(started_at_ns) => started_at_ns,
+        Err(error) => {
+            tracing::debug!(%error, "window-started-at request failed");
+            None
+        }
+    }
+}
+
+fn window_started_at_once(
+    state: &ProducerState,
+    request_bytes: &[u8],
+) -> Result<Option<i64>, ProducerError> {
+    let request = state
+        .window_started_at_client
+        .loan_slice_uninit(request_bytes.len())
+        .map_err(|error| ProducerError::Loan(error.to_string()))?;
+    let request = request.write_from_slice(request_bytes);
+    let pending = request
+        .send()
+        .map_err(|error| ProducerError::Send(error.to_string()))?;
+
+    let response_deadline = Instant::now() + WINDOW_STARTED_AT_RESPONSE_WAIT;
+    loop {
+        match pending.receive() {
+            Ok(Some(response)) => {
+                let reply = WindowStartedAtReply::decode(response.payload())?;
+                return Ok(reply.started_at_ns);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(%error, "window-started-at receive failed; treating as no reply");
+                return Ok(None);
+            }
+        }
+        if Instant::now() >= response_deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(WINDOW_STARTED_AT_RECEIVE_POLL);
     }
 }

--- a/rust/data_daemon_bridge/src/window_identity.rs
+++ b/rust/data_daemon_bridge/src/window_identity.rs
@@ -1,0 +1,97 @@
+//! Which window, if any, THIS process opened for a source.
+//!
+//! The daemon is wholly responsible for whether data is written — nothing here
+//! gates logging, and nothing here talks to the daemon. The one thing a
+//! producer still needs to know locally is what to call the window a later
+//! `stop_recording()` from THIS process means, so a duplicate or delayed stop
+//! can't close the wrong recording. A process that opens its own window knows
+//! that boundary first-hand from the very call that opened it, so this is
+//! nothing more than a fork-safe cache of that value.
+//!
+//! A process that did **not** open the window itself has nothing cached here
+//! and asks the daemon instead, once, at `stop_recording()` time — see
+//! [`crate::query::resolve_window_started_at`].
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+/// A source key, matching the daemon's own `(robot_id, robot_instance)`.
+pub(crate) type Source = (String, i64);
+
+struct Registry {
+    owner_pid: u32,
+    /// The `started_at_ns` of the window this process most recently opened,
+    /// per source. Absent once closed, or for a source never opened here.
+    opened: HashMap<Source, i64>,
+}
+
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| {
+    Mutex::new(Registry {
+        owner_pid: 0,
+        opened: HashMap::new(),
+    })
+});
+
+/// Lock the registry, healing it across a `fork()` first.
+///
+/// A forked child inherits the parent's map but none of its windows: without
+/// this, it could claim to have opened a window it never did, and wrongly name
+/// a stop against a boundary from before the fork.
+fn with_registry<R>(operation: impl FnOnce(&mut HashMap<Source, i64>) -> R) -> R {
+    let mut registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let pid = std::process::id();
+    if registry.owner_pid != pid {
+        registry.opened.clear();
+        registry.owner_pid = pid;
+    }
+    operation(&mut registry.opened)
+}
+
+/// Record that *this* process opened a window for the source, so a later stop
+/// from this process can name it without asking the daemon.
+pub(crate) fn note_opened(robot_id: &str, robot_instance: i64, started_at_ns: i64) {
+    with_registry(|opened| {
+        opened.insert((robot_id.to_string(), robot_instance), started_at_ns);
+    });
+}
+
+/// The `started_at_ns` this process used to open a window for the source, if
+/// it was the one that opened it. `None` for a source this process never
+/// opened (or has since closed) — the caller falls back to asking the daemon.
+pub(crate) fn opened_locally(robot_id: &str, robot_instance: i64) -> Option<i64> {
+    with_registry(|opened| opened.get(&(robot_id.to_string(), robot_instance)).copied())
+}
+
+/// Forget this process's claim on the source's window.
+pub(crate) fn note_closed(robot_id: &str, robot_instance: i64) {
+    with_registry(|opened| {
+        opened.remove(&(robot_id.to_string(), robot_instance));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opening_then_closing_forgets_the_window() {
+        note_opened("identity-robot", 0, 100);
+        assert_eq!(opened_locally("identity-robot", 0), Some(100));
+        note_closed("identity-robot", 0);
+        assert_eq!(opened_locally("identity-robot", 0), None);
+    }
+
+    #[test]
+    fn a_never_opened_source_reads_none() {
+        assert_eq!(opened_locally("identity-never-opened", 0), None);
+    }
+
+    #[test]
+    fn reopening_replaces_the_boundary() {
+        note_opened("identity-cycling", 0, 100);
+        note_opened("identity-cycling", 0, 900);
+        assert_eq!(opened_locally("identity-cycling", 0), Some(900));
+    }
+}

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -342,6 +342,24 @@ pub mod service_name {
     /// the reply are a handful of UUID strings + integers; 4 KiB is generous.
     pub const RECORDING_ID_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
 
+    /// Request-response service a producer uses to ask the daemon which
+    /// window, if any, is currently live for a source.
+    ///
+    /// Only needed by a process that did **not** open the window itself: the
+    /// opener already knows its own window's `started_at_ns` first-hand, from
+    /// the very call that opened it. A non-owner asks this once, when it calls
+    /// `stop_recording()`, so its stop can name the window it means instead of
+    /// being matched by publish timestamp alone (which a delayed or duplicate
+    /// stop can get wrong). The daemon answers from its own live in-memory
+    /// window state — `started_at_ns` is never persisted, since only the
+    /// caller's *capture* clock is stored on the recording row. See
+    /// [`crate::WindowStartedAtQuery`] / [`crate::WindowStartedAtReply`].
+    pub const WINDOW_STARTED_AT: &str = "neuracore/data_daemon/window_started_at";
+
+    /// Maximum size of a single `window_started_at` service sample: a robot id
+    /// plus an instance and an optional nanosecond timestamp.
+    pub const WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES: usize = 1024;
+
     /// Maximum number of concurrent request-response clients. Mirrors
     /// [`MAX_PUBLISHERS_PER_SERVICE`]: the data bridge parks one client port
     /// per OS thread (iceoryx2 ports are `!Sync`), so the cap must cover the
@@ -405,6 +423,19 @@ pub enum Envelope {
         /// the row's `stop_timestamp_ns` and POSTed to the backend as
         /// `end_time`; never used for routing.
         timestamp_ns: i64,
+        /// Which window this stop means: the `publish_timestamp_ns` of the
+        /// [`Envelope::StartRecording`] that opened it, as the producer knows it
+        /// — from opening the window itself, or by asking the daemon (see
+        /// [`crate::WindowStartedAtQuery`]).
+        ///
+        /// Not recording identity on the wire: it is a publish-clock boundary,
+        /// the same quantity `StartRecording` already carries, and the daemon
+        /// still decides which recording that window is. It exists because
+        /// `publish_timestamp_ns` above is stamped at the *send*, so a stop
+        /// delayed behind a slow flush arrives looking like a stop for whatever
+        /// recording is live by then. `None` from a producer that never learned
+        /// the boundary, which the daemon falls back to matching by publish time.
+        window_started_at_ns: Option<i64>,
     },
     /// Producer cancels the source's active recording — the daemon drops every
     /// in-flight per-trace actor, deletes the on-disk artefacts, marks the
@@ -735,6 +766,51 @@ pub struct RecordingIdReply {
     pub recording_id: Option<String>,
 }
 
+/// Request sent on [`service_name::WINDOW_STARTED_AT`] asking the daemon which
+/// window, if any, is currently live for a source.
+///
+/// Only a process that did not open the window itself needs to ask — the
+/// opener already knows its own window's boundary first-hand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowStartedAtQuery {
+    pub robot_id: String,
+    pub robot_instance: i64,
+}
+
+/// Reply to a [`WindowStartedAtQuery`].
+///
+/// `started_at_ns` is the live window's publish-clock lower bound — the same
+/// quantity [`Envelope::StartRecording`] carries as `publish_timestamp_ns` —
+/// or `None` when no window is currently live for the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowStartedAtReply {
+    pub started_at_ns: Option<i64>,
+}
+
+impl WindowStartedAtQuery {
+    /// Encode as a postcard byte vector for a `window_started_at` request sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `window_started_at` request sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl WindowStartedAtReply {
+    /// Encode as a postcard byte vector for a `window_started_at` response sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `window_started_at` response sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
 /// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HealthRequest {
@@ -878,6 +954,34 @@ mod tests {
             VersionReply::decode(&reply.encode().unwrap()).unwrap(),
             reply
         );
+    }
+
+    #[test]
+    fn window_started_at_query_and_reply_round_trip() {
+        let query = WindowStartedAtQuery {
+            robot_id: "robot-1".into(),
+            robot_instance: 3,
+        };
+        let query_bytes = query.encode().unwrap();
+        assert!(
+            query_bytes.len() <= service_name::WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+            "query ({} bytes) must fit the window_started_at slice ({} bytes)",
+            query_bytes.len(),
+            service_name::WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+        );
+        assert_eq!(WindowStartedAtQuery::decode(&query_bytes).unwrap(), query);
+
+        for started_at_ns in [Some(1_700_000_000_000_000_000), None] {
+            let reply = WindowStartedAtReply { started_at_ns };
+            let reply_bytes = reply.encode().unwrap();
+            assert!(
+                reply_bytes.len() <= service_name::WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+                "reply ({} bytes) must fit the window_started_at slice ({} bytes)",
+                reply_bytes.len(),
+                service_name::WINDOW_STARTED_AT_MAX_PAYLOAD_BYTES,
+            );
+            assert_eq!(WindowStartedAtReply::decode(&reply_bytes).unwrap(), reply);
+        }
     }
 
     #[test]
@@ -1034,15 +1138,18 @@ mod tests {
 
     #[test]
     fn stop_and_cancel_round_trip() {
-        let stop = Envelope::StopRecording {
-            robot_id: "robot-1".into(),
-            robot_instance: 2,
-            publish_timestamp_ns: 1_700_000_000_000_000_000,
-            timestamp_ns: 1_700_000_000_000_000_000,
-        };
-        let bytes = stop.encode().expect("encode");
-        assert_eq!(stop, Envelope::decode(&bytes).expect("decode"));
-        assert_eq!(stop.kind(), "stop_recording");
+        for window_started_at_ns in [Some(1_699_999_999_000_000_000), None] {
+            let stop = Envelope::StopRecording {
+                robot_id: "robot-1".into(),
+                robot_instance: 2,
+                publish_timestamp_ns: 1_700_000_000_000_000_000,
+                timestamp_ns: 1_700_000_000_000_000_000,
+                window_started_at_ns,
+            };
+            let bytes = stop.encode().expect("encode");
+            assert_eq!(stop, Envelope::decode(&bytes).expect("decode"));
+            assert_eq!(stop.kind(), "stop_recording");
+        }
 
         let cancel = Envelope::CancelRecording {
             robot_id: "robot-1".into(),

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -100,7 +100,7 @@ def test_log_frame_forwards_dtype_derived_from_the_array(
     native = MagicMock()
     monkeypatch.setattr(recording_context, "_load_native", lambda: native)
     robot = _get_robot(None, 0)
-    monkeypatch.setattr(robot, "get_current_recording_id", lambda: "rec-1")
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
 
     rgb_uint8 = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
     nc.log_rgb("front_camera", rgb_uint8)
@@ -481,23 +481,16 @@ def test_log_parallel_gripper_open_amounts(
     )
 
 
-def test_sse_started_recording_logs_with_bound_robot_source(monkeypatch) -> None:
-    """A producer that did not publish StartRecording can log after SSE state.
-
-    The active recording id represents state learned from SSE. Creating the
-    robot's daemon context must bind its source without publishing a duplicate
-    native start event.
-    """
+def test_json_logs_with_bound_robot_source_without_local_recording(
+    monkeypatch,
+) -> None:
+    """A producer without local recording state still forwards to the daemon."""
     robot = Robot("test_robot", instance=3, org_id="org-1")
     robot.id = "robot-from-sse"
     native = MagicMock()
 
     monkeypatch.setattr(recording_context, "_load_native", lambda: native)
-    monkeypatch.setattr(
-        robot,
-        "get_current_recording_id",
-        lambda: "cloud-recording-id-from-sse",
-    )
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
 
     sample = ParallelGripperOpenAmountData(timestamp=12.5, open_amount=0.4)
     api_logging._record_json_to_daemon(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Producers publish unconditionally; the daemon routes each sample against its own window state, so a process that never called `start_recording` needs no local knowledge of the window. In prior, multi process recordings could only be informed by SSE response.

