### PR TITLE
fix: allow v100 for large vlas

### DIFF
--- a/neuracore/ml/algorithms/groot/groot.py
+++ b/neuracore/ml/algorithms/groot/groot.py
@@ -1245,4 +1245,5 @@ class Groot(NeuracoreModel):
         return frozenset({
             GPUType.NVIDIA_H100_80GB,
             GPUType.NVIDIA_A100_80GB,
+            GPUType.NVIDIA_TESLA_V100,
         })

--- a/neuracore/ml/algorithms/pi0/pi0.py
+++ b/neuracore/ml/algorithms/pi0/pi0.py
@@ -806,4 +806,5 @@ class Pi0(NeuracoreModel):
         return frozenset({
             GPUType.NVIDIA_H100_80GB,
             GPUType.NVIDIA_A100_80GB,
+            GPUType.NVIDIA_TESLA_V100,
         })

--- a/neuracore/ml/algorithms/pi05/pi05.py
+++ b/neuracore/ml/algorithms/pi05/pi05.py
@@ -886,4 +886,5 @@ class Pi05(NeuracoreModel):
         return frozenset({
             GPUType.NVIDIA_H100_80GB,
             GPUType.NVIDIA_A100_80GB,
+            GPUType.NVIDIA_TESLA_V100,
         })

--- a/tests/integration/ml/algorithm_configs.yaml
+++ b/tests/integration/ml/algorithm_configs.yaml
@@ -28,7 +28,6 @@ algorithms:
 
   - name: Pi0
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1
@@ -45,7 +44,6 @@ algorithms:
 
   - name: Pi05
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1
@@ -63,7 +61,6 @@ algorithms:
 
   - name: Groot
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1


### PR DESCRIPTION
### Bugfixes
 - Pi0, Pi05 and Groot declare the V100 as a supported GPU again, because A100 and H100 capacity is limited.
 - The algorithm performance integration test drops its per-algorithm GPU overrides, so these three algorithms go back to the default V100.


### Related PRs
 - Follows #991, which this partly reverts.
