### PR TITLE
feat: answer which recording a source has open over local IPC

### DIFF
--- a/neuracore/data_daemon/bridge.py
+++ b/neuracore/data_daemon/bridge.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from importlib import import_module
 from types import ModuleType
+from typing import NamedTuple
 
 from neuracore.data_daemon.daemon_control import ensure_daemon_running
 
@@ -41,6 +42,67 @@ def _load_native() -> ModuleType:
         except ImportError as error:
             raise RuntimeError(_DATA_BRIDGE_IMPORT_HINT) from error
     return _DATA_BRIDGE_MODULE
+
+
+class LiveRecording(NamedTuple):
+    """The recording a source has open, as the daemon reports it.
+
+    Attributes:
+        recording_index: The daemon's own primary key, once data has opened the
+            recording's window. It exists before the cloud id does, so it is
+            what tells two consecutive recordings of one source apart. ``None``
+            for a recording the backend started that this host has not yet
+            published for.
+        recording_id: The cloud handle, once ``/recording/start`` has been
+            notified. ``None`` while the recording is still local-only.
+        start_timestamp_ns: The recording's capture-clock start marker, as
+            returned by :meth:`RecordingContext.start_recording`.
+    """
+
+    recording_index: int | None
+    recording_id: str | None
+    start_timestamp_ns: int | None
+
+
+class RecordingStateUnavailableError(RuntimeError):
+    """The daemon did not answer a recording-state query in time."""
+
+
+def query_recording_state(
+    robot_id: str, robot_instance: int, timeout_s: float = 0.1
+) -> LiveRecording | None:
+    """Ask the daemon which recording, if any, a source currently has open.
+
+    The daemon owns recording state — including the recordings the backend
+    started, which it alone subscribes to — so this is how a process learns
+    about a recording it did not itself start or stop.
+
+    Returns:
+        The open recording, or ``None`` when the source has none.
+
+    Raises:
+        RecordingStateUnavailableError: nothing answered within ``timeout_s``.
+            Silence is not "not recording", and callers must not read it as
+            such.
+
+    Blocks for up to ``timeout_s``, which bounds a caller's stall. The daemon
+    polls its IPC inbox every 25 ms once idle, so a timeout near that raises
+    against a healthy daemon.
+    """
+    reply = _load_native().recording_state(robot_id, robot_instance, timeout_s)
+    if reply is None:
+        raise RecordingStateUnavailableError(
+            f"the daemon did not answer within {timeout_s}s "
+            f"for {robot_id} instance {robot_instance}"
+        )
+    live = reply["recording"]
+    if live is None:
+        return None
+    return LiveRecording(
+        recording_index=live["recording_index"],
+        recording_id=live["recording_id"],
+        start_timestamp_ns=live["start_timestamp_ns"],
+    )
 
 
 class LoggingStalledError(RuntimeError):
@@ -100,7 +162,7 @@ class RecordingContext:
         dataset_name: str | None = None,
         timestamp: float | None = None,
         cloud_recording_id: str | None = None,
-    ) -> None:
+    ) -> int:
         """Announce a recording to the daemon for a source.
 
         Publishes one ``StartRecording`` envelope tagged with the source
@@ -113,6 +175,11 @@ class RecordingContext:
         stored and reported as such, and returned as the marker that resolves the
         cloud id (:meth:`get_recording_id`). It does **not** bound the recording
         window, which the daemon takes from a publish stamp inside this call.
+
+        Returns:
+            The capture marker the daemon stored as this recording's
+            ``start_timestamp_ns``, which tells it apart from its predecessor
+            before either has a cloud id.
         """
         ensure_daemon_running()
         self.bind_source(robot_id, robot_instance)
@@ -127,6 +194,7 @@ class RecordingContext:
             timestamp_ns,
             cloud_recording_id,
         )
+        return self._recording_marker_ns
 
     def log_joints(
         self,

--- a/rust/data_daemon/src/cli/launch.rs
+++ b/rust/data_daemon/src/cli/launch.rs
@@ -428,7 +428,9 @@ fn run_daemon(
                     spawn_wakelock(event_bus.clone(), shutdown_tx.subscribe())
                 });
 
