### PR TITLE
feat: lossy default encoding

### DIFF
--- a/docs/data_daemon.md
+++ b/docs/data_daemon.md
@@ -202,7 +202,7 @@ These are the supported settings:
 | `offline` | If enabled, uploading is disabled and data is only stored locally. |
 | `api_key` | API key used for authenticating the daemon. |
 | `current_org_id` | Which organisation the daemon should operate under. |
-| `video_codec` |  Video encoding for RGB cameras. `h264_lossless` (default)/ `h264_medium` . |
+| `video_codec` | Video encoding for RGB cameras. `h264_medium` (default) / `h264_lossless`. |
 
 ---
 
@@ -306,25 +306,23 @@ export NEURACORE_DAEMON_RECORDINGS_ROOT=/workspaces/neuracore/recordings
 
 ## Video encoding options
 
-By default every RGB camera is uploaded twice: a **lossless** archive
-(`lossless.mp4`, used for training) and a small **lossy** preview
-(`lossy.mp4`). For long recordings the lossless archive dominates upload size,
-disk, and CPU.
+By default every RGB camera is uploaded as a single full-resolution
+**libx264 CRF 23** video (`lossy.mp4`). That video is used for both preview and
+training, trading a little image fidelity for much smaller uploads. Select the
+`h264_lossless` codec to also upload a lossless archive (`lossless.mp4`) for
+training plus a small lossy preview. For long recordings the lossless archive
+substantially increases upload size, disk use, and CPU. Depth cameras always
+keep their lossless storage (their lossy proxy is a visualisation, not precise
+depth).
 
-Selecting the `h264_medium` codec switches RGB cameras to a single
-full-resolution **libx264 CRF 23** video (`lossy.mp4`) and **drops the lossless
-archive**. That one video is used for both preview and training, trading a
-little image fidelity for much smaller uploads. Depth cameras always keep their
-lossless storage (their lossy proxy is a visualisation, not precise depth).
-
-This is **irreversible for recordings made under it**: the lossless archive is
-never written, so switching back to `h264_lossless` only affects *future*
+The lossy default is **irreversible for recordings made under it**: a lossless
+archive is never written, so selecting `h264_lossless` only affects *future*
 recordings — it cannot restore lossless data for episodes already captured in
 lossy-only mode.
 
 The setting is **global** (it applies to every camera) and lives in the daemon
 profile, so it persists and is picked up for the next recording. The two codecs
-are `h264_lossless` (the default) and `h264_medium` (lossy-only). Set it three
+are `h264_medium` (the lossy-only default) and `h264_lossless`. Set it three
 ways, exactly like the other profile options:
 
 - **From the SDK** (writes the active profile):
@@ -332,12 +330,12 @@ ways, exactly like the other profile options:
   ```python
   import neuracore as nc
 
-  nc.set_video_encoding_options(codec=nc.Codec.H264_MEDIUM)    # lossy-only
+  nc.set_video_encoding_options(codec=nc.Codec.H264_MEDIUM)    # lossy-only default
   nc.start_recording()
   # ... log frames ...
   nc.stop_recording()
 
-  nc.set_video_encoding_options(codec=nc.Codec.H264_LOSSLESS)  # back to default
+  nc.set_video_encoding_options(codec=nc.Codec.H264_LOSSLESS)  # opt in to lossless
   ```
 
 - **With the CLI**, via `profile update`:
@@ -388,7 +386,7 @@ Example:
 ```bash
 neuracore data-daemon profile update laptop --storage-limit 2gb --offline
 neuracore data-daemon profile update laptop --video-codec h264_medium  # lossy-only uploads
-neuracore data-daemon profile update laptop --video-codec h264_lossless # back to the default
+neuracore data-daemon profile update laptop --video-codec h264_lossless # opt in to lossless
 ```
 
 ### `neuracore data-daemon profile get`

--- a/neuracore/api/logging.py
+++ b/neuracore/api/logging.py
@@ -1521,8 +1521,9 @@ def set_video_encoding_options(codec: Codec | str) -> None:
         >>> nc.stop_recording()
 
     Args:
