### PR TITLE
fix: stop carrying recording identity in the data streams

### DIFF
--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -25,16 +25,13 @@ from neuracore_types import (
     PointCloudData,
     PoseData,
     RGBCameraData,
-    RobotInstanceIdentifier,
 )
 from neuracore_types.utils import validate_safe_name
 
 from neuracore.api.core import _get_robot
-from neuracore.api.globals import GlobalSingleton
 from neuracore.core.exceptions import RobotError
 from neuracore.core.robot import Robot
 from neuracore.core.streaming.data_stream import (
-    DataRecordingContext,
     DataStream,
     DepthDataStream,
     JointDataStream,
@@ -49,7 +46,6 @@ from neuracore.core.streaming.p2p.provider.global_live_data_enabled import (
 from neuracore.core.streaming.p2p.stream_manager_orchestrator import (
     StreamManagerOrchestrator,
 )
-from neuracore.core.streaming.recording_state_manager import get_recording_state_manager
 from neuracore.core.utils.depth_utils import MAX_DEPTH
 from neuracore.core.video_encoding import Codec
 from neuracore.data_daemon.bridge import notify_daemon_config_changed
@@ -110,14 +106,11 @@ class ResolvedJointGroup:
         bindings: The frame's bindings in order (``list(JointStreamBinding)``).
         joined_names: ``\0``-joined storage names for the batched
             ``log_joints`` call.
-        started_recording_id: The recording the bindings' streams were started
-            for (``None`` when not recording).
     """
 
     joint_names: tuple[str, ...]
     bindings: list[JointStreamBinding]
     joined_names: str
-    started_recording_id: str | None
 
 
 def _resolve_joint_group(
@@ -125,46 +118,37 @@ def _resolve_joint_group(
     data_type: DataType,
     joint_names: tuple[str, ...],
     bindings_for_type: dict[str, JointStreamBinding],
-    current_recording_id: str | None,
 ) -> ResolvedJointGroup:
     """Return the cached resolution for ``joint_names``, rebuilding if it changed.
+
+    Keyed on the joint names alone, so the resolution survives a recording
+    boundary.
 
     Args:
         robot: Robot instance.
         data_type: Joint data type being logged.
         joint_names: The frame's joint names in order (``tuple(joint_data)``).
         bindings_for_type: The robot's per-joint binding cache for this type.
-        current_recording_id: The active recording id, or ``None``.
 
     Returns:
         The resolved, cached group for this frame.
     """
     cached = robot._joint_group_cache.get(data_type)
-    if (
-        cached is not None
-        and cached.started_recording_id == current_recording_id
-        and cached.joint_names == joint_names
-    ):
+    if cached is not None and cached.joint_names == joint_names:
         return cached
 
-    record_context: DataRecordingContext | None = None
     bindings: list[JointStreamBinding] = []
     for joint_name in joint_names:
         binding = bindings_for_type.get(joint_name)
         if binding is None:
             binding = _get_or_create_joint_stream(data_type, joint_name, robot)
             bindings_for_type[joint_name] = binding
-        if current_recording_id is not None and not binding.stream.is_recording():
-            if record_context is None:
-                record_context = _build_recording_context(robot, current_recording_id)
-            binding.stream.start_recording(record_context)
         bindings.append(binding)
 
     group = ResolvedJointGroup(
         joint_names=joint_names,
         bindings=bindings,
         joined_names="\0".join(binding.storage_name for binding in bindings),
-        started_recording_id=current_recording_id,
     )
     robot._joint_group_cache[data_type] = group
     return group
@@ -266,54 +250,20 @@ def _publish_video_to_p2p(
     )
 
 
-def _build_recording_context(robot: Robot, recording_id: str) -> DataRecordingContext:
-    """Build the recording context a robot's streams start with for one recording.
-
-    Every field is invariant across the streams logged in a single call (they
-    share one recording, robot, and dataset), so this can be resolved once and
-    reused — see :func:`_log_group_of_joint_data`, which hoists it out of the
-    per-joint loop rather than rebuilding it (and re-querying the dataset id) for
-    each of a robot's joints on a recording's first frame.
-
-    Args:
-        robot: Robot instance.
-        recording_id: The active recording id the streams are being started for.
-
-    Returns:
-        The shared :class:`DataRecordingContext` for the streams to start with.
-    """
-    instance_key = RobotInstanceIdentifier(
-        robot_id=robot.id,
-        robot_instance=robot.instance,
-    )
-    dataset_id = get_recording_state_manager().active_dataset_ids.get(instance_key)
-    if dataset_id is None:
-        dataset_id = GlobalSingleton()._active_dataset_id
-        logger.debug(
-            "start_stream: falling back to global dataset_id=%s recording_id=%s",
-            dataset_id,
-            recording_id,
-        )
-    return DataRecordingContext(
-        recording_id=recording_id,
-        robot_id=robot.id,
-        robot_name=robot.name,
-        robot_instance=robot.instance,
-        dataset_id=dataset_id,
-        dataset_name=None,
-    )
-
-
 def start_stream(robot: Robot, data_stream: DataStream) -> None:
-    """Start recording on a data stream if robot is currently recording.
+    """Arm a stream for the robot's current recording, if there is one.
+
+    Arming carries no recording identity into the stream — the daemon owns
+    that. It only starts a fresh timeline for the monotonic-timestamp check.
 
     Args:
         robot: Robot instance
-        data_stream: Data stream to start recording on
+        data_stream: Data stream to arm
     """
-    current_recording = robot.get_current_recording_id()
-    if current_recording is not None and not data_stream.is_recording():
-        data_stream.start_recording(_build_recording_context(robot, current_recording))
+    if data_stream.is_recording():
+        return
+    if robot.is_recording():
+        data_stream.start_recording()
 
 
 def _get_or_create_joint_stream(
@@ -331,6 +281,8 @@ def _get_or_create_joint_stream(
     assert isinstance(
         joint_stream, JointDataStream
     ), "Expected stream to be instance of JointDataStream"
+    if not joint_stream.is_recording() and robot.is_recording():
+        joint_stream.start_recording()
     return JointStreamBinding(
         stream_id=str_id,
         storage_name=storage_name,
@@ -382,7 +334,6 @@ def _log_group_of_joint_data(
     if bindings_for_type is None:
         bindings_for_type = {}
         binding_cache[data_type] = bindings_for_type
-    current_recording_id = robot.get_current_recording_id()
     live_data_disabled = get_provide_live_data_enabled_manager().is_disabled()
     robot_id = robot.id
     robot_instance = robot.instance
@@ -395,7 +346,6 @@ def _log_group_of_joint_data(
         data_type,
         tuple(joint_data),
         bindings_for_type,
-        current_recording_id,
     )
 
     if live_data_orchestrator is None:

--- a/neuracore/core/streaming/data_stream.py
+++ b/neuracore/core/streaming/data_stream.py
@@ -12,28 +12,11 @@ consumers.
 
 import logging
 from abc import ABC
-from dataclasses import dataclass
 
 import numpy as np
 from neuracore_types import CameraData, DataType, JointData, NCData, PointCloudData
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class DataRecordingContext:
-    """Context information needed for recording data to the daemon.
-
-    Contains all identifiers needed to associate recorded data with the
-    correct robot, dataset, and recording session.
-    """
-
-    recording_id: str
-    robot_id: str | None
-    robot_name: str
-    robot_instance: int
-    dataset_id: str | None
-    dataset_name: str | None
 
 
 class DataStream(ABC):
@@ -54,7 +37,6 @@ class DataStream(ABC):
             This must be kept lightweight and not perform any blocking operations.
         """
         self._recording = False
-        self._context: DataRecordingContext | None = None
         self._latest_data: NCData | None = None
         self._data_type = data_type
         self._stream_name = stream_name
@@ -65,21 +47,18 @@ class DataStream(ABC):
         """Get the data type of this stream."""
         return self._data_type
 
-    def start_recording(self, context: DataRecordingContext) -> None:
-        """Start recording data for this stream.
+    def start_recording(self) -> None:
+        """Arm the stream for a new recording.
 
-        Args:
-            context: Recording context containing identifiers for the recording
-                session, robot, and dataset.
+        The stream carries no recording identity — the daemon owns that. This
+        only marks a fresh timeline for :meth:`_enforce_monotonic_timestamp`.
         """
         self._recording = True
         self._last_logged_timestamp = None
-        self._context = context
 
     def stop_recording(self) -> None:
         """Stop recording data for this stream."""
         self._recording = False
-        self._context = None
 
     def is_recording(self) -> bool:
         """Check if recording is active.
@@ -96,10 +75,6 @@ class DataStream(ABC):
             Optional[NCData]: The most recently logged data item
         """
         return self._latest_data
-
-    def get_recording_context(self) -> DataRecordingContext | None:
-        """Return the active recording context for this stream, if present."""
-        return self._context
 
     def _enforce_monotonic_timestamp(self, timestamp: float) -> None:
         """Reject a timestamp that does not strictly increase within a recording.

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -140,7 +140,6 @@ class RecordingStateManager(BaseSSEConsumer):
         self._completed_start_time_watermarks: dict[RobotInstanceIdentifier, float] = {}
         self._expired_recording_ids: set[str] = set()
         self._recording_timers: dict[str, list[asyncio.TimerHandle]] = {}
-        self.active_dataset_ids: dict[RobotInstanceIdentifier, str] = {}
         self._drain_callbacks: dict[RobotInstanceIdentifier, Callable[[str], None]] = {}
 
         self._logout_listener = self._on_logout
@@ -178,7 +177,6 @@ class RecordingStateManager(BaseSSEConsumer):
             self.recording_robot_instances.clear()
             self._completed_start_time_watermarks.clear()
             self._expired_recording_ids.clear()
-            self.active_dataset_ids.clear()
             self._drain_callbacks.clear()
             self._connected_robot_id = None
 
@@ -527,11 +525,9 @@ class RecordingStateManager(BaseSSEConsumer):
             assert (
                 len(details.dataset_ids) == 1
             ), "Recording can only be started in one dataset"
-            dataset_id = details.dataset_ids[0]
-            self.active_dataset_ids[instance_key] = dataset_id
             logger.info(
-                "active_dataset_received_from_sse: dataset_id=%s recording_id=%s",
-                dataset_id,
+                "recording start received from sse: dataset_id=%s recording_id=%s",
+                details.dataset_ids[0],
                 recording_id,
             )
 
@@ -552,7 +548,6 @@ class RecordingStateManager(BaseSSEConsumer):
                     daemon=True,
                     name=f"remote-stop-{recording_id[:8]}",
                 ).start()
-            self.active_dataset_ids.pop(instance_key, None)
             self.recording_stopped(
                 robot_id=robot_id,
                 instance=instance,

--- a/tests/unit/core/p2p/test_logout_event.py
+++ b/tests/unit/core/p2p/test_logout_event.py
@@ -247,7 +247,6 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
     manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
-    manager.active_dataset_ids[key] = "dataset-1"
     manager._drain_callbacks[key] = MagicMock()
     timer = MagicMock()
     manager._recording_timers["recording-1"] = [timer]
@@ -264,7 +263,6 @@ def test_recording_manager_tears_down_owned_state(nc_loop) -> None:
     assert manager.signalling_stream_future.cancelled()
     timer.cancel.assert_called_once_with()
     assert manager.recording_robot_instances == {}
-    assert manager.active_dataset_ids == {}
     assert manager._drain_callbacks == {}
     assert auth.listeners(Auth.LOGOUT_EVENT) == []
 
@@ -297,7 +295,6 @@ def test_recording_manager_keeps_owned_state_when_the_stream_cannot_authenticate
 
     key = RobotInstanceIdentifier(robot_id="robot-1", robot_instance=0)
     manager.recording_robot_instances[key] = TrackedRecording("recording-1", 1.0)
-    manager.active_dataset_ids[key] = "dataset-1"
 
     manager_future: Future[RecordingStateManager] = Future()
     manager_future.set_result(manager)
@@ -308,7 +305,6 @@ def test_recording_manager_keeps_owned_state_when_the_stream_cannot_authenticate
 
         assert manager.get_current_recording_id("robot-1", 0) == "recording-1"
         assert manager.is_recording("robot-1", 0)
-        assert manager.active_dataset_ids[key] == "dataset-1"
         assert enabled.is_enabled()
         assert recording_module._recording_manager is manager_future
 

--- a/tests/unit/core/p2p/test_recording_state_manager.py
+++ b/tests/unit/core/p2p/test_recording_state_manager.py
@@ -20,7 +20,6 @@ def _manager() -> RecordingStateManager:
     manager._completed_start_time_watermarks = {}
     manager._expired_recording_ids = set()
     manager._recording_timers = {}
-    manager.active_dataset_ids = {}
     manager._drain_callbacks = {}
     manager._cancel_recording_timers = MagicMock()
     manager._schedule_recording_timers = MagicMock()
@@ -55,7 +54,6 @@ def test_delayed_start_after_local_stop_does_not_restart_daemon() -> None:
     )
 
     assert source not in manager.recording_robot_instances
-    assert source not in manager.active_dataset_ids
     manager._ensure_daemon_for_recording.assert_not_called()
 
 
@@ -77,5 +75,4 @@ def test_newer_start_after_local_stop_is_applied_and_starts_daemon() -> None:
         recording_id="second-recording",
         start_time=101.0,
     )
-    assert manager.active_dataset_ids[source] == "dataset-1"
     manager._ensure_daemon_for_recording.assert_called_once_with()

--- a/tests/unit/core/test_data_stream.py
+++ b/tests/unit/core/test_data_stream.py
@@ -4,11 +4,7 @@ import numpy as np
 import pytest
 from neuracore_types import DataType, JointData
 
-from neuracore.core.streaming.data_stream import (
-    DataRecordingContext,
-    JointDataStream,
-    RGBDataStream,
-)
+from neuracore.core.streaming.data_stream import JointDataStream, RGBDataStream
 
 
 class _DummyCameraData:
@@ -27,26 +23,14 @@ class _DummyCameraData:
         return payload
 
 
-def _context(recording_id: str = "rec-1") -> DataRecordingContext:
-    return DataRecordingContext(
-        recording_id=recording_id,
-        robot_id="robot-1",
-        robot_name="robot",
-        robot_instance=0,
-        dataset_id="dataset-1",
-        dataset_name="dataset",
-    )
-
-
 def test_stream_tracks_recording_state_and_latest_sample() -> None:
-    """A stream owns no transport — the daemon interface lives at the logging
-    layer (RecordingContext), so a stream only tracks state and latest data."""
+    """A stream owns no transport and no recording identity, so it tracks only
+    whether a timeline is open and the latest sample."""
     width, height = 4, 3
     stream = RGBDataStream("front_camera", width=width, height=height)
-    stream.start_recording(_context())
+    stream.start_recording()
 
     assert stream.is_recording() is True
-    assert stream.get_recording_context() is not None
 
     metadata = _DummyCameraData(timestamp=1.0)
     frame = np.arange(width * height * 3, dtype=np.uint8).reshape((height, width, 3))
@@ -57,12 +41,11 @@ def test_stream_tracks_recording_state_and_latest_sample() -> None:
     stream.stop_recording()
 
     assert stream.is_recording() is False
-    assert stream.get_recording_context() is None
 
 
 def test_video_stream_rejects_non_increasing_timestamp() -> None:
     stream = RGBDataStream("front_camera", width=4, height=3)
-    stream.start_recording(_context())
+    stream.start_recording()
     frame = np.zeros((3, 4, 3), dtype=np.uint8)
 
     stream.log(_DummyCameraData(timestamp=1.0), frame)
@@ -76,7 +59,7 @@ def test_video_stream_rejects_non_increasing_timestamp() -> None:
 
 def test_joint_stream_record_scalar_rejects_non_increasing_timestamp() -> None:
     stream = JointDataStream(data_type=DataType.JOINT_POSITIONS, data_type_name="j1")
-    stream.start_recording(_context())
+    stream.start_recording()
 
     stream.record_scalar(1.0, 0.5)
     stream.record_scalar(2.0, 0.6)
@@ -87,7 +70,7 @@ def test_joint_stream_record_scalar_rejects_non_increasing_timestamp() -> None:
 
 def test_joint_stream_log_rejects_non_increasing_timestamp() -> None:
     stream = JointDataStream(data_type=DataType.JOINT_POSITIONS, data_type_name="j1")
-    stream.start_recording(_context())
+    stream.start_recording()
 
     stream.log(JointData(timestamp=1.0, value=0.5))
 
@@ -97,7 +80,7 @@ def test_joint_stream_log_rejects_non_increasing_timestamp() -> None:
 
 def test_joint_stream_materialises_deferred_scalar_on_demand() -> None:
     stream = JointDataStream(data_type=DataType.JOINT_POSITIONS, data_type_name="j1")
-    stream.start_recording(_context())
+    stream.start_recording()
 
     stream.record_scalar(1.0, 0.5)
 
@@ -111,8 +94,8 @@ def test_monotonic_check_is_per_stream() -> None:
     frame = np.zeros((3, 4, 3), dtype=np.uint8)
     front = RGBDataStream("front_camera", width=4, height=3)
     wrist = RGBDataStream("wrist_camera", width=4, height=3)
-    front.start_recording(_context())
-    wrist.start_recording(_context())
+    front.start_recording()
+    wrist.start_recording()
 
     front.log(_DummyCameraData(timestamp=1.0), frame)
     wrist.log(_DummyCameraData(timestamp=1.0), frame)
@@ -134,9 +117,9 @@ def test_start_recording_resets_monotonic_timeline() -> None:
     stream = RGBDataStream("front_camera", width=4, height=3)
     frame = np.zeros((3, 4, 3), dtype=np.uint8)
 
-    stream.start_recording(_context("rec-1"))
+    stream.start_recording()
     stream.log(_DummyCameraData(timestamp=5.0), frame)
     stream.stop_recording()
 
-    stream.start_recording(_context("rec-2"))
+    stream.start_recording()
     stream.log(_DummyCameraData(timestamp=1.0), frame)


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Data streams carry no recording identity; the daemon owns it, so arming a stream only resets its timestamp timeline
 - The joint group cache is keyed on joint names alone and no longer rebuilds every binding at a recording boundary

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
