### PR TITLE
fix: keep a local recording stoppable when its notification stream is rejected

### DIFF
--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -191,6 +191,23 @@ class RecordingStateManager(BaseSSEConsumer):
 
         self._discard_cached_manager()
 
+    def on_authentication_error(self) -> None:
+        """Stop consuming notifications, but keep locally owned recording state.
+
+        A stream the platform rejects is a lost notification channel, not the
+        end of the session. ``nc.stop_recording`` reads this state to decide
+        there is anything to stop, so clearing it here would leave the stop
+        unpublished and the daemon's recording window open until the reaper's
+        max-duration bound. An explicit logout still goes through
+        :meth:`close`, which clears everything — that is a statement that the
+        session is over, which this is not.
+        """
+        logger.warning(
+            "Recording notifications stopped: the stream could not authenticate. "
+            "Locally started recordings can still be stopped; remote stops will "
+            "not be observed until the next login."
+        )
+
     def _remove_logout_listener(self) -> None:
         """Remove the logout listener when it has not already fired."""
         if self._logout_listener in self.auth.listeners(Auth.LOGOUT_EVENT):

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -273,6 +273,58 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
     auth.emit(Auth.LOGOUT_EVENT)
 
 
+def test_recording_manager_keeps_owned_state_when_the_stream_cannot_authenticate(
+    nc_loop,
+) -> None:
+    """A rejected notification stream must not discard a local recording.
+
+    `nc.stop_recording` reads this state to decide there is anything to stop, so
+    clearing it on a stream failure leaves the stop unpublished and the daemon's
+    window open. Contrast `test_recording_manager_tears_down_owned_state`, where
+    an explicit logout clears it — that says the session is over, this does not.
+    """
+    auth = UnauthenticatedAuth()
+    session = FakeSession()
+    enabled = EnabledManager(True, loop=nc_loop)
+    with patch(
+        "neuracore.core.streaming.base_sse_consumer.ClientSession",
+        return_value=session,
+    ):
+        manager = RecordingStateManager(
+            org_id="org-1",
+            loop=nc_loop,
+            enabled_manager=enabled,
+            auth=auth,
+        )
+
+    key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
+    manager.recording_robot_instances[key] = TrackedRecording(
+        "recording-1", 1.0, opened_locally=True
+    )
+    manager.active_dataset_ids[key] = "dataset-1"
+
+    manager_future: Future[RecordingStateManager] = Future()
+    manager_future.set_result(manager)
+    recording_module._recording_manager = manager_future
+    try:
+        # The consumer loop returns once it gives up on the stream.
+        manager.signalling_stream_future.result(timeout=2)
+
+        assert manager.get_current_recording_id("robot-1", 0) == "recording-1"
+        assert manager.is_recording("robot-1", 0)
+        assert manager.active_dataset_ids[key] == "dataset-1"
+        assert enabled.is_enabled()
+        assert recording_module._recording_manager is manager_future
+
+        # Logout is still the statement that clears it.
+        auth.emit(Auth.LOGOUT_EVENT)
+        assert session.closed_event.wait(timeout=2)
+        assert manager.recording_robot_instances == {}
+        assert recording_module._recording_manager is None
+    finally:
+        recording_module._recording_manager = None
+
+
 @pytest.mark.parametrize(
     "manager_type",
     [StreamManagerOrchestrator, OrgNodesManager, RecordingStateManager],


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - A rejected notification stream no longer makes nc.stop_recording() a silent no-op
