### PR TITLE
feat: alpha release from a branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 name: Release
-run-name: ${{ inputs.emergency_deploy && 'Release (Emergency)' || (inputs.dry_run && 'Release (Dry Run)' || 'Release') }}
+run-name: ${{ inputs.emergency_deploy && 'Release (Emergency)' || (inputs.dry_run && 'Release (Dry Run)' || (inputs.alpha_release && 'Release (Alpha)' || 'Release')) }}
 
 on:
   workflow_dispatch:
@@ -14,6 +14,16 @@ on:
         required: false
         type: boolean
         default: false
+      alpha_release:
+        description: 'Alpha pre-release from `branch` - tags and publishes a pre-release without changing main'
+        required: false
+        type: boolean
+        default: false
+      branch:
+        description: 'Branch to build the alpha pre-release from (alpha releases only)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   analyze-changes:
@@ -24,15 +34,29 @@ jobs:
       pr_data: ${{ steps.analyze.outputs.pr_data }}
 
     steps:
+    - name: Validate alpha release inputs
+      if: ${{ inputs.alpha_release }}
+      env:
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        if [ -z "$BRANCH" ]; then
+          echo "ERROR: alpha_release needs a branch to build from"
+          exit 1
+        fi
+        if [ "${{ inputs.emergency_deploy }}" = "true" ]; then
+          echo "ERROR: alpha_release and emergency_deploy cannot be combined"
+          exit 1
+        fi
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
+        ref: ${{ inputs.alpha_release && inputs.branch || (inputs.emergency_deploy && github.ref_name || 'main') }}
         fetch-depth: 0
 
     - name: Get latest release tag
       id: get_tag
-      if: ${{ !inputs.emergency_deploy }}
+      if: ${{ !inputs.emergency_deploy && !inputs.alpha_release }}
       run: |
         LATEST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
         if [ -z "$LATEST_TAG" ]; then
@@ -43,7 +67,7 @@ jobs:
         echo "Found latest release tag: $LATEST_TAG"
 
     - name: Check for new commits since last tag
-      if: ${{ !inputs.emergency_deploy }}
+      if: ${{ !inputs.emergency_deploy && !inputs.alpha_release }}
       run: |
         COMMITS_SINCE=$(git rev-list --count ${{ steps.get_tag.outputs.latest_tag }}..HEAD)
 
@@ -57,7 +81,7 @@ jobs:
 
     - name: Get commit SHAs since last release
       id: get_commits
-      if: ${{ !inputs.emergency_deploy }}
+      if: ${{ !inputs.emergency_deploy && !inputs.alpha_release }}
       run: |
         TAG="${{ steps.get_tag.outputs.latest_tag }}"
 
@@ -74,13 +98,15 @@ jobs:
       env:
         COMMIT_SHAS: ${{ steps.get_commits.outputs.commit_shas || '[]' }}
         EMERGENCY: ${{ inputs.emergency_deploy }}
+        ALPHA: ${{ inputs.alpha_release }}
       with:
         script: |
-          if (process.env.EMERGENCY === 'true') {
+          if (process.env.EMERGENCY === 'true' || process.env.ALPHA === 'true') {
             core.setOutput('should_release', true);
             core.setOutput('bump_type', 'patch');
             core.setOutput('pr_data', '[]');
-            console.log('Emergency deploy: forcing a patch release and skipping PR/label verification');
+            const mode = process.env.ALPHA === 'true' ? 'Alpha release' : 'Emergency deploy';
+            console.log(`${mode}: forcing a patch bump and skipping PR/label verification`);
             return;
           }
 
@@ -171,7 +197,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
+        ref: ${{ inputs.alpha_release && inputs.branch || (inputs.emergency_deploy && github.ref_name || 'main') }}
         fetch-depth: 0
 
     - name: Calculate new version
@@ -208,6 +234,11 @@ jobs:
         esac
 
         NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+        if [ "${{ inputs.alpha_release }}" = "true" ]; then
+          NEW_VERSION="${NEW_VERSION}a${{ github.run_number }}"
+        fi
+
         echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
         if [ "$BUMP_TYPE" = "none" ]; then
@@ -246,9 +277,11 @@ jobs:
       env:
         PENDING_CONTENT: ${{ steps.read_pending.outputs.pending_content }}
         PR_DATA: ${{ needs.analyze-changes.outputs.pr_data }}
+        ALPHA_BRANCH: ${{ inputs.alpha_release && inputs.branch || '' }}
       with:
         script: |
           const version = '${{ steps.calc_version.outputs.new_version }}';
+          const alphaBranch = process.env.ALPHA_BRANCH;
           const prData = JSON.parse(process.env.PR_DATA);
           const pendingContent = process.env.PENDING_CONTENT ? JSON.parse(process.env.PENDING_CONTENT) : '';
 
@@ -271,6 +304,10 @@ jobs:
           }
 
           let changelog = `# Release v${version} - ${date}\n\n`;