-        codec: The video codec to use, e.g. ``nc.Codec.H264_MEDIUM`` (lossy-only)
-            or the default ``nc.Codec.H264_LOSSLESS``.
+        codec: The video codec to use, e.g. the default
+            ``nc.Codec.H264_MEDIUM`` (lossy-only) or
+            ``nc.Codec.H264_LOSSLESS``.
 
     Raises:
         ValueError: If ``codec`` is not a recognised codec.

--- a/neuracore/core/video_encoding.py
+++ b/neuracore/core/video_encoding.py
@@ -1,10 +1,9 @@
 """Video encoding options for recorded camera streams.
 
-By default each RGB camera is stored as a lossless archive (``lossless.mp4``,
-used for training) plus a small lossy preview (``lossy.mp4``). Selecting a
-:class:`Codec` switches RGB cameras to a single, more compact lossy video that
-is also used for training -- trading a little image fidelity for much smaller
-uploads, which matters for long recordings.
+By default each RGB camera is stored as a single, compact lossy video
+(``lossy.mp4``) that is used for both preview and training. Selecting the
+lossless :class:`Codec` also stores a lossless archive (``lossless.mp4``),
+trading substantially larger uploads for exact captured pixels.
 
 Depth cameras always keep their lossless storage: their lossy proxy is a
 visualisation, not precise depth, so it is never a valid training source.
@@ -34,6 +33,8 @@ _LOSSY_CODEC_OPTIONS: dict[Codec, Libx264Options] = {
     Codec.H264_MEDIUM: {"crf": "23", "preset": "medium"},
 }
 
+_DEFAULT_CODEC = Codec.H264_MEDIUM
+
 
 def resolve_codec(value: str | None) -> Codec | None:
     """Resolve a config/env string to a :class:`Codec`, or ``None``.
@@ -41,7 +42,7 @@ def resolve_codec(value: str | None) -> Codec | None:
     Empty/unset values resolve to ``None`` silently; an unrecognised value also
     resolves to ``None`` but logs a warning. Either way a stray env or config
     value can never break recording -- it simply falls back to the default
-    lossless+lossy encoders.
+    lossy encoder.
 
     Args:
         value: The configured codec identifier, or ``None``.
@@ -65,18 +66,17 @@ def resolve_codec(value: str | None) -> Codec | None:
 def codec_option_overrides(value: str | None) -> Libx264Options | None:
     """Return the lossy-only libx264 options for a codec string, or ``None``.
 
-    ``None`` selects the default lossless-plus-preview encoders; a dict selects a
-    single lossy RGB video with those options. A fresh copy is returned so the
-    caller can mutate it safely.
+    Unset or unknown values select the default lossy RGB encoder. The explicit
+    lossless codec returns ``None``, selecting the lossless-plus-preview
+    encoders. A fresh options copy is returned so the caller can mutate it safely.
 
     Args:
         value: The configured codec identifier, or ``None``.
 
     Returns:
-        A fresh options dict for the lossy encoder, or ``None`` for the default.
+        A fresh options dict for the lossy encoder, or ``None`` for the
+        lossless-plus-preview encoder.
     """
-    codec = resolve_codec(value)
-    if codec is None:
-        return None
+    codec = resolve_codec(value) or _DEFAULT_CODEC
     options = _LOSSY_CODEC_OPTIONS.get(codec)
     return copy.copy(options) if options is not None else None

--- a/neuracore/data_daemon/video_codec.py
+++ b/neuracore/data_daemon/video_codec.py
@@ -32,7 +32,7 @@ def set_active_profile_video_codec(codec: str) -> None:
 
     Args:
         codec: The codec identifier to store (e.g. ``"h264_medium"`` or the
-            ``"h264_lossless"`` default).
+            explicit ``"h264_lossless"`` option).
 
     Raises:
         RuntimeError: If the profile could not be written.

--- a/rust/data_daemon/src/cli/mod.rs
+++ b/rust/data_daemon/src/cli/mod.rs
@@ -127,7 +127,7 @@ enum ProfileCommand {
         /// Active organisation ID for scoping daemon operations.
         #[arg(long = "current-org-id", visible_alias = "current_org_id")]
         current_org_id: Option<String>,
-        /// Global RGB video codec: `h264_lossless` (default) or `h264_medium`.
+        /// Global RGB video codec: `h264_medium` (default) or `h264_lossless`.
         #[arg(long = "video-codec", visible_alias = "video_codec")]
         video_codec: Option<String>,
     },

