### PR TITLE
fix: keep a relayed stop from closing the next recording

### DIFF
--- a/neuracore/api/core.py
+++ b/neuracore/api/core.py
@@ -182,7 +182,6 @@ def connect_robot(
     StreamManagerOrchestrator().get_provider_manager(robot.id, robot.instance)
     get_recording_state_manager().register_connected_robot(robot.id)
     robot._register_remote_stop_handler()
-    robot._register_remote_start_handler()
     return robot
 
 

--- a/neuracore/core/robot.py
+++ b/neuracore/core/robot.py
@@ -346,6 +346,7 @@ class Robot:
         self,
         recording_id: str | None,
         timestamp: float | None = None,
+        notify_daemon: bool = True,
     ) -> None:
         """Stop all streams and send the recording-stopped IPC message to the daemon.
 
@@ -356,12 +357,16 @@ class Robot:
         after the barrier instead leaves it open for as long as the writer's
         backlog takes to drain (over a second under burst logging), publishing
         data the daemon has already stopped accepting and simply throws away.
+
+        ``notify_daemon=False`` drains without publishing the stop — see
+        :meth:`_drain_for_remote_stop`.
         """
         try:
             self._stop_all_streams()
             context = self._get_daemon_recording_context()
             try:
-                context.stop_recording(timestamp=timestamp)
+                if notify_daemon:
+                    context.stop_recording(timestamp=timestamp)
             finally:
                 # Both run even if the notify failed.
                 self._close_local_recording_gate()
@@ -371,6 +376,16 @@ class Robot:
                 "Failed to stop streams and notify daemon for recording_id=%s",
                 recording_id,
             )
+
+    def _drain_for_remote_stop(self, recording_id: str | None) -> None:
+        """Drain for a stop this process learned about over the notification stream.
+
+        The stop is not published: it names no recording on the wire and
+        arrives a hop late, so the daemon would apply it to whichever window is
+        live by then. The daemon reads the same stream and closes the named
+        recording itself.
+        """
+        self._drain_streams_and_notify_daemon(recording_id, notify_daemon=False)
 
     def _close_local_recording_gate(self) -> None:
         """Clear the local recording handle that gates ``log_*`` forwarding."""
@@ -390,41 +405,9 @@ class Robot:
         manager.register_remote_stop_handler(
             robot_id=self.id,
             instance=self.instance,
-            callback=self._drain_streams_and_notify_daemon,
+            callback=self._drain_for_remote_stop,
         )
         self._recording_state_manager = manager
-
-    def _notify_daemon_of_remote_start(
-        self, recording_id: str, dataset_id: str, start_time: float
-    ) -> None:
-        """Open the daemon window for a recording started from the web frontend.
-
-        Args:
-            recording_id: The cloud recording id the backend already minted.
-            dataset_id: Dataset the recording is being saved to.
-            start_time: The recording's capture start time (Unix seconds).
-        """
-        if not self.id:
-            return
-        self._get_daemon_recording_context().start_recording(
-            robot_id=self.id,
-            robot_instance=self.instance,
-            robot_name=self.name,
-            dataset_id=dataset_id,
-            dataset_name=None,
-            timestamp=start_time,
-            cloud_recording_id=recording_id,
-        )
-
-    def _register_remote_start_handler(self) -> None:
-        """Register a callback to notify the daemon of a remote start."""
-        assert self.id is not None
-        manager = get_recording_state_manager()
-        manager.register_remote_start_handler(
-            robot_id=self.id,
-            instance=self.instance,
-            callback=self._notify_daemon_of_remote_start,
-        )
 
     def _stop_all_streams(self) -> None:
         """Stop recording on all data streams for this robot instance."""
@@ -832,7 +815,6 @@ class Robot:
         self._recording_state_manager = None
         if self.id is not None and manager is not None:
             manager.deregister_remote_stop_handler(self.id, self.instance)
-            manager.deregister_remote_start_handler(self.id, self.instance)
         if self._temp_dir is not None:
             self._temp_dir.cleanup()
             self._temp_dir = None

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -55,12 +55,10 @@ class TrackedRecording(NamedTuple):
             backend reports in ``RecordingStartPayload.start_time``. Orders
             notifications against each other: one describing a recording that
             began earlier than this belongs to an already-finished recording.
-        opened_locally: Whether the recording was started by the local client
     """
 
     recording_id: str
     start_time: float
-    opened_locally: bool
 
 
 def _notify_data_bridge_of_expiry(robot_id: str, instance: int) -> None:
@@ -144,9 +142,6 @@ class RecordingStateManager(BaseSSEConsumer):
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
         self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
-        self._start_callbacks: dict[
-            RobotInstanceIdentifier, Callable[[str, str, float], None]
-        ] = {}
 
         self._logout_listener = self._on_logout
         self.auth.once(Auth.LOGOUT_EVENT, self._logout_listener)
@@ -185,7 +180,6 @@ class RecordingStateManager(BaseSSEConsumer):
             self._expired_recording_ids.clear()
             self.active_dataset_ids.clear()
             self._drain_callbacks.clear()
-            self._start_callbacks.clear()
             self._connected_robot_id = None
 
         if not self.loop.is_closed():
@@ -290,7 +284,6 @@ class RecordingStateManager(BaseSSEConsumer):
                 instance=instance,
                 recording_id=recording_id,
                 start_time=start_time,
-                opened_locally=True,
             )
         # After the state is visible, and outside the lock: this normally takes
         # a few milliseconds of filesystem work, which is long enough for a
@@ -316,7 +309,6 @@ class RecordingStateManager(BaseSSEConsumer):
         instance: int,
         recording_id: str,
         start_time: float,
-        opened_locally: bool,
     ) -> None:
         """Make ``recording_id`` this instance's tracked recording.
 
@@ -335,7 +327,6 @@ class RecordingStateManager(BaseSSEConsumer):
         self.recording_robot_instances[instance_key] = TrackedRecording(
             recording_id=recording_id,
             start_time=start_time,
-            opened_locally=opened_locally,
         )
         if previous_recording_id is not None:
             self._cancel_recording_timers(previous_recording_id)
@@ -543,20 +534,12 @@ class RecordingStateManager(BaseSSEConsumer):
                 dataset_id,
                 recording_id,
             )
