### PR TITLE
test: cover cancel from a separate recording-control process

### DIFF
--- a/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
+++ b/tests/integration/platform/data_daemon/behavioural_correctness/test_cancel_recording.py
@@ -28,8 +28,8 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     has_configured_org,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
+    CONTROL_SPLIT_PROCESS,
     MAX_TIME_TO_START_S,
-    STOP_RECORDING_OVERHEAD_PER_SEC,
     camera_names,
     joint_names_for_count,
 )
@@ -40,6 +40,9 @@ from tests.integration.platform.data_daemon.shared.test_case.context_spec import
 from tests.integration.platform.data_daemon.shared.test_case.context_worker import (
     create_testing_dataset_name,
     log_frames,
+)
+from tests.integration.platform.data_daemon.shared.test_case.recording_control import (
+    make_recording_controller,
 )
 from tests.integration.platform.data_daemon.shared.test_infrastructure import (
     scoped_storage_state,
@@ -56,6 +59,7 @@ _CASES = DataDaemonTestBatch(
             video_count=1,
             image_width=64,
             image_height=64,
+            wait=True,
         ),
         Synchronous(
             duration_sec=5,
@@ -63,6 +67,7 @@ _CASES = DataDaemonTestBatch(
             video_count=1,
             image_width=64,
             image_height=64,
+            recording_control=CONTROL_SPLIT_PROCESS,
         ),
     ),
 ).as_cases()
@@ -75,7 +80,11 @@ def test_cancel_recording_produces_no_data(
     request: pytest.FixtureRequest,
     test_wall_timer: Callable[[], float],
 ) -> None:
