### PR TITLE
test: re-enable performance deadlines

### DIFF
--- a/tests/integration/platform/data_daemon/performance/test_network.py
+++ b/tests/integration/platform/data_daemon/performance/test_network.py
@@ -74,7 +74,6 @@ def test_cloud_upload_and_readiness_performance(
                         case_timeout_seconds(case),
                         label="performance.recording_contexts",
                         always_log=True,
-                        assert_deadline=False,
                     ):
                         results = report.capture_results(
                             run_case_contexts(case, specs=specs)
@@ -84,7 +83,6 @@ def test_cloud_upload_and_readiness_performance(
                         case_timeout_seconds(case),
                         label="performance.dataset_ready_wait",
                         always_log=True,
-                        assert_deadline=False,
                     ):
                         wait_for_dataset_ready(
                             results[0].dataset_name,

--- a/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/context_worker.py
@@ -27,6 +27,7 @@ from tests.integration.platform.data_daemon.shared.test_case.boundaries import (
 from tests.integration.platform.data_daemon.shared.test_case.build_test_case import (
     DataDaemonTestCase,
     case_id,
+    case_timeout_seconds,
 )
 from tests.integration.platform.data_daemon.shared.test_case.constants import (
     DATA_TYPE_RGB_IMAGES,
@@ -394,7 +395,11 @@ def run_case_contexts(
     # A late writer is reaped during the wait below, so observe across it.
     with latching_trace_write_observer() as observed:
         results = _run_context_specs(case, specs)
-        wait_for_all_traces_written(results=results, observed=observed)
+        wait_for_all_traces_written(
+            results=results,
+            observed=observed,
+            timeout_s=case_timeout_seconds(case),
+        )
     return results
 
 


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - The performance case asserts its timer deadlines again, with the trace wait bounded by the case timeout rather than its own 120s default

<!--
Things to consider before submitting a PR:

 - Have I executed this code?
 - Have I performed a self review?
 - Have I added/updated relevant documentation?
 - Does this branch have a clean commit history?
 - Can I add informative test cases?
-->
