### PR TITLE
fix: resolve video chunk membership per frame, not per chunk

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -307,6 +307,7 @@ multihead
 Multihead
 multinode
 multirun
+muxed
 muxer
 muxes
 muxing
@@ -452,6 +453,7 @@ seqlen
 serde
 sess
 setpriority
+setpts
 setsid
 setuptools
 shadowsize
@@ -468,6 +470,7 @@ sqlx
 squaredcos
 startcode
 startcodes
+STARTPTS
 staticmethod
 statvfs
 subdirs

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -203,9 +203,14 @@ pub struct ChunkEncodeRequest {
     /// Lossy codec selection for this trace. Controls whether a lossless
     /// archive is produced and how the lossy output is encoded.
     pub codec: LossyVideoCodec,
-    /// Frames to encode from the head of `raw_nut`: the whole file unless the
-    /// dispatcher cut the chunk, and always what the sidecar is built from.
+    /// Frames to encode once `skip_frames` are discarded: the rest of the file
+    /// unless the dispatcher cut the chunk, and always what the sidecar is
+    /// built from.
     pub frame_count: u32,
+    /// Leading frames of `raw_nut` to discard before encoding: the ones the
+    /// dispatcher resolved as published before this recording's window opened.
+    /// Zero for a chunk whose first frame the window already owns.
+    pub skip_frames: u32,
 }
 
 /// One NUT entry of a batched chunk encode.
@@ -220,6 +225,11 @@ pub struct BatchNutInput {
     /// Frames this entry contributes to the batch: the whole NUT unless the
     /// dispatcher cut the chunk (see [`ChunkEncodeRequest::frame_count`]).
     pub frame_count: u32,
+    /// Leading frames to discard (see [`ChunkEncodeRequest::skip_frames`]).
+    /// Always zero unless this entry is its batch's only one — the head cut
+    /// is a whole-stream filter, so a batch never mixes it with a second
+    /// entry (see `drain_encode_batch`).
+    pub skip_frames: u32,
 }
 
 /// Inputs to one batched transcode invocation covering a contiguous run of
@@ -625,6 +635,7 @@ impl VideoEncoder {
             encode_threads,
             self.frame_sync_arg(),
             request.frame_count,
+            request.skip_frames,
             &request.lossy_out,
             &request.lossless_out,
         );
@@ -653,6 +664,7 @@ impl VideoEncoder {
                         lossless_out: request.lossless_out.clone(),
                         codec: request.codec,
                         frame_count: single.frame_count,
+                        skip_frames: single.skip_frames,
                     },
                     encode_threads,
                 )
@@ -697,6 +709,11 @@ impl VideoEncoder {
             encode_threads,
             self.frame_sync_arg(),
             batch_frame_count(&request.inputs),
+            // No head cut on a multi-entry batch: the filter would trim the
+            // concatenated stream, and the trimmed frames still occupy the
+            // first entry's declared span, so the caller keeps a cut entry in
+            // a batch of its own (see `drain_encode_batch`).
+            0,
             &request.lossy_out,
             &request.lossless_out,
         );