+
+          if (alphaBranch) {
+            changelog += `Alpha pre-release built from \`${alphaBranch}\`. Not a production release.\n\n`;
+          }
 
           if (pendingContent && pendingContent.trim()) {
             changelog += `## Summary\n\n${pendingContent.trim()}\n\n---\n\n`;
@@ -343,7 +380,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.emergency_deploy && github.ref_name || 'main' }}
+        ref: ${{ inputs.alpha_release && inputs.branch || (inputs.emergency_deploy && github.ref_name || 'main') }}
         token: ${{ steps.generate-token.outputs.token }}
         fetch-depth: 0
 
@@ -369,7 +406,17 @@ jobs:
         NEW_VERSION=$(grep -m 1 '^current_version = ' .bumpversion.cfg | cut -d'=' -f2 | tr -d ' ')
         echo "Bumped to version: $NEW_VERSION"
 
+        if [ "${{ inputs.alpha_release }}" = "true" ]; then
+          RUN="${{ github.run_number }}"
+          sed -i "s/^current_version = ${NEW_VERSION}$/current_version = ${NEW_VERSION}a${RUN}/" .bumpversion.cfg
+          sed -i "s/^version = \"${NEW_VERSION}\"$/version = \"${NEW_VERSION}a${RUN}\"/" pyproject.toml
+          # Cargo parses semver, which spells the same pre-release differently.
+          sed -i "s/^version = \"${NEW_VERSION}\"$/version = \"${NEW_VERSION}-alpha.${RUN}\"/" rust/Cargo.toml rust/Cargo.lock
+          echo "Alpha version: ${NEW_VERSION}a${RUN}"
+        fi
+
     - name: Reset pending changelog
+      if: ${{ !inputs.alpha_release }}
       run: |
         cp changelogs/template.md changelogs/pending-changelog.md
         echo "Reset pending changelog to template"
@@ -381,10 +428,13 @@ jobs:
         git add .bumpversion.cfg pyproject.toml changelogs/pending-changelog.md rust/Cargo.toml rust/Cargo.lock
         git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
 
-        TARGET_BRANCH="${{ inputs.emergency_deploy && github.ref_name || 'main' }}"
-        git push origin "HEAD:${TARGET_BRANCH}"
-
-        echo "Pushed version bump to ${TARGET_BRANCH}"
+        if [ "${{ inputs.alpha_release }}" = "true" ]; then
+          echo "Alpha release: version bump kept local, only the tag is pushed"
+        else
+          TARGET_BRANCH="${{ inputs.emergency_deploy && github.ref_name || 'main' }}"
+          git push origin "HEAD:${TARGET_BRANCH}"
+          echo "Pushed version bump to ${TARGET_BRANCH}"
+        fi
 
     - name: Create git tag
       run: |
@@ -428,7 +478,7 @@ jobs:
             name: `Release v${version}`,
             body: changelogBody,
             draft: false,
-            prerelease: false
+            prerelease: ${{ inputs.alpha_release }}
           });
 
           console.log(`Created GitHub Release for v${version}`);
@@ -436,14 +486,19 @@ jobs:
 
     - name: Generate release summary
       uses: actions/github-script@v7
+      env:
+        ALPHA_BRANCH: ${{ inputs.alpha_release && inputs.branch || '' }}
       with:
         script: |
           const version = '${{ needs.generate-changelog.outputs.new_version }}';
+          const alphaBranch = process.env.ALPHA_BRANCH;
           const fs = require('fs');
           let summary = `# Release Published Successfully\n\n`;
           summary += `**Version:** \`${version}\`\n\n`;
           summary += `## Actions Completed\n\n`;
-          summary += `- Version bumped and pushed to \`main\`\n`;
+          summary += alphaBranch
+            ? `- Alpha version built from \`${alphaBranch}\`, no version bump pushed\n`
+            : `- Version bumped and pushed to \`main\`\n`;
           summary += `- Git tag \`v${version}\` created\n`;
           summary += `- Platform wheels (linux x86_64 + macOS arm64, cp310-cp314) publishing to PyPI (see publish job)\n`;
           summary += `- GitHub Release created\n\n`;
@@ -503,8 +558,10 @@ jobs:
       uses: actions/github-script@v7
       env:
         CHANGELOG_CONTENT: ${{ needs.generate-changelog.outputs.changelog_content }}
+        ALPHA_BRANCH: ${{ inputs.alpha_release && inputs.branch || '' }}
       with:
         script: |
+          const alphaBranch = process.env.ALPHA_BRANCH;
           const shouldRelease = '${{ needs.analyze-changes.outputs.should_release }}' === 'true';
           const bumpType = '${{ needs.analyze-changes.outputs.bump_type }}';
           const newVersion = '${{ needs.generate-changelog.outputs.new_version }}';
@@ -526,7 +583,9 @@ jobs:
             summary += '## What Would Happen\n\n';
             summary += `- **Version Bump:** \`${bumpType}\` -> \`${newVersion}\`\n`;
             summary += `- Version updated in \`.bumpversion.cfg\`, \`pyproject.toml\`, \`rust/Cargo.toml\` and \`rust/Cargo.lock\`\n`;
