### PR TITLE
fix: Send SDK version to detect breaking API incompatibilities

### DIFF
--- a/neuracore/core/auth.py
+++ b/neuracore/core/auth.py
@@ -177,11 +177,16 @@ class Auth(EventEmitter, metaclass=SingletonMetaclass):
         """
         from neuracore_types import __version__ as nc_types_version
 
+        from neuracore import __version__ as neuracore_version
+
         try:
             session = thread_local_session(retry_transient=True)
             response = session.get(
                 f"{API_URL}/auth/verify-version",
-                params={"version": nc_types_version},
+                params={
+                    "neuracore_types_version": nc_types_version,
+                    "neuracore_version": neuracore_version,
+                },
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as exc:

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -458,3 +458,17 @@ def test_stop_recording_wait_times_out_when_upload_never_completes(
         nc.stop_recording(wait=True, wait_timeout_s=1.0)
 
     assert poll_count == 1
+
+
+def test_version_check_sends_sdk_and_types_versions():
+    """Send both package versions using the backend query parameter names."""
+    from neuracore_types import __version__ as types_version
+
+    with requests_mock.Mocker() as mock:
+        request = mock.get(f"{API_URL}/auth/verify-version", status_code=200)
+        get_auth().validate_version()
+
+    assert request.last_request.qs == {
+        "neuracore_types_version": [types_version.lower()],
+        "neuracore_version": [nc.__version__.lower()],
+    }


### PR DESCRIPTION
### Features

- Send both `neuracore_version` and `neuracore_types_version` to `/auth/verify-version`.

### Bugfixes

- Previously, SDK versions with incompatible API URLs could pass validation when their types major version still matched. Providing the SDK version allows the backend to reject SDK major-version mismatches before authentication proceeds.
- Add a regression test for the exact query parameter names and package versions.

### Related PRs

- https://github.com/NeuracoreAI/neuracore_backend/pull/593