+            let recording_state = dispatcher::RecordingState::default();
             let dispatcher_context = DispatcherContext {
+                recording_state: recording_state.clone(),
                 event_bus: Some(event_bus.clone()),
                 config_refresh_tx: Some(config_refresh_tx),
                 notifications_rx,
@@ -484,6 +486,7 @@ fn run_daemon(
                 transport,
                 dispatcher_tx.clone(),
                 Arc::new(state_store.clone()),
+                recording_state,
                 shutdown_tx.subscribe(),
             )
             .await;

--- a/rust/data_daemon/src/ipc/listener.rs
+++ b/rust/data_daemon/src/ipc/listener.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use data_daemon_shared::{
-    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, VersionReply,
-    VersionRequest,
+    Envelope, HealthReply, HealthRequest, RecordingIdQuery, RecordingIdReply, RecordingStateQuery,
+    RecordingStateReply, VersionReply, VersionRequest,
 };
 use iceoryx2::port::server::Server;
 use iceoryx2::port::subscriber::Subscriber;
@@ -31,6 +31,7 @@ use tokio::time::sleep;
 
 use crate::ipc::node::IpcTransport;
 use crate::lifecycle::shutdown::ShutdownSignal;
+use crate::pipeline::dispatcher::RecordingState;
 use crate::state::{SqliteStateStore, StateStore};
 
 /// Poll cadence while envelopes are actively flowing.
@@ -70,11 +71,13 @@ pub async fn run(
     transport: IpcTransport,
     dispatcher_tx: mpsc::Sender<Envelope>,
     store: Arc<SqliteStateStore>,
+    recording_state: RecordingState,
     mut shutdown_rx: broadcast::Receiver<ShutdownSignal>,
 ) {
     tracing::info!(
         commands = data_daemon_shared::service_name::COMMANDS,
         recording_ids = data_daemon_shared::service_name::RECORDING_IDS,
+        recording_state = data_daemon_shared::service_name::RECORDING_STATE,
         health = data_daemon_shared::service_name::HEALTH,
         version = data_daemon_shared::service_name::VERSION,
         "ipc listener started"
@@ -129,6 +132,11 @@ pub async fn run(
         // borrow makes this future `!Send`, which is fine: `run` is awaited
         // inline under `block_on`, never `tokio::spawn`'d.
         serve_recording_id_queries(transport.recording_id_server(), &store).await;
+
+        // -- Answer recording-state queries --------------------------------------
+        // Every process on this host reads its recording state from here
+        // rather than from its own subscription to the backend.
+        serve_recording_state_queries(transport.recording_state_server(), &recording_state).await;
 
         // -- Yield / shutdown ---------------------------------------------------
         // Poll fast while data is flowing; relax once the bus has been empty
@@ -294,6 +302,65 @@ async fn serve_recording_id_queries(
                 Err(error) => tracing::warn!(%error, "failed to loan recording-id reply sample"),
             },
             Err(error) => tracing::warn!(%error, "failed to encode recording-id reply"),
+        }
+    }
+}
+
+/// Drain every pending recording-state query, answering each from the
+/// dispatcher's own state.
+///
+/// The dispatcher owns what a source is recording: it holds the recordings
+/// local producers bracket *and* the ones the backend announced over the
+/// notification stream, which it alone subscribes to. So a process that
+/// started nothing — on a node that has logged nothing — still gets the true
+/// answer, and it never depends on a row existing yet.
+///
+/// Bounded per tick on the same grounds as [`serve_recording_id_queries`]: each
+/// client keeps one request in flight.
+async fn serve_recording_state_queries(
+    server: &Server<ipc::Service, [u8], (), [u8], ()>,
+    recording_state: &RecordingState,
+) {
+    loop {
+        let active = match server.receive() {
+            Ok(Some(active)) => active,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(%error, "recording-state server receive failed");
+                return;
+            }
+        };
+
+        let query = match RecordingStateQuery::decode(active.payload()) {
+            Ok(query) => query,
+            Err(error) => {
+                tracing::warn!(%error, "dropping malformed recording-state query");
+                continue;
+            }
+        };
+
+        let reply = RecordingStateReply {
+            recording: recording_state.live(&query.robot_id, query.robot_instance),
+        };
+
+        let bytes = match reply.encode() {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::warn!(%error, "failed to encode recording-state reply");
+                continue;
+            }
+        };
+
+        let response = match active.loan_slice_uninit(bytes.len()) {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(%error, "failed to loan recording-state reply sample");
+                continue;
+            }
+        };
+
+        if let Err(error) = response.write_from_slice(&bytes).send() {
+            tracing::warn!(%error, "failed to send recording-state reply");
         }
     }
 }

--- a/rust/data_daemon/src/ipc/node.rs
+++ b/rust/data_daemon/src/ipc/node.rs
@@ -14,7 +14,8 @@ use data_daemon_shared::service_name::{
     COMMANDS, HEALTH, HEALTH_MAX_PAYLOAD_BYTES, LIFECYCLE_SUBSCRIBER_BUFFER_SIZE,
     MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE, MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE, MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS,
-    RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
+    RECORDING_ID_MAX_PAYLOAD_BYTES, RECORDING_STATE, RECORDING_STATE_MAX_PAYLOAD_BYTES, VERSION,
+    VERSION_MAX_PAYLOAD_BYTES,
 };
 use iceoryx2::node::{Node, NodeBuilder};
 use iceoryx2::port::server::Server;