--- a/rust/data_daemon/src/cloud/cloud_files.rs
+++ b/rust/data_daemon/src/cloud/cloud_files.rs
@@ -197,10 +197,12 @@ mod tests {
             registered("RGB_IMAGES", Some("h264_medium")),
             vec!["RGB_IMAGES/cam/lossy.mp4", "RGB_IMAGES/cam/trace.json"]
         );
-        // RGB default and depth-under-lossy both still register the lossless.
-        assert!(registered("RGB_IMAGES", None)
-            .iter()
-            .any(|path| path.ends_with("lossless.mp4")));
+        // RGB defaults to lossy-only, while depth-under-lossy still registers
+        // the lossless archive.
+        assert_eq!(
+            registered("RGB_IMAGES", None),
+            vec!["RGB_IMAGES/cam/lossy.mp4", "RGB_IMAGES/cam/trace.json"]
+        );
         assert!(registered("DEPTH_IMAGES", Some("h264_medium"))
             .iter()
             .any(|path| path.ends_with("lossless.mp4")));

--- a/rust/data_daemon/src/encoding/video_encoder.rs
+++ b/rust/data_daemon/src/encoding/video_encoder.rs
@@ -109,38 +109,39 @@ const LOSSY_PREVIEW_MAX_HEIGHT: u32 = 480;
 /// Lossy RGB video codec selection for a trace, resolved once at the trace's
 /// first chunk (and by the registration coordinator, from the same source).
 ///
-/// The default produces the lossless archive plus a downscaled lossy preview.
-/// `H264MediumLossyOnly` (the SDK's `nc.Codec.H264_MEDIUM`) instead produces a
-/// single full-resolution `libx264 -crf 23 -preset medium` video and skips the
-/// lossless archive — smaller uploads, with that one video used for training.
+/// The default, `H264MediumLossyOnly` (the SDK's `nc.Codec.H264_MEDIUM`),
+/// produces a single full-resolution `libx264 -crf 23 -preset medium` video and
+/// skips the lossless archive — smaller uploads, with that one video used for
+/// training. `LosslessPlusPreview` is the explicit opt-in to a lossless archive
+/// plus a downscaled lossy preview.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LossyVideoCodec {
-    /// Default: lossless archive (`libx264rgb -qp 0`) plus a preview-resolution
-    /// lossy proxy (`libx264 -qp 23`). Both outputs are produced.
-    #[default]
+    /// Lossless archive (`libx264rgb -qp 0`) plus a preview-resolution lossy
+    /// proxy (`libx264 -qp 23`). Both outputs are produced.
     LosslessPlusPreview,
