### PR TITLE
fix: use clock-only classification for cross-process producer frames

### DIFF
--- a/tests/integration/platform/data_daemon/shared/test_case/boundaries.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/boundaries.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     CONDEMNED_PROVENANCE_MARGIN_S,
+    CROSS_PROCESS_STOP_SKEW_MARGIN_S,
 )
 
 
@@ -161,6 +162,45 @@ def _classify_boundary_frames(
         is_outside = frame.completed_at <= bounds.start_called_at or (
             frame.emitted_at >= bounds.stop_settled_at
             and frame.handle not in bounds.handles
+        )
+        if is_inside:
+            owed.append(frame)
+        elif is_outside:
+            condemned.append(frame)
+        else:
+            unknowable.append(frame)
+    return _classification(owed, unknowable, condemned, bounds)
+
+
+def _classify_cross_process_boundary_frames(
+    frames: list[EmittedFrame],
+    bounds: RecordingControlBounds,
+) -> TraceClassification:
+    """Split a child process's frames into those inside a recording and those unknowable.
+
+    A child never calls ``start_recording``/``stop_recording`` itself, so its
+    ``handle`` reflects a recording-state notification propagated to it
+    separately (over its own transport, on its own schedule) rather than the
+    same local gate the owning process's call closes synchronously. That
+    makes gate refusal unreliable as proof of exclusion here, unlike
+    :func:`_classify_boundary_frames`: a child can still read "no recording"
+    for a frame the dispatcher's window legitimately admits, simply because
+    its own notification arrived early. Only clock-based bounds are used —
+    the inside rule stays as tight, and a frame is outside only when it is
+    unambiguously before the window opened or well past
+    :data:`CROSS_PROCESS_STOP_SKEW_MARGIN_S` after stop was called; everything
+    closer to the boundary is unknowable, same as a straddling frame.
+    """
+    owed: list[EmittedFrame] = []
+    unknowable: list[EmittedFrame] = []
+    condemned: list[EmittedFrame] = []
+    for frame in frames:
+        is_inside = (
+            frame.emitted_at >= bounds.start_returned_at
+            and frame.completed_at <= bounds.stop_called_at
+        )
+        is_outside = frame.completed_at <= bounds.start_called_at or (
+            frame.emitted_at >= bounds.stop_called_at + CROSS_PROCESS_STOP_SKEW_MARGIN_S
         )
         if is_inside:
             owed.append(frame)

--- a/tests/integration/platform/data_daemon/shared/test_case/constants.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/constants.py
@@ -269,6 +269,15 @@ PRODUCER_PROCESS_TERMINATE_TIMEOUT_S = 5.0
 GATE_CLOSE_POLL_INTERVAL_S = 0.001
 GATE_CLOSE_WATCHER_JOIN_TIMEOUT_S = 5.0
 
+# How far past stop_called_at a cross-process frame may land and still be
+# unknowable rather than condemned. A child's own recording handle answers a
+# different, SSE-propagated question than the dispatcher's window boundary,
+# so it cannot stand in for the in-process gate-refusal rule (see
+# _classify_cross_process_boundary_frames); this covers the dispatcher's own
+# routing holdback plus IPC latency, well under PER_THREAD_LOGGING_TAIL_S so
+# genuinely stale tail frames are still condemned.
+CROSS_PROCESS_STOP_SKEW_MARGIN_S = 1.0
+
 # How far either side of the control calls a condemned frame keeps its reason.
 CONDEMNED_PROVENANCE_MARGIN_S = 2.0
 

--- a/tests/integration/platform/data_daemon/shared/test_case/producers.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/producers.py
@@ -21,6 +21,7 @@ from tests.integration.platform.data_daemon.shared.test_case.boundaries import (
     RecordingControlBounds,
     TraceClassification,
     _classify_boundary_frames,
+    _classify_cross_process_boundary_frames,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DETAIL_REALISTIC,
@@ -748,7 +749,7 @@ class MultiProcessProducerSession(ProducerSession):
         accepted."""
         if trace_key not in self._child_trace_keys:
             return super().classify(trace_key, frames, bounds)
-        return _classify_boundary_frames(frames, bounds)
+        return _classify_cross_process_boundary_frames(frames, bounds)
 
 
 def make_producer_session(


### PR DESCRIPTION
### Bugfixes
 - classify cross-process producer frames by clock bounds instead of an unreliable child-side recording handle