-            # Only open the window if no one else has already.
-            opened_locally = previous is not None and previous.opened_locally
-            if not opened_locally:
-                start_callback = self._start_callbacks.get(instance_key)
-                if start_callback is not None:
-                    start_callback(recording_id, dataset_id, details.start_time)
-                opened_locally = True
 
             self._track_recording_started(
                 robot_id=robot_id,
                 instance=instance,
                 recording_id=recording_id,
                 start_time=details.start_time,
-                opened_locally=opened_locally,
             )
         else:
             if previous_recording_id != recording_id:
@@ -595,21 +578,6 @@ class RecordingStateManager(BaseSSEConsumer):
         """Remove the drain callback for a robot instance."""
         key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
         self._drain_callbacks.pop(key, None)
-
-    def register_remote_start_handler(
-        self,
-        robot_id: str,
-        instance: int,
-        callback: Callable[[str, str, float], None],
-    ) -> None:
-        """Register a callback to open the daemon window for a web-initiated start."""
-        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
-        self._start_callbacks[key] = callback
-
-    def deregister_remote_start_handler(self, robot_id: str, instance: int) -> None:
-        """Remove the remote-start callback for a robot instance."""
-        key = RobotInstanceIdentifier(robot_id=robot_id, robot_instance=instance)
-        self._start_callbacks.pop(key, None)
 
     def get_sse_client_config(self) -> EventSourceConfig:
         """Used to configure the event client to consume events from the server.

--- a/rust/data_daemon/src/cli/coordinators.rs
+++ b/rust/data_daemon/src/cli/coordinators.rs
@@ -14,10 +14,12 @@ use crate::api::auth::FileAuthProvider;
 use crate::api::client::{ApiClient, ApiClientOptions};
 use crate::cloud::{
     spawn_org_watcher, spawn_progress_reporter, spawn_recording_cancel_notifier,
-    spawn_recording_start_notifier, spawn_recording_stop_notifier, spawn_registration,
-    spawn_status_updater, spawn_uploader, ConfigRx, OrgWatcherHandle, StatusUpdate,
+    spawn_recording_notifications, spawn_recording_start_notifier, spawn_recording_stop_notifier,
+    spawn_registration, spawn_status_updater, spawn_uploader, ConfigRx, OrgWatcherHandle,
+    RecordingNotificationsHandle, StatusUpdate,
 };
 use crate::connection::spawn_connection_monitor;
+use crate::pipeline::dispatcher::RecordingCommand;
 use crate::state::{EventBus, SqliteStateStore, TraceWriteHandle};
 
 /// Bundle of handles for the cloud coordinators.
@@ -31,6 +33,7 @@ pub(crate) struct CloudHandles {
     recording_start: crate::cloud::NotifierHandle,
     recording_stop: crate::cloud::NotifierHandle,
     recording_cancel: crate::cloud::NotifierHandle,
+    recording_notifications: RecordingNotificationsHandle,
 }
 
 impl CloudHandles {
@@ -48,6 +51,7 @@ impl CloudHandles {
         self.recording_start.join().await;
         self.recording_stop.join().await;
         self.recording_cancel.join().await;
+        self.recording_notifications.join().await;
     }
 }
 
@@ -72,7 +76,7 @@ pub(crate) fn spawn_cloud_coordinators(
     fallback_org_id: Option<String>,
     shutdown_tx: crate::lifecycle::shutdown::ShutdownBroadcaster,
     config_rx: ConfigRx,
-) -> CloudHandles {
+) -> (CloudHandles, tokio::sync::mpsc::Receiver<RecordingCommand>) {
     let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<StatusUpdate>();
     // Watch the SDK config for the current org; every coordinator reads the
     // live value at the moment it POSTs rather than a value frozen onto the
@@ -138,19 +142,25 @@ pub(crate) fn spawn_cloud_coordinators(
         state_store,
         event_bus,
         Arc::clone(&client),
-        org_rx,
+        org_rx.clone(),
         shutdown_tx.subscribe(),
     );
+    let (notifications_rx, recording_notifications) =
+        spawn_recording_notifications(client, org_rx, shutdown_tx.subscribe());
 
-    CloudHandles {
-        connection,
-        org_watcher,
-        registration,
-        uploader,
-        status,
-        progress,
-        recording_start,
-        recording_stop,
-        recording_cancel,
-    }
+    (
+        CloudHandles {
+            connection,
+            org_watcher,
+            registration,
+            uploader,
+            status,
+            progress,
+            recording_start,
+            recording_stop,
+            recording_cancel,
+            recording_notifications,
+        },
+        notifications_rx,
+    )
 }

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -389,25 +389,28 @@ fn run_daemon(
             // the next periodic tick. Order is also load-bearing for
             // ordered shutdown: dropping the dispatcher first guarantees
             // no new `TraceWritten` lands while the coordinators drain.
-            let cloud_handles = if config_for_runtime.offline.unwrap_or(false) {
+            let (cloud_handles, notifications_rx) = if config_for_runtime.offline.unwrap_or(false) {
                 tracing::info!("offline mode — skipping cloud coordinator spawn");
-                None
+                (None, None)
             } else {
                 match build_api_client(&api_url, &config_path) {
-                    Ok(api_client) => Some(spawn_cloud_coordinators(
-                        state_store.clone(),
-                        trace_write_handle.clone(),
-                        event_bus.clone(),
-                        api_client,
-                        Arc::new(recordings_root.clone()),
-                        config_path.clone(),
-                        org_id.clone(),
-                        shutdown_tx.clone(),
-                        config_rx.clone(),
-                    )),
+                    Ok(api_client) => {
+                        let (handles, notifications_rx) = spawn_cloud_coordinators(
+                            state_store.clone(),
+                            trace_write_handle.clone(),
+                            event_bus.clone(),
+                            api_client,
+                            Arc::new(recordings_root.clone()),
+                            config_path.clone(),
+                            org_id.clone(),
+                            shutdown_tx.clone(),
+                            config_rx.clone(),
+                        );
+                        (Some(handles), Some(notifications_rx))
+                    }
                     Err(error) => {
                         tracing::warn!(%error, "failed to build API client; cloud uploads disabled");
-                        None
+                        (None, None)
                     }
                 }
             };
@@ -428,6 +431,7 @@ fn run_daemon(
             let dispatcher_context = DispatcherContext {
                 event_bus: Some(event_bus.clone()),
                 config_refresh_tx: Some(config_refresh_tx),
+                notifications_rx,
             };
             let (dispatcher_tx, dispatcher_handle) = dispatcher::spawn_with_context(
                 state_store.clone(),

--- a/rust/data_daemon/src/cloud/mod.rs
+++ b/rust/data_daemon/src/cloud/mod.rs
@@ -36,6 +36,9 @@ pub use notifiers::recording_start_notifier::spawn_recording_start_notifier;
 pub use notifiers::recording_stop_notifier::spawn_recording_stop_notifier;
 pub use watchers::config_watcher::{spawn_config_watcher, ConfigRefreshRequest, ConfigRx};
 pub use watchers::org_watcher::{spawn_org_watcher, OrgIdRx, OrgWatcherHandle};
+pub use watchers::recording_notifications::{
+    spawn_recording_notifications, RecordingNotificationsHandle,
+};
 pub use watchers::recording_reaper::spawn_recording_reaper;
 
 use std::path::Path;

--- a/rust/data_daemon/src/cloud/watchers/mod.rs
+++ b/rust/data_daemon/src/cloud/watchers/mod.rs
@@ -1,8 +1,10 @@
 //! Periodic watchers: the org-id config poller that publishes the live org for
 //! every coordinator, the daemon-profile config poller that publishes the live
 //! effective config (chiefly the video codec), and the recording reaper that
-//! reclaims durably-settled recordings.
+//! reclaims durably-settled recordings. Alongside them, the recording
+//! notification stream: a long-lived subscription rather than a poller.
 
 pub mod config_watcher;
 pub mod org_watcher;
+pub mod recording_notifications;
 pub mod recording_reaper;

--- a/rust/data_daemon/src/cloud/watchers/recording_notifications.rs
+++ b/rust/data_daemon/src/cloud/watchers/recording_notifications.rs
@@ -1,0 +1,402 @@
+//! Backend recording-lifecycle stream.
+//!
+//! Subscribes to `/stream/org/{org}/recording/notifications` — the same
+//! server-sent-event stream the SDK consumes — and turns the recordings the
+//! backend reports into [`RecordingCommand`]s for the dispatcher.
+//!
+//! Producers announce the recordings they bracket themselves; this carries the
+//! ones nobody local brackets, started or stopped from the web. Reading the
+//! stream here keeps the recording's identity attached all the way to the
+//! dispatcher, which acts on the named recording or not at all.
+//!
+//! Availability, not correctness: producer-bracketed recordings work whether or
+//! not this task is connected. A dropped connection is retried with capped
+//! backoff.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
+
+use crate::api::ApiClient;
+use crate::cloud::OrgIdRx;
+use crate::lifecycle::shutdown::ShutdownSignal;
+use crate::pipeline::dispatcher::RecordingCommand;
+
+/// Backoff floor after a failed or dropped connection.
+const RECONNECT_MIN: Duration = Duration::from_secs(1);
+/// Backoff ceiling.
+const RECONNECT_MAX: Duration = Duration::from_secs(30);
+/// Cap on a single SSE frame; anything larger is a malformed stream.
+const MAX_FRAME_BYTES: usize = 256 * 1024;
+
+/// Handle for the notification-stream task.
+pub struct RecordingNotificationsHandle {
+    join: JoinHandle<()>,
+}
+
+impl RecordingNotificationsHandle {
+    /// Wait for the task to exit.
+    pub async fn join(self) {
+        if let Err(error) = self.join.await {
+            tracing::warn!(?error, "recording notifications join failed");
+        }
+    }
+}
+
+/// Spawn the notification-stream consumer.
+///
+/// Returns the receiver the dispatcher selects on alongside its IPC inbox, and
+/// the task handle. The channel is bounded so a busy dispatcher slows this task
+/// rather than letting notifications queue without limit.
+pub fn spawn_recording_notifications(
+    client: Arc<ApiClient>,
+    org_rx: OrgIdRx,
+    shutdown_rx: broadcast::Receiver<ShutdownSignal>,
+) -> (
+    mpsc::Receiver<RecordingCommand>,
+    RecordingNotificationsHandle,
+) {
+    let (tx, rx) = mpsc::channel::<RecordingCommand>(64);
+    let join = tokio::spawn(run(client, org_rx, tx, shutdown_rx));
+    (rx, RecordingNotificationsHandle { join })
+}
+
+async fn run(
+    client: Arc<ApiClient>,
+    mut org_rx: OrgIdRx,
+    tx: mpsc::Sender<RecordingCommand>,
+    mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
+) {
+    let stream_client = match reqwest::Client::builder().build() {
+        Ok(stream_client) => stream_client,
+        Err(error) => {
+            tracing::warn!(%error, "could not build the notification stream client");
+            return;
+        }
+    };
+
+    let mut backoff = RECONNECT_MIN;
+    loop {
+        let Some(org_id) = org_rx.borrow().clone() else {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.recv() => return,
+                changed = org_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                    continue;
+                }
+            }
+        };
+
+        let outcome = tokio::select! {
+            biased;
+            _ = shutdown_rx.recv() => return,
+            changed = org_rx.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+                backoff = RECONNECT_MIN;
+                continue;
+            }
+            outcome = consume(&stream_client, &client, &org_id, &tx) => outcome,
+        };
+
+        match outcome {
+            // A clean end-of-stream is the backend closing an idle connection.
+            Ok(()) => {
+                tracing::debug!(org_id, "recording notification stream ended; reconnecting");
+                backoff = RECONNECT_MIN;
+            }
+            Err(StreamEnded::Closed) => {
+                tracing::debug!("dispatcher gone; stopping recording notifications");
+                return;
+            }
+            Err(StreamEnded::Failed(error)) => {
+                tracing::warn!(
+                    %error,
+                    org_id,
+                    backoff_s = backoff.as_secs(),
+                    "recording notification stream failed; retrying"
+                );
+            }
+        }
+
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.recv() => return,
+            _ = tokio::time::sleep(backoff) => {}
+        }
+        backoff = (backoff * 2).min(RECONNECT_MAX);
+    }
+}
+
+/// Why a subscription stopped.
+enum StreamEnded {
+    /// The dispatcher's receiver is gone — nothing left to feed.
+    Closed,
+    /// Connection or protocol failure; the caller retries.
+    Failed(String),
+}
+
+/// Hold one subscription open, forwarding every recognised event.
+///
+/// Returns `Ok(())` when the backend closes the stream cleanly.
+async fn consume(
+    stream_client: &reqwest::Client,
+    client: &ApiClient,
+    org_id: &str,
+    tx: &mpsc::Sender<RecordingCommand>,
+) -> Result<(), StreamEnded> {
+    let token = client
+        .auth()
+        .bearer_token()
+        .await
+        .map_err(|error| StreamEnded::Failed(format!("auth: {error}")))?;
+    let url = client.url(&format!("/stream/org/{org_id}/recording/notifications"));
+
+    let response = stream_client
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "text/event-stream")
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|error| StreamEnded::Failed(error.to_string()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let _ = client.auth().reload().await;
+        }
+        return Err(StreamEnded::Failed(format!("stream returned {status}")));
+    }
+
+    tracing::info!(org_id, "subscribed to recording notifications");
+    let mut response = response;
+    let mut buffer: Vec<u8> = Vec::new();
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| StreamEnded::Failed(error.to_string()))?
+    {
+        buffer.extend_from_slice(&chunk);
+        for frame in take_frames(&mut buffer) {
+            let Some(command) = parse_notification(&frame) else {
+                continue;
+            };
+            if tx.send(command).await.is_err() {
+                return Err(StreamEnded::Closed);
+            }
+        }
+        if buffer.len() > MAX_FRAME_BYTES {
+            return Err(StreamEnded::Failed(format!(
+                "notification frame exceeded {MAX_FRAME_BYTES} bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Split every complete SSE frame out of `buffer`, leaving any partial tail.
+///
+/// A frame ends at a blank line; within one, a repeated `data:` field is joined
+/// with newlines. Every other field is ignored — the payload is all in `data`.
+fn take_frames(buffer: &mut Vec<u8>) -> Vec<String> {
+    let mut frames = Vec::new();
+    while let Some(end) = find_frame_end(buffer) {
+        let raw = buffer.drain(..end.boundary).collect::<Vec<u8>>();
+        let raw = &raw[..end.content];
+        if let Ok(text) = std::str::from_utf8(raw) {
+            let mut data = String::new();
+            for line in text.split('\n') {
+                let line = line.strip_suffix('\r').unwrap_or(line);
+                let Some(value) = line.strip_prefix("data:") else {
+                    continue;
+                };
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(value.strip_prefix(' ').unwrap_or(value));
+            }
+            if !data.is_empty() {
+                frames.push(data);
+            }
+        }
+    }
+    frames
+}
+
+/// Where the first complete frame ends: `content` bytes of frame, `boundary`
+/// bytes to consume including the terminator.
+struct FrameEnd {
+    content: usize,
+    boundary: usize,
+}
+
+fn find_frame_end(buffer: &[u8]) -> Option<FrameEnd> {
+    for (index, window) in buffer.windows(2).enumerate() {
+        if window == b"\n\n" {
+            return Some(FrameEnd {
+                content: index,
+                boundary: index + 2,
+            });
+        }
+    }
+    for (index, window) in buffer.windows(4).enumerate() {
+        if window == b"\r\n\r\n" {
+            return Some(FrameEnd {
+                content: index,
+                boundary: index + 4,
+            });
+        }
+    }
+    None
+}
+
+/// The subset of the backend's recording notification this daemon acts on.
+#[derive(Debug, Deserialize)]
+struct Notification {
+    #[serde(rename = "type")]
+    kind: String,
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct StartPayload {
+    recording_id: String,
+    robot_id: String,
+    instance: i64,
+    #[serde(default)]
+    dataset_ids: Vec<String>,
+    start_time: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct StopPayload {
+    recording_id: String,
+}
+
+/// Turn one frame's JSON into a command, or `None` for anything this daemon
+/// does not act on (an unparsable frame, or a lifecycle type it ignores).
+fn parse_notification(data: &str) -> Option<RecordingCommand> {
+    let notification: Notification = match serde_json::from_str(data) {
+        Ok(notification) => notification,
+        Err(error) => {
+            tracing::debug!(%error, "ignoring unparsable recording notification");
+            return None;
+        }
+    };
+
+    match notification.kind.as_str() {
+        "START" => {
+            let payload: StartPayload = serde_json::from_value(notification.payload).ok()?;
+            Some(RecordingCommand::Open {
+                cloud_recording_id: payload.recording_id,
+                robot_id: payload.robot_id,
+                robot_instance: payload.instance,
+                dataset_id: payload.dataset_ids.into_iter().next(),
+                start_timestamp_ns: seconds_to_nanos(payload.start_time),
+            })
+        }
+        "STOP" | "DISCARDED" | "EXPIRED" => {
+            let payload: StopPayload = serde_json::from_value(notification.payload).ok()?;
+            Some(RecordingCommand::Close {
+                cloud_recording_id: payload.recording_id,
+                observed_at_ns: wall_clock_ns(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn seconds_to_nanos(seconds: f64) -> i64 {
+    (seconds * 1_000_000_000.0) as i64
+}
+
+fn wall_clock_ns() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_frames_on_the_blank_line() {
+        let mut buffer = b"data: one\n\ndata: two\n\n".to_vec();
+        assert_eq!(take_frames(&mut buffer), vec!["one", "two"]);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn keeps_a_partial_frame_for_the_next_chunk() {
+        let mut buffer = b"data: one\n\ndata: hand".to_vec();
+        assert_eq!(take_frames(&mut buffer), vec!["one"]);
+        buffer.extend_from_slice(b"over\n\n");
+        assert_eq!(take_frames(&mut buffer), vec!["handover"]);
+    }
+
+    #[test]
+    fn joins_repeated_data_fields_and_ignores_other_fields() {
+        let mut buffer = b": keepalive\nevent: message\ndata: a\ndata: b\nid: 7\n\n".to_vec();
+        assert_eq!(take_frames(&mut buffer), vec!["a\nb"]);
+    }
+
+    #[test]
+    fn handles_crlf_frames() {
+        let mut buffer = b"data: one\r\n\r\n".to_vec();
+        assert_eq!(take_frames(&mut buffer), vec!["one"]);
+    }
+
+    #[test]
+    fn start_becomes_an_open_naming_its_recording() {
+        let command = parse_notification(
+            r#"{"type":"START","payload":{"recording_id":"rec-1","robot_id":"robot-1",
+               "instance":2,"created_by":"someone","dataset_ids":["ds-1"],
+               "start_time":1.5}}"#,
+        )
+        .expect("a start command");
+        assert_eq!(
+            command,
+            RecordingCommand::Open {
+                cloud_recording_id: "rec-1".into(),
+                robot_id: "robot-1".into(),
+                robot_instance: 2,
+                dataset_id: Some("ds-1".into()),
+                start_timestamp_ns: 1_500_000_000,
+            }
+        );
+    }
+
+    #[test]
+    fn every_terminal_type_becomes_a_close() {
+        for kind in ["STOP", "DISCARDED", "EXPIRED"] {
+            let command = parse_notification(&format!(
+                r#"{{"type":"{kind}","payload":{{"recording_id":"rec-1",
+                   "robot_id":"robot-1","instance":0}}}}"#
+            ))
+            .expect("a close command");
+            match command {
+                RecordingCommand::Close {
+                    cloud_recording_id, ..
+                } => assert_eq!(cloud_recording_id, "rec-1"),
+                other => panic!("{kind} produced {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn ignores_init_and_unparsable_frames() {
+        assert!(parse_notification(r#"{"type":"INIT","payload":[]}"#).is_none());
+        assert!(parse_notification("not json").is_none());
+        assert!(parse_notification(r#"{"type":"SAVED","payload":{}}"#).is_none());
+    }
+}

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -139,7 +139,10 @@ impl DispatcherHandle {
 }
 
 /// Optional runtime context passed to the dispatcher.
-#[derive(Clone, Default)]
+///
+/// Not `Clone`: `notifications_rx` is the single consumer of the notification
+/// stream, and the dispatcher is its only owner.
+#[derive(Default)]
 pub struct DispatcherContext {
     /// Daemon event bus, used to publish recording/trace lifecycle events.
     pub event_bus: Option<crate::state::EventBus>,
@@ -148,6 +151,56 @@ pub struct DispatcherContext {
     /// `None` in tests / when no watcher is wired, where `RefreshConfig` is a
     /// no-op.
     pub config_refresh_tx: Option<tokio::sync::mpsc::Sender<crate::cloud::ConfigRefreshRequest>>,
+    /// Backend recording lifecycle, read off the notification stream by
+    /// [`crate::cloud::spawn_recording_notifications`]. `None` offline.
+    pub notifications_rx: Option<mpsc::Receiver<RecordingCommand>>,
+}
+
+/// A recording a source has been told to make.
+///
+/// Written the same way whichever end announced it. Kept until the recording
+/// stops, so a stop that names a cloud id can be matched against what the
+/// source actually has open. One announced for a robot publishing to another
+/// host costs a map entry and never mints a row.
+#[derive(Debug, Clone)]
+struct AnnouncedRecording {
+    /// The backend's id, when the announcement carried one.
+    cloud_recording_id: Option<String>,
+    dataset_id: Option<String>,
+    /// The window's lower bound on the publish clock.
+    open_at_ns: i64,
+    /// The recording's own capture-clock start → the row's `start_timestamp_ns`.
+    start_timestamp_ns: i64,
+    /// The recording this announcement opened, once it has.
+    opened_index: Option<i64>,
+}
+
+/// A recording lifecycle event the *backend* originated, delivered over the
+/// daemon's notification stream rather than the IPC bus.
+///
+/// These carry the recordings nobody local brackets — started or stopped from
+/// the web. They are applied through the same two entry points a producer's
+/// envelopes use; the only thing the stream needs of its own is the cloud id,
+/// which says whether a stop that trailed its recording by a network hop still
+/// names the recording this source has open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordingCommand {
+    /// The backend minted a recording for this source.
+    Open {
+        cloud_recording_id: String,
+        robot_id: String,
+        robot_instance: i64,
+        dataset_id: Option<String>,
+        /// The recording's start on the backend's record (Unix nanoseconds).
+        start_timestamp_ns: i64,
+    },
+    /// The named recording ended.
+    Close {
+        cloud_recording_id: String,
+        /// When the daemon learned of the stop (Unix nanoseconds). Used as the
+        /// recording's `end_time` only when nothing local already stopped it.
+        observed_at_ns: i64,
+    },
 }
 
 /// Spawn the dispatcher task and return its inbound `mpsc::Sender`.
@@ -332,6 +385,9 @@ struct Dispatcher {
     actor_handles: Vec<JoinHandle<()>>,
     /// Rate-limited orphan-drop counter (data outside any window).
     orphan_drops: u64,
+    /// What each source has been told to record, announced but not yet proved
+    /// local. Data is that proof — see [`Dispatcher::open_announced_window`].
+    announced: HashMap<Source, AnnouncedRecording>,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
     /// doesn't re-run the two full window scans (and their `Vec` allocations)
@@ -354,6 +410,7 @@ impl Dispatcher {
             held: VecDeque::new(),
             actor_handles: Vec::new(),
             orphan_drops: 0,
+            announced: HashMap::new(),
             last_housekeep: Instant::now(),
         }
     }
@@ -367,6 +424,7 @@ impl Dispatcher {
             holdback_ms = self.holdback.as_millis(),
             "dispatcher started"
         );
+        let mut notifications_rx = self.context.notifications_rx.take();
 
         loop {
             // When there is in-flight work, poll frequently for due releases /
@@ -389,6 +447,22 @@ impl Dispatcher {
                         break;
                     };
                     self.handle_inbound(envelope, Instant::now()).await;
+                }
+                command = async {
+                    match notifications_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    match command {
+                        Some(command) => {
+                            self.handle_recording_command(command, Instant::now()).await;
+                        }
+                        None => {
+                            tracing::debug!("recording notification stream closed");
+                            notifications_rx = None;
+                        }
+                    }
                 }
                 _ = sleep(housekeep_after) => {}
             }
@@ -419,15 +493,20 @@ impl Dispatcher {
                 cloud_recording_id,
                 ..
             } => {
-                self.handle_start(
-                    (robot_id, robot_instance),
+                let source = (robot_id, robot_instance);
+                self.announce_recording(
+                    source.clone(),
                     dataset_id,
                     cloud_recording_id,
                     publish_timestamp_ns,
                     timestamp_ns,
-                    recv_at,
                 )
                 .await;
+                // The envelope came over local IPC, so the producer that sent
+                // it is here: this start is itself the proof an announcement
+                // off the notification stream has to wait for data to get.
+                self.open_announced_window(&source, publish_timestamp_ns, recv_at)
+                    .await;
             }
             Envelope::StopRecording {
                 robot_id,
@@ -607,21 +686,25 @@ impl Dispatcher {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    async fn handle_start(
+    /// Announce a recording for `source`. The window opens when the source is
+    /// known to be here — see [`Dispatcher::open_announced_window`].
+    ///
+    /// Both origins land here unchanged: a producer's `StartRecording` envelope
+    /// and the backend's notification stream.
+    async fn announce_recording(
         &mut self,
         source: Source,
         dataset_id: Option<String>,
         cloud_recording_id: Option<String>,
         publish_timestamp_ns: i64,
         timestamp_ns: i64,
-        recv_at: Instant,
     ) {
-        // A `StartRecording` carrying a known cloud id can reach this daemon
-        // more than once for the very same recording: every local process
+        // The same recording is announced more than once: every local process
         // connected to the source learns about a web-started recording
-        // independently, and each may try to open it. Only the first must
-        // create a row and open a window.
+        // independently, and the notification stream echoes back a recording
+        // this daemon opened itself. An id already on a row belongs to a
+        // recording past announcing — keep the id, drop the echo. Holding the
+        // id is what lets a stop from the web name this recording later.
         if let Some(cloud_recording_id) = cloud_recording_id.as_deref() {
             match self
                 .store
@@ -629,6 +712,11 @@ impl Dispatcher {
                 .await
             {
                 Ok(Some(existing_index)) => {
+                    if let Some(announcement) = self.announced.get_mut(&source) {
+                        if announcement.opened_index == Some(existing_index) {
+                            announcement.cloud_recording_id = Some(cloud_recording_id.to_string());
+                        }
+                    }
                     tracing::debug!(
                         recording_index = existing_index,
                         cloud_recording_id,
@@ -649,6 +737,62 @@ impl Dispatcher {
             }
         }
 
+        let announced = AnnouncedRecording {
+            cloud_recording_id,
+            dataset_id,
+            open_at_ns: publish_timestamp_ns,
+            start_timestamp_ns: timestamp_ns,
+            opened_index: None,
+        };
+        tracing::debug!(robot_id = source.0, "recording announced");
+        self.announced.insert(source, announced);
+    }
+
+    /// Open the window for `source`'s announced recording, now that it has
+    /// published at `publish_ts`.
+    ///
+    /// The lower bound is the recording's own start, so what the producer
+    /// published before this datum still lands inside. It is clamped to
+    /// `publish_ts` so the triggering datum is not excluded, and floored at any
+    /// predecessor's close so it cannot steal that recording's tail.
+    async fn open_announced_window(&mut self, source: &Source, publish_ts: i64, recv_at: Instant) {
+        let Some(announced) = self.announced.get(source) else {
+            return;
+        };
+        if announced.opened_index.is_some() {
+            return;
+        }
+        let announced = announced.clone();
+        let mut open_at_ns = announced.open_at_ns.min(publish_ts);
+        // Catching up on a recording that began before this datum: floor the
+        // window at any predecessor's close so it cannot claim that
+        // recording's tail. A start opening its own window at its own publish
+        // time spans no such gap, and keeps the boundary its envelope set.
+        if publish_ts > announced.open_at_ns {
+            if let Some(entry) = self.windows.get(source) {
+                let predecessor_close_ns = entry
+                    .closing
+                    .iter()
+                    .filter_map(|window| window.stopped_at_ns)
+                    .filter(|stopped_at_ns| *stopped_at_ns != i64::MAX)
+                    .max();
+                if let Some(predecessor_close_ns) = predecessor_close_ns {
+                    open_at_ns = open_at_ns.max(predecessor_close_ns);
+                }
+            }
+        }
+        self.open_window(source.clone(), announced, open_at_ns, recv_at)
+            .await;
+    }
+
+    /// Create the recording row and open its window.
+    async fn open_window(
+        &mut self,
+        source: Source,
+        announced: AnnouncedRecording,
+        publish_timestamp_ns: i64,
+        recv_at: Instant,
+    ) {
         // Insert the recording row synchronously: cloud notifiers react to the
         // `RecordingStarted` event by reading this row, and `cancel_recording`
         // burns it by index, so the row must exist before either runs. After the
@@ -660,8 +804,8 @@ impl Dispatcher {
         let new = NewRecording {
             robot_id: Some(&source.0),
             robot_instance: Some(source.1),
-            dataset_id: dataset_id.as_deref(),
-            start_timestamp_ns: timestamp_ns,
+            dataset_id: announced.dataset_id.as_deref(),
+            start_timestamp_ns: announced.start_timestamp_ns,
         };
         let recording_index = match self.store.create_recording(new).await {
             Ok(row) => row.recording_index,
@@ -671,6 +815,9 @@ impl Dispatcher {
             }
         };
         tracing::info!(recording_index, robot_id = source.0, "recording started");
+        if let Some(announcement) = self.announced.get_mut(&source) {
+            announcement.opened_index = Some(recording_index);
+        }
 
         let entry = self.windows.entry(source).or_default();
         entry.last_seen = Some(recv_at);
@@ -734,7 +881,7 @@ impl Dispatcher {
             }
         }
 
-        match cloud_recording_id {
+        match announced.cloud_recording_id {
             None => {
                 if let Some(bus) = self.context.event_bus.as_ref() {
                     bus.publish(DaemonEvent::RecordingStarted { recording_index });
@@ -762,6 +909,80 @@ impl Dispatcher {
         }
     }
 
+    /// Apply one backend-originated recording lifecycle event, through the same
+    /// two entry points a producer's envelopes use.
+    async fn handle_recording_command(&mut self, command: RecordingCommand, recv_at: Instant) {
+        match command {
+            RecordingCommand::Open {
+                cloud_recording_id,
+                robot_id,
+                robot_instance,
+                dataset_id,
+                start_timestamp_ns,
+            } => {
+                self.announce_recording(
+                    (robot_id, robot_instance),
+                    dataset_id,
+                    Some(cloud_recording_id),
+                    start_timestamp_ns,
+                    start_timestamp_ns,
+                )
+                .await;
+            }
+            RecordingCommand::Close {
+                cloud_recording_id,
+                observed_at_ns,
+            } => {
+                let Some(source) = self.source_recording(&cloud_recording_id).await else {
+                    tracing::debug!(
+                        cloud_recording_id,
+                        "notification names no recording open here; ignoring"
+                    );
+                    return;
+                };
+                tracing::info!(
+                    cloud_recording_id,
+                    robot_id = source.0,
+                    "closing a recording the backend reported stopped"
+                );
+                self.handle_stop(source, observed_at_ns, observed_at_ns, recv_at)
+                    .await;
+            }
+        }
+    }
+
+    /// The source whose current recording is `cloud_recording_id`.
+    ///
+    /// `None` when no source has that recording open — including a stop that
+    /// trailed its successor's start, which retired the recording already, and
+    /// every recording belonging to another host.
+    async fn source_recording(&self, cloud_recording_id: &str) -> Option<Source> {
+        let announced = self.announced.iter().find(|(_, announcement)| {
+            announcement.cloud_recording_id.as_deref() == Some(cloud_recording_id)
+        });
+        if let Some((source, _)) = announced {
+            return Some(source.clone());
+        }
+        // The id was minted after the announcement — a recording started here
+        // and stopped from the web, whose START notification never taught us
+        // its id — so fall back to the row it was written to.
+        let recording_index = self
+            .store
+            .recording_index_for_cloud_id(cloud_recording_id)
+            .await
+            .ok()
+            .flatten()?;
+        self.windows
+            .iter()
+            .find(|(_, entry)| {
+                entry
+                    .live
+                    .as_ref()
+                    .is_some_and(|window| window.recording_index == recording_index)
+            })
+            .map(|(source, _)| source.clone())
+    }
+
     async fn handle_stop(
         &mut self,
         source: Source,
@@ -769,6 +990,8 @@ impl Dispatcher {
         timestamp_ns: i64,
         recv_at: Instant,
     ) {
+        self.announced.remove(&source);
+
         let Some(entry) = self.windows.get_mut(&source) else {
             tracing::debug!(robot_id = source.0, "stop for unknown source; ignoring");
             return;
@@ -777,7 +1000,7 @@ impl Dispatcher {
 
         // A stop whose publish time falls inside the live window closes the live
         // recording normally. A stop that predates the live window is a delayed
-        // stop for a recording `handle_start` already retired (an inverted
+        // stop for a recording `open_window` already retired (an inverted
         // start/stop pair) — it is matched against the closing windows instead.
         // Both paths converge on the shared post-persist tail below, so a
         // retired recording also becomes notifiable (fires `RecordingStopped`).
@@ -818,7 +1041,7 @@ impl Dispatcher {
             let window = &mut entry.closing[position];
             let recording_index = window.recording_index;
             // Deliberately DO NOT narrow the window's in-memory `stopped_at_ns`
-            // to this true (earlier) stop. `handle_start` set it to the
+            // to this true (earlier) stop. `open_window` set it to the
             // successor recording's start time so the two consecutive windows
             // tile the publish-clock line with no gap. Rewinding it to the real
             // stop would re-open a no-window interval `(true stop, successor
@@ -840,7 +1063,7 @@ impl Dispatcher {
                 "stop arrived after a later recording started; refining the retired recording's stop"
             );
             // Refine the row's `stop_timestamp_ns` (→ backend `end_time`) to
-            // this true capture stop. `handle_start` already marked the row with
+            // this true capture stop. `open_window` already marked the row with
             // the successor start's time, and `mark_recording_stopped` is
             // COALESCE-idempotent, so a plain re-mark would no-op — a forced
             // overwrite is required, and correct because `stop < successor
@@ -884,6 +1107,7 @@ impl Dispatcher {
     }
 
     async fn handle_cancel(&mut self, source: Source, timestamp_ns: i64) {
+        self.announced.remove(&source);
         let Some(entry) = self.windows.get_mut(&source) else {
             return;
         };
@@ -1082,6 +1306,10 @@ impl Dispatcher {
     /// `publish_timestamp_ns` as the membership key.
     async fn route(&mut self, held: Held) {
         let publish_ts = held.publish_timestamp_ns;
+        if !self.announced.is_empty() {
+            self.open_announced_window(&held.source, publish_ts, Instant::now())
+                .await;
+        }
         match held.payload {
             HeldPayload::Data {
                 data_type,
@@ -1629,7 +1857,7 @@ mod tests {
     use tokio::sync::{broadcast, mpsc};
     use tokio::time::{timeout, Duration};
 
-    /// A live window for a source, as `handle_start` would have built it.
+    /// A live window for a source, as `open_window` would have built it.
     fn test_window(recording_index: i64, started_at_ns: i64) -> ActiveWindow {
         ActiveWindow {
             recording_index,
@@ -1749,6 +1977,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: None,
             config_refresh_tx: Some(refresh_tx),
+            notifications_rx: None,
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -1788,6 +2017,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: None,
             config_refresh_tx: None,
+            notifications_rx: None,
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -1813,6 +2043,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            notifications_rx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -1918,6 +2149,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            notifications_rx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2340,7 +2572,7 @@ mod tests {
         // The chunk opens inside the window and its frames run past the stop.
         let stop_ns = 150 + 25 * 1_000;
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
@@ -2384,7 +2616,7 @@ mod tests {
         let opened_at = Instant::now();
         let stop_ns = 150 + 25 * 1_000;
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), stop_ns, stop_ns, opened_at)
@@ -2535,6 +2767,7 @@ mod tests {
         let dispatcher_context = DispatcherContext {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
+            notifications_rx: None,
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2569,6 +2802,126 @@ mod tests {
             }
         }
         assert!(saw_cancel, "RecordingCancelled must be published");
+    }
+
+    /// The backend announcing a recording, as the notification watcher relays it.
+    fn announced(robot: &str, cloud_recording_id: &str, start_ns: i64) -> RecordingCommand {
+        RecordingCommand::Open {
+            cloud_recording_id: cloud_recording_id.into(),
+            robot_id: robot.into(),
+            robot_instance: 0,
+            dataset_id: None,
+            start_timestamp_ns: start_ns,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_recording_announced_for_a_silent_source_creates_nothing() {
+        // The notification stream is org-wide: most of what it carries belongs
+        // to robots on other hosts. Announcing one must not mint a row here —
+        // this daemon would then report its own idle-reap to the backend as
+        // that recording's stop.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        dispatcher
+            .handle_recording_command(announced("robot-9", "rec-elsewhere", 100), Instant::now())
+            .await;
+
+        assert!(store
+            .recordings_for_source("robot-9", 0)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(
+            dispatcher.windows.is_empty(),
+            "no window for a silent source"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_source_publishing_here_opens_the_recording_announced_for_it() {
+        // Data is the proof the announcement lacks. The window opens at the
+        // recording's own start, not at the datum that proved it.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let now = Instant::now();
+        dispatcher
+            .handle_recording_command(announced("robot-1", "rec-a", 100), now)
+            .await;
+        dispatcher
+            .handle_inbound(datum("robot-1", 110, 1), now)
+            .await;
+        dispatcher
+            .release_due_holdback(now + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 1);
+        assert_eq!(recordings[0].recording_id, Some("rec-a".to_string()));
+        assert_eq!(
+            dispatcher.windows[&("robot-1".to_string(), 0)]
+                .live
+                .as_ref()
+                .unwrap()
+                .started_at_ns,
+            100,
+            "the window opens at the recording's start, not at the first datum"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_late_remote_stop_does_not_close_the_next_recording() {
+        // A stop notification trails the stop it describes by a network hop,
+        // by which time the source can have started its next recording. It
+        // names its recording, so it closes that one or nothing.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let mut dispatcher = Dispatcher::new(store.clone(), context, DispatcherContext::default());
+
+        let now = Instant::now();
+        dispatcher
+            .handle_recording_command(announced("robot-1", "rec-a", 100), now)
+            .await;
+        dispatcher
+            .handle_inbound(datum("robot-1", 110, 1), now)
+            .await;
+        dispatcher
+            .release_due_holdback(now + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+        dispatcher.handle_inbound(stop("robot-1", 120), now).await;
+        dispatcher.handle_inbound(start("robot-1", 130), now).await;
+
+        // A's stop, arriving after B is already live.
+        dispatcher
+            .handle_recording_command(
+                RecordingCommand::Close {
+                    cloud_recording_id: "rec-a".into(),
+                    observed_at_ns: 150,
+                },
+                now,
+            )
+            .await;
+
+        let recordings = store.recordings_for_source("robot-1", 0).await.unwrap();
+        assert_eq!(recordings.len(), 2);
+        assert!(recordings[0].stopped_at.is_some(), "A was stopped locally");
+        assert!(
+            recordings[1].stopped_at.is_none(),
+            "B must survive a stop naming its predecessor"
+        );
+        assert!(
+            dispatcher.windows[&("robot-1".to_string(), 0)]
+                .live
+                .is_some(),
+            "B's window must still be live"
+        );
     }
 
     #[tokio::test]
@@ -2636,13 +2989,14 @@ mod tests {
             DispatcherContext {
                 event_bus: Some(bus.clone()),
                 config_refresh_tx: None,
+                notifications_rx: None,
             },
         );
 
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         assert!(dispatcher.windows.get(&source).unwrap().live.is_some());
 
@@ -2690,7 +3044,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
 
         // Only a short time has passed — well within the idle horizon.
@@ -2720,7 +3074,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2762,7 +3116,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2808,7 +3162,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         let stopped_at = opened_at + Duration::from_millis(1);
         dispatcher
@@ -2853,7 +3207,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
 
         // The camera process claims the source as it logs, before any chunk.
@@ -2924,7 +3278,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
         dispatcher
             .handle_stop(source.clone(), 200, 200, opened_at)
@@ -2961,7 +3315,7 @@ mod tests {
         let source = ("robot-1".to_string(), 0);
         let opened_at = Instant::now();
         dispatcher
-            .handle_start(source.clone(), None, None, 100, 100, opened_at)
+            .handle_inbound(start("robot-1", 100), opened_at)
             .await;
 
         // Producer A seals a chunk mid-recording, so the window knows of it.

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -246,9 +246,7 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
         )
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
-    manager.recording_robot_instances[key] = TrackedRecording(
-        "recording-1", 1.0, opened_locally=True
-    )
+    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
     manager.active_dataset_ids[key] = "dataset-1"
     manager._drain_callbacks[key] = MagicMock()
     timer = MagicMock()
@@ -298,9 +296,7 @@ def test_recording_manager_keeps_owned_state_when_the_stream_cannot_authenticate
         )
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
-    manager.recording_robot_instances[key] = TrackedRecording(
-        "recording-1", 1.0, opened_locally=True
-    )
+    manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
     manager.active_dataset_ids[key] = "dataset-1"
 
     manager_future: Future[RecordingStateManager] = Future()

--- a/tests/unit/core/p2p/test_recording_state_manager.py
+++ b/tests/unit/core/p2p/test_recording_state_manager.py
@@ -22,7 +22,6 @@ def _manager() -> RecordingStateManager:
     manager._recording_timers = {}
     manager.active_dataset_ids = {}
     manager._drain_callbacks = {}
-    manager._start_callbacks = {}
     manager._cancel_recording_timers = MagicMock()
     manager._schedule_recording_timers = MagicMock()
     manager._ensure_daemon_for_recording = MagicMock()
@@ -47,7 +46,6 @@ def test_delayed_start_after_local_stop_does_not_restart_daemon() -> None:
     manager.recording_robot_instances[source] = TrackedRecording(
         recording_id="local-handle",
         start_time=100.0,
-        opened_locally=True,
     )
 
     manager.recording_stopped("robot-1", 0, "local-handle")
@@ -67,7 +65,6 @@ def test_newer_start_after_local_stop_is_applied_and_starts_daemon() -> None:
     manager.recording_robot_instances[source] = TrackedRecording(
         recording_id="first-recording",
         start_time=100.0,
-        opened_locally=True,
     )
     manager.recording_stopped("robot-1", 0, "first-recording")
 
@@ -79,7 +76,6 @@ def test_newer_start_after_local_stop_is_applied_and_starts_daemon() -> None:
     assert manager.recording_robot_instances[source] == TrackedRecording(
         recording_id="second-recording",
         start_time=101.0,
-        opened_locally=True,
     )
     assert manager.active_dataset_ids[source] == "dataset-1"
     manager._ensure_daemon_for_recording.assert_called_once_with()

--- a/tests/unit/core/test_robot_stop_streams.py
+++ b/tests/unit/core/test_robot_stop_streams.py
@@ -23,8 +23,16 @@ class _FailingStopStream(_ActiveStream):
         raise RuntimeError("stop failed")
 
 
-def test_web_stop_drains_streams_and_notifies_daemon() -> None:
-    """Callback registered at connect time must drain streams and notify the daemon."""
+def test_web_stop_drains_streams_without_publishing_a_stop() -> None:
+    """Callback registered at connect time drains locally and publishes no stop.
+
+    A stop this process only heard about is not its to publish: the envelope
+    names no recording, so a publish arriving a network hop late would close
+    whichever window is live by then — the next recording, back-to-back. The
+    daemon reads the same stream and closes the named recording itself. What
+    still has to happen here is everything only this process can do: stop its
+    streams and seal its writer's tail chunks.
+    """
     robot = Robot("robot", instance=0, org_id="org-1")
     robot.id = "robot-id-1"
 
@@ -56,7 +64,7 @@ def test_web_stop_drains_streams_and_notifies_daemon() -> None:
     callback("rec-abc")
 
     assert active.stop_calls == 1
-    fake_daemon.stop_recording.assert_called_once_with(timestamp=None)
+    fake_daemon.stop_recording.assert_not_called()
     fake_daemon.flush_source.assert_called_once_with()
 
 


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - The daemon reads the backend's recording notification stream and opens or closes windows by cloud recording id

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - A stop the SDK only relayed no longer closes whichever window is live when it lands, truncating the next recording to the network hop

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
