### PR TITLE
fix: recording start from web

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -182,6 +182,7 @@ def connect_robot(
     StreamManagerOrchestrator().get_provider_manager(robot.id, robot.instance)
     get_recording_state_manager().register_connected_robot(robot.id)
     robot._register_remote_stop_handler()
+    robot._register_remote_start_handler()
     return robot
 
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -394,6 +394,38 @@ class Robot:
         )
         self._recording_state_manager = manager
 
+    def _notify_daemon_of_remote_start(
+        self, recording_id: str, dataset_id: str, start_time: float
+    ) -> None:
+        """Open the daemon window for a recording started from the web frontend.
+
+        Args:
+            recording_id: The cloud recording id the backend already minted.
+            dataset_id: Dataset the recording is being saved to.
+            start_time: The recording's capture start time (Unix seconds).
+        """
+        if not self.id:
+            return
+        self._get_daemon_recording_context().start_recording(
+            robot_id=self.id,
+            robot_instance=self.instance,
+            robot_name=self.name,
+            dataset_id=dataset_id,
+            dataset_name=None,
+            timestamp=start_time,
+            cloud_recording_id=recording_id,
+        )
+
+    def _register_remote_start_handler(self) -> None:
+        """Register a callback to notify the daemon of a remote start."""
+        assert self.id is not None
+        manager = get_recording_state_manager()
+        manager.register_remote_start_handler(
+            robot_id=self.id,
+            instance=self.instance,
+            callback=self._notify_daemon_of_remote_start,
+        )
+
     def _stop_all_streams(self) -> None:
         """Stop recording on all data streams for this robot instance."""
         for stream_id, stream in list(self._data_streams.items()):
@@ -797,6 +829,7 @@ class Robot:
         self._recording_state_manager = None
         if self.id is not None and manager is not None:
             manager.deregister_remote_stop_handler(self.id, self.instance)
+            manager.deregister_remote_start_handler(self.id, self.instance)
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -55,10 +55,12 @@ class TrackedRecording(NamedTuple):
             backend reports in ``RecordingStartPayload.start_time``. Orders
             notifications against each other: one describing a recording that
             began earlier than this belongs to an already-finished recording.
+        opened_locally: Whether the recording was started by the local client
     """
 
     recording_id: str
     start_time: float
+    opened_locally: bool
 
 
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
@@ -139,6 +141,9 @@ class RecordingStateManager(BaseSSEConsumer):
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
+        self._start_callbacks: dict[
+            RobotInstanceIdentifier, Callable[[str, str, float], None]
+        ] = {}
 
         self._logout_listener = self._on_logout
         self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
@@ -176,6 +181,7 @@ class RecordingStateManager(BaseSSEConsumer):
             self._expired_recording_ids.clear()
             self.active_dataset_ids.clear()
             self._drain_callbacks.clear()
+            self._start_callbacks.clear()
             self._connected_robot_id = None
 
         if not self.loop.is_closed():
@@ -263,6 +269,7 @@ class RecordingStateManager(BaseSSEConsumer):
                 instance=instance,
                 recording_id=recording_id,
                 start_time=start_time,
+                opened_locally=True,
             )
         # After the state is visible, and outside the lock: this normally takes
         # a few milliseconds of filesystem work, which is long enough for a
@@ -283,7 +290,12 @@ class RecordingStateManager(BaseSSEConsumer):
             logger.exception("Failed to ensure data daemon is running")
 
     def _track_recording_started(
-        self, robot_id: str, instance: int, recording_id: str, start_time: float
+        self,
+        robot_id: str,
+        instance: int,
+        recording_id: str,
+        start_time: float,
+        opened_locally: bool,
     ) -> None:
         """Make ``recording_id`` this instance's tracked recording.
 
@@ -300,7 +312,9 @@ class RecordingStateManager(BaseSSEConsumer):
             return
 
         self.recording_robot_instances[instance_key] = TrackedRecording(
-            recording_id=recording_id, start_time=start_time
+            recording_id=recording_id,
+            start_time=start_time,
+            opened_locally=opened_locally,
         )
         if previous_recording_id is not None:
             self._cancel_recording_timers(previous_recording_id)
@@ -420,11 +434,11 @@ class RecordingStateManager(BaseSSEConsumer):
         robot_id = details.robot_id
         instance = details.instance
         recording_id = details.recording_id
-
-        previous = self.recording_robot_instances.get(
-            RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance),
-            None,
+        instance_key = RobotInstanceIdentifier(
+            robot_id=robot_id, robot_instance=instance
         )
