### PR TITLE
fix: resolve mcap importer timestamps in nanoseconds

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -331,6 +331,7 @@ neginf
 neuraco
 neuracore
 newbyteorder
+nextafter
 nhead
 nheads
 njoints

--- a/neuracore/importer/core/base.py
+++ b/neuracore/importer/core/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import math
 import multiprocessing as mp
 import os
 import random
@@ -65,6 +66,7 @@ from .exceptions import (
 )
 
 JOINT_TARGET_CHECK_TOLERANCE = 1e-6
+TIMESTAMP_COLLISION_TOLERANCE_S = 1e-6
 
 
 @dataclass(frozen=True)
@@ -185,6 +187,7 @@ class NeuracoreDatasetImporter(ABC):
         self.random_sample = random_sample
         self.debug_target_ee_frame = (debug_target_ee_frame or "").strip() or None
         self.worker_errors: list[WorkerError] = []
+        self._last_logged_timestamps: dict[tuple[DataType, str], float] = {}
         self._logged_error_keys: set[tuple[int | None, int | None, str]] = set()
         self.logger = logging.getLogger(
             f"{self.__class__.__module__}.{self.__class__.__name__}"
@@ -358,6 +361,7 @@ class NeuracoreDatasetImporter(ABC):
     def _reset_episode_state(self) -> None:
         """Reset episode-specific state at the start of each episode."""
         self.prev_ik_solution = self.ik_init_config
+        self._last_logged_timestamps = {}
 
     def _reset_step_state(self) -> None:
         """Reset step-specific state at the start of each step."""
@@ -743,6 +747,36 @@ class NeuracoreDatasetImporter(ABC):
             )
             raise
 
+    def _strictly_increasing_timestamp(
+        self, data_type: DataType, name: str, timestamp: float
+    ) -> float:
+        """Return a timestamp strictly greater than the last one for this stream.
+
+        Track the last value per data type and name, matching the granularity
+        Neuracore enforces per stream. Distinct nanosecond capture times can
+        resolve to the same float64 at Unix epoch magnitudes, so raise a
+        timestamp that trails the previous one by at most
+        TIMESTAMP_COLLISION_TOLERANCE_S by one unit in the last place. Return a
+        larger regression unchanged, leaving Neuracore to reject it.
+
+        Args:
+            data_type: The type of data being logged.
+            name: The name of the data.
+            timestamp: The timestamp of the data.
+
+        Returns:
+            float: The timestamp to log, nudged up only when it collides.
+        """
+        key = (data_type, name)
+        previous = self._last_logged_timestamps.get(key)
+        if (
+            previous is not None
+            and 0.0 <= previous - timestamp <= TIMESTAMP_COLLISION_TOLERANCE_S
+        ):
+            timestamp = math.nextafter(previous, math.inf)
+        self._last_logged_timestamps[key] = timestamp
+        return timestamp
+
     def _log_transformed_data(
         self,
         data_type: DataType,
@@ -763,6 +797,9 @@ class NeuracoreDatasetImporter(ABC):
             extrinsics: Optional 4x4 camera extrinsics matrix for camera streams.
             intrinsics: Optional 3x3 camera intrinsics matrix for camera streams.
         """
+        timestamp = self._strictly_increasing_timestamp(
+            data_type=data_type, name=name, timestamp=timestamp
+        )
         instance = self.robot_instance(self._worker_id)
         if data_type == DataType.RGB_IMAGES:
             nc.log_rgb(

--- a/neuracore/importer/mcap/mcap_importer.py
+++ b/neuracore/importer/mcap/mcap_importer.py
@@ -195,7 +195,7 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
         """Stream messages from one MCAP episode file."""
         topics = get_mcap_topics(topic_map=self.topic_map)
         factories = list(self._decoder_factories or [])
-        source_start_timestamp: float | None = None
+        source_start_timestamp_ns: int | None = None
         recording_stop_timestamp = recording_start_timestamp
         message_count = 0
         # Fresh video decoders per episode: state must never carry across files.
@@ -220,14 +220,13 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
                 reader=reader,
                 topics=topics,
             ):
-                if source_start_timestamp is None:
-                    source_start_timestamp = decoded_message.timestamp_seconds
+                if source_start_timestamp_ns is None:
+                    source_start_timestamp_ns = decoded_message.timestamp_ns
 
-                relative_timestamp = max(
-                    0.0,
-                    decoded_message.timestamp_seconds - source_start_timestamp,
+                relative_timestamp_ns = max(
+                    0, decoded_message.timestamp_ns - source_start_timestamp_ns
                 )
-                timestamp = recording_start_timestamp + relative_timestamp
+                timestamp = recording_start_timestamp + relative_timestamp_ns / 1e9
                 recording_stop_timestamp = max(recording_stop_timestamp, timestamp)
 
                 decoded_data = convert_decoded_mcap_data(

--- a/neuracore/importer/mcap/utils.py
+++ b/neuracore/importer/mcap/utils.py
@@ -193,7 +193,7 @@ class DecodedMCAPMessage:
         source topic used to select mapping rules.
     log_time_ns: MCAP message log timestamp in nanoseconds.
     publish_time_ns: MCAP message publish timestamp in nanoseconds.
-    timestamp_seconds: Resolved timestamp in seconds, preferring log time.
+    timestamp_ns: Resolved timestamp in nanoseconds, preferring log time.
     data: Decoded message data returned by the MCAP decoder factory. This is
         the source object Neuracore mappings read from.
     """
@@ -201,7 +201,7 @@ class DecodedMCAPMessage:
     topic: str
     log_time_ns: int
     publish_time_ns: int
-    timestamp_seconds: float
+    timestamp_ns: int
     data: Any
 
 
@@ -246,17 +246,17 @@ def log_mcap_summary_details(summary: Any | None, logger: logging.Logger) -> Non
         )
 
 
