### PR TITLE
ci: publish manylinux aarch64 wheels

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,11 +1,12 @@
 name: Build Wheels
 
 # Builds the merged `neuracore` wheels (SDK + Rust `_data_bridge` extension +
-# bundled `data-daemon` binary) for Linux, macOS arm64 and macOS x86_64, one per
-# Python minor (cp310-cp314) — no sdist, no pure wheel. maturin owns the build;
-# the daemon binary is a separate crate compiled into the package tree first by
-# rust/scripts/build_wheel_artefacts.sh. A separate smoke-test job installs and
-# launches the wheels on a different machine than the one that built them.
+# bundled `data-daemon` binary) for Linux x86_64, Linux aarch64, macOS arm64 and
+# macOS x86_64, one per Python minor (cp310-cp314) — no sdist, no pure wheel.
+# maturin owns the build; the daemon binary is a separate crate compiled into the
+# package tree first by rust/scripts/build_wheel_artefacts.sh. A separate
+# smoke-test job installs and launches the wheels on a different machine than
+# the one that built them.
 
 on:
   pull_request:
@@ -46,6 +47,9 @@ jobs:
           # interpreters in the manylinux container, macOS via setup-python.
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            interpreters: "3.10 3.11 3.12 3.13 3.14"
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
             interpreters: "3.10 3.11 3.12 3.13 3.14"
           - os: macos-26
             target: aarch64-apple-darwin
@@ -123,7 +127,7 @@ jobs:
   # macOS legs run on a different, older OS image (macos-15) than their macos-26
   # builder, so a signature that only validated on the build machine, a
   # deployment-target mismatch, or a glibc-floor problem fails here instead of
-  # at a user's install. Each macOS leg must keep the builder's architecture —
+  # at a user's install. Each leg must keep the builder's architecture —
   # an arm64 runner cannot install an x86_64 wheel, and vice versa.
   smoke-test:
     name: smoke (${{ matrix.target }})
@@ -135,6 +139,8 @@ jobs:
         include:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - os: macos-15
             target: aarch64-apple-darwin
           - os: macos-15-intel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -500,7 +500,7 @@ jobs:
             ? `- Alpha version built from \`${alphaBranch}\`, no version bump pushed\n`
             : `- Version bumped and pushed to \`main\`\n`;
           summary += `- Git tag \`v${version}\` created\n`;
-          summary += `- Platform wheels (linux x86_64 + macOS arm64, cp310-cp314) publishing to PyPI (see publish job)\n`;
+          summary += `- Platform wheels (linux x86_64/aarch64 + macOS arm64/x86_64, cp310-cp314) publishing to PyPI (see publish job)\n`;
           summary += `- GitHub Release created\n\n`;
           summary += `### Links\n\n`;
           summary += `- [PyPI Package](https://pypi.org/project/neuracore/${version}/)\n`;
@@ -541,8 +541,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           ls -l dist/
-          # 3 platform legs x 5 Python minors (cp310-cp314)
-          [ "$(ls dist/*.whl | wc -l)" -eq 15 ] || { echo "expected 15 wheels"; exit 1; }
+          # 4 platform legs x 5 Python minors (cp310-cp314)
+          [ "$(ls dist/*.whl | wc -l)" -eq 20 ] || { echo "expected 20 wheels"; exit 1; }
           # packaging>=24.2 is required for twine to parse maturin's
           # Metadata-Version 2.4 License-File field; the runner ships an older one.
           python -m pip install --upgrade twine "packaging>=24.2"

--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -10,3 +10,8 @@ Example: "This release adds support for multi-GPU training and improves streamin
 ## Summary
 
 <!-- Append your summary here -->
+
+`neuracore` now publishes Linux aarch64 wheels (`manylinux_2_28`) alongside the
+existing x86_64 and macOS ones, so pinning an exact version
+(`pip install neuracore==<version>`) works on 64-bit Arm Linux instead of
+resolving back to the last pure-Python release.