@@ -846,12 +863,14 @@ impl VideoEncoder {
 /// [`VideoEncoder::encode_chunk`] and [`VideoEncoder::encode_chunk_batch`] so
 /// both invocations keep the same output shape (see `encode_chunk` for the
 /// rationale behind each knob).
+#[allow(clippy::too_many_arguments)]
 fn append_encode_output_args(
     command: &mut Command,
     codec: LossyVideoCodec,
     encode_threads: usize,
     frame_sync_arg: &'static str,
     frame_count: u32,
+    skip_frames: u32,
     lossy_out: &Path,
     lossless_out: &Path,
 ) {
@@ -861,6 +880,9 @@ fn append_encode_output_args(
     // Per-output frame cap (see [`ChunkEncodeRequest::frame_count`]), a no-op
     // unless the dispatcher cut a chunk of this encode at a recording boundary.
     let frame_limit = (frame_count > 0).then(|| frame_count.to_string());
+    // Head cut (see [`ChunkEncodeRequest::skip_frames`]). `-frames:v` counts
+    // frames *after* the graph, so the cap above still bounds the tail.
+    let head_skip = (skip_frames > 0).then(|| head_skip_filter(skip_frames));
     command
         .arg("-map")
         .arg("0:v")
@@ -885,6 +907,9 @@ fn append_encode_output_args(
             .arg("23")
             .arg("-video_track_timescale")
             .arg(&track_timescale);
+        if let Some(skip) = head_skip.as_deref() {
+            command.arg("-vf").arg(skip);
+        }
         if let Some(limit) = frame_limit.as_deref() {
             command.arg("-frames:v").arg(limit);
         }
@@ -892,7 +917,12 @@ fn append_encode_output_args(
     } else {
         // Downscale the lossy preview proxy (only) to keep this dominant
         // pass cheap at high resolution; the lossless output stays native.
-        let preview_filter = preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT);
+        let preview_filter = match head_skip.as_deref() {
+            // Trim first, then scale: scaling frames that are about to be
+            // discarded is the expensive half of this pass.
+            Some(skip) => format!("{skip},{}", preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT)),
+            None => preview_scale_filter(LOSSY_PREVIEW_MAX_HEIGHT),
+        };
         command
             // Lossy preview proxy only: cap to preview resolution (see
             // `preview_scale_filter`). Passthrough frame timing still emits
@@ -939,6 +969,9 @@ fn append_encode_output_args(
             .arg("0")
             .arg("-video_track_timescale")
             .arg(&track_timescale);
+        if let Some(skip) = head_skip.as_deref() {
+            command.arg("-vf").arg(skip);
+        }
         if let Some(limit) = frame_limit.as_deref() {
             command.arg("-frames:v").arg(limit);
         }
@@ -949,9 +982,11 @@ fn append_encode_output_args(
 /// Frames a batch's outputs may hold: the sum of what every entry owns.
 ///
 /// The cap drops frames from the tail of the concatenated stream, which is
-/// only correct because a cut entry is always the batch's last: the dispatcher
-/// cuts a chunk at the window's stop, and every chunk that opens after that
-/// stop is dropped whole, so no chunk of the trace follows a cut one.
+/// only correct because a tail-cut entry is always the batch's last: the
+/// dispatcher cuts a chunk at the window's stop, and every chunk that opens
+/// after that stop is dropped whole, so no chunk of the trace follows a cut
+/// one. A head-cut entry (see [`BatchNutInput::skip_frames`]) never shares a
+/// batch at all, so its discarded frames are outside every sum here.
 fn batch_frame_count(inputs: &[BatchNutInput]) -> u32 {
     inputs
         .iter()
@@ -1098,6 +1133,12 @@ fn verify_nut_header(raw_nut: &Path) -> Result<(), VideoEncodeError> {
         });
     }
     Ok(())
+}
+
+/// Filter that discards the first `skip_frames` frames and rebases the PTS of
+/// what remains to zero, so the segment's extent is the kept frames' extent.
+fn head_skip_filter(skip_frames: u32) -> String {
+    format!("trim=start_frame={skip_frames},setpts=PTS-STARTPTS")
 }
 
 /// Build the ffmpeg `-vf` value that downscales the lossy preview proxy to at
@@ -1546,6 +1587,7 @@ mod tests {
             lossless_out: lossless.clone(),
             codec: LossyVideoCodec::LosslessPlusPreview,
             frame_count: 8,
+            skip_frames: 0,
         };
         let outcome = encoder
             .encode_chunk(&request, ENCODE_THREADS_PER_OUTPUT)
@@ -1613,6 +1655,7 @@ mod tests {
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
                     frame_count: 6,
+                    skip_frames: 0,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1675,7 +1718,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn frame_count_encodes_only_the_frames_the_recording_owns() {
+    async fn frame_count_drops_the_tail_and_keeps_the_frames_the_recording_owns() {
         // The NUT cannot be rewritten, so the cut has to reach ffmpeg — on
         // both outputs, or an mp4 outruns the sidecar indexing it.
         let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
@@ -1698,6 +1741,7 @@ mod tests {
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
                     frame_count: 3,
+                    skip_frames: 0,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1732,6 +1776,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn skip_frames_drops_the_head_and_rebases_the_kept_frames() {
+        // The head cut has to reach ffmpeg for the same reason the tail cut
+        // does, and the kept frames must start at PTS 0 so the segment's
+        // extent is the extent the finalise concat floors on.
+        let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
+        else {
+            eprintln!("ffmpeg/ffprobe not on PATH — skipping head-cut encode test.");
+            return;
+        };
+
+        let tempdir = TempDir::new().unwrap();
+        let raw = tempdir.path().join("chunk_0000.nut");
+        write_synthetic_nut(&ffmpeg, &raw, 8);
+
+        let probe = |path: &Path, entries: &str, intervals: Option<&str>| -> String {
+            let mut command = StdCommand::new(&ffprobe);
+            command.args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-count_frames",
+                "-show_entries",
+                entries,
+                "-of",
+                "default=nokey=1:noprint_wrappers=1",
+            ]);
+            if let Some(intervals) = intervals {
+                command.args(["-read_intervals", intervals]);
+            }
+            let out = command.arg(path).output().expect("spawn ffprobe");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        let frame_count =
+            |path: &Path| -> u64 { probe(path, "stream=nb_read_frames", None).parse().unwrap() };
+
+        // Head cut only: the 5 frames past the cut survive on both outputs.
+        let lossy = tempdir.path().join("chunk_0000_lossy.mp4");
+        let lossless = tempdir.path().join("chunk_0000_lossless.mp4");
+        VideoEncoder::new()
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw.clone(),
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 5,
+                    skip_frames: 3,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("transcode");
+        assert_eq!(frame_count(&lossy), 5, "lossy output must drop the head");
+        assert_eq!(
+            frame_count(&lossless),
+            5,
+            "lossless output must drop the same head"
+        );
+        // The synthetic NUT is 1 fps, so the kept run starts at 3 s in the
+        // source; `setpts` has to bring it back to zero.
+        for output in [&lossy, &lossless] {
+            assert_eq!(
+                probe(output, "frame=pts_time", Some("%+#1")),
+                "0.000000",
+                "the first kept frame must be rebased to PTS 0"
+            );
+        }
+
+        // Cut at both ends: `-frames:v` counts frames *after* the filter
+        // graph, so the cap bounds the tail of what the head cut left.
+        let lossy = tempdir.path().join("chunk_0001_lossy.mp4");
+        let lossless = tempdir.path().join("chunk_0001_lossless.mp4");
+        VideoEncoder::new()
+            .encode_chunk(
+                &ChunkEncodeRequest {
+                    raw_nut: raw,
+                    lossy_out: lossy.clone(),
+                    lossless_out: lossless.clone(),
+                    codec: LossyVideoCodec::LosslessPlusPreview,
+                    frame_count: 2,
+                    skip_frames: 3,
+                },
+                ENCODE_THREADS_PER_OUTPUT,
+            )
+            .await
+            .expect("transcode");
+        assert_eq!(frame_count(&lossy), 2, "the cap applies past the head cut");
+        assert_eq!(
+            frame_count(&lossless),
+            2,
+            "the cap applies past the head cut on the lossless output too"
+        );
+    }
+
+    #[tokio::test]
     async fn encode_chunk_lossy_only_writes_single_full_res_h264() {
         let (Some(ffmpeg), Some(ffprobe)) = (locate_binary("ffmpeg"), locate_binary("ffprobe"))
         else {
@@ -1757,6 +1897,7 @@ mod tests {
                     lossless_out: lossless.clone(),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
                     frame_count: 6,
+                    skip_frames: 0,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1844,6 +1985,7 @@ mod tests {
                     lossless_out: split_lossless.clone(),
                     codec: LossyVideoCodec::LosslessPlusPreview,
                     frame_count: 8,
+                    skip_frames: 0,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1858,6 +2000,7 @@ mod tests {
                     lossless_out: tempdir.path().join("unused_lossless.mp4"),
                     codec: LossyVideoCodec::H264MediumLossyOnly,
                     frame_count: 8,
+                    skip_frames: 0,
                 },
                 ENCODE_THREADS_PER_OUTPUT,
             )
@@ -1965,6 +2108,7 @@ mod tests {
                             .join(format!("chunk_{chunk_index:04}_lossless.mp4")),
                         codec: LossyVideoCodec::LosslessPlusPreview,
                         frame_count: frames_per_chunk as u32,
+                        skip_frames: 0,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -2095,6 +2239,7 @@ mod tests {
                         lossless_out: lossless,
                         codec: LossyVideoCodec::LosslessPlusPreview,
                         frame_count: 4,
+                        skip_frames: 0,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -2230,6 +2375,7 @@ mod tests {
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
             frame_count: 1,
+            skip_frames: 0,
         };
         let encoder = VideoEncoder::new();
         let error = encoder
@@ -2253,6 +2399,7 @@ mod tests {
             lossless_out: tempdir.path().join("lossless.mp4"),
             codec: LossyVideoCodec::LosslessPlusPreview,
             frame_count: 1,
+            skip_frames: 0,
         };
         let encoder =
             VideoEncoder::new().with_binary("this-binary-definitely-does-not-exist-ffmpeg");
@@ -2461,16 +2608,19 @@ mod tests {
                 raw_nut: PathBuf::from("/data/trace/chunks/chunk_0000.nut"),
                 span_to_next_us: Some(16_683),
                 frame_count: 2,
+                skip_frames: 0,
             },
             BatchNutInput {
                 raw_nut: PathBuf::from("/data/trace/chunks/chunk_0001.nut"),
                 span_to_next_us: Some(MAX_BOUNDARY_DELTA_US),
                 frame_count: 2,
+                skip_frames: 0,
             },
             BatchNutInput {
                 raw_nut: PathBuf::from("/data/trace/chunks/chunk_0002.nut"),
                 span_to_next_us: None,
                 frame_count: 2,
+                skip_frames: 0,
             },
         ];
         write_batch_concat_list(&list, &inputs).expect("write list");
@@ -2518,6 +2668,7 @@ mod tests {
                         declared_batch_span_us(&chunk_timestamps_s, capture_s(next[0]))
                     }),
                     frame_count: chunk.len() as u32,
+                    skip_frames: 0,
                 });
             }
             let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
@@ -2628,6 +2779,7 @@ mod tests {
                         lossless_out: single_lossless.clone(),
                         codec,
                         frame_count: 4,
+                        skip_frames: 0,
                     },
                     ENCODE_THREADS_PER_OUTPUT,
                 )
@@ -2643,6 +2795,7 @@ mod tests {
                             raw_nut: raw.clone(),
                             span_to_next_us: None,
                             frame_count: 4,
+                            skip_frames: 0,
                         }],
                         lossy_out: batch_lossy.clone(),
                         lossless_out: batch_lossless.clone(),
@@ -2693,6 +2846,7 @@ mod tests {
                 raw_nut,
                 span_to_next_us: (index < 2).then_some(33_366),
                 frame_count: 2,
+                skip_frames: 0,
             });
         }
         let lossy_out = tempdir.path().join("chunk_0000_lossy.mp4");
@@ -2750,6 +2904,7 @@ mod tests {
                             raw_nut: chunk_a,
                             span_to_next_us: Some(33_366),
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                         // Cut at the recording boundary: only its first frame
                         // belongs to this recording.
@@ -2757,6 +2912,7 @@ mod tests {
                             raw_nut: chunk_b,
                             span_to_next_us: None,
                             frame_count: 1,
+                            skip_frames: 0,
                         },
                     ],
                     lossy_out: lossy_out.clone(),
@@ -2804,11 +2960,13 @@ mod tests {
                             raw_nut: good_nut,
                             span_to_next_us: Some(33_366),
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                         BatchNutInput {
                             raw_nut: corrupt_nut.clone(),
                             span_to_next_us: None,
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                     ],
                     lossy_out: lossy_out.clone(),
@@ -2863,11 +3021,13 @@ mod tests {
                             raw_nut: chunk_a,
                             span_to_next_us: Some(span_us),
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                         BatchNutInput {
                             raw_nut: chunk_b,
                             span_to_next_us: None,
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                     ],
                     lossy_out: lossy_out.clone(),
@@ -2925,11 +3085,13 @@ mod tests {
                                 raw_nut: chunk_a,
                                 span_to_next_us: Some(span_us),
                                 frame_count: 3,
+                                skip_frames: 0,
                             },
                             BatchNutInput {
                                 raw_nut: chunk_b,
                                 span_to_next_us: None,
                                 frame_count: 2,
+                                skip_frames: 0,
                             },
                         ],
                         lossy_out: lossy_out.clone(),
@@ -2994,11 +3156,13 @@ mod tests {
                             raw_nut: chunk_a,
                             span_to_next_us: Some(span_us),
                             frame_count: 3,
+                            skip_frames: 0,
                         },
                         BatchNutInput {
                             raw_nut: chunk_b,
                             span_to_next_us: None,
                             frame_count: 2,
+                            skip_frames: 0,
                         },
                     ],
                     lossy_out: lossy_out.clone(),
@@ -3074,6 +3238,7 @@ mod tests {
                     raw_nut,
                     span_to_next_us,
                     frame_count: chunk.len() as u32,
+                    skip_frames: 0,
                 });
             }
             let lossy_out = tempdir

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -26,10 +26,16 @@
 //! actor (no sequence counting).
 //!
 //! A video chunk is the one envelope carrying more than one datum, and the same
-//! rule decides it *per frame*: the window keeps the frames published before its
-//! stop and cuts off the rest (see [`frames_inside_window`], and
-//! `data_daemon_shared::video_boundary` for where the boundary lands and what
-//! the producer does with the other edge).
+//! rule decides it *per frame*, at both bounds: a chunk is a container, not a
+//! member. The producer seals chunks on its own caps and knows nothing of
+//! windows, so one chunk can hold frames from before a recording, inside it, and
+//! inside the next one — and each window claims exactly the run of frames it
+//! owns (see [`claims_for_chunk`] and [`frame_range_in_window`], with
+//! `data_daemon_shared::video_boundary` for where a boundary lands). Deciding
+//! membership by the chunk's *open stamp* instead would hand a window every
+//! frame or none, and none is what a chunk opened before the window got — taking
+//! its in-window frames with it. That is how a camera process that never calls
+//! `start_recording` lost its whole trace.
 //!
 //! **Tail video chunks** escape the holdback: the producer seals them after it
 //! published the stop, so no retention constant bounds their lateness. A stopped
@@ -300,8 +306,8 @@ enum HeldPayload {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
-        /// Per-frame publish time as ms after the chunk's open stamp
-        frame_publish_offsets_ms: Vec<u32>,
+        /// Per-frame publish time as µs after the chunk's open stamp
+        frame_publish_offsets_us: Vec<u32>,
     },
     SourceFlushed {
         producer_pid: u32,
@@ -508,7 +514,7 @@ impl Dispatcher {
                 frame_timestamps_ns,
                 frame_timestamps_s,
                 dtype,
-                frame_publish_offsets_ms,
+                frame_publish_offsets_us,
             } => {
                 let source = (robot_id, robot_instance);
                 self.touch_source(&source, recv_at);
@@ -528,7 +534,7 @@ impl Dispatcher {
                         frame_count,
                         frame_timestamps_s,
                         dtype,
-                        frame_publish_offsets_ms,
+                        frame_publish_offsets_us,
                     },
                 });
             }