-    /// `nc.Codec.H264_MEDIUM`: one full-resolution `libx264 -crf 23 -preset
-    /// medium` video; no lossless archive, no preview downscale.
+    /// Default (`nc.Codec.H264_MEDIUM`): one full-resolution `libx264 -crf 23
+    /// -preset medium` video; no lossless archive, no preview downscale.
+    #[default]
     H264MediumLossyOnly,
 }
 
 impl LossyVideoCodec {
-    /// Resolve a codec from a config/env string. Only `"h264_medium"` selects
-    /// lossy-only; `"h264_lossless"` and unset/empty keep the default silently.
-    /// An unrecognised value also keeps the default but logs a warning (parity
-    /// with the SDK's `resolve_codec`), so a typo can't silently change codecs.
+    /// Resolve a codec from a config/env string. `"h264_lossless"` explicitly
+    /// selects lossless-plus-preview; `"h264_medium"` and unset/empty select the
+    /// lossy-only default silently. An unrecognised value also keeps the default
+    /// but logs a warning (parity with the SDK's `resolve_codec`).
     /// Callers gate this to RGB traces — depth always keeps lossless storage.
     pub fn from_config_str(value: Option<&str>) -> Self {
         match value {
-            Some("h264_medium") => Self::H264MediumLossyOnly,
-            None | Some("") | Some("h264_lossless") => Self::LosslessPlusPreview,
+            Some("h264_lossless") => Self::LosslessPlusPreview,
+            None | Some("") | Some("h264_medium") => Self::H264MediumLossyOnly,
             Some(other) => {
                 tracing::warn!(
                     codec = other,
                     "Ignoring unknown video codec; expected one of: \
                      h264_lossless, h264_medium"
                 );
-                Self::LosslessPlusPreview
+                Self::H264MediumLossyOnly
             }
         }
     }
@@ -151,7 +152,7 @@ impl LossyVideoCodec {
     ///
     /// Only RGB cameras honour the selection — a depth trace's lossy proxy is a
     /// visualisation, not precise depth, so depth (and every non-RGB stream)
-    /// always keeps the default lossless archive. This RGB-only gate is
+    /// always keeps a lossless archive. This RGB-only gate is
     /// deliberately narrower than the video-family predicate in
     /// [`crate::cloud::cloud_files`] (which includes depth). Kept pure (the
     /// config string is passed in, not read here) so the encoder path and the
@@ -1803,6 +1804,9 @@ mod tests {
                 "-of",
                 "default=nokey=1:noprint_wrappers=1",
             ]);
+            if entries.starts_with("frame=") {
+                command.arg("-show_frames");
+            }
             if let Some(intervals) = intervals {
                 command.args(["-read_intervals", intervals]);
             }
@@ -1838,9 +1842,13 @@ mod tests {
         // The synthetic NUT is 1 fps, so the kept run starts at 3 s in the
         // source; `setpts` has to bring it back to zero.
         for output in [&lossy, &lossless] {
+            // Read the complete short stream: packet-limited intervals can stop
+            // before ffprobe has decoded its first frame on some H.264 builds.
+            let pts = probe(output, "frame=pts", None);
+            let first_pts = pts.lines().find_map(|value| value.parse::<i64>().ok());
             assert_eq!(
-                probe(output, "frame=pts_time", Some("%+#1")),
-                "0.000000",
+                first_pts,
+                Some(0),
                 "the first kept frame must be rebased to PTS 0"
             );
         }
@@ -2138,15 +2146,23 @@ mod tests {
             LossyVideoCodec::H264MediumLossyOnly
         );
         assert!(LossyVideoCodec::from_config_str(Some("h264_medium")).is_lossy_only());
-        // h264_lossless is the explicit default; unset/unknown also default.
-        for value in [None, Some(""), Some("unknown"), Some("h264_lossless")] {
+        // Unset/unknown values use the h264_medium lossy-only default.
+        for value in [None, Some(""), Some("unknown")] {
             assert_eq!(
                 LossyVideoCodec::from_config_str(value),
-                LossyVideoCodec::LosslessPlusPreview,
+                LossyVideoCodec::H264MediumLossyOnly,
                 "{value:?} should map to the default codec"
             );
-            assert!(!LossyVideoCodec::from_config_str(value).is_lossy_only());
+            assert!(LossyVideoCodec::from_config_str(value).is_lossy_only());
         }
+        assert_eq!(
+            LossyVideoCodec::from_config_str(Some("h264_lossless")),
+            LossyVideoCodec::LosslessPlusPreview
+        );
+        assert_eq!(
+            LossyVideoCodec::default(),
+            LossyVideoCodec::H264MediumLossyOnly
+        );
     }
 
     #[test]
@@ -2167,13 +2183,17 @@ mod tests {
             );
             assert!(!LossyVideoCodec::for_trace(data_type, Some("h264_medium")).is_lossy_only());
         }
-        // RGB with the default/unset codec stays on the lossless+preview path.
-        for value in [None, Some(""), Some("h264_lossless")] {
+        // RGB with the default/unset codec uses the lossy-only path.
+        for value in [None, Some(""), Some("h264_medium")] {
             assert_eq!(
                 LossyVideoCodec::for_trace("RGB_IMAGES", value),
-                LossyVideoCodec::LosslessPlusPreview
+                LossyVideoCodec::H264MediumLossyOnly
             );
         }
+        assert_eq!(
+            LossyVideoCodec::for_trace("RGB_IMAGES", Some("h264_lossless")),
+            LossyVideoCodec::LosslessPlusPreview
+        );
     }
 
     #[test]

--- a/rust/data_daemon/src/pipeline/trace_actor.rs
+++ b/rust/data_daemon/src/pipeline/trace_actor.rs
@@ -1630,14 +1630,23 @@ mod tests {
         let budget = Arc::new(StorageBudget::new(root, policy));
         let (trace_writer, _writer_owner) = crate::state::trace_event_database_writer::spawn(store);
         let (json_writer, _json_owner) = crate::pipeline::json_writer::spawn();
-        Arc::new(TraceActorContext::with_ffmpeg_permits(
-            root.to_path_buf(),
-            budget,
-            VideoEncoder::new(),
-            ffmpeg_permits,
-            trace_writer,
-            json_writer,
-        ))
+        // Most actor tests assert the legacy lossless artifacts directly, so make
+        // that fixture choice explicit now that production defaults to lossy.
+        let (_config_tx, config_rx) = watch::channel(DaemonConfig {
+            video_codec: Some("h264_lossless".to_string()),
+            ..DaemonConfig::default()
+        });
+        Arc::new(
+            TraceActorContext::with_ffmpeg_permits(
+                root.to_path_buf(),
+                budget,
+                VideoEncoder::new(),
+                ffmpeg_permits,
+                trace_writer,
+                json_writer,
+            )
+            .with_config_rx(config_rx),
+        )
     }
 
     fn identity(recording_index: i64, trace_id: &str, data_type: &str) -> TraceIdentity {

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case.py
@@ -163,11 +163,11 @@ class DataDaemonTestCase:
             in the suite (documented and discoverable) without running.  A
             batch with ``skip=True`` forces every case to skip regardless of
             this per-case value.
-        video_codec: When set (e.g. ``"h264_medium"``), the case selects that
-            global video codec via ``nc.set_video_encoding_options`` before
-            recording, so RGB cameras upload a single lossy CRF-23 video and the
-            lossless archive is dropped.  ``None`` keeps the default
-            lossless+lossy behaviour.
+        video_codec: When set, the case selects that global video codec via
+            ``nc.set_video_encoding_options`` before recording. ``None`` makes
+            the integration harness explicitly select ``h264_lossless`` to
+            preserve its exact-pixel baseline; it does not exercise the daemon's
+            lossy default.
         depth_count: Number of depth camera streams to log per recording. A
             value of ``0`` disables depth entirely. Depth cameras are
             independent streams from RGB cameras (distinct trace identities,

--- a/tests/unit/core/test_video_encoding.py
+++ b/tests/unit/core/test_video_encoding.py
@@ -19,17 +19,16 @@ def test_h264_medium_resolves_and_maps_to_crf_23_medium() -> None:
     }
 
 
-def test_h264_lossless_resolves_but_uses_default_encoders() -> None:
-    # H264_LOSSLESS is a recognised codec (no warning) that maps to the default
-    # lossless+lossy encoders, so it is the explicit "switch back" value.
+def test_h264_lossless_resolves_and_uses_lossless_encoders() -> None:
+    # H264_LOSSLESS is the explicit opt-in to lossless+lossy encoding.
     assert resolve_codec("h264_lossless") is Codec.H264_LOSSLESS
     assert codec_option_overrides("h264_lossless") is None
 
 
-def test_unset_and_unknown_resolve_to_default() -> None:
+def test_unset_and_unknown_resolve_to_default_lossy_options() -> None:
     for value in (None, "", "not-a-codec"):
         assert resolve_codec(value) is None
-        assert codec_option_overrides(value) is None
+        assert codec_option_overrides(value) == {"crf": "23", "preset": "medium"}
 
 
 def test_options_are_a_fresh_copy_each_call() -> None:
@@ -54,8 +53,8 @@ def test_unknown_codec_logs_a_warning(caplog: pytest.LogCaptureFixture) -> None:
 def test_known_and_unset_codecs_do_not_warn(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # The explicit default and unset/empty values are silent — only a genuinely
-    # unrecognised value warns.
+    # Known and unset/empty values are silent — only a genuinely unrecognised
+    # value warns.
     with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
         resolve_codec("h264_lossless")
         resolve_codec("h264_medium")


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Changed default video encoding option to h264_medium lossy encoding, from h264_lossless

### Items
<!-- Please add a link to the jira items this work relates to -->
 - [[NC-XX](https://neuracore.atlassian.net/browse/NC-XX)](https://neuracore.atlassian.net/browse/NCP-1316?atlOrigin=eyJpIjoiNGFhZjM1MGRhNTdjNGFmMzhlMTkyNzJlM2IzMDJlNDUiLCJwIjoiaiJ9)

