### PR TITLE
feat: batch signalling track endpoint

### DIFF
--- a/changelogs/pending-changelog.md
+++ b/changelogs/pending-changelog.md
@@ -23,3 +23,8 @@ algorithm on incompatible hardware.
 
 Existing custom algorithms must add `get_supported_gpus()` and be uploaded again
 before they can start new cloud training runs.
+
+Live-stream tracks are now registered with the server in one request for each
+group of sensors, instead of one request for each track. A robot that starts
+many sensors becomes visible to viewers sooner and puts much less load on the
+signalling service.

--- a/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
+++ b/neuracore/core/streaming/p2p/provider/client_provider_stream_manager.py
@@ -35,6 +35,9 @@ from .video_source import DepthVideoSource, VideoSource
 
 logger = logging.getLogger(__name__)
 
+TRACK_BATCH_MAX_SIZE = 100
+TRACK_BATCH_MAX_WAIT_S = 0.05
+
 
 class ClientProviderStreamManager(BaseP2PStreamManager):
     """Manages WebRTC streaming connections for robot sensor data.
@@ -87,6 +90,7 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
         self.event_source_cache: dict[str, JSONSource] = {}
         self.tracks: list[VideoSource] = []
         self.track_metadata: dict[str, RobotStreamTrack] = {}
+        self._pending_tracks: list[RobotStreamTrack] = []
 
     @property
     def enabled_manager(self) -> EnabledManager:
@@ -191,29 +195,43 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
         )
         self.track_metadata[track.id] = track
 
-        await self._post_track(track)
+        if not self._pending_tracks:
+            self.background_tracker.submit_background_coroutine(
+                self._flush_pending_tracks()
+            )
+        self._pending_tracks.append(track)
 
-    async def _post_track(self, track: RobotStreamTrack) -> None:
+    async def _flush_pending_tracks(self) -> None:
+        """Submit the tracks collected since this flush was scheduled."""
+        await asyncio.sleep(TRACK_BATCH_MAX_WAIT_S)
+        pending, self._pending_tracks = self._pending_tracks, []
+        if not pending or self.streaming.is_disabled():
+            return
+        await self._post_track_batch(pending)
+
+    async def _post_track_batch(self, tracks: list[RobotStreamTrack]) -> None:
         """Submit track metadata to the signalling server.
 
         Args:
