### PR TITLE
fix: exempt small models from gpu check

### DIFF
--- a/neuracore/api/training.py
+++ b/neuracore/api/training.py
@@ -96,12 +96,33 @@ def get_algorithm(algorithm_id: str) -> dict:
     return response.json()
 
 
+# Test-scale variants of the large vision language models fit on any GPU. They
+# exist to keep integration tests cheap, so the hardware a full-size model needs
+# does not apply to them.
+_SMALL_MODEL_CONFIG_MARKERS: frozenset[tuple[str, Any]] = frozenset({
+    ("paligemma_variant", "gemma_tiny"),
+    ("action_expert_variant", "gemma_tiny"),
+    ("use_tiny_vlm", True),
+})
+
+
+def _is_small_model(algorithm_config: dict[str, Any]) -> bool:
+    """Check whether a config selects a test-scale variant of a large model."""
+    return any(
+        algorithm_config.get(key) == value for key, value in _SMALL_MODEL_CONFIG_MARKERS
+    )
+
+
 def _validate_gpu_to_algorithm(
     gpu: GPUType,
     algorithm_name: str,
     algorithm_jsons: list[dict],
+    algorithm_config: dict[str, Any],
 ) -> None:
     """Validate that an algorithm supports the selected GPU."""
+    if _is_small_model(algorithm_config):
+        return
+
     supported_gpus: set[GPUType] = set()
     for algorithm in algorithm_jsons:
         if algorithm.get("name") == algorithm_name:
@@ -195,6 +216,7 @@ def start_training_run(
         GPUType(gpu_type),
         algorithm_name,
         algorithm_jsons,
+        algorithm_config,
     )
 
     # Validate that the machine size is large enough for the dataset.

--- a/tests/integration/ml/algorithm_configs.yaml
+++ b/tests/integration/ml/algorithm_configs.yaml
@@ -28,7 +28,6 @@ algorithms:
 
   - name: Pi0
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1
@@ -45,7 +44,6 @@ algorithms:
 
   - name: Pi05
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1
@@ -63,7 +61,6 @@ algorithms:
 
   - name: Groot
     min_success_rate: 0.0
-    gpu_type: NVIDIA_A100_80GB
     algorithm_config:
       batch_size: 2
       epochs: 1

--- a/tests/unit/api/test_training.py
+++ b/tests/unit/api/test_training.py
@@ -55,6 +55,7 @@ def test_validate_gpu_to_algorithm_accepts_supported_gpu():
                 "NVIDIA_TESLA_V100",
             ],
         }],
+        {},
     )
 
 
@@ -77,6 +78,36 @@ def test_validate_gpu_to_algorithm_rejects_unsupported_gpu():
                     "NVIDIA_A100_80GB",
                 ],
             }],
+            {},
+        )
+
+
+@pytest.mark.parametrize(
+    "algorithm_config",
+    [
+        {"paligemma_variant": "gemma_tiny"},
+        {"action_expert_variant": "gemma_tiny"},
+        {"use_tiny_vlm": True},
+    ],
+)
+def test_validate_gpu_to_algorithm_exempts_small_models(algorithm_config: dict):
+    """A test-scale variant runs on a GPU the full-size model does not declare."""
+    _validate_gpu_to_algorithm(
+        GPUType.NVIDIA_TESLA_V100,
+        "Pi0",
+        [{"name": "Pi0", "supported_gpus": ["NVIDIA_A100_80GB"]}],
+        algorithm_config,
+    )
+
+
+def test_validate_gpu_to_algorithm_rejects_full_size_variant():
+    """A full-size variant of the same algorithm keeps the GPU restriction."""
+    with pytest.raises(ValueError, match="GPU NVIDIA_TESLA_V100 is not supported"):
+        _validate_gpu_to_algorithm(
+            GPUType.NVIDIA_TESLA_V100,
+            "Pi0",
+            [{"name": "Pi0", "supported_gpus": ["NVIDIA_A100_80GB"]}],
+            {"paligemma_variant": "gemma_2b", "use_tiny_vlm": False},
         )
 
 


### PR DESCRIPTION
### Features
 - None

### Bugfixes
 - The GPU compatibility check now skips configs that select a test-scale variant of a large model, so the integration tests can start Pi0, Pi05 and Groot on a V100 while the algorithms keep declaring only the GPUs their full-size variants need.
 - The algorithm performance test drops its per-algorithm GPU overrides, because the exemption lets these three algorithms use the default V100 again.

### Items
 - None

### Related PRs
 - Adjusts the check added in #819 and replaces the overrides added in #991.