+
+        previous = self.recording_robot_instances.get(instance_key, None)
         previous_recording_id = previous.recording_id if previous is not None else None
         was_recording = previous_recording_id is not None
 
@@ -444,7 +458,7 @@ class RecordingStateManager(BaseSSEConsumer):
             # A START describing a recording that began before the tracked one
             # is a late notification for an already-finished recording: the
             # org-wide stream can lag a fast stop-then-start cycle by a whole
-            # recording. Adopting it would hand this instance a finished
+            # recording. Tracking it would hand this instance a finished
             # recording, whose STOP would then drain the live one.
             if (
                 previous is not None
@@ -465,26 +479,29 @@ class RecordingStateManager(BaseSSEConsumer):
                 len(details.dataset_ids) == 1
             ), "Recording can only be started in one dataset"
             dataset_id = details.dataset_ids[0]
-            instance_key = RobotInstanceIdentifier(
-                robot_id=robot_id, robot_instance=instance
-            )
             self.active_dataset_ids[instance_key] = dataset_id
             logger.info(
                 "active_dataset_received_from_sse: dataset_id=%s recording_id=%s",
                 dataset_id,
                 recording_id,
             )
-            # Daemon already ensured above; this is the state transition only.
+
+            # Only open the window if no one else has already.
+            opened_locally = previous is not None and previous.opened_locally
+            if not opened_locally:
+                start_callback = self._start_callbacks.get(instance_key)
+                if start_callback is not None:
+                    start_callback(recording_id, dataset_id, details.start_time)
+                opened_locally = True
+
             self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
                 recording_id=recording_id,
                 start_time=details.start_time,
+                opened_locally=opened_locally,
             )
         else:
-            instance_key = RobotInstanceIdentifier(
-                robot_id=robot_id, robot_instance=instance
-            )
             if previous_recording_id != recording_id:
                 return
             callback = self._drain_callbacks.get(instance_key)
@@ -521,6 +538,21 @@ class RecordingStateManager(BaseSSEConsumer):
         """Remove the drain callback for a robot instance."""
         key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
         self._drain_callbacks.pop(key, None)
+
+    def register_remote_start_handler(
+        self,
+        robot_id: str,
+        instance: int,
+        callback: Callable[[str, str, float], None],
+    ) -> None:
+        """Register a callback to open the daemon window for a web-initiated start."""
+        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
+        self._start_callbacks[key] = callback
+
+    def deregister_remote_start_handler(self, robot_id: str, instance: int) -> None:
+        """Remove the remote-start callback for a robot instance."""
+        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
+        self._start_callbacks.pop(key, None)
 
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -99,12 +99,15 @@ class RecordingContext:
         dataset_id: str | None = None,
         dataset_name: str | None = None,
         timestamp: float | None = None,