@@ -1132,7 +1138,7 @@ impl Dispatcher {
                 frame_count,
                 frame_timestamps_s,
                 dtype,
-                frame_publish_offsets_ms,
+                frame_publish_offsets_us,
             } => {
                 self.route_video(
                     &held.source,
@@ -1147,7 +1153,7 @@ impl Dispatcher {
                     frame_count,
                     frame_timestamps_s,
                     dtype,
-                    frame_publish_offsets_ms,
+                    frame_publish_offsets_us,
                 )
                 .await;
             }
@@ -1179,24 +1185,35 @@ impl Dispatcher {
         }
     }
 
-    /// Credit one producer's drained flush barrier to the oldest closing window
+    /// Credit one producer's drained flush barrier to *every* closing window
     /// still owed a marker from that `producer_pid`.
+    ///
+    /// Every window, not the oldest one: a barrier drains everything the
+    /// producer holds for the source, so one marker speaks for every window its
+    /// chunks reached. A process that publishes no stop of its own flushes once,
+    /// at its own exit — and one of its chunks can carry several recordings —
+    /// so crediting a single window would leave the others waiting out
+    /// [`FLUSH_MARKER_WAIT_CAP`] for a marker that is never coming.
+    ///
+    /// Safe for the owner-driven case too, where each stop produces its own
+    /// marker: a window already credited is skipped, and a window whose chunks
+    /// this producer never reached is not owed one (it is not in
+    /// `video_producers`, so it is not waiting).
     fn mark_source_flushed(&mut self, source: &Source, producer_pid: u32) {
         let Some(entry) = self.windows.get_mut(source) else {
             return;
         };
-        let Some(window) = entry.closing.iter_mut().find(|window| {
+        for window in entry.closing.iter_mut().filter(|window| {
             window.awaiting_flush && !window.flushed_producers.contains(&producer_pid)
-        }) else {
-            return;
-        };
-        window.flushed_producers.insert(producer_pid);
-        tracing::debug!(
-            recording_index = window.recording_index,
-            producer_pid,
-            "producer flush barrier drained; window may retire once every \
-             video-contributing producer has reported"
-        );
+        }) {
+            window.flushed_producers.insert(producer_pid);
+            tracing::debug!(
+                recording_index = window.recording_index,
+                producer_pid,
+                "producer flush barrier drained; window may retire once every \
+                 video-contributing producer has reported"
+            );
+        }
     }
 
     /// Find the window for `source` containing `ts`. Closing windows are
@@ -1215,6 +1232,14 @@ impl Dispatcher {
             return entry.live.as_mut();
         }
         None
+    }
+
+    /// Borrow the window a [`ChunkClaim`] addresses.
+    fn window_at_mut(entry: &mut WindowsForSource, slot: WindowSlot) -> Option<&mut ActiveWindow> {
+        match slot {
+            WindowSlot::Live => entry.live.as_mut(),
+            WindowSlot::Closing(index) => entry.closing.get_mut(index),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1273,7 +1298,7 @@ impl Dispatcher {
         frame_count: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
-        frame_publish_offsets_ms: Vec<u32>,
+        frame_publish_offsets_us: Vec<u32>,
     ) {
         let recordings_root = self.actor_context.recordings_root.clone();
         // The chunk's `publish_timestamp_ns` (its open time) keys both the
@@ -1288,83 +1313,91 @@ impl Dispatcher {
             thread_id,
         );
 
-        // The open stamp picks the window; the per-frame cut is below.
         let Some(entry) = self.windows.get_mut(source) else {
             remove_spool_nut(&spool_nut);
             self.note_orphan();
             return;
         };
-        let Some(window) = Self::window_for_mut(entry, publish_ts) else {
-            remove_spool_nut(&spool_nut);
-            self.note_orphan();
-            return;
-        };
-        window.video_producers.insert(producer_pid);
 
-        // Membership by open stamp, extent by per-frame publish times.
-        let kept_frames = window.stopped_at_ns.map_or(frame_count, |stop| {
-            frames_inside_window(&frame_publish_offsets_ms, publish_ts, stop, frame_count)
-        });
-        let dropped_frames = frame_count.saturating_sub(kept_frames);
-        if kept_frames == 0 {
-            tracing::warn!(
-                recording_index = window.recording_index,
-                frame_count,
-                "video chunk has no frame published inside the window it opened \
-                 in; dropping it"
-            );
-            remove_spool_nut(&spool_nut);
-            self.note_orphan();
-            return;
-        }
-        let mut frame_timestamps_s = frame_timestamps_s;
-        if dropped_frames > 0 {
-            frame_timestamps_s.truncate(kept_frames as usize);
+        // Every window any of this chunk's frames belongs to, and which frames.
+        // A chunk is a container, not a member: the producer seals it on its own
+        // caps and knows nothing of windows, so one chunk can hold frames from
+        // before a recording, inside it, and inside the next one.
+        let claims = claims_for_chunk(entry, publish_ts, &frame_publish_offsets_us, frame_count);
+        if claims.is_empty() {
             tracing::debug!(
-                recording_index = window.recording_index,
-                kept_frames,
-                dropped_frames,
-                "video chunk straddles the window's stop; keeping the frames \
-                 published before it"
-            );
-        }
-        let frame_count = kept_frames;
-
-        let recording_index = window.recording_index;
-        let handle = Self::ensure_actor(
-            window,
-            &self.actor_context,
-            data_type.clone(),
-            sensor_name.clone(),
-            &mut self.actor_handles,
-        );
-        let chunk_index = handle.next_video_chunk;
-        handle.next_video_chunk = handle.next_video_chunk.saturating_add(1);
-        let sender = handle.sender.clone();
-
-        // The actor relinks the spooled NUT into the recording itself — on a
-        // blocking thread inside its background encode task — so the rename's
-        // possible journal-commit stall never lands on this routing path. The
-        // dispatcher only hands over the source spool path.
-        if sender
-            .send(TraceActorMessage::Video {
-                chunk_index,
-                spool_nut: spool_nut.clone(),
-                width,
-                height,
-                byte_count,
                 frame_count,
-                frame_timestamps_s,
-                dtype,
-            })
-            .await
-            .is_err()
-        {
-            tracing::warn!(
-                recording_index,
-                "video trace actor inbox closed; dropping chunk"
+                "video chunk has no frame published inside any window; dropping it"
             );
             remove_spool_nut(&spool_nut);
+            self.note_orphan();
+            return;
+        }
+
+        // One NUT can feed several recordings, so each claim needs its own copy
+        // of the source to relink and unlink. Hard links keep that to a metadata
+        // op and one inode; the last claim consumes the spool file itself.
+        let sources = claim_sources(&spool_nut, claims.len());
+
+        for (claim, source_nut) in claims.iter().zip(sources) {
+            let Some(source_nut) = source_nut else {
+                // Could not give this claim its own name; the others still route.
+                continue;
+            };
+            let Some(window) = Self::window_at_mut(entry, claim.slot) else {
+                remove_spool_nut(&source_nut);
+                continue;
+            };
+            window.video_producers.insert(producer_pid);
+            if claim.skip > 0 || claim.count < frame_count {
+                tracing::debug!(
+                    recording_index = window.recording_index,
+                    skipped = claim.skip,
+                    kept = claim.count,
+                    frame_count,
+                    "video chunk spans this window's boundary; keeping the frames \
+                     published inside it"
+                );
+            }
+            let claimed_timestamps = claim.timestamps(&frame_timestamps_s);
+
+            let recording_index = window.recording_index;
+            let handle = Self::ensure_actor(
+                window,
+                &self.actor_context,
+                data_type.clone(),
+                sensor_name.clone(),
+                &mut self.actor_handles,
+            );
+            let chunk_index = handle.next_video_chunk;
+            handle.next_video_chunk = handle.next_video_chunk.saturating_add(1);
+            let sender = handle.sender.clone();
+
+            // The actor relinks the spooled NUT into the recording itself — on a
+            // blocking thread inside its background encode task — so the
+            // rename's possible journal-commit stall never lands on this routing
+            // path. The dispatcher only hands over the source spool path.
+            if sender
+                .send(TraceActorMessage::Video {
+                    chunk_index,
+                    spool_nut: source_nut.clone(),
+                    width,
+                    height,
+                    byte_count,
+                    frame_count: claim.count,
+                    skip_frames: claim.skip,
+                    frame_timestamps_s: claimed_timestamps,
+                    dtype,
+                })
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    recording_index,
+                    "video trace actor inbox closed; dropping chunk"
+                );
+                remove_spool_nut(&source_nut);
+            }
         }
     }
 
@@ -1445,19 +1478,141 @@ impl Dispatcher {
     }
 }
 
