### PR TITLE
feat: apply training job name to downloaded model

### DIFF
--- a/neuracore/core/endpoint.py
+++ b/neuracore/core/endpoint.py
@@ -802,13 +802,6 @@ def policy_remote_server(
 def _download_model(job_id: str, org_id: str) -> Path:
     """Download model from training run."""
     auth = get_auth()
-    destination = Path(tempfile.gettempdir()) / job_id / "model.nc.zip"
-    if destination.exists():
-        print(f"Model already downloaded at {destination}. Skipping download.")
-        return destination
-    destination.parent.mkdir(parents=True, exist_ok=True)
-
-    print("Downloading model from training run...")
     session = thread_local_session()
     response = session.get(
         f"{API_URL}/org/{org_id}/training/jobs/{job_id}/model_url",
@@ -817,9 +810,17 @@ def _download_model(job_id: str, org_id: str) -> Path:
     )
     response.raise_for_status()
 
-    model_url_response = response.json()
+    data = response.json()
+    train_run_name = data["train_run_name"]
+    destination = Path(tempfile.gettempdir()) / job_id / f"{train_run_name}.nc.zip"
+    if destination.exists():
+        print(f"Model already downloaded at {destination}. Skipping download.")
+        return destination
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    print("Downloading model from training run...")
     model_path = download_with_progress(
-        model_url_response["url"],
+        data["url"],
         "Downloading model...",
         destination=destination,
     )

--- a/tests/unit/ml/test_direct_policy_endpoint.py
+++ b/tests/unit/ml/test_direct_policy_endpoint.py
@@ -205,7 +205,7 @@ def _setup_direct_policy_train_run_mocks(
     _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
     mock_auth_requests.get(
         f"{API_URL}/org/{mocked_org_id}/training/jobs/{job_id}/model_url",
-        json={"url": f"{localhost}/model.nc.zip"},
+        json={"url": f"{localhost}/model.nc.zip", "train_run_name": train_run_name},
         status_code=200,
     )
     mock_auth_requests.get(

--- a/tests/unit/ml/test_server_policy_endpoint.py
+++ b/tests/unit/ml/test_server_policy_endpoint.py
@@ -124,7 +124,7 @@ def _setup_policy_local_server_train_run_mocks(
     _mock_training_job_metadata(mock_auth_requests, mocked_org_id)
     mock_auth_requests.get(
         f"{API_URL}/org/{mocked_org_id}/training/jobs/job_123/model_url",
-        json={"url": f"{localhost}/model.nc.zip"},
+        json={"url": f"{localhost}/model.nc.zip", "train_run_name": "test_run"},
         status_code=200,
     )
     mock_auth_requests.get(


### PR DESCRIPTION
### Features
- When downloading a trained model, previously it would be downloaded as `model.nc.zip` for every training job. This PR applies the unique name of the training job to the downloaded model file to make it easier for users to keep track of multiple downloaded models.

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCRL-811](https://neuracore.atlassian.net/browse/NCRL-811)

### Related PRs
 - [neuracore_backend#550](https://github.com/NeuracoreAI/neuracore_backend/pull/550)