### PR TITLE
fix: stop gating logged data on the SDK's view of a recording

### DIFF
--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -226,8 +226,6 @@ def _record_json_to_daemon(
     ``log_json`` entry point is datatype-agnostic, so adding a new JSON type
     needs no daemon-side change.
 
-    A no-op unless a recording is in progress.
-
     Args:
         robot: Robot instance owning the daemon recording context.
         data_type: Wire label for the sample's trace.
@@ -235,8 +233,6 @@ def _record_json_to_daemon(
         data: Data object to serialize and persist.
         timestamp: Capture timestamp in seconds.
     """
-    if robot.get_current_recording_id() is None:
-        return
     payload = json.dumps(data.model_dump(mode="json")).encode("utf-8")
     robot._get_daemon_recording_context().log_json(
         data_type.value, storage_name, payload, timestamp
@@ -406,10 +402,9 @@ def _log_group_of_joint_data(
         native_values = list(joint_data.values())
         for binding, joint_value in zip(group.bindings, native_values):
             binding.stream.record_scalar(timestamp, joint_value)
-        if current_recording_id is not None:
-            robot._get_daemon_recording_context().log_joints(
-                data_type.value, timestamp, group.joined_names, native_values
-            )
+        robot._get_daemon_recording_context().log_joints(
+            data_type.value, timestamp, group.joined_names, native_values
+        )
         return
 
     native_values = []
@@ -433,8 +428,7 @@ def _log_group_of_joint_data(
             # allocation-free (see JointDataStream).
             binding.stream.record_scalar(timestamp, joint_value)
 
-        if current_recording_id is not None:
-            native_values.append(joint_value)
+        native_values.append(joint_value)
 
     if native_values:
         robot._get_daemon_recording_context().log_joints(
@@ -532,17 +526,16 @@ def _log_camera_data(
     # or having to make two copies for streaming and bucket storage.
     stream.log(camera_data_without_frame, frame=image)
 
-    if robot.get_current_recording_id() is not None:
-        contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
-        robot._get_daemon_recording_context().log_frame(
-            camera_type.value,
-            storage_name,
-            int(image.shape[1]),
-            int(image.shape[0]),
-            image.dtype.name,
-            memoryview(contiguous).cast("B"),
-            camera_data_without_frame.timestamp,
-        )
+    contiguous = image if image.flags.c_contiguous else np.ascontiguousarray(image)
+    robot._get_daemon_recording_context().log_frame(
+        camera_type.value,
+        storage_name,
+        int(image.shape[1]),
+        int(image.shape[0]),
+        image.dtype.name,
+        memoryview(contiguous).cast("B"),
+        camera_data_without_frame.timestamp,
+    )
 
     _publish_video_to_p2p(robot, name, camera_type, camera_data_without_frame, image)
 

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -1657,7 +1657,7 @@ impl Dispatcher {
     fn note_orphan(&mut self) {
         self.orphan_drops = self.orphan_drops.saturating_add(1);
         if self.orphan_drops == 1 || self.orphan_drops.is_multiple_of(1024) {
-            tracing::warn!(
+            tracing::debug!(
                 dropped = self.orphan_drops,
                 "dropped datum outside any recording window"
             );

--- a/tests/unit/api/test_logging.py
+++ b/tests/unit/api/test_logging.py
@@ -75,6 +75,53 @@ def test_log_with_extrinsics_intrinsics(
     nc.log_depth("depth_camera", depth, extrinsics=extrinsics, intrinsics=intrinsics)
 
 
+def test_logging_reaches_the_daemon_with_no_local_recording_handle(
+    temp_config_dir,
+    mock_auth_requests,
+    reset_neuracore,
+    mock_urdf,
+    monkeypatch,
+    mocked_org_id,
+):
+    """Every data type forwards to the daemon even when this process holds no
+    recording handle.
+
+    A producer is a thin shipper: the daemon decides which recording a datum
+    belongs to. A process that never brackets a recording still contributes to
+    one another process started.
+    """
+    nc.login("test_api_key")
+    mock_auth_requests.post(
+        f"{API_URL}/org/{mocked_org_id}/robots",
+        json={"robot_id": "mock_robot_id", "has_urdf": True},
+        status_code=200,
+    )
+    nc.connect_robot("test_robot", urdf_path=mock_urdf)
+
+    native = MagicMock()
+    monkeypatch.setattr(recording_context, "_load_native", lambda: native)
+    robot = _get_robot(None, 0)
+    monkeypatch.setattr(robot, "get_current_recording_id", lambda: None)
+
+    nc.log_joint_positions(positions={"vx300s_left/waist": 0.5})
+    nc.log_rgb("front_camera", np.zeros((8, 8, 3), dtype=np.uint8))
+    api_logging._record_json_to_daemon(
+        robot,
+        DataType.PARALLEL_GRIPPER_OPEN_AMOUNTS,
+        "gripper",
+        ParallelGripperOpenAmountData(timestamp=1.0, open_amount=0.4),
+        1.0,
+    )
+
+    native.log_joints.assert_called_once()
+    native.log_frame.assert_called_once()
+    native.log_json.assert_called_once()
+    native.start_recording.assert_not_called()
+
+    # Avoid Robot.__del__ consulting the process-global recording manager.
+    robot.id = None
+
+
 def test_log_frame_forwards_dtype_derived_from_the_array(
     temp_config_dir,
     mock_auth_requests,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,6 +24,7 @@ from neuracore.core.streaming.p2p.provider.global_live_data_enabled import (
     get_consume_live_data_enabled_manager,
     get_provide_live_data_enabled_manager,
 )
+from neuracore.data_daemon import bridge
 
 
 def pytest_configure(config):
@@ -48,6 +49,17 @@ def isolated_config_dir(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("nc_config")
     with patch.object(config_manager, "CONFIG_DIR", tmpdir):
         yield tmpdir
+
+
+@pytest.fixture(autouse=True)
+def stub_data_bridge(monkeypatch):
+    """Stub the data daemon's native extension for every unit test.
+
+    Tests import ``neuracore`` from the source tree, which holds no compiled
+    ``_data_bridge``; only the installed wheel does. Tests that assert on the
+    daemon patch ``_load_native`` themselves.
+    """
+    monkeypatch.setattr(bridge, "_load_native", lambda: MagicMock())
 
 
 @pytest.fixture


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - `log_*` forwards to the daemon unconditionally; the daemon decides what falls inside a recording window

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
