### PR TITLE
feat: route web-initiated recording lifecycle to the daemon

### DIFF
--- a/rust/data_daemon/src/cli/coordinators.rs
+++ b/rust/data_daemon/src/cli/coordinators.rs
@@ -15,7 +15,7 @@ use crate::api::client::{ApiClient, ApiClientOptions};
 use crate::cloud::{
     spawn_org_watcher, spawn_progress_reporter, spawn_recording_cancel_notifier,
     spawn_recording_start_notifier, spawn_recording_stop_notifier, spawn_registration,
-    spawn_status_updater, spawn_uploader, ConfigRx, OrgWatcherHandle, StatusUpdate,
+    spawn_status_updater, spawn_uploader, ConfigRx, OrgIdRx, OrgWatcherHandle, StatusUpdate,
 };
 use crate::connection::spawn_connection_monitor;
 use crate::state::{EventBus, SqliteStateStore, TraceWriteHandle};
@@ -31,6 +31,10 @@ pub(crate) struct CloudHandles {
     recording_start: crate::cloud::NotifierHandle,
     recording_stop: crate::cloud::NotifierHandle,
     recording_cancel: crate::cloud::NotifierHandle,
+    /// Live org id, re-exposed so the recording-notification stream — which is
+    /// spawned after the dispatcher, because it needs the dispatcher's command
+    /// channel — can share this watcher rather than starting a second one.
+    pub(crate) org_rx: OrgIdRx,
 }
 
 impl CloudHandles {
@@ -138,7 +142,7 @@ pub(crate) fn spawn_cloud_coordinators(
         state_store,
         event_bus,
         Arc::clone(&client),
-        org_rx,
+        org_rx.clone(),
         shutdown_tx.subscribe(),
     );
 
@@ -152,5 +156,6 @@ pub(crate) fn spawn_cloud_coordinators(
         recording_start,
         recording_stop,
         recording_cancel,
+        org_rx,
     }
 }

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -16,7 +16,8 @@ use tokio::sync::{mpsc, watch};
 use crate::cli::coordinators::{build_api_client, spawn_cloud_coordinators};
 use crate::cli::launch_logging::{init_tracing, log_path_for, report_failure};
 use crate::cloud::{
-    read_org_id_from_config, spawn_config_watcher, spawn_recording_reaper, ConfigRefreshRequest,
+    read_org_id_from_config, spawn_config_watcher, spawn_recording_notification_stream,
+    spawn_recording_reaper, ConfigRefreshRequest,
 };
 use crate::config::env::RuntimeEnv;
 use crate::config::profile::{ProfileError, ProfileManager};
