### PR TITLE
fix: stop relaying web recording lifecycle through producers

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -182,7 +182,6 @@ def connect_robot(
     StreamManagerOrchestrator().get_provider_manager(robot.id, robot.instance)
     get_recording_state_manager().register_connected_robot(robot.id)
     robot._register_remote_stop_handler()
-    robot._register_remote_start_handler()
     return robot
 
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -346,22 +346,30 @@ class Robot:
         self,
         recording_id: str | None,
         timestamp: float | None = None,
+        publish_stop: bool = True,
     ) -> None:
-        """Stop all streams and send the recording-stopped IPC message to the daemon.
+        """Stop all streams and, for a local stop, tell the daemon.
 
-        The local ``log_*`` gate closes in the instant between the window
-        closing and the writer's tail-chunk barrier. Closing
-        it before the notify would silently discard data the daemon would still
-        have accepted — the window is open until it receives the stop. Closing it
-        after the barrier instead leaves it open for as long as the writer's
-        backlog takes to drain (over a second under burst logging), publishing
-        data the daemon has already stopped accepting and simply throws away.
+        Args:
+            recording_id: Recording the stop refers to, for logging only.
+            timestamp: Optional capture time for the recording's stop.
+            publish_stop: Whether to publish ``StopRecording``. True for a local
+                ``nc.stop_recording()`` — one process, one envelope, nothing to
+                disambiguate. False for a web-initiated stop, which the daemon
+                hears from the backend itself: a process that merely *learned*
+                of it publishes no lifecycle envelope, so one such stop cannot
+                become one envelope per connected process.
+
+        Either way this process stops its streams and seals its own tail chunks.
+        Those are statements about itself, and stay safe to make from any number
+        of processes.
         """
         try:
             self._stop_all_streams()
             context = self._get_daemon_recording_context()
             try:
-                context.stop_recording(timestamp=timestamp)
+                if publish_stop:
+                    context.stop_recording(timestamp=timestamp)
             finally:
                 # Both run even if the notify failed.
                 self._close_local_recording_gate()
@@ -390,41 +398,17 @@ class Robot:
         manager.register_remote_stop_handler(
             robot_id=self.id,
             instance=self.instance,
-            callback=self._drain_streams_and_notify_daemon,
+            callback=self._drain_streams_for_remote_stop,
         )
         self._recording_state_manager = manager
 
-    def _notify_daemon_of_remote_start(
-        self, recording_id: str, dataset_id: str, start_time: float
-    ) -> None:
-        """Open the daemon window for a recording started from the web frontend.
+    def _drain_streams_for_remote_stop(self, recording_id: str | None) -> None:
+        """Drain this process's streams for a stop the daemon already knows about.
 
         Args:
-            recording_id: The cloud recording id the backend already minted.
-            dataset_id: Dataset the recording is being saved to.
-            start_time: The recording's capture start time (Unix seconds).
+            recording_id: Recording the remote stop refers to.
         """
-        if not self.id:
-            return
-        self._get_daemon_recording_context().start_recording(
-            robot_id=self.id,
-            robot_instance=self.instance,
-            robot_name=self.name,
-            dataset_id=dataset_id,
-            dataset_name=None,
-            timestamp=start_time,
-            cloud_recording_id=recording_id,
-        )
-
-    def _register_remote_start_handler(self) -> None:
-        """Register a callback to notify the daemon of a remote start."""
-        assert self.id is not None
-        manager = get_recording_state_manager()
-        manager.register_remote_start_handler(
-            robot_id=self.id,
-            instance=self.instance,
-            callback=self._notify_daemon_of_remote_start,
-        )
+        self._drain_streams_and_notify_daemon(recording_id, publish_stop=False)
 
     def _stop_all_streams(self) -> None:
         """Stop recording on all data streams for this robot instance."""
@@ -832,7 +816,6 @@ class Robot:
         self._recording_state_manager = None
         if self.id is not None and manager is not None:
             manager.deregister_remote_stop_handler(self.id, self.instance)
-            manager.deregister_remote_start_handler(self.id, self.instance)
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -55,12 +55,10 @@ class TrackedRecording(NamedTuple):
             backend reports in ``RecordingStartPayload.start_time``. Orders
             notifications against each other: one describing a recording that
             began earlier than this belongs to an already-finished recording.
-        opened_locally: Whether the recording was started by the local client
     """
 
     recording_id: str
     start_time: float
-    opened_locally: bool
 
 
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
@@ -141,9 +139,6 @@ class RecordingStateManager(BaseSSEConsumer):
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
-        self._start_callbacks: dict[
-            RobotInstanceIdentifier, Callable[[str, str, float], None]
-        ] = {}
 
         self._logout_listener = self._on_logout
         self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
@@ -181,7 +176,6 @@ class RecordingStateManager(BaseSSEConsumer):
             self._expired_recording_ids.clear()
             self.active_dataset_ids.clear()
             self._drain_callbacks.clear()
-            self._start_callbacks.clear()
             self._connected_robot_id = None
 
         if not self.loop.is_closed():
@@ -286,7 +280,6 @@ class RecordingStateManager(BaseSSEConsumer):
                 instance=instance,
                 recording_id=recording_id,
                 start_time=start_time,
-                opened_locally=True,
             )
         # After the state is visible, and outside the lock: this normally takes
         # a few milliseconds of filesystem work, which is long enough for a
@@ -312,7 +305,6 @@ class RecordingStateManager(BaseSSEConsumer):
         instance: int,
         recording_id: str,
         start_time: float,
-        opened_locally: bool,
     ) -> None:
         """Make ``recording_id`` this instance's tracked recording.
 
