### PR TITLE
feat: announce a producer's source bindings to the daemon

### DIFF
--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -226,7 +226,8 @@ def _record_json_to_daemon(
     ``log_json`` entry point is datatype-agnostic, so adding a new JSON type
     needs no daemon-side change.
 
-    A no-op unless a recording is in progress.
+    Always forwarded; the daemon is the one that decides whether a recording
+    is in progress and drops the sample if not.
 
     Args:
         robot: Robot instance owning the daemon recording context.
@@ -235,12 +236,9 @@ def _record_json_to_daemon(
         data: Data object to serialize and persist.
         timestamp: Capture timestamp in seconds.
     """
-    if robot.get_current_recording_id() is None:
-        return
+    context = robot._get_daemon_recording_context()
     payload = json.dumps(data.model_dump(mode="json")).encode("utf-8")
-    robot._get_daemon_recording_context().log_json(
-        data_type.value, storage_name, payload, timestamp
-    )
+    context.log_json(data_type.value, storage_name, payload, timestamp)
 
 
 def _publish_video_to_p2p(
@@ -386,7 +384,10 @@ def _log_group_of_joint_data(
     if bindings_for_type is None:
         bindings_for_type = {}
         binding_cache[data_type] = bindings_for_type
+    # The bucket/live streams key off this process's own recording handle; the
+    # daemon decides for itself, from the same call, whether it's recording.
     current_recording_id = robot.get_current_recording_id()
+    daemon_context = robot._get_daemon_recording_context()
     live_data_disabled = get_provide_live_data_enabled_manager().is_disabled()
     robot_id = robot.id
     robot_instance = robot.instance
@@ -406,10 +407,9 @@ def _log_group_of_joint_data(
         native_values = list(joint_data.values())
         for binding, joint_value in zip(group.bindings, native_values):
             binding.stream.record_scalar(timestamp, joint_value)
-        if current_recording_id is not None:
-            robot._get_daemon_recording_context().log_joints(
-                data_type.value, timestamp, group.joined_names, native_values
-            )
+        daemon_context.log_joints(
+            data_type.value, timestamp, group.joined_names, native_values
+        )
         return
 
     native_values = []
@@ -433,11 +433,10 @@ def _log_group_of_joint_data(
             # allocation-free (see JointDataStream).
             binding.stream.record_scalar(timestamp, joint_value)
 
-        if current_recording_id is not None:
-            native_values.append(joint_value)
+        native_values.append(joint_value)
 
     if native_values:
-        robot._get_daemon_recording_context().log_joints(
+        daemon_context.log_joints(
             data_type.value, timestamp, group.joined_names, native_values
         )
 
@@ -532,17 +531,19 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
-        contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
-        robot._get_daemon_recording_context().log_frame(
-            camera_type.value,
-            storage_name,
-            int(image.shape[1]),
-            int(image.shape[0]),
-            image.dtype.name,
-            memoryview(contiguous).cast("B"),
-            camera_data_without_frame.timestamp,
-        )
+    # The daemon decides whether this lands in a recording, not this process —
+    # always forward and let it route by window.
+    context = robot._get_daemon_recording_context()
+    contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
+    context.log_frame(
+        camera_type.value,
+        storage_name,
+        int(image.shape[1]),
+        int(image.shape[0]),
+        image.dtype.name,
+        memoryview(contiguous).cast("B"),
+        camera_data_without_frame.timestamp,
+    )
 
     _publish_video_to_p2p(robot, name, camera_type, camera_data_without_frame, image)
 

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -82,6 +82,10 @@ class RecordingContext:
         processes still need the source identity in order to contribute data to
         the daemon-owned recording window, but must not publish another start.
 
+        Announces the binding to the daemon, which reads it only to know that a
+        producer for this source exists on this machine — never as a claim about
+        any recording.
+
         Args:
             robot_id: Robot identifier used as the daemon source key.
             robot_instance: Robot instance used as the daemon source key.
@@ -90,6 +94,7 @@ class RecordingContext:
             raise ValueError("robot_id is required to bind a recording source.")
         self._robot_id = robot_id
         self._robot_instance = robot_instance
+        _load_native().attach_source(robot_id, robot_instance)
 
     def start_recording(
         self,
@@ -309,5 +314,8 @@ class RecordingContext:
         """Release resources owned by this instance.
 
         The native producer is process-global and outlives any single context,
-        so there is nothing to tear down here.
+        so the only thing to release is this process's announced binding to the
+        source — after which the daemon stops counting it as present here.
         """
+        if self._robot_id:
+            _load_native().detach_source(self._robot_id, self._robot_instance)

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -113,6 +113,14 @@ const DISPATCHER_INBOX_CAPACITY: usize = 1024;
 /// Source identity: `(robot_id, robot_instance)`.
 type Source = (String, i64);
 
+/// How long a producer stays counted as present after its last
+/// [`Envelope::ProducerAttached`].
+///
+/// Several of the producer's own 1 s heartbeat, so a briefly busy publisher
+/// thread never reads as a departed process, while a crashed one — which sends
+/// no detach — is forgotten promptly.
+const ATTACH_LIVENESS: Duration = Duration::from_secs(5);
+
 /// Resolve the configured holdback, honouring the `NCD_HOLDBACK_MS` override.
 fn configured_holdback() -> Duration {
     let millis = std::env::var(HOLDBACK_ENV)
@@ -332,6 +340,11 @@ struct Dispatcher {
     actor_handles: Vec<JoinHandle<()>>,
     /// Rate-limited orphan-drop counter (data outside any window).
     orphan_drops: u64,
+    /// Producers bound to each source, by OS pid, with when each was last heard
+    /// from. Says only that a producer for the source exists on this machine —
+    /// never anything about a recording. Read when deciding whether an org-wide
+    /// backend notification concerns a source here.
+    attached: HashMap<Source, HashMap<u32, Instant>>,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
     /// doesn't re-run the two full window scans (and their `Vec` allocations)
@@ -354,6 +367,7 @@ impl Dispatcher {
             held: VecDeque::new(),
             actor_handles: Vec::new(),
             orphan_drops: 0,
+            attached: HashMap::new(),
             last_housekeep: Instant::now(),
         }
     }
@@ -570,8 +584,33 @@ impl Dispatcher {
                     payload: HeldPayload::VideoProducerActive { producer_pid },
                 });
             }
+            Envelope::ProducerAttached {
+                robot_id,
+                robot_instance,
+                producer_pid,
+                ..
+            } => {
+                // Not held: presence is not window membership, and holding it
+                // only delays learning that a producer exists. `publish_timestamp_ns`
+                // is diagnostic — liveness is measured on the daemon's own clock,
+                // so a producer with a skewed clock cannot look departed.
+                self.attached
+                    .entry((robot_id, robot_instance))
+                    .or_default()
+                    .insert(producer_pid, recv_at);
+            }
             Envelope::RefreshConfig {} => self.handle_refresh_config().await,
         }
+    }
+
+    /// Drop producers whose heartbeat has stopped, and sources left with
+    /// none. Runs on the housekeeping cadence, so a departed producer is
+    /// forgotten without a timer of its own.
+    fn prune_attached(&mut self, now: Instant) {
+        self.attached.retain(|_, producers| {
+            producers.retain(|_, last_seen| now.duration_since(*last_seen) < ATTACH_LIVENESS);
+            !producers.is_empty()
+        });
     }
 
     /// Force the config watcher to re-resolve the profile and wait for it to
@@ -953,6 +992,7 @@ impl Dispatcher {
     /// window scans, so throttled to [`HOUSEKEEP_INTERVAL`] by the caller rather
     /// than run per inbound envelope.
     async fn housekeep(&mut self, now: Instant) {
+        self.prune_attached(now);
         let retention = self.holdback * 2;
         let (closing_actors, empty_sources) = self.evict_closing_windows(now, retention);
 
@@ -1903,6 +1943,83 @@ mod tests {
         let a: serde_json::Value =
             serde_json::from_slice(&std::fs::read(a_dir.join("trace.json")).unwrap()).unwrap();
         assert_eq!(a, serde_json::json!([{"i": 1}]));
+    }
+
+    #[tokio::test]
+    async fn an_attached_producer_ages_out_without_a_detach() {
+        // Presence gates whether an org-wide backend notification is acted on
+        // here. A producer that crashes sends no detach, so the only thing that
+        // can retire it is its heartbeat going quiet.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let attached_at = Instant::now();
+        assert!(
+            !dispatcher.attached.contains_key(&source),
+            "nothing has attached to this source yet"
+        );
+
+        dispatcher
+            .handle_inbound(
+                Envelope::ProducerAttached {
+                    robot_id: "robot-1".into(),
+                    robot_instance: 0,
+                    publish_timestamp_ns: 100,
+                    producer_pid: 4242,
+                },
+                attached_at,
+            )
+            .await;
+        assert!(dispatcher.attached.contains_key(&source));
+
+        // Still present while the heartbeat would have been restated.
+        dispatcher.prune_attached(attached_at + ATTACH_LIVENESS / 2);
+        assert!(
+            dispatcher.attached.contains_key(&source),
+            "a producer inside its lease survives a prune"
+        );
+
+        dispatcher.prune_attached(attached_at + ATTACH_LIVENESS + Duration::from_millis(1));
+        assert!(
+            !dispatcher.attached.contains_key(&source),
+            "a source with no live producers is forgotten entirely"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_live_producer_keeps_a_source_present() {
+        // Multi-process is the case this exists for: one process exiting must
+        // not make the source look absent while another still logs to it.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let source = ("robot-1".to_string(), 0);
+        let first_at = Instant::now();
+        let second_at = first_at + ATTACH_LIVENESS - Duration::from_millis(1);
+        for (pid, at) in [(4242u32, first_at), (4243, second_at)] {
+            dispatcher
+                .handle_inbound(
+                    Envelope::ProducerAttached {
+                        robot_id: "robot-1".into(),
+                        robot_instance: 0,
+                        publish_timestamp_ns: 100,
+                        producer_pid: pid,
+                    },
+                    at,
+                )
+                .await;
+        }
+
+        // Past the first producer's lease, inside the second's.
+        dispatcher.prune_attached(first_at + ATTACH_LIVENESS + Duration::from_millis(1));
+        assert_eq!(
+            dispatcher.attached.get(&source).map(HashMap::len),
+            Some(1),
+            "only the departed producer is forgotten"
+        );
     }
 
     #[tokio::test]

--- a/rust/data_daemon_bridge/src/attachment.rs
+++ b/rust/data_daemon_bridge/src/attachment.rs
@@ -1,0 +1,103 @@
+//! Which sources THIS process is bound to.
+//!
+//! Deliberately not recording state. Nothing here knows whether a recording is
+//! in progress, which one, or whether this process started it — the daemon owns
+//! all of that. This records only that a process exists and is bound to a
+//! source, which is a fact about the process and cannot be wrong about a
+//! recording.
+//!
+//! It is published as [`data_daemon_shared::Envelope::ProducerAttached`]. The
+//! daemon reads it to tell whether an org-wide backend recording notification
+//! concerns a source with a producer on this machine — a source nothing has
+//! attached to never has a window opened on its behalf.
+//!
+//! Restated on a heartbeat from the publisher thread (see [`crate::publisher`]),
+//! so a daemon that starts after its producers still learns they are there, and
+//! one whose producers have died stops believing in them.
+
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+/// A source key, matching the daemon's own `(robot_id, robot_instance)`.
+pub(crate) type Source = (String, i64);
+
+struct Registry {
+    owner_pid: u32,
+    attached: HashSet<Source>,
+}
+
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| {
+    Mutex::new(Registry {
+        owner_pid: 0,
+        attached: HashSet::new(),
+    })
+});
+
+/// Lock the registry, healing it across a `fork()` first.
+///
+/// A forked child inherits the parent's set but is a different process under a
+/// different pid. Without this it would heartbeat under its own pid for sources
+/// only its parent ever bound, and the daemon would hold a source present for a
+/// producer that never attached.
+fn with_registry<R>(operation: impl FnOnce(&mut HashSet<Source>) -> R) -> R {
+    let mut registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let pid = std::process::id();
+    if registry.owner_pid != pid {
+        registry.attached.clear();
+        registry.owner_pid = pid;
+    }
+    operation(&mut registry.attached)
+}
+
+/// Record that this process is bound to the source. `true` when this is a new
+/// binding, so the caller announces it immediately rather than waiting a
+/// heartbeat.
+pub(crate) fn attach(robot_id: &str, robot_instance: i64) -> bool {
+    with_registry(|attached| attached.insert((robot_id.to_string(), robot_instance)))
+}
+
+/// Forget this process's binding to the source. It drops out of the heartbeat, and
+/// the daemon drops it once the liveness bound elapses.
+pub(crate) fn detach(robot_id: &str, robot_instance: i64) {
+    with_registry(|attached| {
+        attached.remove(&(robot_id.to_string(), robot_instance));
+    });
+}
+
+/// Every source this process is currently bound to, for the heartbeat.
+pub(crate) fn attached_sources() -> Vec<Source> {
+    with_registry(|attached| attached.iter().cloned().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attaching_is_reported_once_per_source() {
+        assert!(attach("attach-once", 0), "first bind is new");
+        assert!(!attach("attach-once", 0), "re-binding is not new");
+        detach("attach-once", 0);
+    }
+
+    #[test]
+    fn a_detached_source_drops_out_of_the_heartbeat() {
+        attach("attach-detach", 7);
+        assert!(attached_sources().contains(&("attach-detach".to_string(), 7)));
+        detach("attach-detach", 7);
+        assert!(!attached_sources().contains(&("attach-detach".to_string(), 7)));
+    }
+
+    #[test]
+    fn instances_of_one_robot_attach_separately() {
+        attach("attach-instances", 0);
+        attach("attach-instances", 1);
+        detach("attach-instances", 0);
+        let sources = attached_sources();
+        assert!(!sources.contains(&("attach-instances".to_string(), 0)));
+        assert!(sources.contains(&("attach-instances".to_string(), 1)));
+        detach("attach-instances", 1);
+    }
+}

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -31,6 +31,8 @@
 //! This file is a thin PyO3 façade: the `#[pyfunction]` wrappers do argument
 //! validation, release the GIL, and delegate into the submodules.
 //!
+//! - [`attachment`] — which sources this process is bound to, restated on a
+//!   heartbeat so the daemon knows whose robots live on this machine.
 //! - [`paths`] — filesystem layout shared with the daemon (recordings root,
 //!   spool paths, `(source, sensor)` stream keys).
 //! - [`publisher`] — per-thread iceoryx2 publisher state, fork safety, the
@@ -42,6 +44,7 @@
 
 pub mod nut_writer;
 
+mod attachment;
 mod depth;
 mod paths;
 mod publisher;
@@ -422,6 +425,52 @@ fn flush_source(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult
     Ok(())
 }
 
+/// Announce that this process is bound to a source and may log for it.
+///
+/// Publishes one [`Envelope::ProducerAttached`] immediately and enrolls the
+/// source in the publisher thread's heartbeat. Claims nothing about any
+/// recording — the daemon reads it only to know that a producer for this source
+/// exists here, so an org-wide backend notification for a robot on some other
+/// machine is never acted on.
+///
+/// Idempotent: re-binding an already-attached source is a no-op beyond the
+/// heartbeat that was already running.
+#[pyfunction]
+fn attach_source(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let robot_id = robot_id.to_string();
+    py.detach(|| {
+        if !attachment::attach(&robot_id, robot_instance) {
+            return;
+        }
+        // Announce at once rather than waiting a heartbeat: a recording can be
+        // started from the web the instant after a robot connects.
+        let _ = publisher_tx().send(PublishMsg::Announce(Envelope::ProducerAttached {
+            robot_id,
+            robot_instance,
+            publish_timestamp_ns: now_ns(),
+            producer_pid: std::process::id(),
+        }));
+    });
+    Ok(())
+}
+
+/// Stop announcing this process's binding to a source.
+///
+/// The daemon drops the source once its liveness bound elapses; there is no
+/// detach envelope, because a process that has died cannot send one and the
+/// daemon must handle that case identically.
+#[pyfunction]
+fn detach_source(py: Python<'_>, robot_id: &str, robot_instance: i64) -> PyResult<()> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    py.detach(|| attachment::detach(robot_id, robot_instance));
+    Ok(())
+}
+
 /// Cancel a recording — drop the source's in-progress chunk state without
 /// flushing (the daemon's cancel handler removes the relinked artefacts and
 /// the recovery sweep reclaims any spooled NUTs).
@@ -571,6 +620,8 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(log_json, module)?)?;
     module.add_function(wrap_pyfunction!(stop_recording, module)?)?;
     module.add_function(wrap_pyfunction!(flush_source, module)?)?;
+    module.add_function(wrap_pyfunction!(attach_source, module)?)?;
+    module.add_function(wrap_pyfunction!(detach_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -37,9 +37,9 @@
 //! it, so a recording's data is on the wire before the call returns.
 
 use std::cell::RefCell;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::sync::{LazyLock, Mutex, Once};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use data_daemon_shared::service_name::{
     COMMANDS, COMMANDS_MAX_PAYLOAD_BYTES, HEALTH, HEALTH_MAX_PAYLOAD_BYTES,
@@ -253,10 +253,28 @@ pub(crate) fn flush_published_data() -> bool {
     ack_rx.recv().is_ok()
 }
 
-/// The publisher thread's run loop: publish every queued data envelope. Exits
-/// when the last [`Sender`] is dropped (the channel closes).
+/// How often this process restates which sources it is bound to.
+///
+/// Bounded below by IPC cost (one tiny sample per attached source per interval,
+/// nothing next to the data plane) and above by how long a daemon that started
+/// after its producers may go on ignoring notifications for their sources. The
+/// daemon's own liveness bound is several of these, so a briefly busy publisher
+/// thread never looks like a departed producer.
+const ATTACH_HEARTBEAT: Duration = Duration::from_secs(1);
+
+/// The publisher thread's run loop: publish every queued data envelope, and on
+/// each idle tick restate this process's source bindings. Exits when the last
+/// [`Sender`] is dropped (the channel closes).
 fn publish_loop(rx: Receiver<PublishMsg>) {
-    while let Ok(msg) = rx.recv() {
+    loop {
+        let msg = match rx.recv_timeout(ATTACH_HEARTBEAT) {
+            Ok(msg) => msg,
+            Err(RecvTimeoutError::Timeout) => {
+                publish_attachments();
+                continue;
+            }
+            Err(RecvTimeoutError::Disconnected) => return,
+        };
         let result = match msg {
             PublishMsg::Joint {
                 robot_id,
@@ -328,6 +346,26 @@ fn publish_loop(rx: Receiver<PublishMsg>) {
         };
         if let Err(error) = result {
             tracing::warn!(%error, "failed to publish data envelope");
+        }
+    }
+}
+
+/// Restate every source this process is bound to.
+///
+/// Idempotent and free of recording state: the daemon reads these only to know
+/// which sources have a producer here (see [`crate::attachment`]). A failed
+/// publish is dropped rather than retried — the next heartbeat restates it.
+fn publish_attachments() {
+    let producer_pid = std::process::id();
+    for (robot_id, robot_instance) in crate::attachment::attached_sources() {
+        let envelope = Envelope::ProducerAttached {
+            robot_id,
+            robot_instance,
+            publish_timestamp_ns: now_ns(),
+            producer_pid,
+        };
+        if let Err(error) = publish(&envelope) {
+            tracing::debug!(%error, "failed to publish producer attachment heartbeat");
         }
     }
 }

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -627,6 +627,30 @@ pub enum Envelope {
         /// [`Envelope::SourceFlushed`] reports under.
         producer_pid: u32,
     },
+    /// Producer reports that it is bound to a source and may log for it.
+    ///
+    /// A statement about the producer, in the same family as
+    /// [`Envelope::SourceFlushed`] and [`Envelope::VideoProducerActive`]: it
+    /// names a process and a source and claims nothing about any recording.
+    /// Published when a process binds the source and restated on a slow
+    /// heartbeat, so a daemon that starts after its producers still learns they
+    /// are there and one that dies with them stops believing it.
+    ///
+    /// The daemon needs it to tell whether a backend recording notification —
+    /// which is org-wide, and so covers robots on other machines entirely —
+    /// concerns a source with a producer *here*. A source nothing has attached
+    /// to never has a window opened on its behalf.
+    ProducerAttached {
+        robot_id: String,
+        robot_instance: i64,
+        /// Publish time of the bind or heartbeat, stamped on the calling
+        /// thread. Bounds how long the daemon keeps believing this producer is
+        /// present; never used for window membership.
+        publish_timestamp_ns: i64,
+        /// OS process id of the attached producer, the same identity
+        /// [`Envelope::SourceFlushed`] reports under.
+        producer_pid: u32,
+    },
 }
 
 /// Original pixel/sample representation of one video-family frame.
@@ -714,6 +738,7 @@ impl Envelope {
             Envelope::RefreshConfig {} => "refresh_config",
             Envelope::SourceFlushed { .. } => "source_flushed",
             Envelope::VideoProducerActive { .. } => "video_producer_active",
+            Envelope::ProducerAttached { .. } => "producer_attached",
         }
     }
 
@@ -1115,6 +1140,24 @@ mod tests {
         let bytes = claim.encode().expect("encode");
         assert_eq!(claim, Envelope::decode(&bytes).expect("decode"));
         assert_eq!(claim.kind(), "video_producer_active");
+    }
+
+    #[test]
+    fn producer_attached_round_trips() {
+        let attach = Envelope::ProducerAttached {
+            robot_id: "robot-1".into(),
+            robot_instance: 3,
+            publish_timestamp_ns: 1_700_000_000_000_000_000,
+            producer_pid: 4242,
+        };
+        let bytes = attach.encode().expect("encode");
+        assert!(
+            bytes.len() <= service_name::COMMANDS_MAX_PAYLOAD_BYTES,
+            "attach ({} bytes) must fit the commands slice",
+            bytes.len(),
+        );
+        assert_eq!(attach, Envelope::decode(&bytes).expect("decode"));
+        assert_eq!(attach.kind(), "producer_attached");
     }
 
     #[test]

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -100,7 +100,7 @@ def test_log_frame_forwards_dtype_derived_from_the_array(
     native = MagicMock()
     monkeypatch.setattr(recording_context, "_load_native", lambda: native)
     robot = _get_robot(None, 0)
-    monkeypatch.setattr(robot, "get_current_recording_id", lambda: "rec-1")
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
 
     rgb_uint8 = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
     nc.log_rgb("front_camera", rgb_uint8)
@@ -481,23 +481,16 @@ def test_log_parallel_gripper_open_amounts(
     )
 
 
-def test_sse_started_recording_logs_with_bound_robot_source(monkeypatch) -> None:
-    """A producer that did not publish StartRecording can log after SSE state.
-
-    The active recording id represents state learned from SSE. Creating the
-    robot's daemon context must bind its source without publishing a duplicate
-    native start event.
-    """
+def test_json_logs_with_bound_robot_source_without_local_recording(
+    monkeypatch,
+) -> None:
+    """A producer without local recording state still forwards to the daemon."""
     robot = Robot("test_robot", instance=3, org_id="org-1")
     robot.id = "robot-from-sse"
     native = MagicMock()
 
     monkeypatch.setattr(recording_context, "_load_native", lambda: native)
-    monkeypatch.setattr(
-        robot,
-        "get_current_recording_id",
-        lambda: "cloud-recording-id-from-sse",
-    )
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
 
     sample = ParallelGripperOpenAmountData(timestamp=12.5, open_amount=0.4)
     api_logging._record_json_to_daemon(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Producers announce their source bindings, so the daemon knows which robots have a producer on this machine