-            summary += `- Changes committed and pushed to \`main\`\n`;
+            summary += alphaBranch
+              ? `- Alpha built from \`${alphaBranch}\`, nothing pushed to the branch\n`
+              : `- Changes committed and pushed to \`main\`\n`;
             summary += `- Package published to PyPI\n`;
             summary += `- Git tag \`v${newVersion}\` created\n`;
             summary += `- GitHub Release created\n\n`;
@@ -541,7 +600,7 @@ jobs:
 
   no-release-needed:
     needs: [analyze-changes, generate-changelog]
-    if: always() && needs.analyze-changes.outputs.should_release != 'true' && inputs.dry_run == false && inputs.emergency_deploy == false
+    if: always() && needs.analyze-changes.outputs.should_release != 'true' && inputs.dry_run == false && inputs.emergency_deploy == false && inputs.alpha_release == false
     runs-on: ubuntu-24.04
 
     steps:

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -317,6 +317,12 @@ tag, re-runs `build-wheels.yaml` against that tag, and publishes **all** wheels
 in a single job only after every platform leg succeeds — so a version can never
 be half-published. `twine --skip-existing` makes re-running idempotent.
 
+The `alpha_release` option builds the same pipeline from the `branch` input
+instead of `main`. It tags and publishes `<next patch>a<run number>` as a
+pre-release and pushes no commit to the branch. The rust workspace needs
+semver, so an alpha carries `15.0.1-alpha.7` there against `15.0.1a7` in
+pyproject; the daemon version check reads the first as the second.
+
 ---
 
 ## SQLite state inspection

--- a/neuracore/data_daemon/daemon_control.py
+++ b/neuracore/data_daemon/daemon_control.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.metadata
 import logging
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -51,6 +52,17 @@ class DaemonLifecycleError(RuntimeError):
 
 class DaemonVersionMismatchError(DaemonLifecycleError):
     """Raised when the running daemon comes from a different neuracore version."""
+
+
+# Cargo needs semver, so an alpha release carries `15.0.1-alpha.7` in the rust
+# workspace while PyPI normalises the same release to `15.0.1a7`. Pre-releases
+# are the only versions where the two spellings differ.
+_CARGO_PRE_RELEASE = re.compile(r"-alpha\.(\d+)$")
+
+
+def _pep440(version: str) -> str:
+    """Return a cargo version string in the PEP 440 spelling."""
+    return _CARGO_PRE_RELEASE.sub(r"a\1", version)
 
 
 def _sdk_version() -> str | None:
@@ -176,7 +188,7 @@ def _check_daemon_version(timeout_s: float, *, just_launched: bool = False) -> N
     except RuntimeError as error:
         logger.warning("Skipped the daemon version check: %s", error)
         return
-    if daemon_version != sdk_version:
+    if daemon_version is None or _pep440(daemon_version) != sdk_version:
         raise DaemonVersionMismatchError(
             _format_version_mismatch(daemon_version, sdk_version, just_launched)
         )

--- a/tests/unit/data_daemon/test_daemon_control.py
+++ b/tests/unit/data_daemon/test_daemon_control.py
@@ -407,6 +407,37 @@ def test_ensure_daemon_running_adopts_daemon_built_from_the_installed_version(
     assert version_timeouts == [2.5]
 
 
+def test_ensure_daemon_running_accepts_an_alpha_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An alpha wheel ships the two spellings of one version, not two versions."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, "99.9.9a7")
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: "99.9.9-alpha.7",
+    )
+
+    assert daemon_control.ensure_daemon_running(timeout_s=0.0) == os.getpid()
+
+
+def test_ensure_daemon_running_rejects_a_daemon_from_another_alpha(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two alphas of the same release are still two different builds."""
+    _use_live_daemon_paths(monkeypatch, tmp_path)
+    _install_sdk_version(monkeypatch, "99.9.9a7")
+    _install_fake_bridge(
+        monkeypatch,
+        lambda _timeout_s: os.getpid(),
+        daemon_version=lambda _timeout_s: "99.9.9-alpha.6",
+    )
+
+    with pytest.raises(DaemonVersionMismatchError):
+        daemon_control.ensure_daemon_running(timeout_s=0.0)
+
+
 def test_ensure_daemon_running_rejects_daemon_built_from_another_version(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
### Features
 - `release.yaml` gains an `alpha_release` option and a `branch` input. The version bump is committed locally and only the tag is pushed, so the branch and `main` are untouched. PR labels and the pending changelog are left alone.
 
### Bugfixes
 - Cargo parses semver, so an alpha carries `15.0.1-alpha.7` in the rust workspace against `15.0.1a7` in `pyproject.toml`. The daemon version check compared the two as raw strings and would have raised `DaemonVersionMismatchError` on every alpha install, so it now reads the cargo spelling as its PEP 440 equivalent.

### Bugfixes
 - None

### Items
 - [NCP-1299](https://neuracore.atlassian.net/browse/NCP-1299)

