### PR TITLE
fix: stop alpha pre releases reaching prod

### DIFF
--- a/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-evaluate-prod.yaml
@@ -18,7 +18,9 @@ jobs:
     - name: Resolve latest release tag
       id: release-tag
       run: |
-        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        # Exclude alpha pre-releases (vX.Y.ZaNNN, from workflow_dispatch alpha
+        # builds off arbitrary branches) -- only real releases should reach prod.
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | grep -Ev 'a[0-9]+$' | head -n 1)"
         if [ -z "$latest_release_tag" ]; then
           echo "::error::No release tag matching v* found"
           exit 1

--- a/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
+++ b/.github/workflows/integration-ml-algorithm-performance-start-prod.yaml
@@ -18,7 +18,9 @@ jobs:
     - name: Resolve latest release tag
       id: release-tag
       run: |
-        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        # Exclude alpha pre-releases (vX.Y.ZaNNN, from workflow_dispatch alpha
+        # builds off arbitrary branches) -- only real releases should reach prod.
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | grep -Ev 'a[0-9]+$' | head -n 1)"
         if [ -z "$latest_release_tag" ]; then
           echo "::error::No release tag matching v* found"
           exit 1

--- a/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
+++ b/.github/workflows/integration-ml-auto-batch-size-start-prod.yaml
@@ -18,7 +18,9 @@ jobs:
     - name: Resolve latest release tag
       id: release-tag
       run: |
-        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+        # Exclude alpha pre-releases (vX.Y.ZaNNN, from workflow_dispatch alpha
+        # builds off arbitrary branches) -- only real releases should reach prod.
+        latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | grep -Ev 'a[0-9]+$' | head -n 1)"
         if [ -z "$latest_release_tag" ]; then
           echo "::error::No release tag matching v* found"
           exit 1

--- a/.github/workflows/update-google-colab.yaml
+++ b/.github/workflows/update-google-colab.yaml
@@ -49,7 +49,9 @@ jobs:
       - name: Resolve latest release tag
         id: release-tag
         run: |
-          latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          # Exclude alpha pre-releases (vX.Y.ZaNNN, from workflow_dispatch alpha
+          # builds off arbitrary branches) -- only real releases should be published.
+          latest_release_tag="$(git tag --list 'v*' --sort=-v:refname | grep -Ev 'a[0-9]+$' | head -n 1)"
           if [ -z "$latest_release_tag" ]; then
             echo "::error::No release tag matching v* found"
             exit 1


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Used regex to exclude the suffix we provide after a version number as a pre-release tag from testing when running job.