-            track: The track metadata to submit.
+            tracks: The track metadata to submit.
         """
-        await self.client_session.post(
-            f"{STREAM_API_URL}/org/{self.org_id}/signalling/track",
-            headers=self.auth.get_headers(),
-            json=track.model_dump(mode="json"),
-        )
+        for start in range(0, len(tracks), TRACK_BATCH_MAX_SIZE):
+            chunk = tracks[start : start + TRACK_BATCH_MAX_SIZE]
+            await self.client_session.post(
+                f"{STREAM_API_URL}/org/{self.org_id}/signalling/track/batch",
+                headers=self.auth.get_headers(),
+                json={"tracks": [track.model_dump(mode="json") for track in chunk]},
+            )
 
     async def on_stream_resurrected(self) -> None:
         """Resubmit tracks to the signaling server."""
-        results = await asyncio.gather(
-            *(self._post_track(track) for track in self.track_metadata.values()),
-            return_exceptions=True,
-        )
-        for track, result in zip(self.track_metadata.values(), results):
-            if isinstance(result, BaseException):
-                logger.warning("Failed to resubmit track %s: %s", track.id, result)
+        tracks = list(self.track_metadata.values())
+        if not tracks:
+            return
+        try:
+            await self._post_track_batch(tracks)
+        except Exception:
+            logger.warning("Failed to resubmit %d tracks", len(tracks), exc_info=True)
 
     async def create_new_connection(
         self,
@@ -298,3 +316,4 @@ class ClientProviderStreamManager(BaseP2PStreamManager):
         self.video_tracks_cache.clear()
         self.event_source_cache.clear()
         self.track_metadata.clear()
+        self._pending_tracks.clear()

--- a/tests/unit/core/p2p/test_client_provider_stream_manager.py
+++ b/tests/unit/core/p2p/test_client_provider_stream_manager.py
@@ -1,0 +1,226 @@
+"""Tests for the track batching in the client provider stream manager."""
+
+import asyncio
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from neuracore_types import DataType, RobotStreamTrack
+
+from neuracore.core.const import STREAM_API_URL
+from neuracore.core.streaming.p2p.enabled_manager import EnabledManager
+from neuracore.core.streaming.p2p.provider import client_provider_stream_manager
+from neuracore.core.streaming.p2p.provider.client_provider_stream_manager import (
+    TRACK_BATCH_MAX_SIZE,
+    TRACK_BATCH_MAX_WAIT_S,
+    ClientProviderStreamManager,
+)
+
+ORG_ID = "org-1"
+ROBOT_ID = "robot-1"
+STREAM_ID = "stream-1"
+BATCH_URL = f"{STREAM_API_URL}/org/{ORG_ID}/signalling/track/batch"
+
+
+class RecordingClientSession:
+    """Client session stub that records the requests it is given."""
+
+    def __init__(self) -> None:
+        """Initialise the session with no recorded posts."""
+        self.posts: list[tuple[str, Any]] = []
+
+    async def post(
+        self, url: str, headers: dict | None = None, json: Any = None
+    ) -> None:
+        """Record one post request."""
+        self.posts.append((url, json))
+
+
+@pytest.fixture
+def nc_loop():
+    """Event loop that simulates the neuracore async loop (runs in background)."""
+    loop = asyncio.new_event_loop()
+    done = threading.Event()
+
+    def run():
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_forever()
+        finally:
+            try:
+                loop.close()
+            except Exception:
+                pass
+        done.set()
+
+    thread = threading.Thread(target=run, name="nc-async-loop", daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    done.wait(timeout=2.0)
+
+
+@pytest.fixture
+def client_session() -> RecordingClientSession:
+    """Client session stub shared by the manager and the assertions."""
+    return RecordingClientSession()
+
+
+@pytest.fixture
+def manager(
+    nc_loop, client_session: RecordingClientSession, monkeypatch
+) -> ClientProviderStreamManager:
+    """Manager under test, isolated from the session global streaming state."""
+    monkeypatch.setattr(
+        client_provider_stream_manager,
+        "get_provide_live_data_enabled_manager",
+        lambda: EnabledManager(True, loop=nc_loop),
+    )
+    return ClientProviderStreamManager(
+        robot_id=ROBOT_ID,
+        robot_instance=0,
+        local_stream_id=STREAM_ID,
+        client_session=client_session,
+        loop=nc_loop,
+        org_id=ORG_ID,
+        auth=MagicMock(get_headers=lambda: {}),
+    )
+
+
+def make_track(label: str) -> RobotStreamTrack:
+    return RobotStreamTrack(
+        robot_id=ROBOT_ID,
+        robot_instance=0,
+        stream_id=STREAM_ID,
+        data_type=DataType.RGB_IMAGES,
+        label=label,
+        mid=label,
+    )
+
+
+def wait_for_posts(
+    session: RecordingClientSession, count: int, timeout: float = 5.0
+) -> list[tuple[str, Any]]:
+    """Wait until the session has recorded at least `count` posts."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(session.posts) >= count:
+            return session.posts
+        time.sleep(0.01)
+    raise AssertionError(f"expected {count} posts, got {len(session.posts)}")
+
+
+def wait_past_flush() -> None:
+    """Wait long enough for any scheduled flush to have run."""
+    time.sleep(TRACK_BATCH_MAX_WAIT_S * 3)
+
+
+def run_on_loop(loop: asyncio.AbstractEventLoop, coroutine) -> None:
+    """Run a coroutine on the manager's loop and wait for it to finish."""
+    asyncio.run_coroutine_threadsafe(coroutine, loop).result(timeout=5)
+
+
+def labels_of(post: tuple[str, Any]) -> list[str]:
+    return [track["label"] for track in post[1]["tracks"]]
+
+
+def test_burst_of_sources_is_sent_as_one_batch(
+    manager: ClientProviderStreamManager,
+    client_session: RecordingClientSession,
+    nc_loop,
+):
+    async def create_sources() -> None:
+        manager.get_video_source("front", DataType.RGB_IMAGES, "front-rgb")
+        manager.get_video_source("front", DataType.DEPTH_IMAGES, "front-depth")
+        manager.get_json_source("joints", DataType.JOINT_POSITIONS, "joints")
+
+    run_on_loop(nc_loop, create_sources())
+
+    posts = wait_for_posts(client_session, 1)
+    wait_past_flush()
+
+    assert len(posts) == 1
+    url, payload = posts[0]
+    assert url == BATCH_URL
+    assert [track["label"] for track in payload["tracks"]] == [
+        "front",
+        "front",
+        "joints",
+    ]
+
+
+def test_track_submitted_after_a_flush_is_sent_in_a_later_batch(
+    manager: ClientProviderStreamManager, client_session: RecordingClientSession
+):
+    manager.get_video_source("front", DataType.RGB_IMAGES, "front-rgb")
+    wait_for_posts(client_session, 1)
+
+    manager.get_json_source("joints", DataType.JOINT_POSITIONS, "joints")
+
+    posts = wait_for_posts(client_session, 2)
+    assert labels_of(posts[0]) == ["front"]
+    assert labels_of(posts[1]) == ["joints"]
+
+
+def test_resurrected_stream_resubmits_known_tracks_in_one_batch(
+    manager: ClientProviderStreamManager,
+    client_session: RecordingClientSession,
+    nc_loop,
+):
+    for label in ("front", "joints"):
+        track = make_track(label)
+        manager.track_metadata[track.id] = track
+
+    asyncio.run_coroutine_threadsafe(manager.on_stream_resurrected(), nc_loop).result(
+        timeout=5
+    )
+
+    assert len(client_session.posts) == 1
+    assert labels_of(client_session.posts[0]) == ["front", "joints"]
+
+
+def test_resurrected_stream_chunks_tracks_over_the_batch_cap(
+    manager: ClientProviderStreamManager,
+    client_session: RecordingClientSession,
+    nc_loop,
+):
+    track_count = TRACK_BATCH_MAX_SIZE + 50
+    for index in range(track_count):
+        track = make_track(f"sensor-{index}")
+        manager.track_metadata[track.id] = track
+
+    asyncio.run_coroutine_threadsafe(manager.on_stream_resurrected(), nc_loop).result(
+        timeout=5
+    )
+
+    assert [len(payload["tracks"]) for _, payload in client_session.posts] == [
+        TRACK_BATCH_MAX_SIZE,
+        50,
+    ]
+
+
+def test_disabled_streaming_posts_nothing(
+    manager: ClientProviderStreamManager, client_session: RecordingClientSession
+):
+    manager.enabled_manager.disable()
+
+    manager.get_video_source("front", DataType.RGB_IMAGES, "front-rgb")
+    wait_past_flush()
+
+    assert client_session.posts == []
+
+
+def test_pending_tracks_are_dropped_on_close(
+    manager: ClientProviderStreamManager,
+    client_session: RecordingClientSession,
+    nc_loop,
+):
+    run_on_loop(nc_loop, manager.submit_track("0", DataType.RGB_IMAGES, "front"))
+    assert manager._pending_tracks
+
+    manager._on_close()
+    wait_past_flush()
+
+    assert client_session.posts == []


### PR DESCRIPTION
### Features
 - Live stream tracks are now collected for a short moment and registered in one request, so a robot that starts many sensors no longer sends a burst of requests to the signalling service.
 - A resurrected stream resubmits its tracks in one request instead of one for each track.

### Items
 - [NCP-1126](https://neuracore.atlassian.net/browse/NCP-1126)

### Related PRs
 - NeuracoreAI/neuracore_backend#582

This must not be released before NeuracoreAI/neuracore_backend#582 is deployed, because the batch endpoint does not exist on the current backend.