+        cloud_recording_id: str | None = None,
     ) -> None:
         """Announce a recording to the daemon for a source.
 
-        Publishes exactly one ``StartRecording`` envelope tagged with the
-        source ``(robot_id, robot_instance)``. No recording id is on the wire —
-        the daemon allocates and owns recording identity.
+        Publishes one ``StartRecording`` envelope tagged with the source
+        ``(robot_id, robot_instance)``. Normally the daemon mints its own
+        cloud id.
+
+        Cloud recording id is passed only when recording is started from web frontend
 
         ``timestamp`` is the recording's *capture* start time (Unix seconds),
         stored and reported as such, and returned as the marker that resolves the
@@ -122,6 +125,7 @@ class RecordingContext:
             dataset_id,
             dataset_name,
             timestamp_ns,
+            cloud_recording_id,
         )
 
     def log_joints(

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -410,11 +410,13 @@ impl Dispatcher {
                 dataset_id,
                 publish_timestamp_ns,
                 timestamp_ns,
+                cloud_recording_id,
                 ..
             } => {
                 self.handle_start(
                     (robot_id, robot_instance),
                     dataset_id,
+                    cloud_recording_id,
                     publish_timestamp_ns,
                     timestamp_ns,
                     recv_at,
@@ -604,10 +606,43 @@ impl Dispatcher {
         &mut self,
         source: Source,
         dataset_id: Option<String>,
+        cloud_recording_id: Option<String>,
         publish_timestamp_ns: i64,
         timestamp_ns: i64,
         recv_at: Instant,
     ) {
+        // A `StartRecording` carrying a known cloud id can reach this daemon
+        // more than once for the very same recording: every local process
+        // connected to the source learns about a web-started recording
+        // independently, and each may try to open it. Only the first must
+        // create a row and open a window.
+        if let Some(cloud_recording_id) = cloud_recording_id.as_deref() {
+            match self
+                .store
+                .recording_index_for_cloud_id(cloud_recording_id)
+                .await
+            {
+                Ok(Some(existing_index)) => {
+                    tracing::debug!(
+                        recording_index = existing_index,
+                        cloud_recording_id,
+                        robot_id = source.0,
+                        "recording already open for this cloud id; ignoring duplicate start"
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        cloud_recording_id,
+                        robot_id = source.0,
+                        "failed to check for an existing recording; proceeding"
+                    );
+                }
+            }
+        }
+
         // Insert the recording row synchronously: cloud notifiers react to the
         // `RecordingStarted` event by reading this row, and `cancel_recording`
         // burns it by index, so the row must exist before either runs. After the
@@ -693,8 +728,31 @@ impl Dispatcher {
             }
         }
 
-        if let Some(bus) = self.context.event_bus.as_ref() {
-            bus.publish(DaemonEvent::RecordingStarted { recording_index });
+        match cloud_recording_id {
+            None => {
+                if let Some(bus) = self.context.event_bus.as_ref() {
+                    bus.publish(DaemonEvent::RecordingStarted { recording_index });
+                }
+            }
+            Some(cloud_recording_id) => {
+                // The backend already created this id — skip the notifier's
+                // POST and wake its waiters directly.
+                if let Err(error) = self
+                    .store
+                    .mark_recording_start_notified(recording_index, &cloud_recording_id)
+                    .await
+                {
+                    tracing::warn!(
+                        %error,
+                        recording_index,
+                        cloud_recording_id,
+                        "failed to persist recording id"
+                    );
+                }
+                if let Some(bus) = self.context.event_bus.as_ref() {
+                    bus.publish(DaemonEvent::RecordingCloudIdAssigned { recording_index });
+                }
+            }
         }
     }
 
@@ -1464,6 +1522,7 @@ mod tests {
             dataset_name: None,
             publish_timestamp_ns,
             timestamp_ns: publish_timestamp_ns,
+            cloud_recording_id: None,
         }
     }
 
@@ -1950,7 +2009,7 @@ mod tests {
         // The chunk opens inside the window and its frames run past the stop.
         let stop_ns = 150 + 25 * 1_000_000;
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
@@ -1994,7 +2053,7 @@ mod tests {
         let opened_at = Instant::now();
         let stop_ns = 150 + 25 * 1_000_000;
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
@@ -2204,7 +2263,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         assert!(dispatcher.windows.get(&source).unwrap().live.is_some());
 
@@ -2252,7 +2311,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
 
         // Only a short time has passed — well within the idle horizon.
@@ -2282,7 +2341,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2324,7 +2383,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2370,7 +2429,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2415,7 +2474,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
 
         // The camera process claims the source as it logs, before any chunk.
@@ -2486,7 +2545,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), 200, 200, opened_at)
@@ -2523,7 +2582,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, 100, 100, opened_at)
+            .handle_start(source.clone(), None, None, 100, 100, opened_at)
             .await;
 
         // Producer A seals a chunk mid-recording, so the window knows of it.

--- a/rust/data_daemon/src/state/store.rs
+++ b/rust/data_daemon/src/state/store.rs
@@ -117,6 +117,13 @@ pub trait StateStore: Send + Sync {
         recording_id: &str,
     ) -> Result<Option<RecordingRow>, StateStoreError>;
 
+    /// Look up the local `recording_index` already assigned to `recording_id`,
+    /// if any.
+    async fn recording_index_for_cloud_id(
+        &self,
+        recording_id: &str,
+    ) -> Result<Option<i64>, StateStoreError>;
+
     /// List recordings whose `/recording/start` POST has not yet succeeded:
     /// `recording_id IS NULL`, `backend_start_notified_at IS NULL`, and the
     /// recording is not cancelled. The start notifier's startup sweep.
@@ -822,6 +829,19 @@ impl StateStore for SqliteStateStore {
         let row = Self::fetch_recording_locked(&mut tx, recording_index).await?;
         tx.commit().await?;
         Ok(row)
+    }
+
+    async fn recording_index_for_cloud_id(
+        &self,
+        recording_id: &str,
+    ) -> Result<Option<i64>, StateStoreError> {
+        let recording_index = sqlx::query_scalar::<_, i64>(
+            "SELECT recording_index FROM recordings WHERE recording_id = ?1 LIMIT 1",
+        )
+        .bind(recording_id)
+        .fetch_optional(&self.read_pool)
+        .await?;
+        Ok(recording_index)
     }
 
     async fn recordings_pending_start_notify(&self) -> Result<Vec<RecordingRow>, StateStoreError> {

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -74,8 +74,13 @@ use crate::writer::{note_video_activity, writer_queue, FrameJob, WriterMsg};
 /// `start_time`. The capture timestamp is returned so the caller can use it as
 /// the marker that resolves the daemon-assigned cloud recording id
 /// (`get_recording_id`) for this exact recording.
+///
+/// `cloud_recording_id` is set only when the backend already minted the id
+/// itself (a recording started from the web frontend) — the daemon then
+/// reuses it instead of POSTing `/recording/start`.
 #[pyfunction]
-#[pyo3(signature = (robot_id, robot_instance, robot_name = None, dataset_id = None, dataset_name = None, timestamp_ns = None))]
+#[pyo3(signature = (robot_id, robot_instance, robot_name = None, dataset_id = None, dataset_name = None, timestamp_ns = None, cloud_recording_id = None))]
+#[allow(clippy::too_many_arguments)]
 fn start_recording(
     py: Python<'_>,
     robot_id: &str,
@@ -84,6 +89,7 @@ fn start_recording(
     dataset_id: Option<String>,
     dataset_name: Option<String>,
     timestamp_ns: Option<i64>,
+    cloud_recording_id: Option<String>,
 ) -> PyResult<i64> {
     if robot_id.is_empty() {
         return Err(PyValueError::new_err("robot_id must not be empty"));
@@ -102,6 +108,7 @@ fn start_recording(
             dataset_name,
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
+            cloud_recording_id,
         })?;
         // Tell the writer where the window opened, so no chunk spans it.
         let _ = writer_queue().push(WriterMsg::Boundary {

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -34,9 +34,11 @@
 //! events ([`Envelope::StartRecording`] / [`Envelope::StopRecording`] /
 //! [`Envelope::CancelRecording`]) carrying the lifecycle wall-clock timestamp,
 //! and the daemon decides — from its per-source active-window map — which
-//! recording (if any) each datum belongs to. There is **no** `recording_id`,
-//! `recording_index`, `trace_id`, or `sequence_number` on the wire; the daemon
-//! assigns and stores those after routing.
+//! recording (if any) each datum belongs to. There is no `recording_index`,
+//! `trace_id`, or `sequence_number` on the wire; the daemon assigns and
+//! stores those after routing. `StartRecording` carries an optional
+//! `cloud_recording_id` for the one case where the backend, not the daemon,
+//! already minted it — a recording started from the web frontend.
 //!
 //! All envelopes — lifecycle, joints/scalars, and the chunk-ready
 //! notifications for video traces — travel over a single `commands` service.
@@ -384,6 +386,8 @@ pub enum Envelope {
         /// caller supplied none. Stored as the row's `start_timestamp_ns` and
         /// POSTed to the backend as `start_time`; never used for routing.
         timestamp_ns: i64,
+        /// Optional cloud recording id the backend already minted.
+        cloud_recording_id: Option<String>,
     },
     /// Producer announces that the source's active recording has stopped.
     ///
@@ -886,6 +890,7 @@ mod tests {
             dataset_name: Some("warehouse".into()),
             publish_timestamp_ns: 1_700_000_000_000_000_000,
             timestamp_ns: 1_700_000_000_000_000_000,
+            cloud_recording_id: None,
         };
         let bytes = original.encode().expect("encode");
         let decoded = Envelope::decode(&bytes).expect("decode");

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -246,7 +246,9 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
         )
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
-    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
+    manager.recording_robot_instances[key] = TrackedRecording(
+        "recording-1", 1.0, opened_locally=True
+    )
     manager.active_dataset_ids[key] = "dataset-1"
     manager._drain_callbacks[key] = MagicMock()
     timer = MagicMock()


### PR DESCRIPTION
Start recording from web was broken because client only updated its own local state, data daemon was never notified of the start sse. which is why logged data was silently dropped. The frontend test for this has been enabled which should now catch error if this flow gets forgotten about in the future.
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Notifies daemon when a recording is started remotely

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [NCP-1240](https://neuracore.atlassian.net/browse/NCP-1240)

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - [PULL-456](https://github.com/NeuracoreAI/neuracore_frontend/pull/456)

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