--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -119,8 +119,8 @@ neuracore data-daemon launch
 ```
 
 the CLI launches the daemon as a separate background process. It `exec`s the
-native binary bundled in the `neuracore` wheel (Linux x86_64 and Apple-Silicon
-macOS) at `neuracore/data_daemon/bin/data-daemon`; see
+native binary bundled in the `neuracore` wheel (Linux x86_64/aarch64 and macOS)
+at `neuracore/data_daemon/bin/data-daemon`; see
 [rust_data_daemon_development.md](rust_data_daemon_development.md). When that
 binary is absent — a source install that never ran
 `rust/scripts/build_wheel_artefacts.sh`, or a platform with no published wheel —

--- a/docs/rust_data_daemon_development.md
+++ b/docs/rust_data_daemon_development.md
@@ -233,9 +233,10 @@ artefacts script when you want a working daemon in a source checkout.
 
 The Rust daemon ships **inside the `neuracore` wheel**, built by maturin from
 the root [pyproject.toml](../pyproject.toml). Wheels are published for Linux
-x86_64 (`manylinux_2_28`), Apple-Silicon macOS and Intel macOS, one per Python
-minor (cp310–cp314) — **no sdist and no pure wheel**, so `pip install neuracore`
-on Windows or other platforms resolves to the last pure-Python release (13.3.0).
+x86_64 and aarch64 (`manylinux_2_28`), Apple-Silicon macOS and Intel macOS, one
+per Python minor (cp310–cp314) — **no sdist and no pure wheel**, so
+`pip install neuracore` on Windows or other platforms resolves to the last
+pure-Python release (13.3.0).
 
 The two Rust artefacts and how `neuracore` finds them:
 
@@ -287,26 +288,29 @@ minor × one platform and `--interpreter` must be passed.
 > **Daemon: Linux and macOS only.** The daemon stack uses `iceoryx2`
 > shared-memory IPC; platform-specific syscalls (e.g. `sync_file_range`,
 > `gettid` on Linux) are gated behind `cfg(target_os)` so the stack also builds
-> and runs on macOS. Wheels ship for `linux-x86_64`, `macosx-arm64` and
-> `macosx-x86_64` — **not** Windows.
+> and runs on macOS. Wheels ship for `linux-x86_64`, `linux-aarch64`,
+> `macosx-arm64` and `macosx-x86_64` — **not** Windows.
 
 ### CI
 
 [.github/workflows/build-wheels.yaml](../.github/workflows/build-wheels.yaml) builds
 the `neuracore` wheels — a `PyO3/maturin-action` matrix over `linux-x86_64`,
-`macosx-arm64` and `macosx-x86_64`, each leg building all five interpreters
-(cp310–cp314). The Linux leg builds the daemon binary inside the
+`linux-aarch64`, `macosx-arm64` and `macosx-x86_64`, each leg building all five
+interpreters (cp310–cp314). Both Linux legs build the daemon binary inside the
 `manylinux_2_28` container (glibc match, plus a `clang` install for iceoryx2's
 bindgen — `manylinux_2_28` is required over the default `manylinux2014` because
-iceoryx2's bindgen needs libclang >= 5.0, which 2014's clang 3.4 can't provide);
+iceoryx2's bindgen needs libclang >= 5.0, which 2014's clang 3.4 can't provide),
+each on a runner of its own architecture (`ubuntu-22.04` / `ubuntu-22.04-arm`)
+so nothing is cross-compiled or QEMU-emulated;
 both macOS legs build natively (libclang via `brew install llvm`, deployment
 target pinned to 11.0) on `macos-26` for arm64 and `macos-26-intel` for Intel —
 the label suffix picks the architecture: bare and `-xlarge` are arm64, `-intel`
 and `-large` are x86_64. A separate `smoke-test` job then installs each wheel
 and launches the daemon binary on a *different* machine than the builder (the
 macOS legs on a different OS image, `macos-15`/`macos-15-intel`, with a
-`codesign --verify`) — proving the wheels, including the binary's ad-hoc
-signature, work outside the build environment.
+`codesign --verify`; the Linux legs on `ubuntu-24.04`/`ubuntu-24.04-arm`) —
+proving the wheels, including the binary's ad-hoc signature, work outside the
+build environment.
 
 ### Release path
 

--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -1,3 +1,5 @@
+aarch
+aarch64
 absolutises
 absolutising
 acked

--- a/neuracore/data_daemon/binary.py
+++ b/neuracore/data_daemon/binary.py
@@ -17,7 +17,7 @@ INSTALL_COMMAND_HINT = "`pip install --force-reinstall neuracore`"
 
 MISSING_BINARY_HINT = (
     "The neuracore data-daemon binary was not found. It ships in the neuracore "
-    "wheel (prebuilt for Linux x86_64 and Apple-Silicon macOS); reinstall with "
+    "wheel (prebuilt for Linux x86_64/aarch64 and macOS); reinstall with "
     f"{INSTALL_COMMAND_HINT} on one of those platforms, or build it into a "
     f"source checkout with {REBUILD_COMMAND_HINT}."
 )
@@ -31,7 +31,7 @@ def data_daemon_binary_path() -> Path | None:
     """Return the path to the data-daemon binary, if available.
 
     The binary ships in ``neuracore/data_daemon/bin/`` inside the ``neuracore``
-    wheel (prebuilt for Linux x86_64 and Apple-Silicon macOS). Returns ``None``
+    wheel (prebuilt for Linux x86_64/aarch64 and macOS). Returns ``None``
     when it is absent — e.g. a source/editable install without
     ``rust/scripts/build_wheel_artefacts.sh`` having been run.
     """

--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -20,8 +20,8 @@ _DATA_BRIDGE_MODULE: ModuleType | None = None
 
 _DATA_BRIDGE_IMPORT_HINT = (
     "neuracore.data_daemon._data_bridge is not available. The Rust extension "
-    "is bundled in the neuracore wheel (prebuilt for Linux x86_64 and "
-    "Apple-Silicon macOS); reinstall with `pip install neuracore` on one of "
+    "is bundled in the neuracore wheel (prebuilt for Linux x86_64/aarch64 and "
+    "macOS); reinstall with `pip install neuracore` on one of "
     "those platforms, or build it into a source checkout with "
     "`bash rust/scripts/build_wheel_artefacts.sh && pip install -e .`."
 )
@@ -31,7 +31,7 @@ def _load_native() -> ModuleType:
     """Lazily import and cache the PyO3 data daemon bridge module for the process.
 
     The compiled extension ships inside the ``neuracore`` wheel (prebuilt for
-    Linux x86_64 and Apple-Silicon macOS), so this raises a helpful error when
+    Linux x86_64/aarch64 and macOS), so this raises a helpful error when
     it is absent (e.g. a source install without the Rust build).
     """
     global _DATA_BRIDGE_MODULE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ name = "neuracore"
 # `neuracore` is a single merged distribution: the Python SDK plus the Rust
 # data daemon (the `_data_bridge` extension built by maturin from
 # rust/data_daemon_bridge and the standalone `data-daemon` binary bundled via
-# [tool.maturin] include). Wheels ship for Linux x86_64 (manylinux_2_28) and
-# Apple-Silicon macOS only — no sdist and no pure wheel, so other platforms
-# resolve to the last pure release. neuracore/__init__.py re-derives
-# __version__ from the installed metadata, so this is the single source of
-# truth.
+# [tool.maturin] include). Wheels ship for Linux x86_64 and aarch64
+# (manylinux_2_28) and macOS arm64 and x86_64 only — no sdist and no pure wheel,
+# so other platforms resolve to the last pure release. neuracore/__init__.py
+# re-derives __version__ from the installed metadata, so this is the single
+# source of truth.
 version = "16.1.0"
 description = "Neuracore Client Library"
 readme = "README.md"


### PR DESCRIPTION
### Features
 - `neuracore` now builds and publishes Linux aarch64 wheels (`manylinux_2_28`, cp310–cp314) alongside the existing Linux x86_64 and macOS arm64/x86_64 legs.