-/// How many of a chunk's leading frames this window keeps, given the window's
-/// `stop_ns` and the chunk's `frame_publish_offsets_ms`.
-fn frames_inside_window(
-    offsets_ms: &[u32],
-    chunk_open_ns: i64,
-    stop_ns: i64,
-    frame_count: u32,
-) -> u32 {
-    if offsets_ms.is_empty() {
-        return frame_count;
+/// Addresses one window inside a [`WindowsForSource`] without borrowing it, so
+/// a chunk's claims can be resolved in one immutable pass and acted on in a
+/// second, mutable one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowSlot {
+    Live,
+    Closing(usize),
+}
+
+/// One window's claim on a chunk: which window, and which run of frames.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChunkClaim {
+    slot: WindowSlot,
+    /// Leading frames this window does not own (published before it opened).
+    skip: u32,
+    /// Frames it does own, counted from `skip`.
+    count: u32,
+}
+
+impl ChunkClaim {
+    /// This claim's slice of the chunk's per-frame capture timestamps.
+    fn timestamps(&self, frame_timestamps_s: &[f64]) -> Vec<f64> {
+        let start = (self.skip as usize).min(frame_timestamps_s.len());
+        let end = start
+            .saturating_add(self.count as usize)
+            .min(frame_timestamps_s.len());
+        frame_timestamps_s[start..end].to_vec()
     }
-    let cut = video_boundary::frames_before_boundary(offsets_ms, chunk_open_ns, stop_ns);
-    u32::try_from(cut).unwrap_or(u32::MAX).min(frame_count)
+}
+
+/// The run of a chunk's frames that falls inside `[started_at_ns,
+/// stopped_at_ns)`, as `(skip, count)`.
+///
+/// Both ends are cut, and for the same reason: the producer seals chunks on its
+/// own caps, so a boundary can fall anywhere inside one. Membership by the
+/// chunk's open stamp would give a window either every frame or none of them —
+/// and none is what a chunk opened before the window got, taking its in-window
+/// frames with it.
+fn frame_range_in_window(
+    offsets_us: &[u32],
+    chunk_open_ns: i64,
+    started_at_ns: i64,
+    stopped_at_ns: Option<i64>,
+    frame_count: u32,
+) -> (u32, u32) {
+    if offsets_us.is_empty() {
+        // No per-frame data to cut on, so the open stamp is all there is: an
+        // all-or-nothing decision for the whole chunk.
+        let inside =
+            chunk_open_ns >= started_at_ns && stopped_at_ns.is_none_or(|stop| chunk_open_ns < stop);
+        return if inside { (0, frame_count) } else { (0, 0) };
+    }
+    let bounded = |bound_ns| {
+        let index = video_boundary::frames_before_boundary(offsets_us, chunk_open_ns, bound_ns);
+        u32::try_from(index).unwrap_or(u32::MAX).min(frame_count)
+    };
+    let skip = bounded(started_at_ns);
+    let end = stopped_at_ns.map_or(frame_count, bounded);
+    (skip, end.saturating_sub(skip))
+}
+
+/// Resolve which of a source's windows own which of a chunk's frames.
+///
+/// Windows never overlap on the publish clock (a new start clamps any window
+/// still closing), so the claims are disjoint, and they come out oldest-first:
+/// closing windows in order, then the live one.
+fn claims_for_chunk(
+    entry: &WindowsForSource,
+    chunk_open_ns: i64,
+    offsets_us: &[u32],
+    frame_count: u32,
+) -> Vec<ChunkClaim> {
+    let candidates = entry
+        .closing
+        .iter()
+        .enumerate()
+        .map(|(index, window)| (WindowSlot::Closing(index), window))
+        .chain(entry.live.as_ref().map(|window| (WindowSlot::Live, window)));
+    candidates
+        .filter_map(|(slot, window)| {
+            let (skip, count) = frame_range_in_window(
+                offsets_us,
+                chunk_open_ns,
+                window.started_at_ns,
+                window.stopped_at_ns,
+                frame_count,
+            );
+            (count > 0).then_some(ChunkClaim { slot, skip, count })
+        })
+        .collect()
+}
+
+/// One source path per claim, so each can be relinked and unlinked
+/// independently.
+///
+/// The last claim takes the spool file itself; earlier ones get a hard link to
+/// it, which is a metadata op against one inode rather than a copy of the
+/// pixels. `None` for a claim whose link could not be made — its frames are lost
+/// but the other claims still route.
+fn claim_sources(spool_nut: &std::path::Path, claims: usize) -> Vec<Option<std::path::PathBuf>> {
+    (0..claims)
+        .map(|index| {
+            if index + 1 == claims {
+                return Some(spool_nut.to_path_buf());
+            }
+            let link = claim_link_path(spool_nut, index);
+            match std::fs::hard_link(spool_nut, &link) {
+                Ok(()) => Some(link),
+                Err(error) => {
+                    // Fall back to a copy: a spool on a filesystem without hard
+                    // links still splits, just not for free.
+                    match std::fs::copy(spool_nut, &link) {
+                        Ok(_) => Some(link),
+                        Err(copy_error) => {
+                            tracing::warn!(
+                                %error,
+                                %copy_error,
+                                path = %link.display(),
+                                "could not give a chunk claim its own source NUT; \
+                                 dropping that recording's share of the chunk"
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+/// Sibling path for one claim's hard link to a shared spool NUT.
+fn claim_link_path(spool_nut: &std::path::Path, index: usize) -> std::path::PathBuf {
+    let mut name = spool_nut.as_os_str().to_os_string();
+    name.push(format!(".claim{index}.nut"));
+    std::path::PathBuf::from(name)
 }
 
 fn remove_spool_nut(path: &std::path::Path) {
@@ -1480,6 +1635,20 @@ mod tests {
     use tempfile::TempDir;
     use tokio::sync::{broadcast, mpsc};
     use tokio::time::{timeout, Duration};
+
+    /// A live window for a source, as `handle_start` would have built it.
+    fn test_window(recording_index: i64, started_at_ns: i64) -> ActiveWindow {
+        ActiveWindow {
+            recording_index,
+            started_at_ns,
+            stopped_at_ns: None,
+            stop_recv_at: None,
+            awaiting_flush: false,
+            video_producers: HashSet::new(),
+            flushed_producers: HashSet::new(),
+            traces: HashMap::new(),
+        }
+    }
 
     async fn open_store() -> (SqliteStateStore, TempDir) {
         let dir = TempDir::new().expect("tempdir");
@@ -1856,33 +2025,202 @@ mod tests {
     }
 
     #[test]
-    fn frames_inside_window_cuts_at_the_stop_boundary() {
+    fn frame_range_cuts_at_the_stop_boundary() {
         // `video_boundary` tests the cut; this pins the argument order.
         let open_ns = 1_000_000_000;
-        let stop_ns = open_ns + 25 * 1_000_000;
+        let stop_ns = open_ns + 25 * 1_000;
         let offsets = [0, 10, 20, 30, 40];
-        assert_eq!(frames_inside_window(&offsets, open_ns, stop_ns, 5), 3);
-    }
-
-    #[test]
-    fn frames_inside_window_without_per_frame_data_takes_the_chunk_whole() {
-        // No offsets, no cut to make: the chunk routes whole.
         assert_eq!(
-            frames_inside_window(&[], 1_000_000_000, 1_000_000_000, 7),
-            7
+            frame_range_in_window(&offsets, open_ns, open_ns, Some(stop_ns), 5),
+            (0, 3)
         );
     }
 
     #[test]
-    fn frames_inside_window_clamps_to_the_announced_frame_count() {
+    fn frame_range_cuts_the_frames_published_before_the_window_opened() {
+        // The case a chunk-open-stamp membership rule could not express: a
+        // camera process that never calls start_recording has a chunk open when
+        // the window arrives, so its first frames predate the recording and the
+        // rest belong to it.
+        let open_ns = 1_000_000_000;
+        let started_at_ns = open_ns + 25 * 1_000;
+        let offsets = [0, 10, 20, 30, 40];
+        assert_eq!(
+            frame_range_in_window(&offsets, open_ns, started_at_ns, None, 5),
+            (3, 2)
+        );
+    }
+
+    #[test]
+    fn frame_range_cuts_both_ends_of_a_chunk_that_spans_a_whole_window() {
+        // A producer sealing only on its own caps can hold an entire recording
+        // inside one chunk, with frames either side of it.
+        let open_ns = 1_000_000_000;
+        let offsets = [0, 10, 20, 30, 40, 50];
+        assert_eq!(
+            frame_range_in_window(
+                &offsets,
+                open_ns,
+                open_ns + 15 * 1_000,
+                Some(open_ns + 45 * 1_000),
+                6
+            ),
+            (2, 3)
+        );
+    }
+
+    #[test]
+    fn frame_range_without_per_frame_data_is_all_or_nothing() {
+        // No offsets to cut on, so the open stamp decides the whole chunk.
+        let open_ns = 1_000_000_000;
+        assert_eq!(
+            frame_range_in_window(&[], open_ns, open_ns, None, 7),
+            (0, 7)
+        );
+        assert_eq!(
+            frame_range_in_window(&[], open_ns, open_ns + 1, None, 7),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn frame_range_clamps_to_the_announced_frame_count() {
         // The pipeline sizes itself from `frame_count`, so the cut cannot
         // exceed it.
         let open_ns = 1_000_000_000;
         let offsets = [0, 10, 20, 30];
         assert_eq!(
-            frames_inside_window(&offsets, open_ns, open_ns + 60 * 1_000_000, 2),
-            2
+            frame_range_in_window(&offsets, open_ns, open_ns, Some(open_ns + 60 * 1_000), 2),
+            (0, 2)
         );
+    }
+
+    #[test]
+    fn a_chunk_spanning_two_recordings_is_claimed_by_both() {
+        // The defect this replaced: one chunk held both recordings' frames and
+        // was dropped whole, because its open stamp sat before the first window.
+        let open_ns = 1_000_000_000;
+        let us = |n: i64| open_ns + n * 1_000;
+        let mut entry = WindowsForSource::default();
+        let mut first = test_window(1, us(10));
+        first.stopped_at_ns = Some(us(30));
+        entry.closing.push(first);
+        entry.live = Some(test_window(2, us(40)));
+
+        // Frames at 0..50 µs: before recording 1, inside it, between, inside 2.
+        let claims = claims_for_chunk(&entry, open_ns, &[0, 10, 20, 30, 40, 50], 6);
+
+        assert_eq!(
+            claims,
+            vec![
+                ChunkClaim {
+                    slot: WindowSlot::Closing(0),
+                    skip: 1,
+                    count: 2,
+                },
+                ChunkClaim {
+                    slot: WindowSlot::Live,
+                    skip: 4,
+                    count: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_claim_slices_the_sidecar_to_the_frames_it_owns() {
+        // The sidecar indexes the encoded mp4, so its stamps must be the same
+        // run the encode keeps: `skip` off the head, `count` off the tail.
+        let stamps = [0.0, 0.1, 0.2, 0.3, 0.4];
+        let claim = |skip, count| {
+            ChunkClaim {
+                slot: WindowSlot::Live,
+                skip,
+                count,
+            }
+            .timestamps(&stamps)
+        };
+
+        assert_eq!(claim(0, 5), stamps, "an uncut claim keeps every stamp");
+        assert_eq!(claim(0, 3), vec![0.0, 0.1, 0.2], "tail cut");
+        assert_eq!(claim(2, 3), vec![0.2, 0.3, 0.4], "head cut");
+        assert_eq!(claim(1, 2), vec![0.1, 0.2], "cut at both ends");
+        // A claim can only ever be clamped to `frame_count`, but the slice
+        // must not panic if the stamps run short of it.
+        assert_eq!(claim(3, 9), vec![0.3, 0.4]);
+        assert!(claim(9, 2).is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_flush_marker_credits_every_window_that_producer_reached() {
+        // A camera process publishes no stop, so it flushes once — at its own
+        // exit — and one of its chunks can carry several recordings. Crediting
+        // only the oldest window leaves the rest waiting out the flush-marker
+        // cap for a marker that is never coming.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store, context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let entry = dispatcher.windows.entry(source.clone()).or_default();
+        for (recording_index, started_at_ns) in [(1, 100), (2, 200)] {
+            let mut window = test_window(recording_index, started_at_ns);
+            window.stopped_at_ns = Some(started_at_ns + 50);
+            window.awaiting_flush = true;
+            window.video_producers.insert(7);
+            entry.closing.push(window);
+        }
+
+        dispatcher.mark_source_flushed(&source, 7);
+
+        let entry = &dispatcher.windows[&source];
+        assert!(
+            entry
+                .closing
+                .iter()
+                .all(|window| window.flush_markers_settled()),
+            "both windows the producer's chunk reached must be settled by its \
+             single marker"
+        );
+    }
+
+    #[test]
+    fn a_chunk_with_no_in_window_frame_claims_nothing() {
+        let open_ns = 1_000_000_000;
+        let entry = WindowsForSource {
+            live: Some(test_window(1, open_ns + 100 * 1_000)),
+            ..Default::default()
+        };
+        assert!(claims_for_chunk(&entry, open_ns, &[0, 10, 20], 3).is_empty());
+    }
+
+    #[test]
+    fn every_claim_but_the_last_gets_its_own_hard_link() {
+        // Each claim is relinked and unlinked by its own trace actor, so they
+        // cannot share one path.
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("chunk_1_2.nut");
+        std::fs::write(&spool, b"nut").unwrap();
+
+        let sources = claim_sources(&spool, 3);
+
+        let paths: Vec<_> = sources.into_iter().map(|s| s.unwrap()).collect();
+        assert_eq!(paths.len(), 3);
+        assert_eq!(paths[2], spool, "the last claim consumes the spool file");
+        for path in &paths {
+            assert_eq!(std::fs::read(path).unwrap(), b"nut");
+        }
+        // Distinct names over one inode: unlinking one leaves the others.
+        std::fs::remove_file(&paths[0]).unwrap();
+        assert!(paths[1].exists() && paths[2].exists());
+    }
+
+    #[test]
+    fn a_single_claim_never_copies_the_spool_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("chunk_9_9.nut");
+        std::fs::write(&spool, b"nut").unwrap();
+        assert_eq!(claim_sources(&spool, 1), vec![Some(spool)]);
     }
 
     /// Announce a finished single-frame chunk opened at `publish_ts`. The
@@ -1891,17 +2229,17 @@ mod tests {
         video_chunk_frames(robot, publish_ts, thread_id, producer_pid, &[0])
     }
 
-    /// As [`video_chunk`], with one frame per entry in `publish_offsets_ms`.
+    /// As [`video_chunk`], with one frame per entry in `publish_offsets_us`.
     fn video_chunk_frames(
         robot: &str,
         publish_ts: i64,
         thread_id: i64,
         producer_pid: u32,
-        publish_offsets_ms: &[u32],
+        publish_offsets_us: &[u32],
     ) -> Envelope {
-        let capture_stamps: Vec<i64> = publish_offsets_ms
+        let capture_stamps: Vec<i64> = publish_offsets_us
             .iter()
-            .map(|offset| publish_ts + i64::from(*offset) * 1_000_000)
+            .map(|offset| publish_ts + i64::from(*offset) * 1_000)
             .collect();
         Envelope::VideoChunkReady {
             robot_id: robot.into(),
@@ -1914,11 +2252,11 @@ mod tests {
             width: 64,
             height: 64,
             byte_count: 9,
-            frame_count: publish_offsets_ms.len() as u32,
+            frame_count: publish_offsets_us.len() as u32,
             frame_timestamps_s: capture_stamps.iter().map(|ns| *ns as f64 / 1e9).collect(),
             frame_timestamps_ns: capture_stamps,
             dtype: FrameDtype::Rgb8,
-            frame_publish_offsets_ms: publish_offsets_ms.to_vec(),
+            frame_publish_offsets_us: publish_offsets_us.to_vec(),
         }
     }
 
@@ -2007,7 +2345,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         // The chunk opens inside the window and its frames run past the stop.
-        let stop_ns = 150 + 25 * 1_000_000;
+        let stop_ns = 150 + 25 * 1_000;
         dispatcher
             .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
@@ -2051,7 +2389,7 @@ mod tests {
 
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
-        let stop_ns = 150 + 25 * 1_000_000;
+        let stop_ns = 150 + 25 * 1_000;
         dispatcher
             .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -314,8 +314,12 @@ pub enum TraceActorMessage {
         height: u32,
         /// Size of the spooled NUT file in bytes.
         byte_count: u64,
-        /// Number of frames in the chunk.
+        /// Number of frames of the chunk this recording owns, counted from
+        /// `skip_frames`.
         frame_count: u32,
+        /// Leading frames of the chunk published before this recording's window
+        /// opened, discarded by the encode.
+        skip_frames: u32,
         /// Per-frame `timestamp_s` for the metadata sidecar, in capture order.
         frame_timestamps_s: Vec<f64>,
         /// Original dtype of every frame in this chunk. The daemon never
@@ -383,8 +387,13 @@ struct QueuedChunk {
     spool_nut: PathBuf,
     /// Size of the spooled NUT file in bytes.
     byte_count: u64,
-    /// Number of frames in the chunk.
+    /// Number of frames of the chunk this recording owns, counted from
+    /// `skip_frames`.
     frame_count: u32,
+    /// Leading frames the encode discards (see
+    /// [`BatchNutInput::skip_frames`]). A chunk with a head cut is never
+    /// batched with another (see [`drain_encode_batch`]).
+    skip_frames: u32,
     /// Per-frame `timestamp_s` values in capture order. The first entry also
     /// anchors the batch's inter-chunk duration spans.
     frame_timestamps_s: Vec<f64>,
@@ -468,6 +477,7 @@ pub async fn run(
                 height,
                 byte_count,
                 frame_count,
+                skip_frames,
                 frame_timestamps_s,
                 dtype,
             } => {
@@ -480,6 +490,7 @@ pub async fn run(
                         height,
                         byte_count,
                         frame_count,
+                        skip_frames,
                         frame_timestamps_s,
                         dtype,
                     )
@@ -696,6 +707,7 @@ impl ActorState {
         height: u32,
         byte_count: u64,
         frame_count: u32,
+        skip_frames: u32,
         frame_timestamps_s: Vec<f64>,
         dtype: FrameDtype,
     ) {
@@ -780,6 +792,7 @@ impl ActorState {
                 spool_nut,
                 byte_count,
                 frame_count,
+                skip_frames,
                 frame_timestamps_s,
                 dtype,
             });
@@ -1376,6 +1389,7 @@ impl EncodeWorker {
                 // One entry per non-last chunk, so the last gets no line.
                 span_to_next_us: spans_to_next_us.get(position).copied(),
                 frame_count: chunk.frame_count,
+                skip_frames: chunk.skip_frames,
             })
             .collect();
         let request = BatchEncodeRequest {
@@ -1506,8 +1520,18 @@ fn drain_encode_batch(queue: &mut VecDeque<QueuedChunk>) -> Vec<QueuedChunk> {
         }) {
             break;
         }
+        // A head cut is a filter over the whole concatenated stream, and the
+        // frames it discards still occupy the entry's declared span, so a chunk
+        // with one only ever encodes alone.
+        if front.skip_frames > 0 && !batch.is_empty() {
+            break;
+        }
+        let head_cut = front.skip_frames > 0;
         let chunk = queue.pop_front().expect("front exists");
         batch.push(chunk);
+        if head_cut {
+            break;
+        }
     }
     batch
 }
@@ -1830,6 +1854,7 @@ mod tests {
                     16,
                     byte_count,
                     4,
+                    0,
                     frame_timestamps_s,
                     FrameDtype::Rgb8,
                 )
@@ -1930,6 +1955,7 @@ mod tests {
                     16,
                     byte_count,
                     2,
+                    0,
                     frame_timestamps_s,
                     dtype,
                 )
@@ -2160,6 +2186,7 @@ mod tests {
                 16,
                 byte_count,
                 frame_count,
+                0,
                 frame_timestamps_s,
                 dtype,
             )
@@ -2194,6 +2221,7 @@ mod tests {
                 spool_nut: PathBuf::from("unused.nut"),
                 byte_count: 0,
                 frame_count: 1,
+                skip_frames: 0,
                 frame_timestamps_s: vec![0.0],
                 dtype,
             }
@@ -2230,6 +2258,43 @@ mod tests {
     }
 
     #[test]
+    fn drain_keeps_a_head_cut_chunk_in_its_own_batch() {
+        fn queued(chunk_index: u32, skip_frames: u32) -> QueuedChunk {
+            QueuedChunk {
+                chunk_index,
+                spool_nut: PathBuf::from("unused.nut"),
+                byte_count: 0,
+                frame_count: 1,
+                skip_frames,
+                frame_timestamps_s: vec![0.0],
+                dtype: FrameDtype::Rgb8,
+            }
+        }
+        fn indices(batch: &[QueuedChunk]) -> Vec<u32> {
+            batch.iter().map(|chunk| chunk.chunk_index).collect()
+        }
+
+        // The head cut trims the whole concatenated stream, so a chunk that
+        // carries one encodes alone; the chunks behind it batch normally.
+        let mut queue: VecDeque<QueuedChunk> = [queued(0, 2), queued(1, 0), queued(2, 0)]
+            .into_iter()
+            .collect();
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![0]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![1, 2]);
+        assert!(queue.is_empty());
+
+        // A head cut behind an uncut chunk ends that batch before it rather
+        // than joining it.
+        let mut queue: VecDeque<QueuedChunk> = [queued(0, 0), queued(1, 3), queued(2, 0)]
+            .into_iter()
+            .collect();
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![0]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![1]);
+        assert_eq!(indices(&drain_encode_batch(&mut queue)), vec![2]);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
     fn drain_stops_before_a_chunk_past_the_span_cap() {
         fn queued(chunk_index: u32, frame_capture_us: &[i64]) -> QueuedChunk {
             QueuedChunk {
@@ -2237,6 +2302,7 @@ mod tests {
                 spool_nut: PathBuf::from("unused.nut"),
                 byte_count: 0,
                 frame_count: frame_capture_us.len() as u32,
+                skip_frames: 0,
                 frame_timestamps_s: frame_capture_us.iter().map(|us| *us as f64 / 1e6).collect(),
                 dtype: FrameDtype::Rgb8,
             }
@@ -2568,6 +2634,7 @@ mod tests {
                 16,
                 19,
                 2,
+                0,
                 vec![0.1, 0.116683],
                 FrameDtype::Rgb8,
             )

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -101,7 +101,7 @@ fn start_recording(
         // (publish clock when omitted). Decoupled from the window boundary.
         let capture_timestamp_ns = timestamp_ns.unwrap_or(publish_timestamp_ns);
         publish(&Envelope::StartRecording {
-            robot_id: robot_id.clone(),
+            robot_id,
             robot_instance,
             robot_name,
             dataset_id,
@@ -110,12 +110,8 @@ fn start_recording(
             timestamp_ns: capture_timestamp_ns,
             cloud_recording_id,
         })?;
-        // Tell the writer where the window opened, so no chunk spans it.
-        let _ = writer_queue().push(WriterMsg::Boundary {
-            robot_id,
-            robot_instance,
-            publish_ns: publish_timestamp_ns,
-        });
+        // The writer is deliberately not told where the window opened: a chunk
+        // may span the boundary, and the daemon splits it per frame.
         Ok(capture_timestamp_ns)
     })
 }

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -57,7 +57,7 @@ use std::sync::{Arc, Condvar, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::service_name::{MAX_VIDEO_CHUNK_FRAMES, VIDEO_SPOOL_TICKS_PER_SECOND};
-use data_daemon_shared::video_boundary::{at_or_past_boundary, publish_offset_ms};
+use data_daemon_shared::video_boundary::publish_offset_us;
 use data_daemon_shared::{Envelope, FrameDtype};
 
 use crate::nut_writer::{NutVideoConfig, NutWriter};
@@ -72,14 +72,18 @@ use crate::publisher::{now_ns, publisher_tx, ProducerError, PublishMsg};
 /// daemon batches several chunks into one ffmpeg invocation, which amortises
 /// that fixed cost further, but this sizing assumes the keep-pace case. The
 /// threshold is checked *after* each frame, so the on-disk file can exceed it
-/// by at most one frame. A chunk is also rolled at every lifecycle event so a
-/// single NUT only ever holds frames from one recording window.
+/// by at most one frame.
 ///
 /// This byte threshold has a companion frame-count cap
 /// ([`MAX_VIDEO_CHUNK_FRAMES`]): a chunk is sealed at whichever bound is hit
 /// first (see [`should_flush_chunk`]). Small frames never reach 256 MiB
 /// mid-recording, so the frame cap is what bounds the chunk's announcement
 /// envelope to one commands slice.
+///
+/// A chunk is *not* aligned to recording boundaries: it is a container, not a
+/// member. The daemon resolves membership per frame and splits one chunk across
+/// every window its frames fall in, so the producer never needs to know where a
+/// window opened.
 ///
 /// One chunk's worth is also the in-RAM writer-queue ceiling
 /// ([`WRITER_QUEUE_MAX_BYTES`]): changing this size moves both the chunk
@@ -201,9 +205,6 @@ struct VideoChunkState {
     /// Previous chunk's `chunk_publish_ns`, so the next open can be forced
     /// strictly above it. `0` before the first chunk.
     last_chunk_publish_ns: i64,
-    /// A recording-window boundary this stream has yet to cross: the first
-    /// frame to reach it seals the open chunk, so none spans the boundary.
-    pending_split_ns: Option<i64>,
     /// OS thread id (`gettid`) of the thread that opened the in-progress chunk.
     chunk_thread_id: i64,
     /// Frames already written into the in-progress chunk.
@@ -229,9 +230,9 @@ struct VideoChunkState {
     frame_timestamps_ns: Vec<i64>,
     /// Per-frame `timestamp_s` accumulator for the in-progress chunk.
     frame_timestamps_s: Vec<f64>,
-    /// Per-frame publish time as ms after `chunk_publish_ns`, which is what
+    /// Per-frame publish time as µs after `chunk_publish_ns`, which is what
     /// lets the daemon cut this chunk at a boundary inside it.
-    frame_publish_offsets_ms: Vec<u32>,
+    frame_publish_offsets_us: Vec<u32>,
 }
 
 /// Process-wide registry of in-progress per-`(source, sensor)` video chunk
@@ -242,8 +243,6 @@ type VideoChunkSlot = Arc<Mutex<VideoChunkState>>;
 struct VideoChunkRegistry {
     owner_pid: u32,
     streams: HashMap<String, VideoChunkSlot>,
-    /// Latest recording-window boundary seen per source prefix.
-    boundaries: HashMap<String, i64>,
     /// Last claim published per source prefix — the rate limiter's only state.
     claims: HashMap<String, i64>,
 }
@@ -252,7 +251,6 @@ static VIDEO_CHUNKS: LazyLock<Mutex<VideoChunkRegistry>> = LazyLock::new(|| {
     Mutex::new(VideoChunkRegistry {
         owner_pid: 0,
         streams: HashMap::new(),
-        boundaries: HashMap::new(),
         claims: HashMap::new(),
     })
 });
@@ -269,7 +267,6 @@ fn with_video_registry<R>(operation: impl FnOnce(&mut VideoChunkRegistry) -> R) 
     let pid = std::process::id();
     if registry.owner_pid != pid {
         registry.streams.clear();
-        registry.boundaries.clear();
         // A forked child is a different pid, so it owes its own claim.
         registry.claims.clear();
         registry.owner_pid = pid;
@@ -323,12 +320,6 @@ pub(crate) enum WriterMsg {
         robot_id: String,
         robot_instance: i64,
         ack: Sender<()>,
-    },
-    /// A window opened at `publish_ns`; no chunk may straddle it.
-    Boundary {
-        robot_id: String,
-        robot_instance: i64,
-        publish_ns: i64,
     },
 }
 
@@ -951,13 +942,6 @@ fn writer_loop(queue: &FrameQueue, pool: &CompressPool) {
                 });
                 let _ = ack.send(());
             }
-            Some(WriterMsg::Boundary {
-                robot_id,
-                robot_instance,
-                publish_ns,
-            }) => {
-                arm_boundary_split(&robot_id, robot_instance, publish_ns);
-            }
             // pop_timeout elapsed with no message: fall through to the rescan.
             None => {}
         }
@@ -1053,11 +1037,6 @@ fn record_video_frame(
             return Some(slot.clone());
         }
         let spool = spool_dir(robot_id, robot_instance, data_type, sensor_name)?;
-        // This stream is new, but its first frames may predate the window.
-        let pending_split_ns = registry
-            .boundaries
-            .get(&source_prefix(robot_id, robot_instance))
-            .copied();
         let slot = Arc::new(Mutex::new(VideoChunkState {
             width,
             height,
@@ -1066,7 +1045,6 @@ fn record_video_frame(
             nut_writer: None,
             chunk_publish_ns: 0,
             last_chunk_publish_ns: 0,
-            pending_split_ns,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1075,7 +1053,7 @@ fn record_video_frame(
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
-            frame_publish_offsets_ms: Vec::new(),
+            frame_publish_offsets_us: Vec::new(),
         }));
         registry.streams.insert(key.clone(), slot.clone());
         Some(slot)
@@ -1155,20 +1133,6 @@ fn append_frame_locked(
             announcements.push(envelope);
         }
     };
-
-    // A window opened partway through the queued frames. Without this seal one
-    // chunk spans the boundary and its pre-window open stamp orphans every
-    // in-window frame in it. The boundary is one-shot, so the first frame to
-    // reach it consumes it whether or not a chunk was open to seal.
-    if state
-        .pending_split_ns
-        .is_some_and(|split_ns| at_or_past_boundary(split_ns, publish_ns))
-    {
-        state.pending_split_ns = None;
-        if state.nut_writer.is_some() {
-            seal(state, &mut announcements);
-        }
-    }
 
     // A mid-stream resolution *or dtype* change can't share a chunk with the
     // prior state: the NUT header advertises the opening frame's size, and a
@@ -1309,8 +1273,8 @@ fn append_frame_locked(
     state.frame_timestamps_ns.push(timestamp_ns);
     state.frame_timestamps_s.push(timestamp_s);
     state
-        .frame_publish_offsets_ms
-        .push(publish_offset_ms(state.chunk_publish_ns, publish_ns));
+        .frame_publish_offsets_us
+        .push(publish_offset_us(state.chunk_publish_ns, publish_ns));
 
     if should_flush_chunk(logical_bytes_after_write, state.frame_count) {
         seal(state, &mut announcements);
@@ -1340,7 +1304,7 @@ fn flush_chunk_locked(
             state.frame_count = 0;
             state.frame_timestamps_ns.clear();
             state.frame_timestamps_s.clear();
-            state.frame_publish_offsets_ms.clear();
+            state.frame_publish_offsets_us.clear();
             return None;
         }
     };
@@ -1350,7 +1314,7 @@ fn flush_chunk_locked(
     let frame_count = state.frame_count;
     let frame_timestamps_ns = std::mem::take(&mut state.frame_timestamps_ns);
     let frame_timestamps_s = std::mem::take(&mut state.frame_timestamps_s);
-    let frame_publish_offsets_ms = std::mem::take(&mut state.frame_publish_offsets_ms);
+    let frame_publish_offsets_us = std::mem::take(&mut state.frame_publish_offsets_us);
 
     state.frame_count = 0;
 
@@ -1369,27 +1333,8 @@ fn flush_chunk_locked(
         frame_timestamps_ns,
         frame_timestamps_s,
         dtype: state.dtype,
-        frame_publish_offsets_ms,
+        frame_publish_offsets_us,
     })
-}
-
-/// Arm a pending window-boundary split on every stream of a source.
-fn arm_boundary_split(robot_id: &str, robot_instance: i64, publish_ns: i64) {
-    let prefix = source_prefix(robot_id, robot_instance);
-    let slots: Vec<VideoChunkSlot> = with_video_registry(|registry| {
-        // Recorded per source, so a not-yet-created stream still picks it up.
-        registry.boundaries.insert(prefix.clone(), publish_ns);
-        registry
-            .streams
-            .iter()
-            .filter(|(key, _)| key.starts_with(&prefix))
-            .map(|(_, slot)| slot.clone())
-            .collect()
-    });
-    for slot in slots {
-        let mut state = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.pending_split_ns = Some(publish_ns);
-    }
 }
 
 /// Flush and remove every open video chunk for a source. Each flushed chunk is
@@ -1592,7 +1537,6 @@ mod tests {
             nut_writer: None,
             chunk_publish_ns: 0,
             last_chunk_publish_ns: 0,
-            pending_split_ns: None,
             chunk_thread_id: 0,
             frame_count: 0,
             pts_origin_us: None,
@@ -1601,7 +1545,7 @@ mod tests {
             pts_synth_warned: false,
             frame_timestamps_ns: Vec::new(),
             frame_timestamps_s: Vec::new(),
-            frame_publish_offsets_ms: Vec::new(),
+            frame_publish_offsets_us: Vec::new(),
         }
     }
 
@@ -1648,75 +1592,51 @@ mod tests {
     }
 
     #[test]
-    fn a_window_boundary_splits_the_chunk_it_would_have_spanned() {
-        // Frames logged either side of `start_recording` can sit in the queue
-        // together, and a chunk spanning the boundary is orphaned whole.
+    fn a_chunk_may_span_a_window_boundary() {
+        // The producer knows nothing of windows: frames logged either side of a
+        // `start_recording` share a chunk, and the per-frame publish offsets are
+        // what let the daemon cut it at the boundary inside it.
         let dir = tempfile::tempdir().unwrap();
         let mut state = fresh_state(dir.path().to_path_buf(), 2, 2);
         let frame = vec![0u8; 2 * 2 * 3];
         let boundary = TEST_PUBLISH_NS;
 
-        // A frame logged before the window opened.
-        append_frame_locked(
-            &mut state,
-            "r",
-            0,
-            "RGB",
-            "cam",
-            2,
-            2,
-            FrameDtype::Rgb8,
-            &frame,
-            boundary - 1_000_000,
-            1_000,
-            0.0,
-        );
-        let pre_window_stamp = state.chunk_publish_ns;
-        state.pending_split_ns = Some(boundary);
-
-        // The first frame at/after the boundary must seal that chunk first.
-        let sealed = append_frame_locked(
-            &mut state,
-            "r",
-            0,
-            "RGB",
-            "cam",
-            2,
-            2,
-            FrameDtype::Rgb8,
-            &frame,
-            boundary,
-            2_000,
-            0.001,
-        );
-
-        assert_eq!(
-            sealed.len(),
-            1,
-            "crossing the boundary seals the open chunk"
-        );
-        match &sealed[0] {
-            Envelope::VideoChunkReady {
-                publish_timestamp_ns,
-                frame_count,
-                ..
-            } => {
-                assert_eq!(
-                    *publish_timestamp_ns, pre_window_stamp,
-                    "the sealed chunk keeps its pre-window stamp, so the daemon \
-                     orphans only the frames that really are pre-window"
-                );
-                assert_eq!(*frame_count, 1);
-            }
-            other => panic!("expected VideoChunkReady, got {other:?}"),
+        for (publish_ns, timestamp_ns, timestamp_s) in
+            [(boundary - 1_000_000, 1_000, 0.0), (boundary, 2_000, 0.001)]
+        {
+            let sealed = append_frame_locked(
+                &mut state,
+                "r",
+                0,
+                "RGB",
+                "cam",
+                2,
+                2,
+                FrameDtype::Rgb8,
+                &frame,
+                publish_ns,
+                timestamp_ns,
+                timestamp_s,
+            );
+            assert!(
+                sealed.is_empty(),
+                "no bound was reached, so nothing seals at the boundary"
+            );
         }
+
         assert_eq!(
-            state.chunk_publish_ns, boundary,
-            "and the replacement chunk opens inside the window"
+            state.frame_count, 2,
+            "both frames sit in the one open chunk"
         );
-        assert!(
-            state.pending_split_ns.is_none(),
-            "a boundary is applied exactly once"
+        assert_eq!(
+            state.chunk_publish_ns,
+            boundary - 1_000_000,
+            "which keeps the pre-window stamp of the frame that opened it"
+        );
+        assert_eq!(
+            state.frame_publish_offsets_us,
+            vec![0, 1_000],
+            "and each frame carries its own offset, so the daemon can split them"
         );
     }
 
@@ -2024,7 +1944,7 @@ mod tests {
         assert_eq!(state.frame_count, 0);
         assert!(state.frame_timestamps_ns.is_empty());
         assert!(state.frame_timestamps_s.is_empty());
-        assert!(state.frame_publish_offsets_ms.is_empty());
+        assert!(state.frame_publish_offsets_us.is_empty());
     }
 
     #[test]
@@ -2057,14 +1977,14 @@ mod tests {
         match envelope {
             Envelope::VideoChunkReady {
                 publish_timestamp_ns,
-                frame_publish_offsets_ms,
+                frame_publish_offsets_us,
                 ..
             } => {
                 assert_eq!(
                     publish_timestamp_ns, TEST_PUBLISH_NS,
                     "the chunk's open stamp is its first frame's publish stamp"
                 );
-                assert_eq!(frame_publish_offsets_ms, vec![0, 33, 66]);
+                assert_eq!(frame_publish_offsets_us, vec![0, 33_333, 66_666]);
             }
             other => panic!("expected VideoChunkReady, got {other:?}"),
         }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -57,17 +57,34 @@ pub mod paths;
 ///
 /// A chunk is a NUT file appended to until something seals it, so frames logged
 /// either side of a boundary can share one and its open stamp speaks only for
-/// the first. Both sides of the wire divide the work by what each knows in time:
+/// the first. Membership is therefore resolved per frame, at both bounds, and
+/// the **daemon** resolves it: from the per-frame offsets this module encodes it
+/// keeps the run of frames each window owns, and one chunk can be claimed by
+/// several windows.
 ///
-/// - The **producer** seals the open chunk before the first frame at or past a
-///   boundary, which only works at a recording's start and only in the process
-///   that called `start_recording`.
-/// - The **daemon** cuts a chunk it already holds, from the per-frame offsets
-///   this module encodes. Only this works at a stop, where a video-only process
-///   logs on until its notification arrives and the frames are already written.
+/// The **producer** seals on nothing but its own caps — size and frame count —
+/// and is never told where a window opened, so a chunk spanning one (or several)
+/// is the normal case rather than the exception. Nothing aligns a chunk to a
+/// window: that is what lets a camera process which opens no window of its own
+/// still keep every frame it logged inside someone else's recording.
 pub mod video_boundary {
-    /// Nanoseconds per millisecond, the wire resolution of a frame offset.
-    const NS_PER_MS: i64 = 1_000_000;
+    /// Nanoseconds per microsecond, the wire resolution of a frame offset.
+    ///
+    /// Microseconds, not milliseconds, because the offset is **floored**: a
+    /// frame's reconstructed publish time is up to one unit earlier than its
+    /// true one, which can push a frame published just inside a window back
+    /// across its start bound. Adjacent windows do not abut — a recording stops
+    /// before the next starts — so a frame pushed into that gap is claimed by
+    /// neither and its pixels are dropped. At millisecond resolution and a fast
+    /// camera that is a frame lost at a boundary crossing; a microsecond is far
+    /// finer than any frame interval, which closes it.
+    ///
+    /// `u32` microseconds saturates at ~71 minutes of chunk span, far beyond any
+    /// chunk a producer holds open, and [`publish_offset_us`] clamps rather than
+    /// wrapping. It also matches the NUT spool time base
+    /// ([`crate::service_name::VIDEO_SPOOL_TICKS_PER_SECOND`]), so every stage of
+    /// the video path measures in the same unit.
+    const NS_PER_US: i64 = 1_000;
 
     /// Is `frame_publish_ns` at or past the recording boundary `bound_ns`?
     ///
@@ -76,27 +93,27 @@ pub mod video_boundary {
         frame_publish_ns >= bound_ns
     }
 
-    /// One frame's publish time as ms after its chunk's open stamp.
-    pub fn publish_offset_ms(chunk_open_ns: i64, frame_publish_ns: i64) -> u32 {
+    /// One frame's publish time as µs after its chunk's open stamp, floored.
+    pub fn publish_offset_us(chunk_open_ns: i64, frame_publish_ns: i64) -> u32 {
         let offset_ns = frame_publish_ns.saturating_sub(chunk_open_ns).max(0);
-        (offset_ns / NS_PER_MS).try_into().unwrap_or(u32::MAX)
+        (offset_ns / NS_PER_US).try_into().unwrap_or(u32::MAX)
     }
 
-    /// The inverse of [`publish_offset_ms`], paired with it so neither can
+    /// The inverse of [`publish_offset_us`], paired with it so neither can
     /// change alone.
-    pub fn frame_publish_ns(chunk_open_ns: i64, offset_ms: u32) -> i64 {
-        chunk_open_ns.saturating_add(i64::from(offset_ms) * NS_PER_MS)
+    pub fn frame_publish_ns(chunk_open_ns: i64, offset_us: u32) -> i64 {
+        chunk_open_ns.saturating_add(i64::from(offset_us) * NS_PER_US)
     }
 
     /// Leading frames published before `bound_ns`, i.e. the index of the first
     /// that is [`at_or_past_boundary`].
-    pub fn frames_before_boundary(offsets_ms: &[u32], chunk_open_ns: i64, bound_ns: i64) -> usize {
-        offsets_ms
+    pub fn frames_before_boundary(offsets_us: &[u32], chunk_open_ns: i64, bound_ns: i64) -> usize {
+        offsets_us
             .iter()
             .position(|offset| {
                 at_or_past_boundary(bound_ns, frame_publish_ns(chunk_open_ns, *offset))
             })
-            .unwrap_or(offsets_ms.len())
+            .unwrap_or(offsets_us.len())
     }
 
     #[cfg(test)]
@@ -114,22 +131,47 @@ pub mod video_boundary {
         }
 
         #[test]
-        fn offsets_round_trip_at_millisecond_resolution() {
-            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS), 0);
+        fn offsets_round_trip_at_microsecond_resolution() {
+            assert_eq!(publish_offset_us(CHUNK_OPEN_NS, CHUNK_OPEN_NS), 0);
             assert_eq!(
-                publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1_500_000),
-                1
+                publish_offset_us(CHUNK_OPEN_NS, CHUNK_OPEN_NS + 1_500),
+                1,
+                "a sub-microsecond remainder floors away"
             );
             assert_eq!(
-                frame_publish_ns(CHUNK_OPEN_NS, 33),
-                CHUNK_OPEN_NS + 33_000_000
+                frame_publish_ns(CHUNK_OPEN_NS, 33_333),
+                CHUNK_OPEN_NS + 33_333_000
+            );
+        }
+
+        #[test]
+        fn a_frame_just_inside_a_window_is_not_floored_out_of_it() {
+            // The hole microsecond resolution closes. A recording stops, the
+            // next starts a millisecond later, and a frame lands just inside the
+            // new window. Floored to the millisecond it would reconstruct
+            // *before* that start — into the gap between the two recordings,
+            // owned by neither — and its pixels would be dropped.
+            let stop_ns = CHUNK_OPEN_NS + 4_000_000;
+            let start_ns = stop_ns + 1_000_000;
+            let frame_ns = start_ns + 400_000; // 0.4 ms into the new recording
+
+            let offset = publish_offset_us(CHUNK_OPEN_NS, frame_ns);
+            let reconstructed = frame_publish_ns(CHUNK_OPEN_NS, offset);
+
+            assert!(
+                reconstructed >= start_ns,
+                "the frame must still read as inside the window it was logged in"
+            );
+            assert!(
+                reconstructed > stop_ns,
+                "and must not fall back into the gap before it"
             );
         }
 
         #[test]
         fn publish_offset_saturates_at_the_chunk_open() {
             // A backwards caller clock reads as 0 rather than wrapping.
-            assert_eq!(publish_offset_ms(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 5), 0);
+            assert_eq!(publish_offset_us(CHUNK_OPEN_NS, CHUNK_OPEN_NS - 5), 0);
         }
 
         #[test]
@@ -191,7 +233,7 @@ pub mod service_name {
     /// [`crate::Envelope::VideoChunkReady`] announcement: a `frame_timestamps_ns`
     /// element is an `i64` zigzag varint (≤10 bytes for a full-range Unix-ns
     /// value), a `frame_timestamps_s` element is a fixed 8-byte `f64`, and a
-    /// `frame_publish_offsets_ms` element is a `u32` varint (≤5 bytes).
+    /// `frame_publish_offsets_us` element is a `u32` varint (≤5 bytes).
     pub const VIDEO_CHUNK_BYTES_PER_FRAME: usize = 10 + 8 + 5;
 
     /// Bytes held back from [`COMMANDS_MAX_PAYLOAD_BYTES`] for a
@@ -205,7 +247,7 @@ pub mod service_name {
     /// The producer seals a chunk at the **lower** of its byte threshold and
     /// this frame cap. The cap exists so a [`crate::Envelope::VideoChunkReady`]
     /// announcement always fits one [`COMMANDS_MAX_PAYLOAD_BYTES`] sample: the
-    /// per-frame `frame_timestamps_{ns,s}` and `frame_publish_offsets_ms`
+    /// per-frame `frame_timestamps_{ns,s}` and `frame_publish_offsets_us`
     /// vectors are the only unbounded part
     /// of the envelope, so a long recording of small frames — which never
     /// reaches the byte threshold mid-recording — would otherwise accumulate
@@ -535,7 +577,7 @@ pub enum Envelope {
         frame_count: u32,
         /// Per-frame capture time in nanoseconds since the Unix epoch, in
         /// arrival order. Length equals `frame_count`. Capture-clock content for
-        /// the trace sidecar; routing uses `frame_publish_offsets_ms`.
+        /// the trace sidecar; routing uses `frame_publish_offsets_us`.
         frame_timestamps_ns: Vec<i64>,
         /// Per-frame `timestamp_s` (Unix seconds, f64) in arrival order.
         /// Length equals `frame_count`; values round-trip bit-exact through
@@ -546,10 +588,10 @@ pub enum Envelope {
         /// geometry change). The daemon never decodes pixels; it threads this
         /// straight into the trace's `trace.json` sidecar for depth frames.
         dtype: FrameDtype,
-        /// Per-frame publish time as ms after this chunk's own
+        /// Per-frame publish time as µs after this chunk's own
         /// `publish_timestamp_ns`, in arrival order. What makes chunk membership
         /// per-frame rather than atomic; see [`video_boundary`].
-        frame_publish_offsets_ms: Vec<u32>,
+        frame_publish_offsets_us: Vec<u32>,
     },
     /// Force the daemon to re-read its profile config immediately, rather than
     /// waiting for the config watcher's next poll. Sent by the SDK's
@@ -1102,7 +1144,7 @@ mod tests {
                 7.0_f64 / 60.0_f64,
             ],
             dtype: FrameDtype::Rgb8,
-            frame_publish_offsets_ms: vec![0, 16, 33, 50],
+            frame_publish_offsets_us: vec![0, 16, 33, 50],
         };
         let bytes = original.encode().expect("encode");
         let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1135,7 +1177,7 @@ mod tests {
                 frame_timestamps_ns: vec![1_700_000_000_000_000_000],
                 frame_timestamps_s: vec![1_700_000_000.0],
                 dtype,
-                frame_publish_offsets_ms: vec![0],
+                frame_publish_offsets_us: vec![0],
             };
             let bytes = original.encode().expect("encode");
             let decoded = Envelope::decode(&bytes).expect("decode");
@@ -1179,7 +1221,7 @@ mod tests {
         // COMMANDS_MAX_PAYLOAD_BYTES even at an implausible frame count.
         let frame_timestamps_ns: Vec<i64> = (0..10_000).map(|i| i as i64 * 1_000_000).collect();
         let frame_timestamps_s: Vec<f64> = (0..10_000).map(|i| i as f64 * 1e-3).collect();
-        let frame_publish_offsets_ms: Vec<u32> = (0..10_000).collect();
+        let frame_publish_offsets_us: Vec<u32> = (0..10_000).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: 0,
@@ -1195,7 +1237,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
-            frame_publish_offsets_ms,
+            frame_publish_offsets_us,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(
@@ -1218,7 +1260,7 @@ mod tests {
         let count = service_name::MAX_VIDEO_CHUNK_FRAMES as usize;
         let frame_timestamps_ns: Vec<i64> = (0..count).map(|i| i64::MAX - i as i64).collect();
         let frame_timestamps_s: Vec<f64> = (0..count).map(|i| i as f64).collect();
-        let frame_publish_offsets_ms: Vec<u32> = (0..count).map(|_| u32::MAX).collect();
+        let frame_publish_offsets_us: Vec<u32> = (0..count).map(|_| u32::MAX).collect();
         let envelope = Envelope::VideoChunkReady {
             robot_id: "11111111-2222-3333-4444-555555555555".into(),
             robot_instance: i64::MAX,
@@ -1234,7 +1276,7 @@ mod tests {
             frame_timestamps_ns,
             frame_timestamps_s,
             dtype: FrameDtype::Rgb8,
-            frame_publish_offsets_ms,
+            frame_publish_offsets_us,
         };
         let bytes = envelope.encode().expect("encode");
         assert!(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Per-frame publish offsets on chunk announcements, so one video chunk can be claimed by several recordings

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Frames logged either side of a recording boundary are no longer dropped with the chunk that held them