-def resolve_timestamp_seconds(
+def resolve_timestamp_ns(
     *,
     log_time_ns: int,
     publish_time_ns: int,
-) -> float:
-    """Resolve message timestamp from log/publish time nanoseconds."""
+) -> int:
+    """Resolve message timestamp in nanoseconds from log/publish time."""
     if log_time_ns > 0:
-        return log_time_ns / 1e9
+        return log_time_ns
     if publish_time_ns > 0:
-        return publish_time_ns / 1e9
-    return time.time()
+        return publish_time_ns
+    return time.time_ns()
 
 
 def iter_decoded_mcap_messages(
@@ -281,7 +281,7 @@ def iter_decoded_mcap_messages(
             topic=str(getattr(channel, "topic", "") or ""),
             log_time_ns=log_time_ns,
             publish_time_ns=publish_time_ns,
-            timestamp_seconds=resolve_timestamp_seconds(
+            timestamp_ns=resolve_timestamp_ns(
                 log_time_ns=log_time_ns,
                 publish_time_ns=publish_time_ns,
             ),

--- a/tests/unit/importer/test_base_log_data_behavior.py
+++ b/tests/unit/importer/test_base_log_data_behavior.py
@@ -1,5 +1,6 @@
 """Unit tests for NeuracoreDatasetImporter data logging and config ordering."""
 
+import math
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -372,3 +373,124 @@ def test_get_ordered_import_configs_raises_when_fk_and_ik_both_requested():
 
     with pytest.raises(ImportError, match="Cannot request both FK and IK"):
         importer._get_ordered_import_configs()
+
+
+def _make_importer_for_timestamp_guard() -> NeuracoreDatasetImporter:
+    """Build an importer instance carrying only the monotonic guard state."""
+    importer = object.__new__(_ConcreteImporter)
+    importer._last_logged_timestamps = {}
+    return importer
+
+
+def test_strictly_increasing_timestamp_nudges_colliding_float():
+    importer = _make_importer_for_timestamp_guard()
+    collided = 1788363776958256896 / 1e9
+    assert collided == 1788363776958257000 / 1e9
+
+    first = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="head_camera2", timestamp=collided
+    )
+    second = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="head_camera2", timestamp=collided
+    )
+
+    assert first == collided
+    assert second > first
+    assert second == math.nextafter(first, math.inf)
+
+
+def test_strictly_increasing_timestamp_leaves_increasing_input_untouched():
+    importer = _make_importer_for_timestamp_guard()
+
+    values = [100.0, 100.5, 101.0]
+    logged = [
+        importer._strictly_increasing_timestamp(
+            data_type=DataType.RGB_IMAGES, name="cam", timestamp=value
+        )
+        for value in values
+    ]
+
+    assert logged == values
+
+
+def test_strictly_increasing_timestamp_tracks_streams_independently():
+    importer = _make_importer_for_timestamp_guard()
+
+    first = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam_a", timestamp=100.0
+    )
+    other_name = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam_b", timestamp=100.0
+    )
+    other_type = importer._strictly_increasing_timestamp(
+        data_type=DataType.DEPTH_IMAGES, name="cam_a", timestamp=100.0
+    )
+
+    assert first == other_name == other_type == 100.0
+
+
+def test_strictly_increasing_timestamp_passes_through_large_regression():
+    importer = _make_importer_for_timestamp_guard()
+    importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam", timestamp=9.22e9
+    )
+
+    out_of_order = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam", timestamp=1.79e9
+    )
+
+    assert out_of_order == 1.79e9
+
+
+def test_strictly_increasing_timestamp_does_not_nudge_from_infinity():
+    importer = _make_importer_for_timestamp_guard()
+    importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam", timestamp=math.inf
+    )
+
+    following = importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam", timestamp=1.79e9
+    )
+
+    assert following == 1.79e9
+
+
+def test_reset_episode_state_clears_timestamp_guard():
+    importer = _make_importer_for_timestamp_guard()
+    importer.ik_init_config = None
+    importer._strictly_increasing_timestamp(
+        data_type=DataType.RGB_IMAGES, name="cam", timestamp=100.0
+    )
+
+    importer._reset_episode_state()
+
+    assert (
+        importer._strictly_increasing_timestamp(
+            data_type=DataType.RGB_IMAGES, name="cam", timestamp=100.0
+        )
+        == 100.0
+    )
+
+
+def test_log_transformed_data_applies_timestamp_guard(monkeypatch):
+    importer = _make_importer_for_timestamp_guard()
+    importer.dry_run = False
+    importer._worker_id = 0
+    importer.dataset_config = SimpleNamespace(robot=SimpleNamespace(name="robot"))
+    importer.robot_instance = MagicMock(return_value=0)
+    logged = MagicMock()
+    monkeypatch.setattr(
+        "neuracore.importer.core.base.nc", SimpleNamespace(log_rgb=logged)
+    )
+
+    collided = 1788363776958256896 / 1e9
+    for _ in range(2):
+        importer._log_transformed_data(
+            data_type=DataType.RGB_IMAGES,
+            transformed_data=None,
+            name="head_camera2",
+            timestamp=collided,
+        )
+
+    stamps = [call.kwargs["timestamp"] for call in logged.call_args_list]
+    assert stamps[1] > stamps[0]

