### PR TITLE
feat: push recording windows to producers and gate logging on them

### DIFF
--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -25,6 +25,15 @@ data and fire-and-forget lifecycle events, and the daemon owns all recording
 identity and routing. Pixel data never travels the IPC bus — the producer spools
 NUT chunks to disk and only announces them.
 
+One channel runs the other way. The daemon publishes which sources have a live
+recording window on `recording_windows`, and the producer's `log_*` entry points
+drop a sample before any work when the source has none. It is what lets a camera
+process that never brackets a recording contribute to one another process
+started, without spooling every frame it ever captures. The producer still owns
+no recording state: it caches the daemon's answer, and covers the round trip
+after its own `start_recording` with a claim that the daemon's next snapshot
+supersedes.
+
 ```mermaid
 flowchart LR
     subgraph SDK["Python SDK"]
@@ -38,6 +47,9 @@ flowchart LR
     WRT -. VideoChunkReady .-> PUBT
     BUS --> LIS["ipc::listener (adaptive poll)"]
     LIS --> DISP["dispatcher<br/>single task · holdback · publish-clock routing"]
+    DISP -. live-window snapshot .-> LIS
+    LIS -->|iceoryx2 recording_windows| GATE[("log gate")]
+    GATE -. drop when no window .-> LOG
     DISP --> ACT["per-trace actors"]
     ACT -->|fire-and-forget| TW["trace_writer<br/>batched DB write-behind"]
     ACT -->|fire-and-forget| JW["json_writer (IO thread)"]

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -226,7 +226,8 @@ def _record_json_to_daemon(
     ``log_json`` entry point is datatype-agnostic, so adding a new JSON type
     needs no daemon-side change.
 
-    A no-op unless a recording is in progress.
+    Always forwarded: the bridge drops the sample before any work if no window
+    is open for the source, and it — not this process — knows whether one is.
 
     Args:
         robot: Robot instance owning the daemon recording context.
@@ -235,8 +236,6 @@ def _record_json_to_daemon(
         data: Data object to serialize and persist.
         timestamp: Capture timestamp in seconds.
     """
-    if robot.get_current_recording_id() is None:
-        return
     payload = json.dumps(data.model_dump(mode="json")).encode("utf-8")
     robot._get_daemon_recording_context().log_json(
         data_type.value, storage_name, payload, timestamp
@@ -386,6 +385,9 @@ def _log_group_of_joint_data(
     if bindings_for_type is None:
         bindings_for_type = {}
         binding_cache[data_type] = bindings_for_type
+    # Still read: the bucket and live-data streams key off this process's own
+    # recording handle. The daemon path no longer consults it — the bridge does,
+    # from the window the daemon publishes.
     current_recording_id = robot.get_current_recording_id()
     live_data_disabled = get_provide_live_data_enabled_manager().is_disabled()
     robot_id = robot.id
@@ -406,10 +408,9 @@ def _log_group_of_joint_data(
         native_values = list(joint_data.values())
         for binding, joint_value in zip(group.bindings, native_values):
             binding.stream.record_scalar(timestamp, joint_value)
-        if current_recording_id is not None:
-            robot._get_daemon_recording_context().log_joints(
-                data_type.value, timestamp, group.joined_names, native_values
-            )
+        robot._get_daemon_recording_context().log_joints(
+            data_type.value, timestamp, group.joined_names, native_values
+        )
         return
 
     native_values = []
@@ -433,8 +434,7 @@ def _log_group_of_joint_data(
             # allocation-free (see JointDataStream).
             binding.stream.record_scalar(timestamp, joint_value)
 
-        if current_recording_id is not None:
-            native_values.append(joint_value)
+        native_values.append(joint_value)
 
     if native_values:
         robot._get_daemon_recording_context().log_joints(
@@ -532,17 +532,21 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
-        contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
-        robot._get_daemon_recording_context().log_frame(
-            camera_type.value,
-            storage_name,
-            int(image.shape[1]),
-            int(image.shape[0]),
-            image.dtype.name,
-            memoryview(contiguous).cast("B"),
-            camera_data_without_frame.timestamp,
-        )
+    # Forwarded unconditionally: whether this lands in a recording is the
+    # daemon's to know, and the bridge drops the frame before copying or
+    # spooling it when no window is open for the source. A camera process that
+    # never brackets a recording of its own has no other way to contribute to
+    # one.
+    contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
+    robot._get_daemon_recording_context().log_frame(
+        camera_type.value,
+        storage_name,
+        int(image.shape[1]),
+        int(image.shape[0]),
+        image.dtype.name,
+        memoryview(contiguous).cast("B"),
+        camera_data_without_frame.timestamp,
+    )
 
     _publish_video_to_p2p(robot, name, camera_type, camera_data_without_frame, image)
 

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -43,6 +43,11 @@ const SIGNAL_CAPTURE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Buffer for dispatcher → config-watcher refresh requests (rare, drained promptly).
 const CONFIG_REFRESH_CHANNEL_CAPACITY: usize = 8;
 
+/// Buffer for dispatcher → listener window snapshots. One per recording start or
+/// stop, and the listener keeps only the newest, so this only has to cover a
+/// burst of lifecycle events arriving inside one listener pass.
+const WINDOW_SNAPSHOT_CAPACITY: usize = 16;
+
 /// Run the launch command.
 pub fn run(profile: Option<String>, background: bool, debug: bool) -> Result<()> {
     let runtime_env = RuntimeEnv::from_env();
@@ -425,9 +430,14 @@ fn run_daemon(
                     spawn_wakelock(event_bus.clone(), shutdown_tx.subscribe())
                 });
 
+            // Window snapshots run dispatcher → listener → producers: the
+            // dispatcher owns the state, the listener owns the iceoryx2 port.
+            let (window_snapshot_tx, window_snapshot_rx) =
+                tokio::sync::mpsc::channel(WINDOW_SNAPSHOT_CAPACITY);
             let dispatcher_context = DispatcherContext {
                 event_bus: Some(event_bus.clone()),
                 config_refresh_tx: Some(config_refresh_tx),
+                window_snapshot_tx: Some(window_snapshot_tx),
             };
             let (dispatcher_tx, dispatcher_handle) = dispatcher::spawn_with_context(
                 state_store.clone(),
@@ -479,6 +489,7 @@ fn run_daemon(
             listener::run(
                 transport,
                 dispatcher_tx.clone(),
+                window_snapshot_rx,
                 Arc::new(state_store.clone()),
                 shutdown_tx.subscribe(),
             )

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -16,12 +16,13 @@
 //! the later `serve_recording_id_queries` borrow is itself held across an await.)
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use data_daemon_shared::{
-    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, VersionReply,
-    VersionRequest,
+    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, RecordingWindows,
+    VersionReply, VersionRequest,
 };
+use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::ipc;
@@ -56,6 +57,17 @@ const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 /// cost and avoids relaxing during a brief lull mid-recording.
 const IDLE_POLL_AFTER_EMPTY: u32 = 64;
 
+/// How often the current window snapshot is re-sent unchanged.
+///
+/// Change-driven publishing alone does not reach a producer that attaches
+/// *between* two changes: iceoryx2 hands a new subscriber the service history
+/// only when the publisher next sends, and `update_connections` is not public,
+/// so a process that starts mid-recording would stay blind until the next start
+/// or stop — and drop every frame until then. Re-sending bounds that at one
+/// interval, and 250 ms costs four ~50-byte samples a second against ~8 dropped
+/// frames from a 30 fps camera.
+const WINDOW_REPUBLISH_INTERVAL: Duration = Duration::from_millis(250);
+
 /// Drain the iceoryx2 subscriber until a shutdown signal arrives.
 ///
 /// Each successfully decoded envelope is forwarded to the dispatcher's
@@ -69,6 +81,7 @@ const IDLE_POLL_AFTER_EMPTY: u32 = 64;
 pub async fn run(
     transport: IpcTransport,
     dispatcher_tx: mpsc::Sender<Envelope>,
+    mut window_snapshot_rx: mpsc::Receiver<RecordingWindows>,
     store: Arc<SqliteStateStore>,
     mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) {
@@ -81,6 +94,7 @@ pub async fn run(
     );
 
     let mut counters = LoopCounters::default();
+    let mut windows = WindowPublishState::default();
     let mut batch: Vec<Envelope> = Vec::with_capacity(64);
     // Consecutive empty drains, used to relax the poll cadence on an idle
     // daemon. Reset to 0 the moment any envelope arrives.
@@ -110,6 +124,16 @@ pub async fn run(
                 return;
             }
         }
+
+        // -- Tell producers which sources have a window open --------------------
+        // The dispatcher owns the window state but not the publisher port, so it
+        // hands snapshots here. Published from this loop, which is the only
+        // thread allowed to touch iceoryx2 ports.
+        publish_window_snapshots(
+            transport.recording_window_publisher(),
+            &mut window_snapshot_rx,
+            &mut windows,
+        );
 
         // -- Answer readiness probes --------------------------------------------
         // A health reply is the SDK launcher's readiness contract: reaching this
@@ -303,6 +327,70 @@ async fn serve_recording_id_queries(
 struct LoopCounters {
     decode_failures: u64,
     receive_failures: u64,
+}
+
+/// The window snapshot most recently sent to producers, and when it last went
+/// out.
+#[derive(Default)]
+struct WindowPublishState {
+    latest: Option<RecordingWindows>,
+    last_sent: Option<Instant>,
+}
+
+/// Publish the dispatcher's window snapshots, and re-send the current one on
+/// [`WINDOW_REPUBLISH_INTERVAL`].
+///
+/// A snapshot is a complete statement of which sources have a live window, so an
+/// older one queued behind a newer has nothing to add and is skipped rather than
+/// sent. The re-send exists for producers that attach between changes (see
+/// [`WINDOW_REPUBLISH_INTERVAL`]) and carries the snapshot **verbatim**,
+/// `published_at_ns` included: a producer expires its own claim against that
+/// stamp, so re-stamping a re-send would retire a claim the snapshot never
+/// spoke about.
+///
+/// Failures are logged and dropped — the next re-send is 250 ms away.
+fn publish_window_snapshots(
+    publisher: &Publisher<ipc::Service, [u8], ()>,
+    rx: &mut mpsc::Receiver<RecordingWindows>,
+    state: &mut WindowPublishState,
+) {
+    let mut newest = None;
+    while let Ok(snapshot) = rx.try_recv() {
+        newest = Some(snapshot);
+    }
+    if let Some(snapshot) = newest {
+        state.latest = Some(snapshot);
+        state.last_sent = None;
+    }
+    let Some(snapshot) = state.latest.as_ref() else {
+        return;
+    };
+    let now = Instant::now();
+    let due = state
+        .last_sent
+        .is_none_or(|sent| now.duration_since(sent) >= WINDOW_REPUBLISH_INTERVAL);
+    if !due {
+        return;
+    }
+    state.last_sent = Some(now);
+
+    let bytes = match snapshot.encode() {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(%error, "window snapshot encode failed");
+            return;
+        }
+    };
+    let sample = match publisher.loan_slice_uninit(bytes.len()) {
+        Ok(sample) => sample,
+        Err(error) => {
+            tracing::warn!(%error, "window snapshot loan failed");
+            return;
+        }
+    };
+    if let Err(error) = sample.write_from_slice(&bytes).send() {
+        tracing::warn!(%error, "window snapshot send failed");
+    }
 }
 
 /// Synchronously drain every available sample on `subscriber`, appending

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -14,12 +14,16 @@ use data_daemon_shared::service_name::{
     COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
     MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
-    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
+    RECORDING_ID_MAX_PAYLOAD_BYTES, RECORDING_WINDOWS, RECORDING_WINDOWS_HISTORY_SIZE,
+    RECORDING_WINDOWS_MAX_PAYLOAD_BYTES, RECORDING_WINDOWS_MAX_PUBLISHERS,
+    RECORDING_WINDOWS_MAX_SUBSCRIBERS, RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE, VERSION,
+    VERSION_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
+use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
-use iceoryx2::prelude::{ipc, NodeName};
+use iceoryx2::prelude::{ipc, NodeName, UnableToDeliverStrategy};
 use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
 use iceoryx2::service::port_factory::request_response::PortFactory as QueryPortFactory;
 use thiserror::Error;
@@ -66,6 +70,14 @@ pub enum IpcSetupError {
         /// Underlying iceoryx2 error message.
         detail: String,
     },
+    /// Building a publisher port failed.
+    #[error("failed to create publisher on '{name}': {detail}")]
+    PublisherCreate {
+        /// Owning service.
+        name: String,
+        /// Underlying iceoryx2 error message.
+        detail: String,
+    },
     /// Building a request-response server port failed.
     #[error("failed to create server on '{name}': {detail}")]
     ServerCreate {
@@ -106,6 +118,11 @@ pub struct IpcTransport {
     version_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the version server.
     _version_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Publisher on `neuracore/data_daemon/recording_windows` — the one channel
+    /// that runs daemon → producer, carrying which sources have a live window.
+    recording_window_publisher: Publisher<ipc::Service, [u8], ()>,
+    /// Service handle held alongside the window publisher.
+    _recording_window_service: PortFactory<ipc::Service, [u8], ()>,
 }
 
 impl IpcTransport {
@@ -136,6 +153,8 @@ impl IpcTransport {
         let (version_service, version_server) =
             open_query_server(&node, VERSION, VERSION_MAX_PAYLOAD_BYTES)?;
 
+        let (recording_window_service, recording_window_publisher) = open_window_publisher(&node)?;
+
         Ok(IpcTransport {
             _node: node,
             commands_subscriber,
@@ -146,6 +165,8 @@ impl IpcTransport {
             _health_service: health_service,
             version_server,
             _version_service: version_service,
+            recording_window_publisher,
+            _recording_window_service: recording_window_service,
         })
     }
 
@@ -168,11 +189,61 @@ impl IpcTransport {
     pub fn version_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
         &self.version_server
     }
+
+    /// Borrow the `recording_windows` publisher port.
+    pub fn recording_window_publisher(&self) -> &Publisher<ipc::Service, [u8], ()> {
+        &self.recording_window_publisher
+    }
+}
+
+/// Open (or attach to) the `recording_windows` pub/sub service and build the
+/// daemon's single publisher on it.
+///
+/// The mirror image of [`open_subscriber`], and configured the opposite way on
+/// purpose: safe overflow is left **on** and delivery discards rather than
+/// blocks, so a producer that stops draining its buffer can never stall the
+/// daemon's listener loop. Losing a snapshot costs nothing — the next one is a
+/// complete replacement, and one sample of history hands the current state to
+/// any producer that attaches later.
+fn open_window_publisher(
+    node: &Node<ipc::Service>,
+) -> Result<(ByteSliceFactory, ByteSlicePublisher), IpcSetupError> {
+    let service_name =
+        RECORDING_WINDOWS
+            .try_into()
+            .map_err(|error| IpcSetupError::InvalidServiceName {
+                name: RECORDING_WINDOWS.to_string(),
+                detail: format!("{error}"),
+            })?;
+    let service = node
+        .service_builder(&service_name)
+        .publish_subscribe::<[u8]>()
+        .history_size(RECORDING_WINDOWS_HISTORY_SIZE)
+        .subscriber_max_buffer_size(RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE)
+        .max_publishers(RECORDING_WINDOWS_MAX_PUBLISHERS)
+        .max_subscribers(RECORDING_WINDOWS_MAX_SUBSCRIBERS)
+        .max_nodes(MAX_NODES_PER_SERVICE)
+        .open_or_create()
+        .map_err(|error| IpcSetupError::ServiceOpen {
+            name: RECORDING_WINDOWS.to_string(),
+            detail: error.to_string(),
+        })?;
+    let publisher = service
+        .publisher_builder()
+        .initial_max_slice_len(RECORDING_WINDOWS_MAX_PAYLOAD_BYTES)
+        .unable_to_deliver_strategy(UnableToDeliverStrategy::DiscardSample)
+        .create()
+        .map_err(|error| IpcSetupError::PublisherCreate {
+            name: RECORDING_WINDOWS.to_string(),
+            detail: error.to_string(),
+        })?;
+    Ok((service, publisher))
 }
 
 /// Convenience alias for the `[u8]` pub/sub factory + subscriber pair
 /// [`open_subscriber`] returns.
 type ByteSliceFactory = PortFactory<ipc::Service, [u8], ()>;
+type ByteSlicePublisher = Publisher<ipc::Service, [u8], ()>;
 type ByteSliceSubscriber = Subscriber<ipc::Service, [u8], ()>;
 
 /// Open or attach to a `[u8]` pub/sub service and build a subscriber on it.

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -57,7 +57,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype};
+use data_daemon_shared::{
+    video_boundary, BatchedDataItem, Envelope, FrameDtype, OpenWindow, RecordingWindows,
+};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -148,6 +150,11 @@ pub struct DispatcherContext {
     /// `None` in tests / when no watcher is wired, where `RefreshConfig` is a
     /// no-op.
     pub config_refresh_tx: Option<tokio::sync::mpsc::Sender<crate::cloud::ConfigRefreshRequest>>,
+    /// Where window snapshots go on their way to producers. The IPC listener
+    /// owns the only publisher port, so the dispatcher hands snapshots to it
+    /// rather than publishing them itself. `None` in tests, where nothing
+    /// subscribes.
+    pub window_snapshot_tx: Option<mpsc::Sender<RecordingWindows>>,
 }
 
 /// Spawn the dispatcher task and return its inbound `mpsc::Sender`.
@@ -332,6 +339,14 @@ struct Dispatcher {
     actor_handles: Vec<JoinHandle<()>>,
     /// Rate-limited orphan-drop counter (data outside any window).
     orphan_drops: u64,
+    /// The live-window set as last published to producers, sorted, so an
+    /// unchanged set publishes nothing.
+    published_windows: Vec<(Source, i64)>,
+    /// Whether anything since the last publish could have opened or closed a
+    /// window. Set by the three lifecycle handlers and by housekeeping, which
+    /// are the only things that can: re-deriving the set on every wake-up would
+    /// clone every source id on the data path, which is most of them.
+    windows_dirty: bool,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
     /// doesn't re-run the two full window scans (and their `Vec` allocations)
@@ -354,6 +369,10 @@ impl Dispatcher {
             held: VecDeque::new(),
             actor_handles: Vec::new(),
             orphan_drops: 0,
+            published_windows: Vec::new(),
+            // Publish the (empty) set once at startup, so a producer that
+            // attaches before any recording is told so rather than left waiting.
+            windows_dirty: true,
             last_housekeep: Instant::now(),
         }
     }
@@ -401,6 +420,7 @@ impl Dispatcher {
                 self.housekeep(now).await;
                 self.last_housekeep = now;
             }
+            self.publish_windows_if_changed();
         }
 
         self.shutdown().await;
@@ -617,6 +637,7 @@ impl Dispatcher {
         timestamp_ns: i64,
         recv_at: Instant,
     ) {
+        self.windows_dirty = true;
         // A `StartRecording` carrying a known cloud id can reach this daemon
         // more than once for the very same recording: every local process
         // connected to the source learns about a web-started recording
@@ -769,6 +790,7 @@ impl Dispatcher {
         timestamp_ns: i64,
         recv_at: Instant,
     ) {
+        self.windows_dirty = true;
         let Some(entry) = self.windows.get_mut(&source) else {
             tracing::debug!(robot_id = source.0, "stop for unknown source; ignoring");
             return;
@@ -884,6 +906,7 @@ impl Dispatcher {
     }
 
     async fn handle_cancel(&mut self, source: Source, timestamp_ns: i64) {
+        self.windows_dirty = true;
         let Some(mut entry) = self.windows.remove(&source) else {
             return;
         };
@@ -953,6 +976,8 @@ impl Dispatcher {
     /// window scans, so throttled to [`HOUSEKEEP_INTERVAL`] by the caller rather
     /// than run per inbound envelope.
     async fn housekeep(&mut self, now: Instant) {
+        // The idle reaper below can close a live window.
+        self.windows_dirty = true;
         let retention = self.holdback * 2;
         let (closing_actors, empty_sources) = self.evict_closing_windows(now, retention);
 
@@ -1433,6 +1458,60 @@ impl Dispatcher {
         })
     }
 
+    /// Publish the live-window set to producers, if it has changed since the
+    /// last time.
+    ///
+    /// A producer decides whether logging for a source is worth spooling by
+    /// reading this, so the snapshot is a complete statement every time: a
+    /// source absent from it has no live window. `try_send` rather than `send`
+    /// because the dispatcher must never wait on the listener — snapshots are
+    /// rare (one per start or stop) and a dropped one is corrected by the next.
+    fn publish_windows_if_changed(&mut self) {
+        if !self.windows_dirty {
+            return;
+        }
+        self.windows_dirty = false;
+        let Some(tx) = self.context.window_snapshot_tx.as_ref() else {
+            return;
+        };
+        let mut live: Vec<(Source, i64)> = self
+            .windows
+            .iter()
+            .filter_map(|(source, entry)| {
+                entry
+                    .live
+                    .as_ref()
+                    .map(|window| (source.clone(), window.started_at_ns))
+            })
+            .collect();
+        live.sort();
+        if live == self.published_windows {
+            return;
+        }
+
+        let snapshot = RecordingWindows {
+            windows: live
+                .iter()
+                .map(|((robot_id, robot_instance), started_at_ns)| OpenWindow {
+                    robot_id: robot_id.clone(),
+                    robot_instance: *robot_instance,
+                    started_at_publish_ns: *started_at_ns,
+                })
+                .collect(),
+            // Same wall clock the producer stamps its publish times on, so a
+            // producer can compare this against its own claim.
+            published_at_ns: Utc::now().timestamp_nanos_opt().unwrap_or(i64::MAX),
+        };
+        match tx.try_send(snapshot) {
+            Ok(()) => self.published_windows = live,
+            // Stay dirty so the next wake-up tries again.
+            Err(error) => {
+                self.windows_dirty = true;
+                tracing::warn!(%error, "window snapshot not queued for producers");
+            }
+        }
+    }
+
     fn note_orphan(&mut self) {
         self.orphan_drops = self.orphan_drops.saturating_add(1);
         if self.orphan_drops == 1 || self.orphan_drops.is_multiple_of(1024) {
@@ -1756,6 +1835,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: None,
             config_refresh_tx: Some(refresh_tx),
+            window_snapshot_tx: None,
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -1795,6 +1875,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: None,
             config_refresh_tx: None,
+            window_snapshot_tx: None,
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -1820,6 +1901,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            window_snapshot_tx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -1906,6 +1988,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn producers_are_told_which_sources_have_a_window_open() {
+        // What a producer gates its logging on. A camera process that publishes
+        // no lifecycle envelope of its own has no other way to know, so a start
+        // must produce a snapshot naming the source and a stop must produce one
+        // that does not.
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let (window_snapshot_tx, mut window_snapshot_rx) = mpsc::channel(8);
+        let mut dispatcher = Dispatcher::new(
+            store.clone(),
+            context,
+            DispatcherContext {
+                window_snapshot_tx: Some(window_snapshot_tx),
+                ..DispatcherContext::default()
+            },
+        );
+
+        dispatcher
+            .handle_inbound(start("robot-1", 100), Instant::now())
+            .await;
+        dispatcher.publish_windows_if_changed();
+
+        let opened = window_snapshot_rx.try_recv().expect("a start is published");
+        assert_eq!(opened.windows.len(), 1);
+        assert_eq!(opened.windows[0].robot_id, "robot-1");
+        assert_eq!(opened.windows[0].started_at_publish_ns, 100);
+
+        // Nothing changed, so nothing is said again — the snapshot is a
+        // statement about the window set, not a heartbeat. True both when
+        // nothing marked the set dirty and when something did but the set is
+        // the same (housekeeping runs on a timer and marks it every time).
+        dispatcher.publish_windows_if_changed();
+        assert!(window_snapshot_rx.try_recv().is_err());
+        dispatcher.windows_dirty = true;
+        dispatcher.publish_windows_if_changed();
+        assert!(window_snapshot_rx.try_recv().is_err());
+
+        dispatcher
+            .handle_inbound(stop("robot-1", 200), Instant::now())
+            .await;
+        dispatcher.publish_windows_if_changed();
+
+        let closed = window_snapshot_rx.try_recv().expect("a stop is published");
+        assert!(
+            closed.windows.is_empty(),
+            "the source must be absent, which is how a producer closes its gate"
+        );
+        assert!(
+            closed.published_at_ns >= opened.published_at_ns,
+            "snapshots must be orderable, so a producer can tell which is newer"
+        );
+
+        dispatcher.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn inverted_stop_after_next_start_preserves_both_recordings() {
         // A slow stop can reach the daemon after the next recording's start
         // (start/stop inversion). Listener order here is:
@@ -1925,6 +2063,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            window_snapshot_tx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2542,6 +2681,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            window_snapshot_tx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2595,6 +2735,7 @@ mod tests {
             DispatcherContext {
                 event_bus: Some(bus.clone()),
                 config_refresh_tx: None,
+                window_snapshot_tx: None,
             },
         );
 

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -46,6 +46,7 @@ mod depth;
 mod paths;
 mod publisher;
 mod query;
+mod windows;
 mod writer;
 
 use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery};
@@ -100,6 +101,10 @@ fn start_recording(
         // Caller-supplied capture time, mirroring the `log_*` timestamp default
         // (publish clock when omitted). Decoupled from the window boundary.
         let capture_timestamp_ns = timestamp_ns.unwrap_or(publish_timestamp_ns);
+        // Open this process's logging gate before the envelope goes out, so a
+        // `log_*` on the very next line is not dropped while the daemon is still
+        // answering. The claim expires against the daemon's own snapshots.
+        windows::claim(&robot_id, robot_instance, publish_timestamp_ns);
         publish(&Envelope::StartRecording {
             robot_id,
             robot_instance,
@@ -139,6 +144,14 @@ fn log_joints(
     timestamp_ns: i64,
     timestamp_s: Option<f64>,
 ) -> PyResult<()> {
+    // Nothing is recording for this source: drop the sample before copying,
+    // spooling or publishing anything. This is where the SDK's Python-side
+    // recording gate used to sit, and it sits *before* argument validation for
+    // the same reason it used to skip this call entirely — a caller logging
+    // while idle sees the same nothing it always did.
+    if !windows::is_open(robot_id, robot_instance) {
+        return Ok(());
+    }
     if robot_id.is_empty() || data_type.is_empty() {
         return Err(PyValueError::new_err(
             "robot_id and data_type must not be empty",
@@ -208,6 +221,10 @@ fn log_frame(
     timestamp_ns: i64,
     timestamp_s: Option<f64>,
 ) -> PyResult<()> {
+    // Not recording: drop it before any work (see `log_joints`).
+    if !windows::is_open(robot_id, robot_instance) {
+        return Ok(());
+    }
     if robot_id.is_empty() || data_type.is_empty() || name.is_empty() {
         return Err(PyValueError::new_err(
             "robot_id, data_type and name must not be empty",
@@ -296,6 +313,10 @@ fn log_json(
     timestamp_ns: i64,
     timestamp_s: Option<f64>,
 ) -> PyResult<()> {
+    // Not recording: drop it before any work (see `log_joints`).
+    if !windows::is_open(robot_id, robot_instance) {
+        return Ok(());
+    }
     if robot_id.is_empty() || data_type.is_empty() || name.is_empty() {
         return Err(PyValueError::new_err(
             "robot_id, data_type and name must not be empty",
@@ -385,6 +406,10 @@ fn stop_recording(
             publish_timestamp_ns,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        // Only now: the daemon's window is open until it receives the stop, so
+        // closing this process's gate any earlier would discard data the daemon
+        // would still have accepted.
+        windows::release(&robot_id, robot_instance);
         // Split from [`flush_source`] so the caller can close its logging gate
         // in between, rather than after a backlog-length barrier.
         Ok(())
@@ -459,10 +484,11 @@ fn cancel_recording(
         // Publish `CancelRecording` from THIS (the calling) thread's publisher,
         // ordered with Start/Stop on the same port (see the writer module note).
         publish(&Envelope::CancelRecording {
-            robot_id,
+            robot_id: robot_id.clone(),
             robot_instance,
             timestamp_ns: capture_timestamp_ns,
         })?;
+        windows::release(&robot_id, robot_instance);
         Ok(())
     })
 }

--- a/rust/data_daemon_bridge/src/windows.rs
+++ b/rust/data_daemon_bridge/src/windows.rs
@@ -1,0 +1,506 @@
+//! Which of this process's sources have a recording window open.
+//!
+//! The producer does not decide this and cannot be authoritative about it: a
+//! recording is opened and closed by the daemon, and a source can be logged from
+//! several processes at once, only one of which called `start_recording`. So the
+//! daemon publishes a snapshot of its live windows on
+//! [`RECORDING_WINDOWS`](data_daemon_shared::service_name::RECORDING_WINDOWS)
+//! and this module keeps the latest one, for the `log_*` entry points to consult
+//! before doing any work.
+//!
+//! That is the whole reason it exists. A camera process that never brackets a
+//! recording has no way to know one is in progress, so it either discards every
+//! frame of someone else's recording or spools every frame it ever captures.
+//! Reading the daemon's own answer is the third option.
+//!
+//! ## Two sources of truth, deliberately
+//!
+//! [`is_open`] answers from the snapshot *or* from a claim this process made
+//! itself, and the claim is what covers the round trip: `start_recording`
+//! publishes its envelope and claims the source here in the same breath, so the
+//! very next `log_*` on the calling thread is never dropped waiting for the
+//! daemon to answer. The claim then expires on its own — the first snapshot
+//! taken *after* it supersedes it, whether or not the source appears in that
+//! snapshot. Which means a recording stopped by someone else closes this gate
+//! without anything having to tell this process so.
+//!
+//! ## First call in a process
+//!
+//! The subscriber starts on the first [`is_open`], so that call answers from
+//! claims alone — a process whose very first sample lands inside a recording
+//! someone else started drops it, and is correct from the next one. One sample
+//! once per process, at process start rather than at a recording boundary; the
+//! alternative is blocking a `log_*` under the GIL on an IPC round trip.
+//!
+//! ## Fork safety
+//!
+//! The registry stores the pid that owns it and wipes itself on first use from a
+//! different process, exactly like the video-chunk registry: a forked
+//! `multiprocessing` child inherits the parent's state and its dead subscriber
+//! thread, and must start from nothing.
+
+use std::sync::{LazyLock, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use data_daemon_shared::service_name::{
+    MAX_NODES_PER_SERVICE, RECORDING_WINDOWS, RECORDING_WINDOWS_HISTORY_SIZE,
+    RECORDING_WINDOWS_MAX_PUBLISHERS, RECORDING_WINDOWS_MAX_SUBSCRIBERS,
+    RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE,
+};
+use data_daemon_shared::RecordingWindows;
+use iceoryx2::node::{Node, NodeBuilder};
+use iceoryx2::port::subscriber::Subscriber;
+use iceoryx2::prelude::ipc;
+use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
+
+/// How often the subscriber thread checks for a new snapshot.
+///
+/// The daemon publishes only when its window set changes, so this is pure
+/// overhead while nothing happens — but it is also the delay before a window
+/// opened by *another* process becomes visible here, and every frame captured in
+/// that delay is dropped. 10 ms keeps it under a third of a frame interval at
+/// 30 fps while waking the thread only 100 times a second.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// One source, with the publish time it was opened or claimed at.
+///
+/// Held in `Vec`s and scanned linearly rather than hashed: a machine hosts a
+/// handful of sources, and `is_open` sits on the `log_*` hot path where hashing
+/// a `(String, i64)` key would mean allocating one per call.
+struct Entry {
+    robot_id: String,
+    robot_instance: i64,
+    at_ns: i64,
+}
+
+impl Entry {
+    fn matches(&self, robot_id: &str, robot_instance: i64) -> bool {
+        self.robot_instance == robot_instance && self.robot_id == robot_id
+    }
+}
+
+struct Registry {
+    owner_pid: u32,
+    /// Sources the newest snapshot says are open.
+    pushed: Vec<Entry>,
+    /// Daemon clock of that snapshot. Zero until the first one arrives, so no
+    /// claim is ever superseded by a snapshot that does not exist.
+    pushed_at_ns: i64,
+    /// Sources this process opened itself by publishing a `StartRecording`.
+    claimed: Vec<Entry>,
+    /// Whether this process's subscriber thread is running.
+    subscribed: bool,
+}
+
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| {
+    Mutex::new(Registry {
+        owner_pid: 0,
+        pushed: Vec::new(),
+        pushed_at_ns: 0,
+        claimed: Vec::new(),
+        subscribed: false,
+    })
+});
+
+/// Lock the registry, healing it across a `fork()` first.
+fn with_registry<R>(operation: impl FnOnce(&mut Registry) -> R) -> R {
+    let mut registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let pid = std::process::id();
+    if registry.owner_pid != pid {
+        registry.owner_pid = pid;
+        registry.pushed.clear();
+        registry.pushed_at_ns = 0;
+        registry.claimed.clear();
+        // The parent's thread did not survive the fork; the child needs its own.
+        registry.subscribed = false;
+    }
+    operation(&mut registry)
+}
+
+/// Does the source have a recording window open, as far as this process can
+/// tell?
+///
+/// Consulted by every `log_*` before it copies, spools or publishes anything, so
+/// it is one mutex acquisition and two short scans and nothing more. Answers
+/// `false` when the daemon has never spoken and this process has claimed
+/// nothing — the correct answer, and the one that keeps an idle camera from
+/// spooling.
+pub(crate) fn is_open(robot_id: &str, robot_instance: i64) -> bool {
+    let (open, start_subscriber) = with_registry(|registry| {
+        let open = registry
+            .pushed
+            .iter()
+            .any(|entry| entry.matches(robot_id, robot_instance))
+            // A claim outlives only the snapshots that predate it.
+            || registry
+                .claimed
+                .iter()
+                .any(|entry| entry.matches(robot_id, robot_instance) && entry.at_ns >= registry.pushed_at_ns);
+        (open, take_subscribe_duty(registry))
+    });
+    if start_subscriber {
+        spawn_subscriber();
+    }
+    open
+}
+
+/// Record that this process has just published a `StartRecording` for the
+/// source, so its own logging is not gated on the daemon answering.
+///
+/// `publish_timestamp_ns` must be the stamp carried on that envelope: it is what
+/// decides which snapshots are new enough to supersede the claim.
+pub(crate) fn claim(robot_id: &str, robot_instance: i64, publish_timestamp_ns: i64) {
+    let start_subscriber = with_registry(|registry| {
+        registry
+            .claimed
+            .retain(|entry| !entry.matches(robot_id, robot_instance));
+        registry.claimed.push(Entry {
+            robot_id: robot_id.to_string(),
+            robot_instance,
+            at_ns: publish_timestamp_ns,
+        });
+        take_subscribe_duty(registry)
+    });
+    if start_subscriber {
+        spawn_subscriber();
+    }
+}
+
+/// Drop this process's claim on the source, after publishing its stop.
+///
+/// Only the claim goes: if another process still has the recording open the
+/// daemon's snapshot says so, and this process keeps logging into it.
+pub(crate) fn release(robot_id: &str, robot_instance: i64) {
+    with_registry(|registry| {
+        registry
+            .claimed
+            .retain(|entry| !entry.matches(robot_id, robot_instance));
+    });
+}
+
+/// Replace the pushed snapshot with a newer one.
+fn apply_snapshot(snapshot: RecordingWindows) {
+    with_registry(|registry| {
+        // iceoryx2 delivers in order per publisher, but the guard is free and
+        // keeps the registry monotonic if that ever stops being true.
+        if snapshot.published_at_ns < registry.pushed_at_ns {
+            return;
+        }
+        registry.pushed = snapshot
+            .windows
+            .into_iter()
+            .map(|window| Entry {
+                robot_id: window.robot_id,
+                robot_instance: window.robot_instance,
+                at_ns: window.started_at_publish_ns,
+            })
+            .collect();
+        registry.pushed_at_ns = snapshot.published_at_ns;
+    });
+}
+
+/// Claim the duty of starting this process's subscriber thread, if nobody has.
+/// The caller must hold the registry lock, and must spawn once it has released
+/// it — the thread's first act is to take the same lock.
+fn take_subscribe_duty(registry: &mut Registry) -> bool {
+    let duty = !registry.subscribed;
+    registry.subscribed = true;
+    duty
+}
+
+fn spawn_subscriber() {
+    if let Err(error) = thread::Builder::new()
+        .name("nc-windows".to_string())
+        .spawn(subscribe_loop)
+    {
+        tracing::debug!(%error, "failed to start recording-window subscriber");
+        with_registry(|registry| registry.subscribed = false);
+    }
+}
+
+/// The subscriber's iceoryx2 ports. The node and service handle must outlive the
+/// subscriber built off them, so the loop owns all three together.
+struct WindowSubscriber {
+    _node: Node<ipc::Service>,
+    _service: PortFactory<ipc::Service, [u8], ()>,
+    subscriber: Subscriber<ipc::Service, [u8], ()>,
+}
+
+/// Poll the `recording_windows` service for as long as the process lives.
+///
+/// A failure to open the service is not retried: the daemon seeds it at startup,
+/// so failing here means no daemon is running, and a process logging with no
+/// daemon has nowhere for its data to go regardless. Its own claims still open
+/// its gate, which is what keeps a locally started recording working while the
+/// daemon is still coming up.
+fn subscribe_loop() {
+    let ports = match open_subscriber() {
+        Ok(ports) => ports,
+        Err(error) => {
+            tracing::warn!(%error, "recording-window subscriber unavailable");
+            with_registry(|registry| registry.subscribed = false);
+            return;
+        }
+    };
+    loop {
+        // Drain everything pending and keep only the last: a snapshot is
+        // absolute, so an older one has nothing left to say.
+        let mut newest = None;
+        loop {
+            match ports.subscriber.receive() {
+                Ok(Some(sample)) => match RecordingWindows::decode(sample.payload()) {
+                    Ok(snapshot) => newest = Some(snapshot),
+                    Err(error) => {
+                        tracing::warn!(%error, "recording-window snapshot decode failed")
+                    }
+                },
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::warn!(%error, "recording-window receive failed");
+                    break;
+                }
+            }
+        }
+        if let Some(snapshot) = newest {
+            apply_snapshot(snapshot);
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Open (or attach to) the `recording_windows` service and build this process's
+/// subscriber. Every attribute must match the daemon's publisher side, which
+/// `open_or_create` reconciles against whichever party came up first.
+fn open_subscriber() -> Result<WindowSubscriber, String> {
+    let node = NodeBuilder::new()
+        .create::<ipc::Service>()
+        .map_err(|error| error.to_string())?;
+    let service_name = RECORDING_WINDOWS
+        .try_into()
+        .map_err(|error| format!("invalid service name: {error}"))?;
+    let service = node
+        .service_builder(&service_name)
+        .publish_subscribe::<[u8]>()
+        .history_size(RECORDING_WINDOWS_HISTORY_SIZE)
+        .subscriber_max_buffer_size(RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE)
+        .max_publishers(RECORDING_WINDOWS_MAX_PUBLISHERS)
+        .max_subscribers(RECORDING_WINDOWS_MAX_SUBSCRIBERS)
+        .max_nodes(MAX_NODES_PER_SERVICE)
+        .open_or_create()
+        .map_err(|error| error.to_string())?;
+    let subscriber = service
+        .subscriber_builder()
+        .create()
+        .map_err(|error| error.to_string())?;
+    Ok(WindowSubscriber {
+        _node: node,
+        _service: service,
+        subscriber,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use data_daemon_shared::OpenWindow;
+
+    /// The registry is process-wide and a snapshot replaces all of it, so these
+    /// tests cannot run concurrently with each other. Held for the body of each.
+    static SERIALISE: Mutex<()> = Mutex::new(());
+
+    /// Take the test lock and clear the registry behind it.
+    fn isolated() -> std::sync::MutexGuard<'static, ()> {
+        let guard = SERIALISE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        with_registry(|registry| {
+            registry.pushed.clear();
+            registry.pushed_at_ns = 0;
+            registry.claimed.clear();
+        });
+        guard
+    }
+
+    fn snapshot(sources: &[(&str, i64)], published_at_ns: i64) -> RecordingWindows {
+        RecordingWindows {
+            windows: sources
+                .iter()
+                .map(|(robot_id, robot_instance)| OpenWindow {
+                    robot_id: (*robot_id).to_string(),
+                    robot_instance: *robot_instance,
+                    started_at_publish_ns: published_at_ns,
+                })
+                .collect(),
+            published_at_ns,
+        }
+    }
+
+    /// The daemon's side of the window channel, kept alive by the test.
+    ///
+    /// The publisher owns the service history, so a short-lived one would take
+    /// the snapshot with it and a subscriber that connects a moment later would
+    /// see nothing — exactly the daemon's own arrangement, where the publisher
+    /// lives as long as the listener loop.
+    struct DaemonSide {
+        _node: Node<ipc::Service>,
+        _service: PortFactory<ipc::Service, [u8], ()>,
+        publisher: iceoryx2::port::publisher::Publisher<ipc::Service, [u8], ()>,
+    }
+
+    /// Open the daemon's publisher exactly as `ipc::node` does, so the two
+    /// service configurations have to reconcile for real.
+    fn daemon_side() -> Result<DaemonSide, String> {
+        use data_daemon_shared::service_name::RECORDING_WINDOWS_MAX_PAYLOAD_BYTES;
+        use iceoryx2::prelude::UnableToDeliverStrategy;
+
+        let node = NodeBuilder::new()
+            .create::<ipc::Service>()
+            .map_err(|error| error.to_string())?;
+        let service_name = RECORDING_WINDOWS
+            .try_into()
+            .map_err(|error| format!("{error}"))?;
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(RECORDING_WINDOWS_HISTORY_SIZE)
+            .subscriber_max_buffer_size(RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE)
+            .max_publishers(RECORDING_WINDOWS_MAX_PUBLISHERS)
+            .max_subscribers(RECORDING_WINDOWS_MAX_SUBSCRIBERS)
+            .max_nodes(MAX_NODES_PER_SERVICE)
+            .open_or_create()
+            .map_err(|error| error.to_string())?;
+        let publisher = service
+            .publisher_builder()
+            .initial_max_slice_len(RECORDING_WINDOWS_MAX_PAYLOAD_BYTES)
+            .unable_to_deliver_strategy(UnableToDeliverStrategy::DiscardSample)
+            .create()
+            // The daemon holds the only publisher slot, so this is what a
+            // running data-daemon looks like from here.
+            .map_err(|error| format!("{error} (is a data-daemon running?)"))?;
+        Ok(DaemonSide {
+            _node: node,
+            _service: service,
+            publisher,
+        })
+    }
+
+    impl DaemonSide {
+        fn publish(&self, snapshot: &RecordingWindows) {
+            let bytes = snapshot.encode().expect("encode");
+            let sample = self
+                .publisher
+                .loan_slice_uninit(bytes.len())
+                .expect("loan a window sample");
+            sample.write_from_slice(&bytes).send().expect("send");
+        }
+    }
+
+    #[test]
+    fn a_snapshot_published_over_real_ipc_opens_the_gate() {
+        // Everything above this test drives `apply_snapshot` directly, which
+        // proves the decision but not the transport: the daemon's publisher and
+        // this subscriber configure the same service independently and
+        // `open_or_create` has to reconcile them, so a mismatch would leave
+        // every producer permanently gated shut with nothing logged anywhere.
+        let _guard = isolated();
+
+        let daemon = daemon_side().expect("open the daemon's publisher");
+        let live = snapshot(&[("ipc-robot", 4)], 1_000);
+
+        // Starts this process's subscriber; false, since nothing has been said.
+        assert!(!is_open("ipc-robot", 4));
+
+        // Re-sent on a cadence, as the daemon's listener does. A single send
+        // would not do: iceoryx2 hands a new subscriber the service history only
+        // when the publisher next sends, so a snapshot published before this
+        // subscriber's port existed would never arrive at all.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            daemon.publish(&live);
+            if is_open("ipc-robot", 4) {
+                return;
+            }
+            thread::sleep(POLL_INTERVAL);
+        }
+        panic!("the subscriber never received the daemon's snapshot");
+    }
+
+    #[test]
+    fn a_source_nothing_has_said_anything_about_is_closed() {
+        let _guard = isolated();
+        assert!(!is_open("silent-robot", 0));
+    }
+
+    #[test]
+    fn a_pushed_window_opens_a_source_this_process_never_started() {
+        // The camera child: it published no lifecycle envelope of its own and
+        // learns of the recording only from the daemon.
+        let _guard = isolated();
+        apply_snapshot(snapshot(&[("pushed-robot", 2)], 1_000));
+        assert!(is_open("pushed-robot", 2));
+        assert!(
+            !is_open("pushed-robot", 3),
+            "a sibling instance is separate"
+        );
+    }
+
+    #[test]
+    fn a_claim_opens_the_gate_before_any_snapshot_arrives() {
+        // The round trip this covers: start_recording has published, the daemon
+        // has not answered yet, and the next log_* must not be dropped.
+        let _guard = isolated();
+        claim("claiming-robot", 0, 5_000);
+        assert!(is_open("claiming-robot", 0));
+    }
+
+    #[test]
+    fn a_snapshot_taken_after_a_claim_supersedes_it() {
+        // How a recording stopped by someone else closes this gate: the daemon
+        // simply stops naming the source, and the claim no longer counts.
+        let _guard = isolated();
+        claim("superseded-robot", 0, 5_000);
+        apply_snapshot(snapshot(&[], 6_000));
+        assert!(!is_open("superseded-robot", 0));
+    }
+
+    #[test]
+    fn a_snapshot_taken_before_a_claim_does_not_supersede_it() {
+        let _guard = isolated();
+        apply_snapshot(snapshot(&[], 4_000));
+        claim("early-snapshot-robot", 0, 5_000);
+        assert!(
+            is_open("early-snapshot-robot", 0),
+            "the snapshot predates the claim, so it cannot speak for it"
+        );
+    }
+
+    #[test]
+    fn releasing_a_claim_closes_a_gate_no_snapshot_holds_open() {
+        let _guard = isolated();
+        claim("released-robot", 0, 5_000);
+        release("released-robot", 0);
+        assert!(!is_open("released-robot", 0));
+    }
+
+    #[test]
+    fn releasing_a_claim_leaves_a_pushed_window_open() {
+        // This process stopped its own recording; another process still has one
+        // open for the source, and the daemon says so.
+        let _guard = isolated();
+        claim("shared-robot", 0, 5_000);
+        apply_snapshot(snapshot(&[("shared-robot", 0)], 6_000));
+        release("shared-robot", 0);
+        assert!(is_open("shared-robot", 0));
+    }
+
+    #[test]
+    fn an_older_snapshot_cannot_move_the_registry_backwards() {
+        let _guard = isolated();
+        apply_snapshot(snapshot(&[("ordered-robot", 0)], 9_000));
+        apply_snapshot(snapshot(&[], 8_000));
+        assert!(is_open("ordered-robot", 0));
+    }
+}

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -313,8 +313,10 @@ pub mod service_name {
 
     /// Maximum number of concurrent subscribers per service.
     ///
-    /// The daemon opens exactly one subscriber per service; producers never
-    /// subscribe. iceoryx2 sizes every publisher's data segment as
+    /// The daemon opens exactly one subscriber per producer-published service,
+    /// and producers subscribe to none of them (they subscribe only to
+    /// [`RECORDING_WINDOWS`], which has its own cap). iceoryx2 sizes every
+    /// publisher's data segment as
     /// `max_subscribers × (buffer + borrowed) × slice`, so the default of 8
     /// inflates each segment 8× for subscribers that never exist. Pinning
     /// this to 1 keeps the segment proportional to the real topology.
@@ -392,6 +394,54 @@ pub mod service_name {
 
     /// Maximum number of concurrent request-response servers. The daemon opens exactly one.
     pub const MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE: usize = 1;
+
+    /// Pub/sub service the **daemon** publishes on and producers subscribe to:
+    /// which sources currently have an open recording window.
+    ///
+    /// The only channel that runs daemon → producer. It carries no instruction
+    /// and names no producer: it is a snapshot of the daemon's own window state
+    /// ([`crate::RecordingWindows`]), which a producer reads to decide whether
+    /// logging for its source is worth spooling. A process that opened no window
+    /// of its own learns of one this way — which is the whole point, since it is
+    /// the camera child that would otherwise discard every frame of a recording
+    /// another process started.
+    pub const RECORDING_WINDOWS: &str = "neuracore/data_daemon/recording_windows";
+
+    /// Maximum size of a single `recording_windows` sample.
+    ///
+    /// A snapshot is one entry per source with a live window — a robot UUID plus
+    /// two integers, ~50 bytes — so 4 KiB holds ~80 concurrent sources, far past
+    /// any real machine. Sized tightly on purpose: iceoryx2 allocates the
+    /// publisher's segment as `max_subscribers x (buffer + borrowed) x slice`, and
+    /// this service's subscriber cap is high, so a generous slice here would cost
+    /// tens of MiB of `/dev/shm`. Guarded by
+    /// `a_full_window_snapshot_fits_the_slice`.
+    pub const RECORDING_WINDOWS_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
+
+    /// History depth for `recording_windows`, so a producer that starts *during*
+    /// a recording is handed the current snapshot on connect rather than waiting
+    /// for the next change. One is enough: a snapshot is absolute, never a delta,
+    /// so the newest one is the whole truth and older ones are worthless.
+    pub const RECORDING_WINDOWS_HISTORY_SIZE: usize = 1;
+
+    /// Subscriber buffer depth for `recording_windows`. Two, because a reader
+    /// drains everything pending and keeps only the last: depth buys nothing but
+    /// staleness, and this service is deliberately lossy (see
+    /// [`RECORDING_WINDOWS_MAX_SUBSCRIBERS`]).
+    pub const RECORDING_WINDOWS_SUBSCRIBER_BUFFER_SIZE: usize = 2;
+
+    /// Publishers on `recording_windows`. The daemon's listener thread owns the
+    /// only one; producers never publish window state, because they do not own
+    /// it.
+    pub const RECORDING_WINDOWS_MAX_PUBLISHERS: usize = 1;
+
+    /// Subscribers on `recording_windows` — one per producer *process* (not per
+    /// thread, unlike the publisher ports on [`COMMANDS`]).
+    ///
+    /// Unlike [`COMMANDS`], this service leaves iceoryx2's safe-overflow *on*:
+    /// a producer that stops draining must never block the daemon, and evicting
+    /// the oldest snapshot costs nothing when only the newest is meaningful.
+    pub const RECORDING_WINDOWS_MAX_SUBSCRIBERS: usize = 128;
 }
 
 /// A single message exchanged between the producer and the daemon.
@@ -775,6 +825,50 @@ pub struct RecordingIdQuery {
 pub struct RecordingIdReply {
     /// The daemon-owned cloud recording id, once available.
     pub recording_id: Option<String>,
+}
+
+/// One source with a recording window open right now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenWindow {
+    pub robot_id: String,
+    pub robot_instance: i64,
+    /// The window's inclusive lower bound on the producer publish clock — the
+    /// same `started_at_ns` the daemon routes membership against. Carried so a
+    /// reader can say *since when*, not merely *whether*.
+    pub started_at_publish_ns: i64,
+}
+
+/// Every source the daemon currently holds a live window for, published on
+/// [`service_name::RECORDING_WINDOWS`] whenever that set changes.
+///
+/// A **complete snapshot**, never a delta: a reader that misses one sample and
+/// sees the next is fully caught up, which is what lets the service be lossy and
+/// its history exactly one deep. A source absent from `windows` has no live
+/// window — an empty snapshot is meaningful, not "no news".
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RecordingWindows {
+    pub windows: Vec<OpenWindow>,
+    /// Daemon wall clock (Unix nanoseconds) at which this snapshot was taken.
+    ///
+    /// Lets a producer retire its *own* optimistic claim: having published a
+    /// `StartRecording` it opens its gate at once, without waiting for a round
+    /// trip, and keeps it open only until a snapshot taken after that claim
+    /// arrives. From then on the daemon's silence about the source is
+    /// meaningful — it is how a producer learns its recording was stopped by
+    /// someone else, even if nothing else tells it.
+    pub published_at_ns: i64,
+}
+
+impl RecordingWindows {
+    /// Encode as a postcard byte vector for a `recording_windows` sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `recording_windows` sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
 }
 
 /// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
@@ -1284,6 +1378,58 @@ mod tests {
             "chunk at frame cap ({count} frames, {} bytes) must fit the commands slice ({} bytes)",
             bytes.len(),
             service_name::COMMANDS_MAX_PAYLOAD_BYTES,
+        );
+    }
+
+    #[test]
+    fn window_snapshots_round_trip() {
+        let snapshot = RecordingWindows {
+            windows: vec![OpenWindow {
+                robot_id: "11111111-2222-3333-4444-555555555555".into(),
+                robot_instance: i64::MAX,
+                started_at_publish_ns: i64::MAX,
+            }],
+            published_at_ns: i64::MAX,
+        };
+        let bytes = snapshot.encode().expect("encode");
+        assert_eq!(snapshot, RecordingWindows::decode(&bytes).expect("decode"));
+    }
+
+    #[test]
+    fn an_empty_snapshot_is_distinguishable_from_no_snapshot() {
+        // "Nothing is recording" is a statement the service must be able to
+        // make: a producer that reads an empty snapshot closes its gate, so
+        // this must decode to an empty vec rather than fail.
+        let bytes = RecordingWindows::default().encode().expect("encode");
+        assert!(RecordingWindows::decode(&bytes)
+            .expect("decode")
+            .windows
+            .is_empty());
+    }
+
+    #[test]
+    fn a_full_window_snapshot_fits_the_slice() {
+        // Sizing claim behind RECORDING_WINDOWS_MAX_PAYLOAD_BYTES: a snapshot of
+        // far more sources than a machine can host still fits one sample, so the
+        // publish never fails for want of room.
+        let windows = (0..64)
+            .map(|instance| OpenWindow {
+                robot_id: "11111111-2222-3333-4444-555555555555".into(),
+                robot_instance: instance,
+                started_at_publish_ns: i64::MAX,
+            })
+            .collect();
+        let bytes = RecordingWindows {
+            windows,
+            published_at_ns: i64::MAX,
+        }
+        .encode()
+        .expect("encode");
+        assert!(
+            bytes.len() <= service_name::RECORDING_WINDOWS_MAX_PAYLOAD_BYTES,
+            "64 open windows ({} bytes) must fit the slice ({} bytes)",
+            bytes.len(),
+            service_name::RECORDING_WINDOWS_MAX_PAYLOAD_BYTES,
         );
     }
 }

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -481,10 +481,12 @@ def test_log_parallel_gripper_open_amounts(
     )
 
 
-def test_sse_started_recording_logs_with_bound_robot_source(monkeypatch) -> None:
-    """A producer that did not publish StartRecording can log after SSE state.
+def test_logs_forward_without_any_local_recording_state(monkeypatch) -> None:
+    """A producer with no recording state of its own still forwards.
 
-    The active recording id represents state learned from SSE. Creating the
+    The camera-child case: this process published no `StartRecording` and knows
+    of no recording, and its samples must still reach the bridge — which drops
+    them itself unless the daemon has told it a window is open. Creating the
     robot's daemon context must bind its source without publishing a duplicate
     native start event.
     """
@@ -493,11 +495,7 @@ def test_sse_started_recording_logs_with_bound_robot_source(monkeypatch) -> None
     native = MagicMock()
 
     monkeypatch.setattr(recording_context, "_load_native", lambda: native)
-    monkeypatch.setattr(
-        robot,
-        "get_current_recording_id",
-        lambda: "cloud-recording-id-from-sse",
-    )
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
 
     sample = ParallelGripperOpenAmountData(timestamp=12.5, open_amount=0.4)
     api_logging._record_json_to_daemon(


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - The daemon publishes which sources have a live recording window, and the producer's `log_*` entry points gate on it — so a camera process that never brackets a recording contributes to the one another process started, without spooling every frame it ever captures

### Bugfixes
 - None

### Items
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)

### Related PRs
 - Replaces #943 in this stack

---

Replaces #943. Same slot (base `fix/local-stop-survives-rejected-stream`), opposite direction: rather than the producer announcing its presence upward so the daemon can act on its behalf, the daemon publishes its window state downward and the producer reads it.

**Why not #943's approach.** Stripping the producer's log gate makes every camera spool raw frames continuously whether or not anything is recording — ~27.6 MB/s per 640x480@30 camera, which is the unbuilt fail-open cost gate. Keeping the gate and *feeding* it from the daemon is correct in every process and costs nothing when idle. Presence-up (`ProducerAttached` + heartbeat) then has no job left: a snapshot names sources, and a process that isn't bound to one simply ignores it.

**How it works.**
- New iceoryx2 pub/sub service `recording_windows`, the only channel that runs daemon → producer. The daemon's dispatcher owns the window state; the IPC listener owns the port, so snapshots go dispatcher → listener → producers.
- A snapshot is a **complete statement**, never a delta — a source absent from it has no live window — which is what lets the service be lossy, one deep, and safe to re-send.
- The producer keeps the latest snapshot in a process-wide registry (fork-healed) and `log_joints` / `log_frame` / `log_json` drop a sample before copying, spooling or publishing anything when the source has no window.
- `start_recording` claims the source locally in the same breath as publishing its envelope, so a local recording is never gated on a round trip. The claim expires against the daemon's own snapshots — which is also how a recording stopped by someone else closes this gate, with nothing having to tell the process so.
- The listener re-sends the current snapshot every 250 ms. Change-driven publishing alone does not reach a producer that attaches *between* changes: iceoryx2 hands a new subscriber the service history only when the publisher next sends, and `update_connections` is not public. Found by end-to-end testing, not by inspection.

**Verified end to end** against a real daemon, two processes:
- 20 frames logged with no recording anywhere → **0 spool files, no spool directory** — the idle cost is gone.
- Parent process opens a recording; a separate child that brackets nothing logs 30 frames → **all 30 land** in the recording (`ffprobe`: 30 frames), zero orphan drops.

`tests/unit/api` + `tests/unit/core`: 461 passed. Rust workspace: 418 passed. The `recording_windows` transport itself is covered by a test that stands up the daemon's publisher and this subscriber for real, so a service-attribute mismatch cannot pass silently.