@@ -331,7 +323,6 @@ class RecordingStateManager(BaseSSEConsumer):
         self.recording_robot_instances[instance_key] = TrackedRecording(
             recording_id=recording_id,
             start_time=start_time,
-            opened_locally=opened_locally,
         )
         if previous_recording_id is not None:
             self._cancel_recording_timers(previous_recording_id)
@@ -503,20 +494,14 @@ class RecordingStateManager(BaseSSEConsumer):
                 recording_id,
             )
 
-            # Only open the window if no one else has already.
-            opened_locally = previous is not None and previous.opened_locally
-            if not opened_locally:
-                start_callback = self._start_callbacks.get(instance_key)
-                if start_callback is not None:
-                    start_callback(recording_id, dataset_id, details.start_time)
-                opened_locally = True
-
+            # The daemon hears this start from the backend itself, so nothing
+            # here opens its window: this only tracks what the local client's
+            # `log_*` gate and `stop_recording` read.
             self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
                 recording_id=recording_id,
                 start_time=details.start_time,
-                opened_locally=opened_locally,
             )
         else:
             if previous_recording_id != recording_id:
@@ -555,21 +540,6 @@ class RecordingStateManager(BaseSSEConsumer):
         """Remove the drain callback for a robot instance."""
         key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
         self._drain_callbacks.pop(key, None)
-
-    def register_remote_start_handler(
-        self,
-        robot_id: str,
-        instance: int,
-        callback: Callable[[str, str, float], None],
-    ) -> None:
-        """Register a callback to open the daemon window for a web-initiated start."""
-        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
-        self._start_callbacks[key] = callback
-
-    def deregister_remote_start_handler(self, robot_id: str, instance: int) -> None:
-        """Remove the remote-start callback for a robot instance."""
-        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
-        self._start_callbacks.pop(key, None)
 
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -246,9 +246,7 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
         )
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
-    manager.recording_robot_instances[key] = TrackedRecording(
-        "recording-1", 1.0, opened_locally=True
-    )
+    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
     manager.active_dataset_ids[key] = "dataset-1"
     manager._drain_callbacks[key] = MagicMock()
     timer = MagicMock()
@@ -298,9 +296,7 @@ def test_recording_manager_keeps_owned_state_when_the_stream_cannot_authenticate
         )
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
-    manager.recording_robot_instances[key] = TrackedRecording(
-        "recording-1", 1.0, opened_locally=True
-    )
+    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
     manager.active_dataset_ids[key] = "dataset-1"
 
     manager_future: Future[RecordingStateManager] = Future()

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -23,8 +23,15 @@ class _FailingStopStream(_ActiveStream):
         raise RuntimeError("stop failed")
 
 
-def test_web_stop_drains_streams_and_notifies_daemon() -> None:
-    """Callback registered at connect time must drain streams and notify the daemon."""
+def test_web_stop_drains_streams_without_publishing_a_stop() -> None:
+    """A web stop drains this process but publishes no lifecycle envelope.
+
+    The daemon hears a web-initiated stop from the backend itself, so a process
+    that merely learned of it must not publish ``StopRecording`` — otherwise one
+    stop becomes one envelope per connected process, and the daemon has to work
+    out which recording each of them meant. Sealing this process's own tail
+    chunks is a statement about itself and still happens.
+    """
     robot = Robot("robot", instance=0, org_id="org-1")
     robot.id = "robot-id-1"
 
@@ -56,7 +63,32 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
     callback("rec-abc")
 
     assert active.stop_calls == 1
-    fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.stop_recording.assert_not_called()
+    fake_daemon.flush_source.assert_called_once_with()
+
+
+def test_local_stop_publishes_a_stop() -> None:
+    """A local ``stop_recording()`` is one process's intent, so it does publish.
+
+    There is no fan-out to disambiguate here: exactly one process calls it, so
+    exactly one ``StopRecording`` reaches the daemon and matching it by publish
+    stamp is unambiguous.
+    """
+    robot = Robot("robot", instance=0, org_id="org-1")
+    robot.id = "robot-id-1"
+
+    active = _ActiveStream()
+    robot.add_data_stream("JOINT_POSITIONS:joint", active)  # type: ignore[arg-type]
+
+    fake_daemon = MagicMock()
+    robot._daemon_recording_context = fake_daemon
+
+    with patch("neuracore.core.robot.get_recording_state_manager"):
+        robot.stop_recording(timestamp=123.0)
+        robot.id = None  # prevent __del__ from hitting the real manager
+
+    assert active.stop_calls == 1
+    fake_daemon.stop_recording.assert_called_once_with(timestamp=123.0)
     fake_daemon.flush_source.assert_called_once_with()
 
 


### PR DESCRIPTION
### Features

- A process that merely learned of a web-initiated recording no longer publishes either end of its lifecycle: the daemon hears both start and stop from the backend itself, so one web event cannot become one envelope per connected process.
- Such a process still stops its own streams and seals its own tail chunks — statements about itself, safe from any number of processes.
- A local `nc.start_recording()` / `nc.stop_recording()` still publishes, since exactly one process calls it and there is nothing to disambiguate.
- Drops the SDK's remote-start callback registry along with it; the daemon ignores the `robot_name` and `dataset_name` only that path carried, and derives the same capture stamp from the notification.
