### PR TITLE
feat: reject mcap datasets whose episodes disagree on a topic type

### DIFF
--- a/neuracore/importer/core/base.py
+++ b/neuracore/importer/core/base.py
@@ -955,6 +955,18 @@ class NeuracoreDatasetImporter(ABC):
             urdf_packages_dir = os.path.dirname(self.urdf_path)
             self.robot_utils = RobotUtils(self.urdf_path, urdf_packages_dir)
 
+    def validate_work_items(self, items: Sequence[ImportItem]) -> None:
+        """Validate the selected work items before any episode is imported.
+
+        Run in the parent process once the item list is final, so a dataset level
+        problem is reported before workers start. The base implementation accepts
+        every item.
+
+        Args:
+            items: The work items selected for import.
+        """
+        return None
+
     def import_all(self) -> None:
         """Run imports across workers while aggregating errors.
 
@@ -1001,6 +1013,8 @@ class NeuracoreDatasetImporter(ABC):
                 n,
                 original_count,
             )
+
+        self.validate_work_items(items)
 
         # Pre-check: dry run to check for errors
         precheck_items = [random.choice(items)]

--- a/neuracore/importer/mcap/mcap_importer.py
+++ b/neuracore/importer/mcap/mcap_importer.py
@@ -30,6 +30,7 @@ from neuracore.importer.mcap.utils import (
     log_mcap_summary_details,
     read_mcap_header,
     read_mcap_summary,
+    topic_schema_names,
     validate_channel_decoder_support,
     validate_requested_topics,
 )
@@ -107,6 +108,63 @@ class MCAPDatasetImporter(NeuracoreDatasetImporter):
             ImportItem(index=i, description=path.name, metadata={"path": str(path)})
             for i, path in enumerate(self.mcap_files)
         ]
+
+    def validate_work_items(self, items: Sequence[ImportItem]) -> None:
+        """Reject a dataset whose episodes record different types on one topic.
+
+        Compare every episode against the first on the message type of each
+        mapped topic, reading only the summary section. Schema ids are file
+        local and are deliberately not compared.
+
+        Args:
+            items: The work items selected for import.
+
+        Raises:
+            ImportError: If two episodes disagree on a mapped topic's type.
+        """
+        topics = get_mcap_topics(topic_map=self.topic_map)
+        if not topics:
+            return
+
+        baseline: dict[str, str] = {}
+        baseline_label = ""
+        mismatches: list[str] = []
+
+        for item in items:
+            file_path_raw = (item.metadata or {}).get("path")
+            if not file_path_raw:
+                continue
+            file_path = Path(file_path_raw)
+            if not file_path.exists():
+                continue
+            with file_path.open("rb") as stream:
+                summary = read_mcap_summary(reader=make_reader(stream=stream))
+            schema_names = topic_schema_names(summary=summary, topics=topics)
+            if not schema_names:
+                continue
+            if not baseline:
+                baseline = schema_names
+                baseline_label = file_path.name
+                continue
+            for topic in sorted(schema_names):
+                expected = baseline.get(topic)
+                if expected is not None and expected != schema_names[topic]:
+                    mismatches.append(
+                        f"  {topic}: '{expected}' in {baseline_label}, "
+                        f"'{schema_names[topic]}' in {file_path.name}"
+                    )
+
+        if mismatches:
+            raise ImportError(
+                f"MCAP episodes disagree on the message type of "
+                f"{len(mismatches)} topic(s). Every episode must record the same "
+                "message type on a given topic:\n" + "\n".join(mismatches)
+            )
+
+        self.logger.debug(
+            f"Schema check passed across {len(items)} MCAP episode(s) "
+            f"for {len(topics)} topic(s)."
+        )
 
     def import_item(self, item: ImportItem) -> None:
         """Import one MCAP file."""

--- a/neuracore/importer/mcap/utils.py
+++ b/neuracore/importer/mcap/utils.py
@@ -306,6 +306,36 @@ def estimate_total_messages(summary: Any | None, topics: list[str]) -> int | Non
     return total if total > 0 else None
 
 
+def topic_schema_names(summary: Any | None, topics: list[str]) -> dict[str, str]:
+    """Map each requested topic to its schema type name in one MCAP summary.
+
+    Read from the summary section, so no message is decoded. Topics absent from
+    the file, and channels carrying no schema, are left out of the result.
+
+    Args:
+        summary: The MCAP summary, or None when the file has no summary section.
+        topics: The topics to look up.
+
+    Returns:
+        dict[str, str]: Schema type name keyed by topic.
+    """
+    if summary is None or not getattr(summary, "channels", None):
+        return {}
+
+    schemas = getattr(summary, "schemas", None) or {}
+    requested = set(topics)
+    names: dict[str, str] = {}
+    for channel in summary.channels.values():
+        topic = getattr(channel, "topic", "")
+        if topic not in requested:
+            continue
+        schema = schemas.get(getattr(channel, "schema_id", 0))
+        schema_name = getattr(schema, "name", "") if schema is not None else ""
+        if schema_name:
+            names[topic] = schema_name
+    return names
+
+
 def validate_requested_topics(summary: Any | None, topics: list[str]) -> None:
     """Validate configured topics against the MCAP summary when available."""
     if summary is None or not getattr(summary, "channels", None) or not topics:

--- a/tests/unit/importer/test_mcap_importer.py
+++ b/tests/unit/importer/test_mcap_importer.py
@@ -10,6 +10,7 @@ from typing import cast
 import numpy as np
 import pytest
 from google.protobuf import descriptor_pb2
+from mcap.reader import make_reader
 from mcap.writer import Writer
 from neuracore_types import DataType
 from neuracore_types.nc_data import DatasetImportConfig
@@ -37,12 +38,14 @@ from neuracore.importer.mcap.utils import (
     iter_mcap_source_events,
     list_decoder_factories,
     read_image_data,
+    read_mcap_summary,
     repair_protobuf_schema_data,
     resolve_path,
     resolve_timestamp_ns,
     split_topic_path,
     to_numpy,
     to_python_types,
+    topic_schema_names,
     validate_requested_topics,
 )
 
@@ -1126,14 +1129,21 @@ _MCAP_TEST_TYPES = {
 }
 
 
-def _write_protobuf_mcap(path: Path, registration_order: list[str]) -> None:
-    """Write a two topic protobuf MCAP, assigning schema ids in the given order."""
+def _write_protobuf_mcap(
+    path: Path, registration_order: list[str], *, swap_types: bool = False
+) -> None:
+    """Write a two topic protobuf MCAP, assigning schema ids in the given order.
+
+    Set swap_types to record each topic with the other topic's message type.
+    """
+    other = {"/cam": "/jnt", "/jnt": "/cam"}
     with path.open("wb") as handle:
         writer = Writer(handle)
         writer.start()
         schema_ids = {}
         for topic in registration_order:
-            message_name, file_name, fields, _payload = _MCAP_TEST_TYPES[topic]
+            source = other[topic] if swap_types else topic
+            message_name, file_name, fields, _payload = _MCAP_TEST_TYPES[source]
             schema_ids[topic] = writer.register_schema(
                 name=f"demo.{message_name}",
                 encoding="protobuf",
@@ -1145,10 +1155,11 @@ def _write_protobuf_mcap(path: Path, registration_order: list[str]) -> None:
                 message_encoding="protobuf",
                 schema_id=schema_ids[topic],
             )
+            payload_topic = other[topic] if swap_types else topic
             writer.add_message(
                 channel_id,
                 log_time=log_time,
-                data=_MCAP_TEST_TYPES[topic][3],
+                data=_MCAP_TEST_TYPES[payload_topic][3],
                 publish_time=log_time,
             )
         writer.finish()
@@ -1188,3 +1199,71 @@ def test_stream_episode_file_decodes_each_file_with_its_own_schema_ids(
     expected = {"/cam": "demo.CompressedImage", "/jnt": "demo.JointState"}
     assert dict(decoded[:2]) == expected
     assert dict(decoded[2:]) == expected
+
+
+def test_topic_schema_names_reads_types_without_decoding(tmp_path: Path):
+    path = tmp_path / "ep.mcap"
+    _write_protobuf_mcap(path, ["/cam", "/jnt"])
+    with path.open("rb") as stream:
+        summary = read_mcap_summary(reader=make_reader(stream=stream))
+
+    assert topic_schema_names(summary=summary, topics=["/cam", "/jnt"]) == {
+        "/cam": "demo.CompressedImage",
+        "/jnt": "demo.JointState",
+    }
+
+
+def test_topic_schema_names_ignores_unrequested_topics(tmp_path: Path):
+    path = tmp_path / "ep.mcap"
+    _write_protobuf_mcap(path, ["/cam", "/jnt"])
+    with path.open("rb") as stream:
+        summary = read_mcap_summary(reader=make_reader(stream=stream))
+
+    assert topic_schema_names(summary=summary, topics=["/cam"]) == {
+        "/cam": "demo.CompressedImage"
+    }
+
+
+def _work_items(paths: list[Path]) -> list[ImportItem]:
+    return [
+        ImportItem(index=i, description=path.name, metadata={"path": str(path)})
+        for i, path in enumerate(paths)
+    ]
+
+
+def test_validate_work_items_accepts_permuted_schema_ids(monkeypatch, tmp_path: Path):
+    first = tmp_path / "ep1.mcap"
+    second = tmp_path / "ep2.mcap"
+    _write_protobuf_mcap(first, ["/cam", "/jnt"])
+    _write_protobuf_mcap(second, ["/jnt", "/cam"])
+
+    importer = _make_importer(monkeypatch, tmp_path, dry_run=True)
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.get_mcap_topics",
+        lambda topic_map: ["/cam", "/jnt"],
+    )
+
+    importer.validate_work_items(_work_items([first, second]))
+
+
+def test_validate_work_items_raises_on_topic_type_change(monkeypatch, tmp_path: Path):
+    first = tmp_path / "ep1.mcap"
+    second = tmp_path / "ep2.mcap"
+    _write_protobuf_mcap(first, ["/cam", "/jnt"])
+    _write_protobuf_mcap(second, ["/cam", "/jnt"], swap_types=True)
+
+    importer = _make_importer(monkeypatch, tmp_path, dry_run=True)
+    monkeypatch.setattr(
+        "neuracore.importer.mcap.mcap_importer.get_mcap_topics",
+        lambda topic_map: ["/cam", "/jnt"],
+    )
+
+    with pytest.raises(ImportError) as excinfo:
+        importer.validate_work_items(_work_items([first, second]))
+
+    message = str(excinfo.value)
+    assert "/cam" in message
+    assert "demo.CompressedImage" in message
+    assert "demo.JointState" in message
+    assert "ep1.mcap" in message
+    assert "ep2.mcap" in message


### PR DESCRIPTION
### Features
 - Before importing, the importer now checks that every episode records the same message type on each topic it reads.
 - If two episodes disagree it stops with a message naming the topic, both types and both files, instead of failing partway through.
 - The check reads only each file's index, so nothing is uploaded until it passes.

### Bugfixes
 - None

### Items
 - [NC-XX](https://neuracore.atlassian.net/browse/NC-XX)

### Related PRs
 - Stacked on #978
