### PR TITLE
fix: improve test failed training logs

### DIFF
--- a/tests/integration/ml/shared/training.py
+++ b/tests/integration/ml/shared/training.py
@@ -203,6 +203,30 @@ def assert_no_training_log_errors(
     )
 
 
+def get_training_failure_context(job_id: str, max_entries: int = 10_000) -> str:
+    """Fetch ERROR/CRITICAL training log entries for a failed job's message.
+
+    Best-effort: if the logs themselves can't be fetched, returns a note to
+    that effect rather than raising, so a failure here never masks the
+    original training failure.
+    """
+    try:
+        offending_entries: list[dict] = []
+        for severity in ("ERROR", "CRITICAL"):
+            logs = nc.get_training_job_logs(
+                job_id,
+                max_entries=max_entries,
+                severity_filter=severity,
+            )
+            offending_entries.extend(logs.get("logs", []))
+    except Exception as e:
+        return f"(failed to fetch training logs for {job_id}: {e})"
+
+    if not offending_entries:
+        return f"(no ERROR/CRITICAL training log entries found for {job_id})"
+    return format_training_log_entries(offending_entries)
+
+
 def get_training_job_metrics(job_id: str) -> Metrics:
     """Fetch training metrics for a completed or in-progress job."""
     org_id = get_current_org()

--- a/tests/integration/ml/test_algorithm_performance.py
+++ b/tests/integration/ml/test_algorithm_performance.py
@@ -41,7 +41,10 @@ from neuracore_types.training.training import GPUType
 
 import neuracore as nc
 from neuracore.core.endpoint import Policy
-from tests.integration.ml.shared.training import wait_for_training
+from tests.integration.ml.shared.training import (
+    get_training_failure_context,
+    wait_for_training,
+)
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(THIS_DIR, "..", "..", "..", "examples"))
@@ -235,9 +238,10 @@ class TestAlgorithmPerformance:
             poll_seconds=60,
         )
         if training_job_status != "COMPLETED":
+            failure_context = get_training_failure_context(training_job_id)
             raise ValueError(
                 f"[{algorithm_name}] Training job did not complete, "
-                f"status: {training_job_status}"
+                f"status: {training_job_status}\n\n{failure_context}"
             )
 
         timestamp = int(time.time())


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Provide errorred or failed training logs in the test output by pulling from gcloud, matching the `assert_no_training_log_errors` pattern in `tests/integration/ml/shared/training.py`