@@ -389,25 +390,35 @@ fn run_daemon(
             // the next periodic tick. Order is also load-bearing for
             // ordered shutdown: dropping the dispatcher first guarantees
             // no new `TraceWritten` lands while the coordinators drain.
-            let cloud_handles = if config_for_runtime.offline.unwrap_or(false) {
+            // The API client is kept alongside the handles: the recording
+            // notification stream needs it, but cannot be spawned until the
+            // dispatcher exists to give it a command channel.
+            let (cloud_handles, notification_client) = if config_for_runtime
+                .offline
+                .unwrap_or(false)
+            {
                 tracing::info!("offline mode — skipping cloud coordinator spawn");
-                None
+                (None, None)
             } else {
                 match build_api_client(&api_url, &config_path) {
-                    Ok(api_client) => Some(spawn_cloud_coordinators(
-                        state_store.clone(),
-                        trace_write_handle.clone(),
-                        event_bus.clone(),
-                        api_client,
-                        Arc::new(recordings_root.clone()),
-                        config_path.clone(),
-                        org_id.clone(),
-                        shutdown_tx.clone(),
-                        config_rx.clone(),
-                    )),
+                    Ok(api_client) => {
+                        let handles = spawn_cloud_coordinators(
+                            state_store.clone(),
+                            trace_write_handle.clone(),
+                            event_bus.clone(),
+                            Arc::clone(&api_client),
+                            Arc::new(recordings_root.clone()),
+                            config_path.clone(),
+                            org_id.clone(),
+                            shutdown_tx.clone(),
+                            config_rx.clone(),
+                        );
+                        let org_rx = handles.org_rx.clone();
+                        (Some(handles), Some((api_client, org_rx)))
+                    }
                     Err(error) => {
                         tracing::warn!(%error, "failed to build API client; cloud uploads disabled");
-                        None
+                        (None, None)
                     }
                 }
             };
@@ -435,6 +446,19 @@ fn run_daemon(
                 dispatcher_context,
                 shutdown_tx.subscribe(),
             );
+
+            // Web-initiated start/stop reach the daemon here rather than being
+            // relayed by producers, so one such event stays one event and needs
+            // no disambiguating on the producer side. Offline has no backend to
+            // hear from, and no web-initiated recording to hear about.
+            let notification_handle = notification_client.map(|(api_client, org_rx)| {
+                spawn_recording_notification_stream(
+                    api_client,
+                    org_rx,
+                    dispatcher_handle.recording_command_tx.clone(),
+                    shutdown_tx.subscribe(),
+                )
+            });
 
             // Reclaim fully-uploaded recordings' files + rows. On by default
             // (opt out via the `recording_reaper` profile field or
@@ -501,6 +525,9 @@ fn run_daemon(
             // before the store closes so finalise/failed states are durable.
             trace_writer.shutdown().await;
             if let Some(handle) = reaper_handle {
+                handle.join().await;
+            }
+            if let Some(handle) = notification_handle {
                 handle.join().await;
             }
             if let Some(handles) = cloud_handles {

--- a/rust/data_daemon/src/cloud/mod.rs
+++ b/rust/data_daemon/src/cloud/mod.rs
@@ -36,6 +36,7 @@ pub use notifiers::recording_start_notifier::spawn_recording_start_notifier;
 pub use notifiers::recording_stop_notifier::spawn_recording_stop_notifier;
 pub use watchers::config_watcher::{spawn_config_watcher, ConfigRefreshRequest, ConfigRx};
 pub use watchers::org_watcher::{spawn_org_watcher, OrgIdRx, OrgWatcherHandle};
+pub use watchers::recording_notification_stream::spawn_recording_notification_stream;
 pub use watchers::recording_reaper::spawn_recording_reaper;
 
 use std::path::Path;

--- a/rust/data_daemon/src/cloud/watchers/mod.rs
+++ b/rust/data_daemon/src/cloud/watchers/mod.rs
@@ -1,8 +1,10 @@
 //! Periodic watchers: the org-id config poller that publishes the live org for
 //! every coordinator, the daemon-profile config poller that publishes the live
-//! effective config (chiefly the video codec), and the recording reaper that
-//! reclaims durably-settled recordings.
+//! effective config (chiefly the video codec), the recording reaper that
+//! reclaims durably-settled recordings, and the backend recording-notification
+//! stream that delivers web-initiated start and stop straight to the daemon.
 
 pub mod config_watcher;
 pub mod org_watcher;
+pub mod recording_notification_stream;
 pub mod recording_reaper;

--- a/rust/data_daemon/src/cloud/watchers/recording_notification_stream.rs
+++ b/rust/data_daemon/src/cloud/watchers/recording_notification_stream.rs
@@ -1,0 +1,452 @@
+//! Backend → daemon recording lifecycle.
+//!
+//! The daemon reads web-initiated start and stop from the backend directly,
+//! over the same authenticated, org-scoped connection it already POSTs
+//! `/recording/{start,stop}` on.
+//!
+//! ## Why the daemon, and not the producers
+//!
+//! A web-initiated start or stop is one event. Delivered to N producer
+//! processes it becomes N lifecycle envelopes, and each process then has to
+//! work out *which* recording it means — which it cannot, because the daemon
+//! owns recording identity. Every attempt to give a producer that knowledge
+//! (a query, an announcement lease, a local map, an ownership flag) is a
+//! reconstruction of something that was never ambiguous at the source.
+//!
+//! So the notification is consumed where identity already lives. Producers are
+//! told nothing, publish no lifecycle envelope for it, and hold no claim about
+//! any recording. `nc.start_recording()` / `nc.stop_recording()` are untouched:
+//! those are one process expressing intent, with no fan-out to disambiguate.
+//!
+//! ## Shape of the stream
+//!
+//! `GET /stream/org/{org}/recording/notifications` is Server-Sent Events, framed
+//! as `event:data\ndata:{json}\n\n`, with `event:heartbeat\ndata:ping\n\n`
+//! keep-alive frames. On connect the backend replays an `INIT` carrying every
+//! currently-live recording for the org, so a daemon that restarts — or one
+//! whose connection dropped — recovers the full picture without a reconciliation
+//! pass of its own. That snapshot is why reconnecting is a complete repair and
+//! not just a resumption.
+//!
+//! Everything the stream reports is org-wide, so it includes robots whose
+//! producers run on entirely different machines. The dispatcher drops anything
+//! for a source with no producer attached here; see
+//! [`crate::pipeline::dispatcher::RecordingCommand`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION};
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
+
+use crate::api::ApiClient;
+use crate::cloud::OrgIdRx;
+use crate::lifecycle::shutdown::ShutdownSignal;
+use crate::pipeline::dispatcher::RecordingCommand;
+
+/// How long to wait before redialling after the stream ends or fails.
+///
+/// The backend replays a full `INIT` snapshot on connect, so a reconnect is a
+/// repair rather than a resumption and there is no urgency to redial instantly —
+/// but a recording cannot start on this machine while the stream is down, so
+/// this stays short.
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+
+/// How long to wait for the org id to appear before re-checking.
+///
+/// A daemon can outlive `nc select-org`, so "no org yet" is a normal startup
+/// state rather than an error.
+const ORG_WAIT: Duration = Duration::from_secs(1);
+
+/// Connect timeout for the stream. Deliberately the *only* timeout: the request
+/// itself must be allowed to stay open indefinitely, which is the whole point.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Largest SSE frame buffer to hold before giving up on the connection.
+///
+/// An `INIT` carrying every live recording in a busy org is the biggest frame
+/// that can legitimately arrive, and is still far below this. A buffer growing
+/// past it means the framing is wrong (a proxy rewriting the body, say), which a
+/// reconnect handles better than unbounded growth.
+const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+
+/// Handle for the notification-stream task.
+pub struct RecordingNotificationHandle {
+    join: JoinHandle<()>,
+}
+
+impl RecordingNotificationHandle {
+    /// Wait for the task to exit.
+    pub async fn join(self) {
+        if let Err(error) = self.join.await {
+            tracing::warn!(?error, "recording notification stream join failed");
+        }
+    }
+}
+
+/// Lifecycle notification types the backend emits. Everything else is ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+enum NotificationType {
+    /// Snapshot of every live recording, replayed on connect.
+    #[serde(rename = "INIT")]
+    Init,
+    #[serde(rename = "START")]
+    Start,
+    #[serde(rename = "STOP")]
+    Stop,
+    /// A recording discarded rather than kept — still an end to the window.
+    #[serde(rename = "DISCARDED")]
+    Discarded,
+    /// A recording that ran past the backend's maximum duration.
+    #[serde(rename = "EXPIRED")]
+    Expired,
+    /// Post-stop disposition; the window is already closed by the time it lands.
+    #[serde(rename = "SAVED")]
+    Saved,
+}
+
+/// The envelope every notification arrives in. `payload` stays untyped until the
+/// type is known, because `INIT` carries a *list* where the rest carry one
+/// object.
+#[derive(Debug, Deserialize)]
+struct Notification {
+    #[serde(rename = "type")]
+    kind: NotificationType,
+    payload: serde_json::Value,
+}
+
+/// A recording the backend reports as started.
+#[derive(Debug, Deserialize)]
+struct StartPayload {
+    recording_id: String,
+    robot_id: String,
+    instance: i64,
+    start_time: f64,
+    #[serde(default)]
+    dataset_ids: Vec<String>,
+}
+
+/// The minimum any non-start notification carries.
+#[derive(Debug, Deserialize)]
+struct UpdatePayload {
+    recording_id: String,
+    robot_id: String,
+    instance: i64,
+}
+
+/// Spawn the notification stream reader.
+///
+/// Spawned only when the daemon is online — offline has no backend to hear from,
+/// and no web-initiated recording can exist there, so the local
+/// `nc.start_recording()` path is the only one and needs nothing from here.
+pub fn spawn_recording_notification_stream(
+    client: Arc<ApiClient>,
+    org_rx: OrgIdRx,
+    command_tx: mpsc::Sender<RecordingCommand>,
+    mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
+) -> RecordingNotificationHandle {
+    let join = tokio::spawn(async move {
+        let stream_client = match Client::builder().connect_timeout(CONNECT_TIMEOUT).build() {
+            Ok(stream_client) => stream_client,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "failed to build the notification stream client; \
+                     web-initiated recordings will not reach this daemon"
+                );
+                return;
+            }
+        };
+
+        loop {
+            tokio::select! {
+                biased;
+                signal = shutdown_rx.recv() => {
+                    tracing::debug!(?signal, "recording notification stream shutting down");
+                    return;
+                }
+                outcome = consume_stream(&stream_client, &client, &org_rx, &command_tx) => {
+                    match outcome {
+                        // A clean end still means we are no longer being told
+                        // about recordings, so it is redialled like a failure.
+                        Ok(()) => tracing::debug!("recording notification stream ended; redialling"),
+                        Err(error) => {
+                            tracing::warn!(%error, "recording notification stream failed; redialling")
+                        }
+                    }
+                }
+            }
+
+            tokio::select! {
+                biased;
+                signal = shutdown_rx.recv() => {
+                    tracing::debug!(?signal, "recording notification stream shutting down");
+                    return;
+                }
+                _ = tokio::time::sleep(RECONNECT_DELAY) => {}
+            }
+        }
+    });
+
+    RecordingNotificationHandle { join }
+}
+
+/// Open one connection and read it until it ends.
+async fn consume_stream(
+    stream_client: &Client,
+    api: &Arc<ApiClient>,
+    org_rx: &OrgIdRx,
+    command_tx: &mpsc::Sender<RecordingCommand>,
+) -> Result<(), String> {
+    let Some(org_id) = org_rx.borrow().clone() else {
+        // Not an error: the daemon can start before an org is selected.
+        tokio::time::sleep(ORG_WAIT).await;
+        return Ok(());
+    };
+
+    let url = api.url(&format!("/stream/org/{org_id}/recording/notifications"));
+    let token = api
+        .auth()
+        .bearer_token()
+        .await
+        .map_err(|error| format!("no bearer token: {error}"))?;
+    let authorization = HeaderValue::from_str(&format!("Bearer {token}"))
+        .map_err(|_| "bearer token contains invalid header characters".to_string())?;
+
+    let response = stream_client
+        .get(&url)
+        .header(AUTHORIZATION, authorization)
+        .header(ACCEPT, HeaderValue::from_static("text/event-stream"))
+        .send()
+        .await
+        .map_err(|error| format!("connect failed: {error}"))?;
+
+    if response.status() == StatusCode::UNAUTHORIZED {
+        // Drop the cached JWT so the redial exchanges a fresh one, matching the
+        // API client's own 401 handling.
+        if let Err(error) = api.auth().reload().await {
+            tracing::debug!(%error, "failed to reload auth after 401");
+        }
+        return Err("unauthorized".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!("unexpected status {}", response.status()));
+    }
+
+    tracing::info!(org_id, "listening for recording notifications");
+    read_frames(response, command_tx).await
+}
+
+/// Read SSE frames off an open response until it ends.
+async fn read_frames(
+    mut response: reqwest::Response,
+    command_tx: &mpsc::Sender<RecordingCommand>,
+) -> Result<(), String> {
+    // `chunk()` is an inherent method on `Response` under reqwest's `stream`
+    // feature, so framing needs no `Stream` adapter crate.
+    let mut buffer = String::new();
+    loop {
+        let chunk = response
+            .chunk()
+            .await
+            .map_err(|error| format!("read failed: {error}"))?;
+        let Some(chunk) = chunk else { return Ok(()) };
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(split_at) = buffer.find("\n\n") {
+            let frame = buffer[..split_at].to_string();
+            buffer.drain(..split_at + 2);
+            for command in commands_from_frame(&frame) {
+                if command_tx.send(command).await.is_err() {
+                    return Err("dispatcher command inbox closed".to_string());
+                }
+            }
+        }
+
+        if buffer.len() > MAX_FRAME_BYTES {
+            return Err(format!(
+                "frame exceeded {MAX_FRAME_BYTES} bytes without a terminator"
+            ));
+        }
+    }
+}
+
+/// Turn one SSE frame into the lifecycle commands it implies.
+///
+/// A frame yields more than one command only for `INIT`, which carries every
+/// live recording at once. Anything unparseable is dropped with a log rather
+/// than killing the connection: one malformed notification must not stop the
+/// daemon hearing about the next recording.
+fn commands_from_frame(frame: &str) -> Vec<RecordingCommand> {
+    let mut lines = Vec::new();
+    for line in frame.lines() {
+        if let Some(value) = line.strip_prefix("data:") {
+            // The SSE spec strips a single leading space; the backend emits
+            // none, so this handles both. Repeated `data:` lines join with a
+            // newline, per the spec — the backend sends one, and JSON does not
+            // care either way.
+            lines.push(value.strip_prefix(' ').unwrap_or(value));
+        }
+    }
+    let data = lines.join("\n");
+    // A keep-alive frame carries a literal `ping`, not JSON.
+    if data.is_empty() || data == "ping" {
+        return Vec::new();
+    }
+
+    let notification: Notification = match serde_json::from_str(&data) {
+        Ok(notification) => notification,
+        Err(error) => {
+            tracing::debug!(%error, "dropping unparseable recording notification");
+            return Vec::new();
+        }
+    };
+
+    match notification.kind {
+        NotificationType::Init => {
+            match serde_json::from_value::<Vec<StartPayload>>(notification.payload) {
+                Ok(payloads) => payloads.into_iter().map(start_command).collect(),
+                Err(error) => {
+                    tracing::debug!(%error, "dropping malformed INIT payload");
+                    Vec::new()
+                }
+            }
+        }
+        NotificationType::Start => {
+            match serde_json::from_value::<StartPayload>(notification.payload) {
+                Ok(payload) => vec![start_command(payload)],
+                Err(error) => {
+                    tracing::debug!(%error, "dropping malformed START payload");
+                    Vec::new()
+                }
+            }
+        }
+        NotificationType::Stop | NotificationType::Discarded | NotificationType::Expired => {
+            match serde_json::from_value::<UpdatePayload>(notification.payload) {
+                Ok(payload) => vec![RecordingCommand::Stop {
+                    source: (payload.robot_id, payload.instance),
+                    recording_id: payload.recording_id,
+                }],
+                Err(error) => {
+                    tracing::debug!(%error, "dropping malformed stop payload");
+                    Vec::new()
+                }
+            }
+        }
+        // The window is already closed by the time this lands.
+        NotificationType::Saved => Vec::new(),
+    }
+}
+
+fn start_command(payload: StartPayload) -> RecordingCommand {
+    RecordingCommand::Start {
+        source: (payload.robot_id, payload.instance),
+        recording_id: payload.recording_id,
+        // A recording is created in exactly one dataset; take the first rather
+        // than rejecting a payload that grows a second.
+        dataset_id: payload.dataset_ids.into_iter().next(),
+        start_time_s: payload.start_time,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a frame the way the backend does: `event:data`, then the JSON on
+    /// one `data:` line.
+    fn frame(json: &str) -> String {
+        let single_line = json.replace('\n', "");
+        format!("event:data\ndata:{single_line}")
+    }
+
+    #[test]
+    fn a_heartbeat_yields_nothing() {
+        assert!(commands_from_frame("event:heartbeat\ndata:ping").is_empty());
+        assert!(commands_from_frame("").is_empty());
+    }
+
+    #[test]
+    fn a_start_becomes_a_start_command() {
+        let commands = commands_from_frame(&frame(
+            r#"{"type":"START","id":"n1","payload":{
+                "recording_id":"rec-1","robot_id":"robot-1","instance":0,
+                "created_by":"user-1","dataset_ids":["ds-1"],
+                "data_types":[],"start_time":1700000000.5}}"#,
+        ));
+        match commands.as_slice() {
+            [RecordingCommand::Start {
+                source,
+                recording_id,
+                dataset_id,
+                start_time_s,
+            }] => {
+                assert_eq!(source, &("robot-1".to_string(), 0));
+                assert_eq!(recording_id, "rec-1");
+                assert_eq!(dataset_id.as_deref(), Some("ds-1"));
+                assert_eq!(*start_time_s, 1_700_000_000.5);
+            }
+            other => panic!("expected one start command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_replays_every_live_recording() {
+        // The reconnect repair path: one frame, N recordings.
+        let commands = commands_from_frame(&frame(
+            r#"{"type":"INIT","id":"n0","payload":[
+                {"recording_id":"rec-1","robot_id":"robot-1","instance":0,
+                 "created_by":"u","dataset_ids":["ds-1"],"data_types":[],
+                 "start_time":1700000000.0},
+                {"recording_id":"rec-2","robot_id":"robot-2","instance":3,
+                 "created_by":"u","dataset_ids":["ds-2"],"data_types":[],
+                 "start_time":1700000001.0}]}"#,
+        ));
+        assert_eq!(commands.len(), 2);
+        assert!(matches!(
+            &commands[1],
+            RecordingCommand::Start { source, recording_id, .. }
+                if source == &("robot-2".to_string(), 3) && recording_id == "rec-2"
+        ));
+    }
+
+    #[test]
+    fn every_ending_notification_stops_the_window() {
+        // A discarded or expired recording ends its window exactly as a stop
+        // does — the data stops being accepted either way.
+        for kind in ["STOP", "DISCARDED", "EXPIRED"] {
+            let commands = commands_from_frame(&frame(&format!(
+                r#"{{"type":"{kind}","id":"n2","payload":{{
+                    "recording_id":"rec-1","robot_id":"robot-1","instance":0}}}}"#
+            )));
+            assert!(
+                matches!(
+                    commands.as_slice(),
+                    [RecordingCommand::Stop { source, recording_id }]
+                        if source == &("robot-1".to_string(), 0) && recording_id == "rec-1"
+                ),
+                "{kind} must end the window, got {commands:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn saved_is_not_a_window_event() {
+        let commands = commands_from_frame(&frame(
+            r#"{"type":"SAVED","id":"n3","payload":{
+                "recording_id":"rec-1","robot_id":"robot-1","instance":0}}"#,
+        ));
+        assert!(commands.is_empty(), "SAVED lands after the window closed");
+    }
+
+    #[test]
+    fn a_malformed_notification_is_dropped_not_fatal() {
+        // One bad frame must not cost us the next recording.
+        assert!(commands_from_frame(&frame("{not json")).is_empty());
+        assert!(commands_from_frame(&frame(r#"{"type":"START","payload":{}}"#)).is_empty());
+        assert!(commands_from_frame(&frame(r#"{"type":"WHAT","payload":{}}"#)).is_empty());
+    }
+}

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -113,6 +113,58 @@ const DISPATCHER_INBOX_CAPACITY: usize = 1024;
 /// Source identity: `(robot_id, robot_instance)`.
 type Source = (String, i64);
 
+/// Wall clock in nanoseconds, the same clock a producer stamps its envelopes
+/// with. Used for the boundaries of a backend-driven start or stop, which carry
+/// no publish stamp of their own.
+fn now_ns() -> i64 {
+    Utc::now().timestamp_nanos_opt().unwrap_or(i64::MAX)
+}
+
+/// A recording lifecycle decision the backend has already made, delivered by
+/// [`crate::cloud::watchers::recording_notification_stream`].
+///
+/// The daemon learns web-initiated start and stop on the connection that
+/// already carries recording identity — its own — rather than having them
+/// relayed by N producer processes that would each have to work out which
+/// window they meant. Producers publish no lifecycle envelope for these at all.
+#[derive(Debug, Clone)]
+pub enum RecordingCommand {
+    /// The backend has a recording open for this source.
+    Start {
+        source: Source,
+        /// Cloud id the backend already minted. The daemon adopts it instead of
+        /// POSTing `/recording/start` for a recording that already exists.
+        recording_id: String,
+        dataset_id: Option<String>,
+        /// Backend-reported capture-clock start (Unix seconds).
+        start_time_s: f64,
+    },
+    /// The backend considers this recording over.
+    Stop {
+        source: Source,
+        /// Cloud id of the recording being stopped. Matched against the live
+        /// window's own row, so a notification for a recording that already
+        /// ended cannot close its successor.
+        recording_id: String,
+    },
+}
+
+/// Whether a source's live window is the recording a backend notification named.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveMatch {
+    /// The live window is that recording, at this local index.
+    Matches(i64),
+    /// A window is live, but it is a different recording (or the named one is
+    /// unknown here) — so the notification must not touch it.
+    Different,
+    /// Nothing is live for the source.
+    None,
+}
+
+/// Bounded backend → dispatcher command channel. Lifecycle events are rare, so
+/// a small buffer is ample.
+const RECORDING_COMMAND_CAPACITY: usize = 64;
+
 /// How long a producer stays counted as present after its last
 /// [`Envelope::ProducerAttached`].
 ///
@@ -134,6 +186,10 @@ fn configured_holdback() -> Duration {
 /// per-trace actor.
 pub struct DispatcherHandle {
     join: JoinHandle<()>,
+    /// Sender the backend's recording notification stream reaches the
+    /// dispatcher's window state through. Cloned by the notification watcher;
+    /// producers never touch it.
+    pub recording_command_tx: mpsc::Sender<RecordingCommand>,
 }
 
 impl DispatcherHandle {
@@ -183,11 +239,19 @@ pub fn spawn_with_context(
     shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) -> (mpsc::Sender<Envelope>, DispatcherHandle) {
     let (tx, rx) = mpsc::channel::<Envelope>(DISPATCHER_INBOX_CAPACITY);
+    let (recording_command_tx, recording_command_rx) =
+        mpsc::channel::<RecordingCommand>(RECORDING_COMMAND_CAPACITY);
     let join = tokio::spawn(async move {
         let mut dispatcher = Dispatcher::new(store, actor_context, context);
-        dispatcher.run(rx, shutdown_rx).await;
+        dispatcher.run(rx, recording_command_rx, shutdown_rx).await;
     });
-    (tx, DispatcherHandle { join })
+    (
+        tx,
+        DispatcherHandle {
+            join,
+            recording_command_tx,
+        },
+    )
 }
 
 /// A per-trace actor's routing handle, stored inside its window.
@@ -343,7 +407,8 @@ struct Dispatcher {
     /// Producers bound to each source, by OS pid, with when each was last heard
     /// from. Says only that a producer for the source exists on this machine —
     /// never anything about a recording. Read when deciding whether an org-wide
-    /// backend notification concerns a source here.
+    /// backend notification concerns a source here; see
+    /// [`Dispatcher::has_attached_producer`].
     attached: HashMap<Source, HashMap<u32, Instant>>,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
@@ -375,6 +440,7 @@ impl Dispatcher {
     async fn run(
         &mut self,
         mut rx: mpsc::Receiver<Envelope>,
+        mut recording_command_rx: mpsc::Receiver<RecordingCommand>,
         mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
     ) {
         tracing::info!(
@@ -403,6 +469,11 @@ impl Dispatcher {
                         break;
                     };
                     self.handle_inbound(envelope, Instant::now()).await;
+                }
+                command = recording_command_rx.recv() => {
+                    if let Some(command) = command {
+                        self.handle_recording_command(command, Instant::now()).await;
+                    }
                 }
                 _ = sleep(housekeep_after) => {}
             }
@@ -603,6 +674,23 @@ impl Dispatcher {
         }
     }
 
+    /// Whether any producer on this machine is currently bound to the source.
+    ///
+    /// The gate on acting for a backend recording notification: the stream is
+    /// org-wide, so it carries robots whose producers live on other machines
+    /// entirely, and opening a window for one of those would mint a recording
+    /// that could never receive data.
+    ///
+    /// A producer that dies stops sending its heartbeat and ages out — there is no
+    /// detach envelope to rely on, because a crashed process cannot send one.
+    fn has_attached_producer(&self, source: &Source, now: Instant) -> bool {
+        self.attached.get(source).is_some_and(|producers| {
+            producers
+                .values()
+                .any(|last_seen| now.duration_since(*last_seen) < ATTACH_LIVENESS)
+        })
+    }
+
     /// Drop producers whose heartbeat has stopped, and sources left with
     /// none. Runs on the housekeeping cadence, so a departed producer is
     /// forgotten without a timer of its own.
@@ -643,6 +731,148 @@ impl Dispatcher {
             window.last_seen = Some(recv_at);
         } else {
             self.windows.entry(source.clone()).or_default().last_seen = Some(recv_at);
+        }
+    }
+
+    /// Act on a lifecycle decision the backend has already made.
+    ///
+    /// Ignored outright for a source no producer here is bound to: the
+    /// notification stream is org-wide, so most of what arrives concerns robots
+    /// on other machines.
+    async fn handle_recording_command(&mut self, command: RecordingCommand, recv_at: Instant) {
+        let source = match &command {
+            RecordingCommand::Start { source, .. } | RecordingCommand::Stop { source, .. } => {
+                source.clone()
+            }
+        };
+        if !self.has_attached_producer(&source, recv_at) {
+            tracing::debug!(
+                robot_id = source.0,
+                "ignoring recording notification for a source with no producer here"
+            );
+            return;
+        }
+        match command {
+            RecordingCommand::Start {
+                recording_id,
+                dataset_id,
+                start_time_s,
+                ..
+            } => {
+                self.handle_backend_start(source, recording_id, dataset_id, start_time_s, recv_at)
+                    .await
+            }
+            RecordingCommand::Stop { recording_id, .. } => {
+                self.handle_backend_stop(source, recording_id, recv_at)
+                    .await
+            }
+        }
+    }
+
+    /// Open a window for a recording the backend already created.
+    ///
+    /// Idempotent against both a repeat `START` and the `INIT` snapshot every
+    /// reconnect replays: if this source's live window already *is* that
+    /// recording, there is nothing to do. That check is what replaces a
+    /// producer-side "did someone already open this?" flag — it reads state the
+    /// daemon owns rather than state a process guessed at.
+    async fn handle_backend_start(
+        &mut self,
+        source: Source,
+        recording_id: String,
+        dataset_id: Option<String>,
+        start_time_s: f64,
+        recv_at: Instant,
+    ) {
+        if let LiveMatch::Matches(_) = self.live_recording_index_for(&source, &recording_id).await {
+            tracing::debug!(
+                robot_id = source.0,
+                recording_id,
+                "recording notification names the window already open; ignoring"
+            );
+            return;
+        }
+        // The window's lower bound is the publish clock, as for a producer's own
+        // start: it is when the daemon began accepting data for this recording,
+        // which is the only thing it can honestly claim.
+        let publish_timestamp_ns = now_ns();
+        let capture_timestamp_ns = (start_time_s * 1e9) as i64;
+        self.handle_start(
+            source,
+            dataset_id,
+            Some(recording_id),
+            publish_timestamp_ns,
+            capture_timestamp_ns,
+            recv_at,
+        )
+        .await;
+    }
+
+    /// Close the window carrying the named recording.
+    ///
+    /// Matched on the recording the notification names, never on "whatever is
+    /// live now": a `STOP` that arrives after the next recording has begun — or
+    /// an `INIT` replay of an already-finished one — must not end its successor.
+    async fn handle_backend_stop(
+        &mut self,
+        source: Source,
+        recording_id: String,
+        recv_at: Instant,
+    ) {
+        let LiveMatch::Matches(recording_index) =
+            self.live_recording_index_for(&source, &recording_id).await
+        else {
+            tracing::debug!(
+                robot_id = source.0,
+                recording_id,
+                "stop notification does not name the live window; ignoring"
+            );
+            return;
+        };
+        // The backend initiated this stop, so it already knows: stamping the
+        // notify keeps the stop notifier from POSTing it straight back.
+        if let Err(error) = self
+            .store
+            .mark_recording_stop_notified(recording_index)
+            .await
+        {
+            tracing::warn!(%error, recording_index, "failed to stamp backend-originated stop");
+        }
+        let stop_ns = now_ns();
+        self.handle_stop(source, stop_ns, stop_ns, recv_at).await;
+    }
+
+    /// Whether the source's live window is the recording the backend named.
+    ///
+    /// Resolved through the recording row rather than any in-memory map,
+    /// because a locally-started recording's cloud id is stamped there
+    /// asynchronously by the start notifier — the dispatcher never sees it
+    /// otherwise.
+    async fn live_recording_index_for(&self, source: &Source, recording_id: &str) -> LiveMatch {
+        let Some(live_index) = self
+            .windows
+            .get(source)
+            .and_then(|entry| entry.live.as_ref())
+            .map(|window| window.recording_index)
+        else {
+            return LiveMatch::None;
+        };
+        match self.store.recordings_for_source(&source.0, source.1).await {
+            Ok(rows) => {
+                let named = rows
+                    .iter()
+                    .find(|row| row.recording_id.as_deref() == Some(recording_id));
+                match named {
+                    Some(row) if row.recording_index == live_index => {
+                        LiveMatch::Matches(live_index)
+                    }
+                    _ => LiveMatch::Different,
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, robot_id = source.0, "failed to resolve recording by cloud id");
+                LiveMatch::Different
+            }
         }
     }
 
@@ -1943,6 +2173,164 @@ mod tests {
         let a: serde_json::Value =
             serde_json::from_slice(&std::fs::read(a_dir.join("trace.json")).unwrap()).unwrap();
         assert_eq!(a, serde_json::json!([{"i": 1}]));
+    }
+
+    /// Attach a producer so backend notifications for the source are acted on.
+    async fn attach_producer(dispatcher: &mut Dispatcher, robot: &str, at: Instant) {
+        dispatcher
+            .handle_inbound(
+                Envelope::ProducerAttached {
+                    robot_id: robot.into(),
+                    robot_instance: 0,
+                    publish_timestamp_ns: 1,
+                    producer_pid: 4242,
+                },
+                at,
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn a_backend_notification_is_ignored_without_a_producer_here() {
+        // The stream is org-wide, so most of what arrives is for robots on other
+        // machines. Opening a window for one would mint a recording that could
+        // never receive data.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        dispatcher
+            .handle_recording_command(
+                RecordingCommand::Start {
+                    source: ("robot-elsewhere".to_string(), 0),
+                    recording_id: "cloud-1".into(),
+                    dataset_id: Some("ds-1".into()),
+                    start_time_s: 1_700_000_000.0,
+                },
+                Instant::now(),
+            )
+            .await;
+
+        assert!(
+            store
+                .recordings_for_source("robot-elsewhere", 0)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no recording may be minted for a source with no producer here"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_backend_start_adopts_the_cloud_id_and_is_idempotent() {
+        // The INIT snapshot replays every live recording on each reconnect, so a
+        // repeat of the recording already open must do nothing. This is what
+        // replaces a producer-side "did someone already open this?" flag: it
+        // reads state the daemon owns.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let now = Instant::now();
+        attach_producer(&mut dispatcher, "robot-1", now).await;
+        let command = RecordingCommand::Start {
+            source: ("robot-1".to_string(), 0),
+            recording_id: "cloud-1".into(),
+            dataset_id: Some("ds-1".into()),
+            start_time_s: 1_700_000_000.0,
+        };
+        dispatcher
+            .handle_recording_command(command.clone(), now)
+            .await;
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 1);
+        assert_eq!(
+            recordings[0].recording_id.as_deref(),
+            Some("cloud-1"),
+            "the backend's id is adopted rather than re-minted"
+        );
+
+        // Replayed by the next INIT.
+        dispatcher.handle_recording_command(command, now).await;
+        assert_eq!(
+            store
+                .recordings_for_source("robot-1", 0)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "replaying the live recording must not open a second window"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stale_backend_stop_never_closes_the_next_recording() {
+        // The case the whole design exists for. A stop for recording A that
+        // arrives after B has begun — a delayed notification, or an INIT replay
+        // of an already-finished recording — must not end B.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let now = Instant::now();
+        attach_producer(&mut dispatcher, "robot-1", now).await;
+        for recording_id in ["cloud-a", "cloud-b"] {
+            dispatcher
+                .handle_recording_command(
+                    RecordingCommand::Start {
+                        source: ("robot-1".to_string(), 0),
+                        recording_id: recording_id.into(),
+                        dataset_id: Some("ds-1".into()),
+                        start_time_s: 1_700_000_000.0,
+                    },
+                    now,
+                )
+                .await;
+        }
+        let live_index = dispatcher.windows[&("robot-1".to_string(), 0)]
+            .live
+            .as_ref()
+            .expect("B is live")
+            .recording_index;
+
+        // A's stop, arriving late.
+        dispatcher
+            .handle_recording_command(
+                RecordingCommand::Stop {
+                    source: ("robot-1".to_string(), 0),
+                    recording_id: "cloud-a".into(),
+                },
+                now,
+            )
+            .await;
+
+        let still_live = dispatcher.windows[&("robot-1".to_string(), 0)]
+            .live
+            .as_ref()
+            .map(|window| window.recording_index);
+        assert_eq!(
+            still_live,
+            Some(live_index),
+            "a stop naming an earlier recording must leave the live one open"
+        );
+
+        // B's own stop does close it.
+        dispatcher
+            .handle_recording_command(
+                RecordingCommand::Stop {
+                    source: ("robot-1".to_string(), 0),
+                    recording_id: "cloud-b".into(),
+                },
+                now,
+            )
+            .await;
+        assert!(
+            dispatcher.windows[&("robot-1".to_string(), 0)]
+                .live
+                .is_none(),
+            "the recording its own stop names does close"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Web-initiated start and stop reach the daemon straight from the backend, rather than through a producer