-    """Verify that cancelling a recording discards all logged data."""
+    """Verify that cancelling a recording discards all logged data.
+
+    Runs for every way a case can make the cancel: from this process, and from
+    a peer that knows of the window only because the backend said so.
+    """
     if not has_configured_org():
         pytest.skip(
             "Cancel-recording behavioural tests require NEURACORE_ORG_ID"
@@ -86,6 +95,7 @@ def test_cancel_recording_produces_no_data(
     specs = build_context_specs(case, dataset_name=dataset_name)
     spec = specs[0]
     robot_name = spec.robot_name
+    controller = None
 
     try:
         with scoped_storage_state(case, specs):
@@ -101,23 +111,16 @@ def test_cancel_recording_produces_no_data(
                 ):
                     robot = nc.connect_robot(robot_name, overwrite=False)
 
-                with Timer(
-                    MAX_TIME_TO_START_S, label="nc.start_recording", always_log=True
-                ):
-                    nc.start_recording(robot_name=robot_name)
-                assert robot.is_recording()
+                controller = make_recording_controller(spec, robot=robot)
+                controller.open(time.time())
+                cancelled_recording_id = robot.get_current_recording_id()
+                assert cancelled_recording_id is not None
 
                 log_frames(
                     spec, robot=robot, recording_index=0, marker_name="marker_cancel"
                 )
 
-                with Timer(
-                    case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
-                    label="nc.cancel_recording",
-                    always_log=True,
-                    assert_deadline=False,
-                ):
-                    nc.cancel_recording(robot_name=robot_name)
+                controller.cancel(time.time())
 
                 time.sleep(5)
 
@@ -132,6 +135,8 @@ def test_cancel_recording_produces_no_data(
                     len(dataset) == 0
                 ), f"Expected 0 recordings after cancel, got {len(dataset)}"
     finally:
+        if controller is not None:
+            controller.shutdown()
         set_case_analysis_report(
             request=request,
             case=case,
@@ -154,7 +159,10 @@ def test_cancel_then_start_new_recording(
     """Verify a valid recording succeeds after cancelling a prior one.
 
     Two variants are tested: resuming immediately (gap_s=0) and after a 10s
-    pause (gap_s=10) to cover both tight and relaxed timing paths.
+    pause (gap_s=10) to cover both tight and relaxed timing paths. Under split
+    control this is the sharper of the two cancel tests: a successor window
+    opens right behind a cancelled one, which is exactly the shape that lets an
+    unqualified control call reach the wrong recording.
     """
     if not has_configured_org():
         pytest.skip(
@@ -167,6 +175,7 @@ def test_cancel_then_start_new_recording(
     spec = specs[0]
     robot_name = spec.robot_name
     results: list[ContextResult] = []
+    controller = None
 
     try:
         with scoped_storage_state(case, specs):
@@ -185,24 +194,18 @@ def test_cancel_then_start_new_recording(
                 ):
                     robot = nc.connect_robot(robot_name, overwrite=False)
 
+                controller = make_recording_controller(spec, robot=robot)
+
                 # --- cancelled recording ---
-                with Timer(
-                    MAX_TIME_TO_START_S, label="nc.start_recording", always_log=True
-                ):
-                    nc.start_recording(robot_name=robot_name)
-                assert robot.is_recording()
+                controller.open(time.time())
+                cancelled_recording_id = robot.get_current_recording_id()
+                assert cancelled_recording_id is not None
 
                 log_frames(
                     spec, robot=robot, recording_index=0, marker_name="marker_cancelled"
                 )
 
-                with Timer(
-                    case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
-                    label="nc.cancel_recording",
-                    always_log=True,
-                    assert_deadline=False,
-                ):
-                    nc.cancel_recording(robot_name=robot_name)
+                controller.cancel(time.time())
 
                 if gap_s > 0:
                     logger.info("Waiting %ds between cancel and next recording", gap_s)
@@ -210,10 +213,7 @@ def test_cancel_then_start_new_recording(
 
                 # --- valid recording ---
                 wall_started_at = time.time()
-                with Timer(
-                    MAX_TIME_TO_START_S, label="nc.start_recording", always_log=True
-                ):
-                    nc.start_recording(robot_name=robot_name)
+                controller.open(wall_started_at)
                 resumed_recording_id = robot.get_cloud_recording_id()
                 assert resumed_recording_id is not None
 
@@ -221,14 +221,8 @@ def test_cancel_then_start_new_recording(
                     spec, robot=robot, recording_index=0, marker_name="marker_resume"
                 )
 
-                with Timer(
-                    case.duration_sec * STOP_RECORDING_OVERHEAD_PER_SEC,
-                    label="nc.stop_recording",
-                    always_log=True,
-                    assert_deadline=False,
-                ):
-                    nc.stop_recording(robot_name=robot_name, wait=True)
-                wall_stopped_at = time.time()
+                closed = controller.close(time.time())
+                wall_stopped_at = closed.settled_at
 
                 results = [
                     ContextResult(
@@ -254,6 +248,8 @@ def test_cancel_then_start_new_recording(
                 ]
                 verify_cloud_results(results=results, case=case)
     finally:
+        if controller is not None:
+            controller.shutdown()
         set_case_analysis_report(
             request=request,
             case=case,

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -453,11 +453,12 @@ class PerThread(DataDaemonTestCase):
 
 
 @dataclass(frozen=True)
-class SeparateProcessStartStop(PerThread):
+class SeparateProcessRecordingControl(PerThread):
     """:class:`PerThread`, with every stream produced in one OS process of its
-    own, so the original process does nothing but start and stop the recording.
+    own, so the original process only ever controls the recording — starting,
+    stopping, or cancelling it — and never logs into it.
 
-    A robot driver logging alongside an application that brackets the windows:
+    A robot driver logging alongside an application that controls the windows:
     every trace is written by a process that learns its window second-hand.
     Subclasses keep that and split the producing further.
     """
@@ -506,8 +507,8 @@ class SeparateProcessStartStop(PerThread):
 
 
 @dataclass(frozen=True)
-class ProcessPerCamera(SeparateProcessStartStop):
-    """:class:`SeparateProcessStartStop`, with the producing split per camera,
+class ProcessPerCamera(SeparateProcessRecordingControl):
+    """:class:`SeparateProcessRecordingControl`, with the producing split per camera,
     so ``max(video_count, depth_count)`` decides how many camera children there
     are and the joints keep a child of their own."""
 

--- a/tests/integration/platform/data_daemon/shared/test_case/recording_control.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/recording_control.py
@@ -111,6 +111,14 @@ class RecordingController(ABC):
     def close(self, capture_stop_s: float) -> ControlBracket:
         """Close the current window and return once it is known to be closed."""
 
+    def cancel(self, capture_stop_s: float) -> ControlBracket:
+        """Discard the current window and return once it is known to be gone.
+
+        Not abstract: a case that never cancels should not have to carry an
+        implementation for it.
+        """
+        raise NotImplementedError(f"{type(self).__name__} cannot cancel a recording")
+
     def shutdown(self) -> None:
         """Release whatever this controller holds past the last recording."""
 
@@ -134,6 +142,23 @@ class LocalRecordingController(RecordingController):
             called_at=called_at,
             settled_at=time.time(),
             handle=self.robot.get_current_recording_id(),
+        )
+
+    def cancel(self, capture_stop_s: float) -> ControlBracket:
+        """Discard the recording with the SDK's own call, from this process."""
+        called_at = time.time()
+        handle = self.robot.get_current_recording_id()
+        with Timer(
+            self.spec.case.stop_recording_sla_s,
+            label="nc.cancel_recording",
+            always_log=True,
+            assert_deadline=self.spec.assert_deadline,
+        ):
+            nc.cancel_recording(
+                robot_name=self.spec.robot_name, timestamp=capture_stop_s
+            )
+        return ControlBracket(
+            called_at=called_at, settled_at=time.time(), handle=handle
         )
 
     def close(self, capture_stop_s: float) -> ControlBracket:
@@ -279,6 +304,7 @@ class RemoteRecordingController(RecordingController):
 
 _PEER_AWAIT_OPEN = "await-open"
 _PEER_STOP = "stop"
+_PEER_CANCEL = "cancel"
 
 
 @dataclass(frozen=True, slots=True)
@@ -307,6 +333,14 @@ class _StopAck:
     returned_at: float
 
 
+@dataclass(frozen=True, slots=True)
+class _CancelAck:
+    """When the peer's cancel call returned. Separate from :class:`_StopAck` so
+    an answer out of step is caught by kind, not read as the other call."""
+
+    returned_at: float
+
+
 def _peer_control_process(
     spec: ControlProcessSpec,
     ready_event: Any,
@@ -314,12 +348,13 @@ def _peer_control_process(
     acks: Any,
     result_queue: Any,
 ) -> None:
-    """Stop recordings this process never started, in its own OS process.
+    """End recordings this process never started, in its own OS process.
 
     Logs nothing and starts nothing. It connects — which subscribes it to the
-    notification stream — waits to be told a window opened, and closes it with
-    the SDK's own call. Every order is answered, so a caller blocked on one
-    learns of a failure from the reaped traceback rather than a timeout.
+    notification stream — waits to be told a window opened, and ends it with
+    the SDK's own call: a stop that keeps the data, or a cancel that discards
+    it. Every order is answered, so a caller blocked on one learns of a failure
+    from the reaped traceback rather than a timeout.
     """
     robot = None
     try:
@@ -333,6 +368,8 @@ def _peer_control_process(
             order, timestamp = command
             if order == _PEER_AWAIT_OPEN:
                 acks.put(_await_peer_open(spec, robot, announced_start_s=timestamp))
+            elif order == _PEER_CANCEL:
+                acks.put(_cancel_from_peer(spec, robot, capture_stop_s=timestamp))
             else:
                 acks.put(_stop_from_peer(spec, robot, capture_stop_s=timestamp))
         result_queue.put({
@@ -374,6 +411,28 @@ def _await_peer_open(
             ),
         )
     )
+
+
+def _cancel_from_peer(
+    spec: ControlProcessSpec, robot: object, *, capture_stop_s: float
+) -> _CancelAck:
+    """Make the SDK's own cancel call for a window this process never opened.
+
+    The discarding counterpart of :func:`_stop_from_peer`: it has to reach every
+    trace of a recording this process never wrote a byte of, and drop them.
+    """
+    with Timer(
+        spec.stop_sla_s,
+        label="peer.cancel_recording",
+        always_log=True,
+        assert_deadline=spec.assert_deadline,
+    ):
+        nc.cancel_recording(robot_name=spec.robot_name, timestamp=capture_stop_s)
+    assert robot.get_current_recording_id() is None, (  # type: ignore[attr-defined]
+        "the cancelling peer's nc.cancel_recording left its gate open, so the "
+        "call was refused before it reached the daemon at all"
+    )
+    return _CancelAck(returned_at=time.time())
 
 
 def _stop_from_peer(
@@ -466,17 +525,7 @@ class SplitProcessRecordingController(RecordingController):
         transition is the only thing that settles the close and is always
         waited for.
         """
-        opened: _OpenAck = self._await_ack(
-            _PEER_AWAIT_OPEN,
-            _OpenAck,
-            deadline=time.time() + REMOTE_CONTROL_REQUEST_TIMEOUT_S,
-        )
-        peer_start_lag_s = opened.gate_opened_at - self._window_start_s
-        assert peer_start_lag_s <= REMOTE_START_ANNOUNCEMENT_SLA_S, (
-            f"the window opened at {self._window_start_s} reached the stopping "
-            f"peer {peer_start_lag_s:.3f}s later, over the "
-            f"{REMOTE_START_ANNOUNCEMENT_SLA_S}s allowed"
-        )
+        self._await_peer_heard_of_the_window()
         called_at = time.time()
         handle = self.robot.get_current_recording_id()
         self._commands.put((_PEER_STOP, capture_stop_s))
@@ -503,6 +552,56 @@ class SplitProcessRecordingController(RecordingController):
             ),
         )
         return ControlBracket(called_at=called_at, settled_at=settled_at, handle=handle)
+
+    def cancel(self, capture_stop_s: float) -> ControlBracket:
+        """Have the peer cancel the recording, then wait to be told it did.
+
+        The same split as :meth:`close`, discarding instead of keeping: the
+        peer must still have heard the window open before it can name anything
+        to cancel.
+        """
+        self._await_peer_heard_of_the_window()
+        called_at = time.time()
+        handle = self.robot.get_current_recording_id()
+        self._commands.put((_PEER_CANCEL, capture_stop_s))
+        cancelled: _CancelAck = self._await_ack(
+            _PEER_CANCEL,
+            _CancelAck,
+            deadline=time.time()
+            + self.spec.case.stop_recording_sla_s
+            + REMOTE_CONTROL_REQUEST_TIMEOUT_S,
+        )
+        settled_at = await_gate(
+            self.robot,
+            open_gate=False,
+            deadline=cancelled.returned_at + REMOTE_STOP_PROPAGATION_SLA_S,
+            label="split.cancel_gate_wait",
+            assert_deadline=self.spec.assert_deadline,
+            overdue=(
+                "the peer's cancel never came back round to this process: its "
+                f"own gate was still open {REMOTE_STOP_PROPAGATION_SLA_S}s "
+                "after the peer's call returned"
+            ),
+        )
+        return ControlBracket(called_at=called_at, settled_at=settled_at, handle=handle)
+
+    def _await_peer_heard_of_the_window(self) -> None:
+        """Block until the peer has been told the window this process opened.
+
+        Nothing the peer can do names a recording until this lands, so both
+        ways of ending one wait on it, and both assert the same SLA.
+        """
+        opened: _OpenAck = self._await_ack(
+            _PEER_AWAIT_OPEN,
+            _OpenAck,
+            deadline=time.time() + REMOTE_CONTROL_REQUEST_TIMEOUT_S,
+        )
+        peer_start_lag_s = opened.gate_opened_at - self._window_start_s
+        assert peer_start_lag_s <= REMOTE_START_ANNOUNCEMENT_SLA_S, (
+            f"the window opened at {self._window_start_s} reached the stopping "
+            f"peer {peer_start_lag_s:.3f}s later, over the "
+            f"{REMOTE_START_ANNOUNCEMENT_SLA_S}s allowed"
+        )
 
     def shutdown(self) -> None:
         """Retire the peer and surface anything it raised."""

--- a/tests/unit/data_daemon/test_producer_placement.py
+++ b/tests/unit/data_daemon/test_producer_placement.py
@@ -13,7 +13,7 @@ from tests.integration.platform.data_daemon.shared.test_case.build_test_case imp
     PerThread,
     ProcessPerCamera,
     ProcessPerLimbPerCamera,
-    SeparateProcessStartStop,
+    SeparateProcessRecordingControl,
     Synchronous,
     case_id,
 )
@@ -466,7 +466,8 @@ def test_split_joints_can_still_be_placed_by_kind() -> None:
 
 
 @pytest.mark.parametrize(
-    "variant", [SeparateProcessStartStop, ProcessPerCamera, ProcessPerLimbPerCamera]
+    "variant",
+    [SeparateProcessRecordingControl, ProcessPerCamera, ProcessPerLimbPerCamera],
 )
 def test_every_trace_starts_late_whatever_the_owner_splits(variant) -> None:
     """The owner only holds the window in all of them, however many children


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Case cancelling a recording from a process that did not open it

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