@@ -96,6 +97,11 @@ pub struct IpcTransport {
     recording_id_server: Server<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the server, as for the commands service.
     _recording_id_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response server on `neuracore/data_daemon/recording_state` that
+    /// answers "is this source recording, and as what?".
+    recording_state_server: Server<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the recording-state server.
+    _recording_state_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
     /// Request-response server on `neuracore/data_daemon/health` that answers
     /// side-effect-free readiness probes.
     health_server: Server<ipc::Service, [u8], (), [u8], ()>,
@@ -131,6 +137,8 @@ impl IpcTransport {
 
         let (recording_id_service, recording_id_server) =
             open_query_server(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
+        let (recording_state_service, recording_state_server) =
+            open_query_server(&node, RECORDING_STATE, RECORDING_STATE_MAX_PAYLOAD_BYTES)?;
         let (health_service, health_server) =
             open_query_server(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
         let (version_service, version_server) =
@@ -142,6 +150,8 @@ impl IpcTransport {
             _commands_service: commands_service,
             recording_id_server,
             _recording_id_service: recording_id_service,
+            recording_state_server,
+            _recording_state_service: recording_state_service,
             health_server,
             _health_service: health_service,
             version_server,
@@ -157,6 +167,11 @@ impl IpcTransport {
     /// Borrow the `recording_ids` request-response server port.
     pub fn recording_id_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
         &self.recording_id_server
+    }
+
+    /// Borrow the `recording_state` request-response server port.
+    pub fn recording_state_server(&self) -> &Server<ipc::Service, [u8], (), [u8], ()> {
+        &self.recording_state_server
     }
 
     /// Borrow the `health` request-response server port.

--- a/rust/data_daemon/src/pipeline/dispatcher.rs
+++ b/rust/data_daemon/src/pipeline/dispatcher.rs
@@ -57,7 +57,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype};
+use dashmap::DashMap;
+use data_daemon_shared::{video_boundary, BatchedDataItem, Envelope, FrameDtype, LiveRecording};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -83,6 +84,20 @@ const HOLDBACK_ENV: &str = "NCD_HOLDBACK_MS";
 /// Hard bound on how long a stopped window waits for its producer's
 /// [`Envelope::SourceFlushed`] marker before being evicted anyway.
 const FLUSH_MARKER_WAIT_CAP: Duration = Duration::from_secs(30);
+
+/// How long a source must publish nothing at all before a stopped window owed
+/// a flush marker settles on that silence instead.
+///
+/// A recording ended from the web has no local stop, so no producer publishes
+/// an [`Envelope::SourceFlushed`] and the window would sit out the whole
+/// [`FLUSH_MARKER_WAIT_CAP`]. Silence is the substitute proof: a source that
+/// has published nothing for longer than the producer's own seal deadline
+/// ([`VIDEO_CHUNK_MAX_OPEN_NS`](data_daemon_shared::service_name::VIDEO_CHUNK_MAX_OPEN_NS)),
+/// its sweep, and the holdback has nothing left for this window. Generous by
+/// design — settling early drops a tail chunk, late only delays the recording.
+const PRODUCER_QUIET_SETTLE: Duration = Duration::from_nanos(
+    data_daemon_shared::service_name::VIDEO_CHUNK_MAX_OPEN_NS as u64 + 3_000_000_000,
+);
 
 /// A source silent (no data, no lifecycle) for this long has its open window
 /// force-closed as a crash backstop, so a producer that died without a Stop
@@ -154,6 +169,30 @@ pub struct DispatcherContext {
     /// Backend recording lifecycle, read off the notification stream by
     /// [`crate::cloud::spawn_recording_notifications`]. `None` offline.
     pub notifications_rx: Option<mpsc::Receiver<RecordingCommand>>,
+    /// The recording state this dispatcher writes and the IPC listener reads.
+    pub recording_state: RecordingState,
+}
+
+/// The recording state the daemon owns, shared read-only with the IPC
+/// listener so a process can ask what its source has open.
+///
+/// The dispatcher is the only writer. It answers for a recording the backend
+/// announced but nothing local has opened yet, which is what lets a node that
+/// has logged nothing still know it is recording.
+#[derive(Clone, Default)]
+pub struct RecordingState(Arc<DashMap<Source, AnnouncedRecording>>);
+
+impl RecordingState {
+    /// What `(robot_id, robot_instance)` currently has open, if anything.
+    pub fn live(&self, robot_id: &str, robot_instance: i64) -> Option<LiveRecording> {
+        self.0
+            .get(&(robot_id.to_string(), robot_instance))
+            .map(|announced| LiveRecording {
+                recording_index: announced.opened_index,
+                recording_id: announced.cloud_recording_id.clone(),
+                start_timestamp_ns: Some(announced.start_timestamp_ns),
+            })
+    }
 }
 
 /// A recording a source has been told to make.
@@ -283,13 +322,23 @@ impl ActiveWindow {
     }
 
     /// Time elapsed since stop once this window may be evicted: retention has
-    /// passed *and* either every owed flush marker is in or
-    /// [`FLUSH_MARKER_WAIT_CAP`] has expired. `None` while it must be kept.
-    fn eviction_elapsed(&self, now: Instant, retention: Duration) -> Option<Duration> {
+    /// passed *and* the flush is settled. `None` while it must be kept.
+    ///
+    /// A flush settles three ways: every owed marker is in, the source has been
+    /// silent for [`PRODUCER_QUIET_SETTLE`] (`source_quiet_for`), or the window
+    /// has waited out [`FLUSH_MARKER_WAIT_CAP`]. The middle one is what keeps a
+    /// recording ended from the web off the full cap.
+    fn eviction_elapsed(
+        &self,
+        now: Instant,
+        retention: Duration,
+        source_quiet_for: Option<Duration>,
+    ) -> Option<Duration> {
         let since_stop = self.stop_recv_at.map(|at| now.duration_since(at))?;
         let retained = since_stop >= retention;
         let flush_settled = !self.awaiting_flush
             || self.flush_markers_settled()
+            || source_quiet_for.is_some_and(|quiet| quiet >= PRODUCER_QUIET_SETTLE)
             || since_stop >= FLUSH_MARKER_WAIT_CAP;
         (retained && flush_settled).then_some(since_stop)
     }
@@ -385,9 +434,9 @@ struct Dispatcher {
     actor_handles: Vec<JoinHandle<()>>,
     /// Rate-limited orphan-drop counter (data outside any window).
     orphan_drops: u64,
-    /// What each source has been told to record, announced but not yet proved
-    /// local. Data is that proof — see [`Dispatcher::open_announced_window`].
-    announced: HashMap<Source, AnnouncedRecording>,
+    /// What each source has been told to record. Shared with the IPC listener,
+    /// which answers `recording_state` queries from it.
+    announced: RecordingState,
     /// When the eviction + idle-reap scans last ran. Those scans are throttled
     /// to [`HOUSEKEEP_INTERVAL`] so a data stream arriving faster than that
     /// doesn't re-run the two full window scans (and their `Vec` allocations)
@@ -404,13 +453,13 @@ impl Dispatcher {
         Self {
             store,
             actor_context,
+            announced: context.recording_state.clone(),
             context,
             holdback: configured_holdback(),
             windows: HashMap::new(),
             held: VecDeque::new(),
             actor_handles: Vec::new(),
             orphan_drops: 0,
-            announced: HashMap::new(),
             last_housekeep: Instant::now(),
         }
     }
@@ -712,7 +761,7 @@ impl Dispatcher {
                 .await
             {
                 Ok(Some(existing_index)) => {
-                    if let Some(announcement) = self.announced.get_mut(&source) {
+                    if let Some(mut announcement) = self.announced.0.get_mut(&source) {
                         if announcement.opened_index == Some(existing_index) {
                             announcement.cloud_recording_id = Some(cloud_recording_id.to_string());
                         }
@@ -745,7 +794,7 @@ impl Dispatcher {
             opened_index: None,
         };
         tracing::debug!(robot_id = source.0, "recording announced");
-        self.announced.insert(source, announced);
+        self.announced.0.insert(source, announced);
     }
 
     /// Open the window for `source`'s announced recording, now that it has
@@ -756,13 +805,13 @@ impl Dispatcher {
     /// `publish_ts` so the triggering datum is not excluded, and floored at any
     /// predecessor's close so it cannot steal that recording's tail.
     async fn open_announced_window(&mut self, source: &Source, publish_ts: i64, recv_at: Instant) {
-        let Some(announced) = self.announced.get(source) else {
+        let announced = self.announced.0.get(source).map(|entry| entry.clone());
+        let Some(announced) = announced else {
             return;
         };
         if announced.opened_index.is_some() {
             return;
         }
-        let announced = announced.clone();
         let mut open_at_ns = announced.open_at_ns.min(publish_ts);
         // Catching up on a recording that began before this datum: floor the
         // window at any predecessor's close so it cannot claim that
@@ -815,7 +864,7 @@ impl Dispatcher {
             }
         };
         tracing::info!(recording_index, robot_id = source.0, "recording started");
-        if let Some(announcement) = self.announced.get_mut(&source) {
+        if let Some(mut announcement) = self.announced.0.get_mut(&source) {
             announcement.opened_index = Some(recording_index);
         }
 
@@ -957,11 +1006,14 @@ impl Dispatcher {
     /// trailed its successor's start, which retired the recording already, and
     /// every recording belonging to another host.
     async fn source_recording(&self, cloud_recording_id: &str) -> Option<Source> {
-        let announced = self.announced.iter().find(|(_, announcement)| {
-            announcement.cloud_recording_id.as_deref() == Some(cloud_recording_id)
-        });
-        if let Some((source, _)) = announced {
-            return Some(source.clone());
+        let announced = self
+            .announced
+            .0
+            .iter()
+            .find(|entry| entry.value().cloud_recording_id.as_deref() == Some(cloud_recording_id))
+            .map(|entry| entry.key().clone());
+        if let Some(source) = announced {
+            return Some(source);
         }
         // The id was minted after the announcement — a recording started here
         // and stopped from the web, whose START notification never taught us
@@ -990,7 +1042,7 @@ impl Dispatcher {
         timestamp_ns: i64,
         recv_at: Instant,
     ) {
-        self.announced.remove(&source);
+        self.announced.0.remove(&source);
 
         let Some(entry) = self.windows.get_mut(&source) else {
             tracing::debug!(robot_id = source.0, "stop for unknown source; ignoring");
@@ -1107,7 +1159,7 @@ impl Dispatcher {
     }
 
     async fn handle_cancel(&mut self, source: Source, timestamp_ns: i64) {
-        self.announced.remove(&source);
+        self.announced.0.remove(&source);
         let Some(entry) = self.windows.get_mut(&source) else {
             return;
         };
@@ -1196,8 +1248,10 @@ impl Dispatcher {
         let mut closing_actors: Vec<TraceHandle> = Vec::new();
         let mut empty_sources: Vec<Source> = Vec::new();
         for (source, entry) in self.windows.iter_mut() {
+            let source_quiet_for = entry.last_seen.map(|at| now.duration_since(at));
             entry.closing.retain_mut(|window| {
-                let Some(elapsed) = window.eviction_elapsed(now, retention) else {
+                let Some(elapsed) = window.eviction_elapsed(now, retention, source_quiet_for)
+                else {
                     return true;
                 };
                 Self::finish_eviction(source, window, elapsed, retention, &mut closing_actors);
@@ -1279,6 +1333,7 @@ impl Dispatcher {
             let Some(mut window) = entry.live.take() else {
                 continue;
             };
+            self.announced.0.remove(&source);
             // The producer crashed without a Stop, so there is no next
             // recording to partition against — keep the window's publish upper
             // bound open (`i64::MAX`) to catch any straggler data before
@@ -1306,7 +1361,7 @@ impl Dispatcher {
     /// `publish_timestamp_ns` as the membership key.
     async fn route(&mut self, held: Held) {
         let publish_ts = held.publish_timestamp_ns;
-        if !self.announced.is_empty() {
+        if !self.announced.0.is_empty() {
             self.open_announced_window(&held.source, publish_ts, Instant::now())
                 .await;
         }
@@ -1978,6 +2033,7 @@ mod tests {
             event_bus: None,
             config_refresh_tx: Some(refresh_tx),
             notifications_rx: None,
+            recording_state: RecordingState::default(),
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -2018,6 +2074,7 @@ mod tests {
             event_bus: None,
             config_refresh_tx: None,
             notifications_rx: None,
+            recording_state: RecordingState::default(),
         };
         let (tx, handle) =
             spawn_with_context(store.clone(), context, dispatcher_context, shutdown_rx);
@@ -2044,6 +2101,7 @@ mod tests {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
             notifications_rx: None,
+            recording_state: RecordingState::default(),
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2150,6 +2208,7 @@ mod tests {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
             notifications_rx: None,
+            recording_state: RecordingState::default(),
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2406,6 +2465,58 @@ mod tests {
                 .all(|window| window.flush_markers_settled()),
             "both windows the producer's chunk reached must be settled by its \
              single marker"
+        );
+    }
+
+    /// A window stopped `stopped_ago` ago, still owed a marker from producer 7.
+    fn window_awaiting_a_flush(now: Instant, stopped_ago: Duration) -> ActiveWindow {
+        let mut window = test_window(1, 100);
+        window.stopped_at_ns = Some(150);
+        window.stop_recv_at = Some(now - stopped_ago);
+        window.awaiting_flush = true;
+        window.video_producers.insert(7);
+        window
+    }
+
+    #[test]
+    fn a_silent_source_settles_a_window_no_producer_will_flush() {
+        let now = Instant::now();
+        let retention = Duration::from_secs(1);
+        let window = window_awaiting_a_flush(now, Duration::from_secs(2));
+
+        assert_eq!(
+            window.eviction_elapsed(now, retention, Some(PRODUCER_QUIET_SETTLE)),
+            Some(Duration::from_secs(2)),
+            "a source silent past the producer's own seal deadline has nothing \
+             left to send for this window"
+        );
+    }
+
+    #[test]
+    fn a_source_still_publishing_keeps_its_window_until_the_cap() {
+        let now = Instant::now();
+        let retention = Duration::from_secs(1);
+        let window = window_awaiting_a_flush(now, Duration::from_secs(2));
+
+        assert_eq!(
+            window.eviction_elapsed(now, retention, Some(Duration::from_millis(10))),
+            None
+        );
+        assert_eq!(window.eviction_elapsed(now, retention, None), None);
+
+        let capped = window_awaiting_a_flush(now, FLUSH_MARKER_WAIT_CAP);
+        assert!(capped
+            .eviction_elapsed(now, retention, Some(Duration::from_millis(10)))
+            .is_some());
+    }
+
+    #[test]
+    fn silence_does_not_shortcut_the_retention_a_window_still_owes() {
+        let now = Instant::now();
+        let window = window_awaiting_a_flush(now, Duration::from_millis(100));
+        assert_eq!(
+            window.eviction_elapsed(now, Duration::from_secs(1), Some(PRODUCER_QUIET_SETTLE)),
+            None
         );
     }
 
@@ -2768,6 +2879,7 @@ mod tests {
             event_bus: Some(bus.clone()),
             config_refresh_tx: None,
             notifications_rx: None,
+            recording_state: RecordingState::default(),
         };
         let (tx, handle) = spawn_with_context(
             store.clone(),
@@ -2872,6 +2984,59 @@ mod tests {
                 .started_at_ns,
             100,
             "the window opens at the recording's start, not at the first datum"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_node_that_has_published_nothing_still_reads_its_recording_as_open() {
+        // Started on another machine: this daemon learns the recording from the
+        // notification stream alone. A process here must read "recording"
+        // before anything local publishes — there is no row to read yet, which
+        // is why the answer comes from the dispatcher and not the store.
+        fast_holdback();
+        let (store, dir) = open_store().await;
+        let context = test_context(dir.path().join("recordings"), store.clone());
+        let recording_state = RecordingState::default();
+        let mut dispatcher = Dispatcher::new(
+            store.clone(),
+            context,
+            DispatcherContext {
+                recording_state: recording_state.clone(),
+                ..Default::default()
+            },
+        );
+
+        let now = Instant::now();
+        dispatcher
+            .handle_recording_command(announced("robot-1", "rec-a", 100), now)
+            .await;
+
+        let live = recording_state
+            .live("robot-1", 0)
+            .expect("the recording the backend announced");
+        assert_eq!(live.recording_id, Some("rec-a".to_string()));
+        assert_eq!(
+            live.recording_index, None,
+            "no row exists until data opens the window"
+        );
+
+        // Once the source publishes, the same answer carries the row's index.
+        dispatcher
+            .handle_inbound(datum("robot-1", 110, 1), now)
+            .await;
+        dispatcher
+            .release_due_holdback(now + dispatcher.holdback + Duration::from_millis(1))
+            .await;
+        assert!(recording_state
+            .live("robot-1", 0)
+            .expect("still open")
+            .recording_index
+            .is_some());
+
+        dispatcher.handle_inbound(stop("robot-1", 120), now).await;
+        assert!(
+            recording_state.live("robot-1", 0).is_none(),
+            "a stopped recording is not open"
         );
     }
 
@@ -2990,6 +3155,7 @@ mod tests {
                 event_bus: Some(bus.clone()),
                 config_refresh_tx: None,
                 notifications_rx: None,
+                recording_state: RecordingState::default(),
             },
         );
 

--- a/rust/data_daemon_bridge/src/lib.rs
+++ b/rust/data_daemon_bridge/src/lib.rs
@@ -48,16 +48,17 @@ mod publisher;
 mod query;
 mod writer;
 
-use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery};
+use data_daemon_shared::{Envelope, FrameDtype, RecordingIdQuery, RecordingStateQuery};
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use crate::publisher::{
     flush_published_data, now_ns, publish, publisher_tx, ProducerError, PublishMsg,
 };
 use crate::query::{
-    daemon_version as daemon_version_impl, resolve_recording_id,
+    daemon_version as daemon_version_impl, query_recording_state, resolve_recording_id,
     wait_until_ready as wait_until_ready_impl,
 };
 use crate::writer::{note_video_activity, writer_queue, FrameJob, WriterMsg};
@@ -529,6 +530,52 @@ fn get_recording_id(
     })
 }
 
+/// Ask the daemon which recording, if any, a source currently has open.
+///
+/// The daemon holds the only subscription to the backend's org-wide
+/// notification stream, so this is how an SDK process learns about a recording
+/// it did not itself start or stop.
+///
+/// Returns `None` when nothing answered within `timeout_s` — "unknown", never
+/// "not recording". An answer is a dict whose `"recording"` is `None` or the
+/// recording's `recording_index` / `recording_id` / `start_timestamp_ns`.
+///
+/// Blocks for up to `timeout_s` with the GIL released; for a polling thread,
+/// not the logging path.
+#[pyfunction]
+#[pyo3(signature = (robot_id, robot_instance, timeout_s))]
+fn recording_state<'py>(
+    py: Python<'py>,
+    robot_id: &str,
+    robot_instance: i64,
+    timeout_s: f64,
+) -> PyResult<Option<Bound<'py, PyDict>>> {
+    if robot_id.is_empty() {
+        return Err(PyValueError::new_err("robot_id must not be empty"));
+    }
+    let query = RecordingStateQuery {
+        robot_id: robot_id.to_string(),
+        robot_instance,
+    };
+    let request_bytes = query.encode().map_err(ProducerError::from)?;
+    let answer = py.detach(|| query_recording_state(&request_bytes, timeout_s))?;
+    let Some(recording) = answer else {
+        return Ok(None);
+    };
+    let reply = PyDict::new(py);
+    match recording {
+        Some(recording) => {
+            let live = PyDict::new(py);
+            live.set_item("recording_index", recording.recording_index)?;
+            live.set_item("recording_id", recording.recording_id)?;
+            live.set_item("start_timestamp_ns", recording.start_timestamp_ns)?;
+            reply.set_item("recording", live)?;
+        }
+        None => reply.set_item("recording", py.None())?,
+    }
+    Ok(Some(reply))
+}
+
 /// Wait until the Rust daemon answers a side-effect-free IPC health probe.
 #[pyfunction]
 #[pyo3(signature = (timeout_s))]
@@ -573,6 +620,7 @@ fn _data_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(flush_source, module)?)?;
     module.add_function(wrap_pyfunction!(cancel_recording, module)?)?;
     module.add_function(wrap_pyfunction!(get_recording_id, module)?)?;
+    module.add_function(wrap_pyfunction!(recording_state, module)?)?;
     module.add_function(wrap_pyfunction!(wait_until_ready, module)?)?;
     module.add_function(wrap_pyfunction!(daemon_version, module)?)?;
     module.add_function(wrap_pyfunction!(refresh_config, module)?)?;

--- a/rust/data_daemon_bridge/src/publisher.rs
+++ b/rust/data_daemon_bridge/src/publisher.rs
@@ -45,8 +45,8 @@ use data_daemon_shared::service_name::{
     COMMANDS, COMMANDS_MAX_PAYLOAD_BYTES, HEALTH, HEALTH_MAX_PAYLOAD_BYTES,
     LIFECYCLE_SUBSCRIBER_BUFFER_SIZE, MAX_NODES_PER_SERVICE, MAX_PUBLISHERS_PER_SERVICE,
     MAX_REQUEST_RESPONSE_CLIENTS_PER_SERVICE, MAX_REQUEST_RESPONSE_SERVERS_PER_SERVICE,
-    MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES, VERSION,
-    VERSION_MAX_PAYLOAD_BYTES,
+    MAX_SUBSCRIBERS_PER_SERVICE, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES, RECORDING_STATE,
+    RECORDING_STATE_MAX_PAYLOAD_BYTES, VERSION, VERSION_MAX_PAYLOAD_BYTES,
 };
 use data_daemon_shared::{BatchedDataItem, Envelope};
 use iceoryx2::node::{Node, NodeBuilder};
@@ -107,6 +107,12 @@ pub(crate) struct ProducerState {
     /// Request-response client used by `get_recording_id` to ask the daemon
     /// for a recording's cloud id.
     pub(crate) recording_id_client: Client<ipc::Service, [u8], (), [u8], ()>,
+    /// Service handle held alongside the recording-state client so port
+    /// discovery doesn't race the handle going out of scope.
+    _recording_state_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
+    /// Request-response client used to ask the daemon which recording, if any,
+    /// a source currently has open.
+    pub(crate) recording_state_client: Client<ipc::Service, [u8], (), [u8], ()>,
     /// Service handle held alongside the health client so port discovery doesn't
     /// race the handle going out of scope.
     _health_service: QueryPortFactory<ipc::Service, [u8], (), [u8], ()>,
@@ -374,6 +380,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
 
     let (recording_id_service, recording_id_client) =
         open_query_client(&node, RECORDING_IDS, RECORDING_ID_MAX_PAYLOAD_BYTES)?;
+    let (recording_state_service, recording_state_client) =
+        open_query_client(&node, RECORDING_STATE, RECORDING_STATE_MAX_PAYLOAD_BYTES)?;
     let (health_service, health_client) =
         open_query_client(&node, HEALTH, HEALTH_MAX_PAYLOAD_BYTES)?;
     let (version_service, version_client) =
@@ -385,6 +393,8 @@ fn build_producer_state() -> Result<ProducerState, ProducerError> {
         commands_publisher,
         _recording_id_service: recording_id_service,
         recording_id_client,
+        _recording_state_service: recording_state_service,
+        recording_state_client,
         _health_service: health_service,
         health_client,
         _version_service: version_service,

--- a/rust/data_daemon_bridge/src/query.rs
+++ b/rust/data_daemon_bridge/src/query.rs
@@ -8,7 +8,8 @@
 use std::time::{Duration, Instant};
 
 use data_daemon_shared::{
-    HealthReply, HealthRequest, RecordingIdReply, VersionReply, VersionRequest,
+    HealthReply, HealthRequest, LiveRecording, RecordingIdReply, RecordingStateReply, VersionReply,
+    VersionRequest,
 };
 
 use crate::publisher::{now_ns, with_producer, ProducerError, ProducerState};
@@ -19,6 +20,8 @@ const RECORDING_ID_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const RECORDING_ID_RESPONSE_WAIT: Duration = Duration::from_millis(40);
 /// Poll cadence while waiting for a single request's reply.
 const RECORDING_ID_RECEIVE_POLL: Duration = Duration::from_millis(2);
+/// Poll cadence while waiting for one recording-state reply.
+const RECORDING_STATE_RECEIVE_POLL: Duration = Duration::from_millis(2);
 /// Interval between successive health probes to the daemon.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(25);
 /// How long a single health request waits for the daemon's reply before re-asking.
@@ -210,4 +213,49 @@ fn resolve_recording_id_once(
         }
         std::thread::sleep(RECORDING_ID_RECEIVE_POLL);
     }
+}
+
+/// Ask the daemon which recording, if any, `request_bytes` names a source for.
+///
+/// Single-shot: one request, one bounded wait, because the caller is a poll
+/// loop that re-asks on its own cadence.
+///
+/// The two "no" answers are distinct and must stay so:
+///
+/// * `Ok(None)` — nothing answered; the caller leaves its state alone.
+/// * `Ok(Some(None))` — the daemon answered: no open recording. That is the
+///   edge a producer drains and seals its tail chunks on.
+pub(crate) fn query_recording_state(
+    request_bytes: &[u8],
+    timeout_s: f64,
+) -> Result<Option<Option<LiveRecording>>, ProducerError> {
+    with_producer(|state| {
+        let request = state
+            .recording_state_client
+            .loan_slice_uninit(request_bytes.len())
+            .map_err(|error| ProducerError::Loan(error.to_string()))?;
+        let request = request.write_from_slice(request_bytes);
+        let pending = request
+            .send()
+            .map_err(|error| ProducerError::Send(error.to_string()))?;
+
+        let response_deadline = Instant::now() + bounded_timeout(timeout_s);
+        loop {
+            match pending.receive() {
+                Ok(Some(response)) => {
+                    let reply = RecordingStateReply::decode(response.payload())?;
+                    return Ok(Some(reply.recording));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(%error, "recording-state receive failed; treating as no reply");
+                    return Ok(None);
+                }
+            }
+            if Instant::now() >= response_deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(RECORDING_STATE_RECEIVE_POLL);
+        }
+    })
 }

--- a/rust/data_daemon_bridge/src/writer.rs
+++ b/rust/data_daemon_bridge/src/writer.rs
@@ -117,7 +117,7 @@ const CHUNK_FLUSH_BYTES: u64 = 256 * 1024 * 1024;
 /// queue room to route a sealed chunk with time to spare. The cost is one extra
 /// per-chunk encode (~100-200 ms of daemon-side ffmpeg) per 5 s per camera that
 /// would not otherwise have sealed.
-const CHUNK_MAX_OPEN_NS: i64 = 5 * 1_000_000_000;
+const CHUNK_MAX_OPEN_NS: i64 = data_daemon_shared::service_name::VIDEO_CHUNK_MAX_OPEN_NS;
 
 /// Backpressure cap for the writer's frame queue. `log_frame` copies a frame in
 /// and returns; the background writer thread drains the queue to disk, so the

--- a/rust/data_daemon_shared/src/lib.rs
+++ b/rust/data_daemon_shared/src/lib.rs
@@ -258,6 +258,14 @@ pub mod service_name {
         - VIDEO_CHUNK_HEADER_RESERVE)
         / VIDEO_CHUNK_BYTES_PER_FRAME) as u32;
 
+    /// How long the producer's writer leaves a video chunk open on a stream
+    /// that has stopped receiving frames before sealing it anyway.
+    ///
+    /// Shared because it is the daemon's only handle on when a quiet producer
+    /// has finished: a stopped window owed a flush marker no producer will
+    /// send waits out this bound and settles on the source's silence instead.
+    pub const VIDEO_CHUNK_MAX_OPEN_NS: i64 = 5 * 1_000_000_000;
+
     /// The microsecond clock shared by every stage of the video path: the
     /// producer writes spool NUT chunks with a `1/1_000_000` time base, and
     /// the daemon pins its per-chunk encode outputs to the same clock
@@ -383,6 +391,22 @@ pub mod service_name {
     /// Maximum size of a single `recording_ids` service sample. Both the request and
     /// the reply are a handful of UUID strings + integers; 4 KiB is generous.
     pub const RECORDING_ID_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
+
+    /// Request-response service the SDK uses to read a source's *current*
+    /// recording state.
+    ///
+    /// The daemon is the only party subscribed to the backend's org-wide
+    /// notification stream, so it is the only one that knows a recording
+    /// nothing local bracketed. Distinct from [`RECORDING_IDS`], which resolves
+    /// the cloud id of *one named* recording: this asks which recording, if
+    /// any, is live right now.
+    ///
+    /// See [`crate::RecordingStateQuery`] / [`crate::RecordingStateReply`].
+    pub const RECORDING_STATE: &str = "neuracore/data_daemon/recording_state";
+
+    /// Maximum size of a single `recording_state` service sample. Mirrors
+    /// [`RECORDING_ID_MAX_PAYLOAD_BYTES`].
+    pub const RECORDING_STATE_MAX_PAYLOAD_BYTES: usize = 4 * 1024;
 
     /// Maximum number of concurrent request-response clients. Mirrors
     /// [`MAX_PUBLISHERS_PER_SERVICE`]: the data bridge parks one client port
@@ -777,6 +801,38 @@ pub struct RecordingIdReply {
     pub recording_id: Option<String>,
 }
 
+/// Request sent over [`service_name::RECORDING_STATE`] asking which recording,
+/// if any, is currently open for a source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordingStateQuery {
+    pub robot_id: String,
+    pub robot_instance: i64,
+}
+
+/// The recording a source has open, as the daemon sees it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveRecording {
+    /// The daemon's local primary key, once data has opened the recording's
+    /// window. It exists before [`Self::recording_id`] does, so it is what
+    /// tells two consecutive recordings apart. `None` for a recording the
+    /// backend has announced that this host has not yet published for.
+    pub recording_index: Option<i64>,
+    /// The cloud handle, once `/recording/start` has been notified. `None`
+    /// while the recording is still local-only.
+    pub recording_id: Option<String>,
+    /// The recording's capture-clock start (Unix nanoseconds), when known.
+    pub start_timestamp_ns: Option<i64>,
+}
+
+/// Reply to a [`RecordingStateQuery`].
+///
+/// `recording` is `None` when the source has no open recording, however it
+/// came to have none: the caller acts on "recording" versus "not recording".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordingStateReply {
+    pub recording: Option<LiveRecording>,
+}
+
 /// Side-effect-free readiness probe sent over [`service_name::HEALTH`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HealthRequest {
@@ -829,6 +885,30 @@ impl RecordingIdReply {
     }
 
     /// Decode from the byte slice carried in a `recording_ids` service response sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl RecordingStateQuery {
+    /// Encode as a postcard byte vector for a `recording_state` request sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `recording_state` request sample.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
+        decode_postcard(bytes)
+    }
+}
+
+impl RecordingStateReply {
+    /// Encode as a postcard byte vector for a `recording_state` response sample.
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeCodecError> {
+        encode_postcard(self)
+    }
+
+    /// Decode from the byte slice carried in a `recording_state` response sample.
     pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeCodecError> {
         decode_postcard(bytes)
     }


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - `query_recording_state` reports the recording a source has open, so a process can learn about one it did not start

### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - A recording stopped from the web is owed a flush marker no producer will send; the window now settles on the source falling silent rather than sitting out the full 30s cap

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
