### PR TITLE
test: override lossy video for daemon tests

### DIFF
--- a/tests/integration/platform/data_daemon/conftest.py
+++ b/tests/integration/platform/data_daemon/conftest.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 
 import neuracore as nc
-from neuracore.data_daemon.const import active_profile_name
 from tests.integration.platform.data_daemon.shared.assertions import (
     clear_daemon_timer_stats as _clear_daemon_timer_stats,
 )
@@ -20,7 +19,8 @@ from tests.integration.platform.data_daemon.shared.process_control import (
 )
 from tests.integration.platform.data_daemon.shared.profiles import (
     cleanup_test_profiles,
-    profile_path,
+    preserved_active_profile,
+    scoped_default_profile,
 )
 from tests.integration.platform.data_daemon.shared.reporting import (
     PerformanceReportContext,
@@ -123,30 +123,21 @@ def cleanup_profiles():
 
 
 @pytest.fixture(autouse=True)
-def reset_video_codec():
-    """Restore the active daemon profile to its exact pre-test state.
+def case_video_codec(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Select the case's video codec before any daemon starts.
 
-    The codec is a persistent daemon-profile setting, so a case selecting a
-    lossy codec must not leak into a later test or the developer's real profile.
-    Offline cases write an ephemeral profile (removed by ``cleanup_profiles``),
-    but online cases write the default profile. Snapshot the active profile file
-    and restore it byte-for-byte (or delete it if it did not exist), rather than
-    forcing a literal ``h264_lossless`` — which would otherwise leave a residual
-    ``video_codec`` key on a developer's default profile that had none. Only
-    writes when the test actually changed the file, so non-video tests are free.
+    Defaults to lossless; the daemon's own default is lossy and smears the frame
+    codes embedded in test video.
     """
-    active_path = profile_path(active_profile_name())
-    original_bytes = active_path.read_bytes() if active_path.exists() else None
-    try:
+    case = request.getfixturevalue("case") if "case" in request.fixturenames else None
+    codec = (
+        nc.Codec(case.video_codec)
+        if case is not None and case.video_codec
+        else nc.Codec.H264_LOSSLESS
+    )
+    with scoped_default_profile(), preserved_active_profile():
+        nc.set_video_encoding_options(codec)
         yield
-    finally:
-        current_bytes = active_path.read_bytes() if active_path.exists() else None
-        if current_bytes == original_bytes:
-            return
-        if original_bytes is not None:
-            active_path.write_bytes(original_bytes)
-        elif active_path.exists():
-            active_path.unlink()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/platform/data_daemon/shared/profiles.py
+++ b/tests/integration/platform/data_daemon/shared/profiles.py
@@ -1,8 +1,8 @@
 """Daemon profile and environment context managers for integration tests.
 
-Manages temporary offline YAML profiles and online-mode env overrides.
-No process control and no assertions — composes with :mod:`process_control`
-and :mod:`runners`.
+Manages temporary offline YAML profiles, online-mode env overrides, and
+restoration of profiles a test writes.  No process control and no assertions —
+composes with :mod:`process_control` and :mod:`runners`.
 """
 
 from __future__ import annotations
@@ -12,6 +12,10 @@ import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
+
+import yaml
+
+from neuracore.data_daemon.const import active_profile_name
 
 TEST_PROFILE_PATHS: set[Path] = set()
 """Tracks daemon profile files created by tests for cleanup on teardown."""
@@ -39,6 +43,44 @@ def cleanup_test_profiles() -> None:
 
 
 @contextmanager
+def scoped_default_profile() -> Generator[None]:
+    """Clear ``NEURACORE_DAEMON_PROFILE`` so the default profile is active.
+
+    Yields:
+        ``None`` — the default profile is active while the body executes.
+    """
+    previous_profile = os.environ.pop("NEURACORE_DAEMON_PROFILE", None)
+    try:
+        yield
+    finally:
+        if previous_profile is not None:
+            os.environ["NEURACORE_DAEMON_PROFILE"] = previous_profile
+
+
+@contextmanager
+def preserved_active_profile() -> Generator[None]:
+    """Restore the profile active on entry, deleting it if the block created it.
+
+    Enter after whatever selects the profile.
+
+    Yields:
+        ``None``.
+    """
+    active_path = profile_path(active_profile_name())
+    original_bytes = active_path.read_bytes() if active_path.exists() else None
+    try:
+        yield
+    finally:
+        current_bytes = active_path.read_bytes() if active_path.exists() else None
+        if current_bytes == original_bytes:
+            return
+        if original_bytes is not None:
+            active_path.write_bytes(original_bytes)
+        elif active_path.exists():
+            active_path.unlink()
+
+
+@contextmanager
 def scoped_offline_profile() -> Generator[None]:
     """Activate a temporary offline daemon profile for the duration of the block.
 
@@ -47,6 +89,9 @@ def scoped_offline_profile() -> Generator[None]:
     ``NEURACORE_DAEMON_PROFILE`` at it, then restores the previous value on
     exit.  The profile path is added to :data:`TEST_PROFILE_PATHS` so that
     :func:`cleanup_test_profiles` can remove it at teardown.
+
+    A named profile is resolved standalone, never merged over the default, so
+    the active profile's ``video_codec`` is copied in.
 
     Does **not** start, stop, or clean up any daemon processes or storage.
 
@@ -57,7 +102,14 @@ def scoped_offline_profile() -> Generator[None]:
     profile_name = f"offline_profile_{uuid.uuid4().hex[:8]}"
     offline_profile_path = profile_path(profile_name)
     offline_profile_path.parent.mkdir(parents=True, exist_ok=True)
-    offline_profile_path.write_text("offline: true\n", encoding="utf-8")
+    contents = "offline: true\n"
+    active_profile = profile_path(active_profile_name())
+    if active_profile.exists():
+        active = yaml.safe_load(active_profile.read_text(encoding="utf-8")) or {}
+        codec = active.get("video_codec")
+        if codec:
+            contents += f"video_codec: {codec}\n"
+    offline_profile_path.write_text(contents, encoding="utf-8")
     TEST_PROFILE_PATHS.add(offline_profile_path)
 
     previous_profile = os.environ.get("NEURACORE_DAEMON_PROFILE")

--- a/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
+++ b/tests/integration/platform/data_daemon/shared/test_case/build_test_case_context.py
@@ -1240,11 +1240,6 @@ def run_case_contexts(
     if specs is None:
         specs = build_context_specs(case)
 
-    if case.has_video:
-        nc.set_video_encoding_options(
-            nc.Codec(case.video_codec) if case.video_codec else nc.Codec.H264_LOSSLESS
-        )
-
     if specs:
         with Timer(MAX_TIME_TO_START_S, label="nc.create_dataset", always_log=True):
             nc.create_dataset(specs[0].dataset_name)


### PR DESCRIPTION
### Bugfixes
<!-- Please explain any existing functionality improved/changed -->
 - Daemon now lossy by default. Fails some functional tests. Add override so lossless is the default in the tests. Still acknowledge profile overrides further along.