--- a/tests/unit/importer/test_mcap_importer.py
+++ b/tests/unit/importer/test_mcap_importer.py
@@ -36,7 +36,7 @@ from neuracore.importer.mcap.utils import (
     read_image_data,
     repair_protobuf_schema_data,
     resolve_path,
-    resolve_timestamp_seconds,
+    resolve_timestamp_ns,
     split_topic_path,
     to_numpy,
     to_python_types,
@@ -358,20 +358,28 @@ def test_resolve_path_missing_key_raises():
 @pytest.mark.parametrize(
     "log_ns,pub_ns,expected",
     [
-        (2_000_000_000, 0, 2.0),
-        (0, 1_000_000_000, 1.0),
+        (2_000_000_000, 0, 2_000_000_000),
+        (0, 1_000_000_000, 1_000_000_000),
     ],
 )
-def test_resolve_timestamp_seconds(log_ns, pub_ns, expected):
-    assert resolve_timestamp_seconds(
-        log_time_ns=log_ns, publish_time_ns=pub_ns
-    ) == pytest.approx(expected)
+def test_resolve_timestamp_ns(log_ns, pub_ns, expected):
+    assert resolve_timestamp_ns(log_time_ns=log_ns, publish_time_ns=pub_ns) == expected
+
+
+def test_resolve_timestamp_ns_preserves_sub_microsecond_spacing():
+    first = 1788363776958256896
+    second = 1788363776958257000
+    assert (
+        resolve_timestamp_ns(log_time_ns=second, publish_time_ns=0)
+        - resolve_timestamp_ns(log_time_ns=first, publish_time_ns=0)
+        == 104
+    )
 
 
 def test_resolve_timestamp_falls_back_to_wall_clock():
-    before = time.time()
-    ts = resolve_timestamp_seconds(log_time_ns=0, publish_time_ns=0)
-    assert before <= ts <= time.time()
+    before = time.time_ns()
+    ts = resolve_timestamp_ns(log_time_ns=0, publish_time_ns=0)
+    assert before <= ts <= time.time_ns()
 
 
 def test_validate_requested_topics_raises_on_missing():


### PR DESCRIPTION
### Features
 - None

### Bugfixes
 - Importing an MCAP file could throw away a whole episode because of a rounding problem in how timestamps were stored. MCAP records the time of each frame as a whole number of nanoseconds. The importer turned that into a decimal number of seconds, and a decimal number that large can only tell apart times that are about 238 nanoseconds apart. Two frames recorded closer together than that ended up with exactly the same time. Neuracore requires each frame in a recording to have a later time than the one before it, so the import stopped and the entire episode was skipped.
 - The MCAP importer now keeps the original whole numbers of nanoseconds and works out how far each frame is from the start of the episode using them, so no accuracy is lost along the way.
 - The importer also makes sure each frame's time is later than the previous one for the same sensor. If two times still come out identical, the second is moved forward by the smallest amount the number format allows, under a millionth of a second. Every frame is kept, and the shift is far too small to matter for a camera recording at 30 frames per second.
 - Times that are further out of order than a millionth of a second are left exactly as they are, so genuinely broken recordings still fail loudly rather than being quietly patched up.

### Items
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)

### Related PRs
 - None
