### PR TITLE
feat: add client support for launching data synthesis jobs

### DIFF
--- a/neuracore-dictionary.txt
+++ b/neuracore-dictionary.txt
@@ -207,6 +207,7 @@ ghjdidnia
 gitignored
 gptj
 GPTJ
+greenaug
 groot
 Groot
 hdlc

--- a/neuracore/__init__.py
+++ b/neuracore/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 from .api.core import *  # noqa: F403
+from .api.data_synthesis import *  # noqa: F403
 from .api.datasets import *  # noqa: F403
 from .api.endpoints import *  # noqa: F403
 from .api.logging import *  # noqa: F403

--- a/neuracore/api/data_synthesis.py
+++ b/neuracore/api/data_synthesis.py
@@ -1,0 +1,308 @@
+"""Data synthesis job management utilities.
+
+Data synthesis runs as its own service, reached under the /synthesis prefix
+rather than the backend's org routes.
+
+Data synthesis expands a dataset by regenerating the imagery of its recordings
+while leaving every other modality untouched, so the actions recorded against
+those frames stay valid.
+"""
+
+from typing import Any
+
+import requests
+from neuracore_types import (
+    DataSynthesisAlgorithmConfig,
+    DataSynthesisJobRequest,
+    DataSynthesisPreviewRequest,
+)
+
+from neuracore.core.config.get_current_org import get_current_org
+from neuracore.core.utils.http_errors import extract_error_detail
+from neuracore.core.utils.http_session import thread_local_session
+
+from ..core.auth import get_auth
+from ..core.const import SYNTHESIS_API_URL
+from ..core.data.dataset import Dataset
+from .training import _resolve_next_name
+
+
+def start_data_synthesis_run(
+    name: str,
+    dataset_name: str,
+    algorithm_name: str,
+    algorithm_config: dict[str, Any],
+    scaling_factor: int = 2,
+    output_dataset_name: str | None = None,
+    include_original: bool = False,
+    name_auto_increment: bool = False,
+) -> dict:
+    """Start a new data synthesis run.
+
+    Args:
+        name: Name of the synthesis job.
+        dataset_name: Name of the dataset to expand.
+        algorithm_name: Name of the algorithm to use, as
+            get_data_synthesis_algorithms names it.
+        algorithm_config: Configuration parameters for the algorithm. What each
+            algorithm takes, and what it defaults, is described by
+            get_data_synthesis_algorithms; anything with a default may be left
+            out. The service checks these against the algorithm and says what
+            is wrong with them.
+        scaling_factor: How many recordings to produce per original. A whole
+            number from 1 to 10.
+        output_dataset_name: Name of the dataset to write results into.
+            Defaults to the source dataset's name with a suffix.
+        include_original: Whether the output dataset should also contain the
+            source recordings. They are referenced, never copied.
+        name_auto_increment: If True and a job with this name already exists,
+            use name_1, name_2, ... instead of duplicating the name.
+
+    Returns:
+        dict: Job data including job ID and status.
+
+    Raises:
+        ValueError: If the dataset is not found, or the algorithm and its
+            configuration are not something the service can run.
+        requests.exceptions.HTTPError: If the API request fails.
+        requests.exceptions.RequestException: If there is a network problem.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    if name_auto_increment:
+        jobs = get_data_synthesis_jobs()
+        existing_names = {
+            job["name"] for job in jobs if isinstance(job.get("name"), str)
+        }
+        name = _resolve_next_name(name, existing_names)
+
+    dataset = Dataset.get_by_name(dataset_name)
+    if dataset is None:
+        raise ValueError(f"Dataset '{dataset_name}' not found")
+
+    data = DataSynthesisJobRequest(
+        name=name,
+        dataset_id=dataset.id,
+        output_dataset_name=output_dataset_name or f"{dataset.name} (synthetic)",
+        algorithm=DataSynthesisAlgorithmConfig(
+            name=algorithm_name, parameters=algorithm_config
+        ),
+        scaling_factor=scaling_factor,
+        include_original=include_original,
+    )
+
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.post(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/jobs",
+        headers=auth.get_headers(),
+        json=data.model_dump(mode="json"),
+        timeout=(5.0, 60.0),
+    )
+    if not response.ok:
+        detail = extract_error_detail(response)
+        raise ValueError(f"Error starting data synthesis run: {detail}")
+    return response.json()
+
+
+def generate_data_synthesis_preview(
+    dataset_name: str,
+    algorithm_name: str,
+    algorithm_config: dict[str, Any],
+    recording_index: int = 0,
+    frame_index: int = 0,
+) -> dict:
+    """Generate example frames showing what a synthesis run would produce.
+
+    Every camera of the sampled recording is generated, because a prompt that
+    segments the right object from one viewpoint can miss from another.
+
+    Args:
+        dataset_name: Name of the dataset to sample from.
+        algorithm_name: Name of the algorithm to use, as
+            get_data_synthesis_algorithms names it.
+        algorithm_config: Configuration parameters for that algorithm.
+        recording_index: Which recording of the dataset to sample from.
+        frame_index: Which frame of each camera's video to sample.
+
+    Returns:
+        dict: A ``frames`` entry per camera, each holding the camera name and
+        URLs of the original and generated frames, plus a digest of the
+        configuration that produced them.
+
+    Raises:
+        ValueError: If the dataset is not found, the algorithm and its
+            configuration are not something the service can run, or generating
+            the preview failed.
+        requests.exceptions.RequestException: If there is a network problem.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    dataset = Dataset.get_by_name(dataset_name)
+    if dataset is None:
+        raise ValueError(f"Dataset '{dataset_name}' not found")
+
+    data = DataSynthesisPreviewRequest(
+        dataset_id=dataset.id,
+        algorithm=DataSynthesisAlgorithmConfig(
+            name=algorithm_name, parameters=algorithm_config
+        ),
+        recording_index=recording_index,
+        frame_index=frame_index,
+    )
+
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    # A diffusion preview runs the model on CPU once per camera, so give it
+    # several minutes before giving up.
+    response = session.post(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/preview",
+        headers=auth.get_headers(),
+        json=data.model_dump(mode="json"),
+        timeout=(5.0, 900.0),
+    )
+    if not response.ok:
+        detail = extract_error_detail(response)
+        raise ValueError(f"Error generating data synthesis preview: {detail}")
+    return response.json()
+
+
+def get_data_synthesis_algorithms() -> list[dict]:
+    """List the algorithms a data synthesis run can be started with.
+
+    Read out of the package the synthesis worker runs, so this is the only
+    thing that says what is on offer and what each algorithm takes.
+
+    Returns:
+        One entry per algorithm, each with its ``name``, a ``title`` and a
+        ``description``, and its parameters as JSON Schema under
+        ``json_schema`` -- their types, defaults, choices, which are required,
+        and what each one means.
+
+    Raises:
+        requests.exceptions.HTTPError: If the API request fails.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.get(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/algorithms",
+        headers=auth.get_headers(),
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_data_synthesis_jobs() -> list[dict]:
+    """List all data synthesis jobs for the current organization.
+
+    Returns:
+        List of job dicts (id, name, status, etc.).
+
+    Raises:
+        requests.exceptions.HTTPError: If the API request fails.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.get(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/jobs",
+        headers=auth.get_headers(),
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_data_synthesis_job_data(job_id: str) -> dict:
+    """Retrieve complete data for a data synthesis job.
+
+    Args:
+        job_id: The ID of the job.
+
+    Returns:
+        dict: Complete job data including status, configuration, and progress.
+
+    Raises:
+        ValueError: If the job is not found.
+        requests.exceptions.HTTPError: If the API request returns an error status.
+        requests.exceptions.RequestException: If there is a network problem.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    try:
+        response = session.get(
+            f"{SYNTHESIS_API_URL}/org/{org_id}/jobs/{job_id}",
+            headers=auth.get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as error:
+        if error.response is not None and error.response.status_code == 404:
+            raise ValueError("Job not found") from error
+        raise
+
+
+def get_data_synthesis_job_status(job_id: str) -> str:
+    """Get the current status of a data synthesis job.
+
+    Args:
+        job_id: The ID of the job.
+
+    Returns:
+        str: Current status, e.g. "RUNNING", "COMPLETED" or "FAILED".
+
+    Raises:
+        ValueError: If the job is not found.
+        requests.exceptions.RequestException: If there is a network problem.
+    """
+    return get_data_synthesis_job_data(job_id)["status"]
+
+
+def cancel_data_synthesis_job(job_id: str) -> None:
+    """Stop a running data synthesis job and release its machine.
+
+    Args:
+        job_id: The ID of the job to cancel.
+
+    Raises:
+        ValueError: If the job is not found or cancelling it failed.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.post(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/jobs/{job_id}/cancel",
+        headers=auth.get_headers(),
+    )
+    if not response.ok:
+        detail = extract_error_detail(response)
+        raise ValueError(f"Error cancelling data synthesis job: {detail}")
+
+
+def delete_data_synthesis_job(job_id: str) -> None:
+    """Delete a data synthesis job and release its machine.
+
+    The dataset the job produced is left in place.
+
+    Args:
+        job_id: The ID of the job to delete.
+
+    Raises:
+        ValueError: If the job is not found or deleting it failed.
+        ConfigError: If there is an error trying to get the current org.
+    """
+    auth = get_auth()
+    org_id = get_current_org()
+    session = thread_local_session()
+    response = session.delete(
+        f"{SYNTHESIS_API_URL}/org/{org_id}/jobs/{job_id}",
+        headers=auth.get_headers(),
+    )
+    if not response.ok:
+        detail = extract_error_detail(response)
+        raise ValueError(f"Error deleting data synthesis job: {detail}")

--- a/neuracore/core/const.py
+++ b/neuracore/core/const.py
@@ -24,6 +24,11 @@ API_URL = os.getenv("NEURACORE_API_URL", "https://api.neuracore.com/api")
 # the path, which it cannot match.
 STREAM_API_URL = f"{API_URL}/stream"
 
+# Data synthesis is served by its own backend service, selected by the same kind
+# of path prefix. Overridable on its own so that a local run can reach a
+# synthesis service that is not behind the same host as the rest of the API.
+SYNTHESIS_API_URL = os.getenv("NEURACORE_SYNTHESIS_API_URL") or f"{API_URL}/synthesis"
+
 DEFAULT_CACHE_DIR = Path.home() / ".neuracore" / "training"
 DEFAULT_RECORDING_CACHE_DIR = DEFAULT_CACHE_DIR / "recording_cache"
 MAX_DATA_STREAMS = 1000

--- a/tests/integration/platform/test_data_synthesis.py
+++ b/tests/integration/platform/test_data_synthesis.py
@@ -1,0 +1,225 @@
+"""Integration test: expanding a dataset with data synthesis.
+
+Drives a synthesis job end to end against a real backend: collect a small
+dataset, preview what the configuration produces, run the job, and check the
+dataset it produced.
+
+The invariant worth the most here is that only the imagery changed. A
+synthesized recording is derived from its source by copying every non-video
+trace byte for byte, so the joint positions, poses and language recorded
+against those frames still describe them. If that ever stops holding, the
+generated data is quietly wrong in a way no model would tell you about.
+
+Runs the procedural in-painter, which needs no model download and no
+meaningful GPU time. Diffusion is the same code path with a slower generator,
+so it is left to be triggered by hand.
+
+Target environment
+------------------
+Needs a backend that can provision a machine, so staging or production. The
+preview step additionally needs SYNTHESIS_PREVIEW_URL configured there; it is
+skipped rather than failed when previews are unavailable, so the rest of the
+run is still covered.
+"""
+
+import logging
+import time
+
+import pytest
+
+import neuracore as nc
+from neuracore.core.data.dataset import Dataset
+
+from ..ml.shared.dataset import collect_demo_data
+from ..ml.shared.utils import unique_name
+
+logger = logging.getLogger(__name__)
+
+RECORDINGS = 2
+SCALING_FACTOR = 2
+"""Two copies per source recording, so the distribution logic is exercised."""
+
+JOB_POLL_SECONDS = 30
+JOB_TIMEOUT_MINUTES = 40
+
+TERMINAL_STATUSES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+ALGORITHM_NAME = "procedural-in-painter"
+"""Needs no model download and no diffusion weights."""
+
+ALGORITHM_CONFIG = {
+    "segmentation_prompts": ["table"],
+}
+
+
+def _wait_for_job(job_id: str) -> dict:
+    """Poll a synthesis job until it reaches a terminal status.
+
+    Args:
+        job_id: The job to wait for.
+
+    Returns:
+        The job's final data.
+
+    Raises:
+        AssertionError: If the job does not finish in time.
+    """
+    deadline = time.time() + JOB_TIMEOUT_MINUTES * 60
+    while time.time() < deadline:
+        job = nc.get_data_synthesis_job_data(job_id)
+        logger.info(
+            "Synthesis job %s: %s (%s/%s recordings)",
+            job_id,
+            job["status"],
+            job.get("recordings_completed"),
+            job.get("recordings_total"),
+        )
+        if job["status"] in TERMINAL_STATUSES:
+            return job
+        time.sleep(JOB_POLL_SECONDS)
+
+    raise AssertionError(
+        f"Synthesis job {job_id} did not finish within "
+        f"{JOB_TIMEOUT_MINUTES} minutes"
+    )
+
+
+class TestDataSynthesis:
+    """Expands a dataset and checks what came out of it."""
+
+    source_dataset: Dataset
+    job_id: str
+    output_dataset_name: str
+    all_steps_passed = True
+
+    @classmethod
+    def setup_class(cls) -> None:
+        nc.login()
+        cls.robot_name = unique_name("synthesis_robot")
+        cls.source_dataset_name = unique_name("synthesis_source")
+        cls.output_dataset_name = unique_name("synthesis_output")
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        # A failed run leaves its artifacts behind so they can be inspected.
+        if not cls.all_steps_passed:
+            logger.warning("Leaving synthesis artifacts in place after failure")
+            return
+        for cleanup in (
+            lambda: nc.delete_data_synthesis_job(cls.job_id),
+            lambda: nc.get_dataset(name=cls.output_dataset_name).delete(),
+            lambda: cls.source_dataset.delete(),
+        ):
+            try:
+                cleanup()
+            except Exception:
+                logger.warning("Cleanup step failed", exc_info=True)
+
+    def test_step01_collect_a_source_dataset(self) -> None:
+        type(self).source_dataset = collect_demo_data(
+            robot_name=self.robot_name,
+            dataset_name=self.source_dataset_name,
+            joint_names=("joint1", "joint2"),
+            gripper_names=["gripper"],
+            language_label="pick up the block from the table",
+            nc_cam_name="front",
+            pose_sensor_name="end_effector",
+            num_episodes=RECORDINGS,
+            instance_id=0,
+        )
+
+        assert len(self.source_dataset) == RECORDINGS
+
+    def test_step02_preview_the_configuration(self) -> None:
+        try:
+            preview = nc.generate_data_synthesis_preview(
+                dataset_name=self.source_dataset_name,
+                algorithm_name=ALGORITHM_NAME,
+                algorithm_config=ALGORITHM_CONFIG,
+            )
+        except ValueError as error:
+            if "not available" in str(error):
+                pytest.skip("No preview service configured in this environment")
+            raise
+
+        # A job regenerates every camera, so the preview covers every camera,
+        # each handed back as URLs the caller can fetch.
+        assert preview["frames"]
+        for frame in preview["frames"]:
+            assert frame["camera"]
+            assert frame["before_url"]
+            assert frame["after_url"]
+        cameras = [frame["camera"] for frame in preview["frames"]]
+        assert len(set(cameras)) == len(cameras)
+        assert preview["config_hash"]
+
+    def test_step03_start_the_run(self) -> None:
+        job = nc.start_data_synthesis_run(
+            name=unique_name("synthesis_job"),
+            dataset_name=self.source_dataset_name,
+            algorithm_name=ALGORITHM_NAME,
+            algorithm_config=ALGORITHM_CONFIG,
+            scaling_factor=SCALING_FACTOR,
+            output_dataset_name=self.output_dataset_name,
+        )
+
+        type(self).job_id = job["id"]
+        assert job["status"] == "QUEUED"
+
+    def test_step04_the_run_completes(self) -> None:
+        job = _wait_for_job(self.job_id)
+
+        assert job["status"] == "COMPLETED", job.get("error")
+
+    def test_step05_the_output_holds_the_expected_recordings(self) -> None:
+        output = nc.get_dataset(name=self.output_dataset_name)
+
+        assert len(output) == RECORDINGS * SCALING_FACTOR
+
+    def test_step06_only_the_imagery_changed(self) -> None:
+        """Every non-video trace must survive synthesis untouched.
+
+        Checked through synchronization rather than by comparing blobs: if the
+        copied traces were damaged, a synchronized view of them would not line
+        up with the source's.
+        """
+        output = nc.get_dataset(name=self.output_dataset_name)
+
+        source_synced = self.source_dataset.synchronize(frequency=10)
+        output_synced = output.synchronize(frequency=10)
+
+        source_point = next(iter(next(iter(source_synced))))
+        output_point = next(iter(next(iter(output_synced))))
+
+        for data_type, source_sensors in source_point.data.items():
+            if data_type.value == "RGB_IMAGES":
+                continue
+            assert (
+                data_type in output_point.data
+            ), f"{data_type} did not survive synthesis"
+            assert set(output_point.data[data_type]) == set(
+                source_sensors
+            ), f"{data_type} sensors changed during synthesis"
+
+    def test_step07_the_output_is_trainable(self) -> None:
+        """A dataset that cannot be synchronized cannot be trained on.
+
+        Synthesis never synchronizes, so this is the first time the recordings
+        it wrote are read the way training reads them.
+        """
+        output = nc.get_dataset(name=self.output_dataset_name)
+
+        synced = output.synchronize(frequency=10)
+
+        assert len(synced) == RECORDINGS * SCALING_FACTOR
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # type: ignore[no-untyped-def]
+    """Record a failure so teardown can leave the artifacts alone."""
+    outcome = yield
+    report = outcome.get_result()
+    if report.when == "call" and report.failed:
+        cls = getattr(item, "cls", None)
+        if cls is not None:
+            cls.all_steps_passed = False

--- a/tests/unit/api/test_data_synthesis.py
+++ b/tests/unit/api/test_data_synthesis.py
@@ -1,0 +1,292 @@
+"""Tests for the data synthesis client API."""
+
+import pytest
+from neuracore_types import Dataset, DataType
+
+import neuracore as nc
+from neuracore.core.const import API_URL
+
+TEST_DATASET_ID = "dataset123"
+
+
+@pytest.fixture
+def job_response() -> dict:
+    return {
+        "id": "synth_job_123",
+        "name": "expand tabletop",
+        "dataset_id": TEST_DATASET_ID,
+        "output_dataset_name": "test_dataset (synthetic)",
+        "algorithm": {
+            "name": "procedural-in-painter",
+            "parameters": {"segmentation_prompts": ["Table"]},
+        },
+        "scaling_factor": 2,
+        "include_original": False,
+        "status": "QUEUED",
+        "launch_time": 1.0,
+        "recordings_total": 0,
+        "recordings_completed": 0,
+        "deleted": False,
+        "deleted_at": None,
+    }
+
+
+@pytest.fixture
+def algorithm_specs() -> list[dict]:
+    """What the service says is on offer.
+
+    The client no longer holds a list of algorithms, so this is a response
+    shape rather than anything the client knows.
+    """
+    return [{
+        "name": "procedural-in-painter",
+        "config_name": "procedural_in_painter",
+        "title": "Procedural in-painting",
+        "description": "Fills the objects a prompt names with a pattern.",
+        "json_schema": {
+            "properties": {"segmentation_prompts": {"type": "array"}},
+            "required": ["segmentation_prompts"],
+        },
+    }]
+
+
+@pytest.fixture
+def mock_endpoints(mock_auth_requests, mocked_org_id, job_response, algorithm_specs):
+    """Register the endpoints the data synthesis API walks through."""
+
+    def register(
+        job_status_code: int = 200,
+        existing_jobs: list[dict] | None = None,
+    ) -> str:
+        dataset = Dataset(
+            id=TEST_DATASET_ID,
+            name="test_dataset",
+            created_at=0.0,
+            modified_at=0.0,
+            size_bytes=2048,
+            tags=[],
+            is_shared=False,
+            num_demonstrations=20,
+            all_data_types={DataType.RGB_IMAGES: 1},
+            common_data_types={DataType.RGB_IMAGES: 1},
+        )
+        org_url = f"{API_URL}/synthesis/org/{mocked_org_id}"
+        mock_auth_requests.get(
+            f"{API_URL}/org/{mocked_org_id}/datasets/search/by-name",
+            json=dataset.model_dump(mode="json"),
+            status_code=200,
+        )
+        mock_auth_requests.get(
+            f"{org_url}/jobs",
+            json=existing_jobs if existing_jobs is not None else [],
+            status_code=200,
+        )
+        mock_auth_requests.post(
+            f"{org_url}/jobs",
+            json=job_response,
+            status_code=job_status_code,
+        )
+        mock_auth_requests.get(
+            f"{org_url}/algorithms",
+            json=algorithm_specs,
+            status_code=200,
+        )
+        nc.login("test_api_key")
+        return org_url
+
+    return register
+
+
+class TestAlgorithmListing:
+    def test_lists_what_the_service_offers(self, mock_endpoints) -> None:
+        # The client holds no list of its own: adding an algorithm to the
+        # worker's package is meant to reach a notebook without a release of
+        # this package.
+        mock_endpoints()
+
+        algorithms = nc.get_data_synthesis_algorithms()
+
+        assert [algorithm["name"] for algorithm in algorithms] == [
+            "procedural-in-painter"
+        ]
+        assert algorithms[0]["json_schema"]["required"] == ["segmentation_prompts"]
+
+
+class TestStartRun:
+    def test_starts_a_run_and_returns_the_job(self, mock_endpoints) -> None:
+        mock_endpoints()
+
+        job = nc.start_data_synthesis_run(
+            name="expand tabletop",
+            dataset_name="test_dataset",
+            algorithm_name="procedural-in-painter",
+            algorithm_config={"segmentation_prompts": ["Table"]},
+        )
+
+        assert job["id"] == "synth_job_123"
+
+    def test_sends_the_resolved_dataset_id(
+        self, mock_endpoints, mock_auth_requests
+    ) -> None:
+        mock_endpoints()
+
+        nc.start_data_synthesis_run(
+            name="expand tabletop",
+            dataset_name="test_dataset",
+            algorithm_name="procedural-in-painter",
+            algorithm_config={"segmentation_prompts": ["Table"]},
+            scaling_factor=3,
+        )
+
+        sent = mock_auth_requests.request_history[-1].json()
+        assert sent["dataset_id"] == TEST_DATASET_ID
+        assert sent["scaling_factor"] == 3
+        assert sent["algorithm"]["name"] == "procedural-in-painter"
+        assert sent["algorithm"]["parameters"] == {"segmentation_prompts": ["Table"]}
+        # Synthesis never synchronizes, so no frequency is sent.
+        assert "synchronization_details" not in sent
+
+    def test_defaults_the_output_name_from_the_source(
+        self, mock_endpoints, mock_auth_requests
+    ) -> None:
+        mock_endpoints()
+
+        nc.start_data_synthesis_run(
+            name="expand tabletop",
+            dataset_name="test_dataset",
+            algorithm_name="procedural-in-painter",
+            algorithm_config={"segmentation_prompts": ["Table"]},
+        )
+
+        assert (
+            mock_auth_requests.request_history[-1].json()["output_dataset_name"]
+            == "test_dataset (synthetic)"
+        )
+
+    def test_auto_increments_a_name_already_in_use(
+        self, mock_endpoints, mock_auth_requests, job_response
+    ) -> None:
+        mock_endpoints(existing_jobs=[{**job_response, "name": "expand"}])
+
+        nc.start_data_synthesis_run(
+            name="expand",
+            dataset_name="test_dataset",
+            algorithm_name="procedural-in-painter",
+            algorithm_config={"segmentation_prompts": ["Table"]},
+            name_auto_increment=True,
+        )
+
+        assert mock_auth_requests.request_history[-1].json()["name"] == "expand_1"
+
+    def test_rejects_a_scaling_factor_that_is_not_a_whole_number_of_copies(
+        self, mock_endpoints
+    ) -> None:
+        mock_endpoints()
+
+        for bad in (0, -1, 11, 1.5):
+            with pytest.raises(Exception):
+                nc.start_data_synthesis_run(
+                    name="expand",
+                    dataset_name="test_dataset",
+                    algorithm_name="procedural-in-painter",
+                    algorithm_config={"segmentation_prompts": ["Table"]},
+                    scaling_factor=bad,
+                )
+
+    def test_passes_an_algorithm_the_client_has_never_heard_of(
+        self, mock_endpoints, mock_auth_requests
+    ) -> None:
+        # Whether an algorithm exists, and whether its parameters are valid, is
+        # the service's to say. The client only has to carry them.
+        mock_endpoints()
+
+        nc.start_data_synthesis_run(
+            name="expand",
+            dataset_name="test_dataset",
+            algorithm_name="greenaug",
+            algorithm_config={"key_color": "auto"},
+        )
+
+        sent = mock_auth_requests.request_history[-1].json()
+        assert sent["algorithm"] == {
+            "name": "greenaug",
+            "parameters": {"key_color": "auto"},
+        }
+
+    def test_surfaces_a_server_error_message(self, mock_endpoints) -> None:
+        mock_endpoints(job_status_code=400)
+
+        with pytest.raises(ValueError, match="Error starting data synthesis run"):
+            nc.start_data_synthesis_run(
+                name="expand",
+                dataset_name="test_dataset",
+                algorithm_name="procedural-in-painter",
+                algorithm_config={"segmentation_prompts": ["Table"]},
+            )
+
+
+class TestJobQueries:
+    def test_lists_jobs(self, mock_endpoints, job_response) -> None:
+        mock_endpoints(existing_jobs=[job_response])
+
+        assert [job["id"] for job in nc.get_data_synthesis_jobs()] == ["synth_job_123"]
+
+    def test_reads_a_job_status(
+        self, mock_endpoints, mock_auth_requests, mocked_org_id, job_response
+    ) -> None:
+        org_url = mock_endpoints()
+        mock_auth_requests.get(
+            f"{org_url}/jobs/synth_job_123",
+            json={**job_response, "status": "RUNNING"},
+            status_code=200,
+        )
+
+        assert nc.get_data_synthesis_job_status("synth_job_123") == "RUNNING"
+
+    def test_reports_a_missing_job(
+        self, mock_endpoints, mock_auth_requests, mocked_org_id
+    ) -> None:
+        org_url = mock_endpoints()
+        mock_auth_requests.get(f"{org_url}/jobs/absent", json={}, status_code=404)
+
+        with pytest.raises(ValueError, match="Job not found"):
+            nc.get_data_synthesis_job_data("absent")
+
+
+class TestLifecycleActions:
+    def test_cancels_a_job(
+        self, mock_endpoints, mock_auth_requests, mocked_org_id
+    ) -> None:
+        org_url = mock_endpoints()
+        mock_auth_requests.post(
+            f"{org_url}/jobs/synth_job_123/cancel",
+            json={"status": "cancelled"},
+            status_code=200,
+        )
+
+        nc.cancel_data_synthesis_job("synth_job_123")
+
+    def test_deletes_a_job(
+        self, mock_endpoints, mock_auth_requests, mocked_org_id
+    ) -> None:
+        org_url = mock_endpoints()
+        mock_auth_requests.delete(
+            f"{org_url}/jobs/synth_job_123",
+            json={"status": "deleted"},
+            status_code=200,
+        )
+
+        nc.delete_data_synthesis_job("synth_job_123")
+
+    def test_surfaces_a_failed_cancel(
+        self, mock_endpoints, mock_auth_requests, mocked_org_id
+    ) -> None:
+        org_url = mock_endpoints()
+        mock_auth_requests.post(
+            f"{org_url}/jobs/synth_job_123/cancel",
+            json={"detail": "already finished"},
+            status_code=409,
+        )
+
+        with pytest.raises(ValueError, match="Error cancelling"):
+            nc.cancel_data_synthesis_job("synth_job_123")


### PR DESCRIPTION
### Features
<!-- Please explain any additional functionality introduced -->
 - Client support for data synthesis, which expands a dataset by regenerating the imagery of its recordings while leaving every other modality untouched, so the actions recorded against those frames stay valid.
 - `start_data_synthesis_run` starts a job, naming the dataset to expand, the algorithm to run and how many recordings to produce per original. `generate_data_synthesis_preview` renders one frame per camera first, since running a machine for a whole job to find out a prompt segmented the wrong object is expensive.
 - `get_data_synthesis_algorithms` lists what a run can be started with: each algorithm's name, title, description, and its parameters as JSON Schema. The synthesis service reads that out of the package its worker runs, so a new algorithm reaches a notebook without a release of this package.
 - `get_data_synthesis_jobs`, `get_data_synthesis_job_data`, `get_data_synthesis_job_status`, `cancel_data_synthesis_job` and `delete_data_synthesis_job` cover the rest of a job's life.
 - `SYNTHESIS_API_URL` reaches the synthesis service, which is its own backend service behind a path prefix. Overridable on its own, so a local run can point at a synthesis service that is not behind the same host as the rest of the API.

### Related PRs
<!-- Please add a link to PRs from other repos that may be related -->
 - https://github.com/NeuracoreAI/neuracore_types/pull/127
 - https://github.com/NeuracoreAI/neuracore_data_synthesis/pull/6
 - https://github.com/NeuracoreAI/neuracore_backend/pull/595
 - https://github.com/NeuracoreAI/neuracore_frontend/pull/483
